### PR TITLE
Enlarge the Simulation workspace and waveform plots

### DIFF
--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -336,6 +336,25 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   await expect(panel.locator(".spice-ac-plot svg")).toHaveCount(3);
   await expect(panel.locator('svg[aria-label="AC magnitude"]')).toBeVisible();
   await expect(panel.locator('svg[aria-label="AC phase"]')).toBeVisible();
+  await expect
+    .poll(
+      async () =>
+        (await panel.locator('svg[aria-label="AC magnitude"]').boundingBox())
+          ?.height ?? 0,
+    )
+    .toBeGreaterThan(300);
+  expect(
+    await panel
+      .locator(".ac-response .ac-trace")
+      .first()
+      .evaluate((trace) => getComputedStyle(trace).strokeWidth),
+  ).toBe("2.4px");
+  expect(
+    await panel
+      .locator(".ac-response .ac-axis-label")
+      .first()
+      .evaluate((label) => getComputedStyle(label).fill),
+  ).toBe("rgb(52, 64, 84)");
   await expect(panel.getByText("first-output", { exact: true })).toHaveCount(2);
   const magnitudePlot = panel
     .locator(".ac-plot-row")
@@ -671,6 +690,7 @@ test("Simulation creates an ordinary testbench and offers the current Cell at th
   const initialWidth = Number(
     await simulationResize.getAttribute("aria-valuenow"),
   );
+  expect(initialWidth).toBe(Math.round(page.viewportSize()!.width * 0.4));
   await simulationResize.press("ArrowRight");
   await expect(simulationResize).toHaveAttribute(
     "aria-valuenow",

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -300,10 +300,19 @@ const DEFAULT_VIEWBOX: GridRect = { x: 0, y: 0, width: 960, height: 640 };
 const RECENT_COMPONENTS_STORAGE_KEY = "icm.recent-components.v1";
 const LIBRARY_PANEL_STORAGE_KEY = "icm.library-panel-open.v1";
 const LIBRARY_WIDTH_STORAGE_KEY = "icm.library-panel-width.v1";
-const SIMULATION_WIDTH_STORAGE_KEY = "icm.simulation-panel-width.v1";
+const SIMULATION_WIDTH_STORAGE_KEY = "icm.simulation-panel-width.v2";
 const SIMULATION_WIDTH_MIN = 320;
-const SIMULATION_WIDTH_MAX = 760;
-const SIMULATION_WIDTH_DEFAULT = 440;
+const SIMULATION_WIDTH_MAX = 1200;
+const SIMULATION_WIDTH_RATIO = 0.4;
+
+function defaultSimulationWidth(viewportWidth: number): number {
+  return Math.round(
+    Math.min(
+      SIMULATION_WIDTH_MAX,
+      Math.max(SIMULATION_WIDTH_MIN, viewportWidth * SIMULATION_WIDTH_RATIO),
+    ),
+  );
+}
 const COMPACT_LAYOUT_MEDIA_QUERY = "(max-width: 860px)";
 const DRAG_START_DISTANCE_PX = 4;
 const SNAP_CAPTURE_RADIUS_PX = 4;
@@ -349,16 +358,16 @@ export function App({
     width: number;
   } | null>(null);
   const [simulationWidth, setSimulationWidthState] = useState(() => {
-    if (typeof window === "undefined") return SIMULATION_WIDTH_DEFAULT;
+    if (typeof window === "undefined") return defaultSimulationWidth(1100);
     try {
       const stored = Number(
         window.localStorage.getItem(SIMULATION_WIDTH_STORAGE_KEY),
       );
       return Number.isFinite(stored) && stored > 0
         ? Math.min(SIMULATION_WIDTH_MAX, Math.max(SIMULATION_WIDTH_MIN, stored))
-        : SIMULATION_WIDTH_DEFAULT;
+        : defaultSimulationWidth(window.innerWidth);
     } catch {
-      return SIMULATION_WIDTH_DEFAULT;
+      return defaultSimulationWidth(window.innerWidth);
     }
   });
   const setSimulationWidth = (width: number): void => {

--- a/apps/editor/src/features/simulation/ac-response-plot.test.ts
+++ b/apps/editor/src/features/simulation/ac-response-plot.test.ts
@@ -169,6 +169,10 @@ describe("AC response plot", () => {
       "utf8",
     );
     expect(css).toMatch(/\.ac-response \.ac-trace \{[^}]*fill:\s*none/u);
+    expect(css).toMatch(
+      /\.ac-response \.ac-trace \{[^}]*stroke-width:\s*2\.4/u,
+    );
+    expect(css).toMatch(/\.ac-response \.ac-axis-label,[^}]*fill:\s*#344054/u);
     for (let index = 0; index < 6; index += 1) {
       expect(css).toContain(`.ac-trace-${index}`);
     }

--- a/apps/editor/src/features/simulation/ac-results-explorer.tsx
+++ b/apps/editor/src/features/simulation/ac-results-explorer.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useMemo, useState, type SetStateAction } from "react";
-import { WaveformInteraction, useWaveformWidth } from "./waveform-interaction";
+import {
+  WaveformInteraction,
+  responsiveWaveformHeight,
+  useWaveformWidth,
+} from "./waveform-interaction";
 import { useWaveformView } from "./waveform-view";
 import { WaveformTools, WaveformMeasurements } from "./waveform-tools";
 import type { SimulationProbeSpec } from "@icm/model";
@@ -34,7 +38,7 @@ export interface AcResultsExplorerProps {
   onFocusProbe?(probe: SimulationProbeSpec): void;
 }
 
-const PLOT_SIZE = { width: 760, height: 280 } as const;
+const PLOT_SIZE = { width: 760, height: 395 } as const;
 const EXPANDED_PLOT_SIZE = { width: 1400, height: 700 } as const;
 
 /** Keep phase continuous instead of drawing artificial 360-degree jumps. */
@@ -158,7 +162,11 @@ export function AcResultsExplorer({
   ) => {
     const size = expanded
       ? EXPANDED_PLOT_SIZE
-      : { ...PLOT_SIZE, width: measured.width };
+      : {
+          ...PLOT_SIZE,
+          width: measured.width,
+          height: responsiveWaveformHeight(measured.width),
+        };
     const valueRange = valueRanges[plot.quantity + plot.kind];
     const layout = layoutAcPlot(
       plotTraces,

--- a/apps/editor/src/features/simulation/transient-results-explorer.tsx
+++ b/apps/editor/src/features/simulation/transient-results-explorer.tsx
@@ -7,6 +7,7 @@ import {
 } from "react";
 import {
   WaveformInteraction,
+  responsiveWaveformHeight,
   waveformTicks,
   waveformTickLabel,
   useWaveformWidth,
@@ -38,7 +39,7 @@ export interface TransientResultsExplorerProps {
 
 const PLOT = {
   width: 760,
-  height: 280,
+  height: 395,
   left: 64,
   right: 18,
   top: 16,
@@ -241,7 +242,11 @@ export function TransientResultsExplorer({
   ) => {
     const geometry = expanded
       ? EXPANDED_PLOT
-      : { ...PLOT, width: measured.width };
+      : {
+          ...PLOT,
+          width: measured.width,
+          height: responsiveWaveformHeight(measured.width),
+        };
     const range = timeRange ?? fullRange;
     const clipId = `${clipPrefix}-${quantity}-${expanded}`;
     const visibleValues = quantityTraces.flatMap((trace) =>

--- a/apps/editor/src/features/simulation/waveform-interaction.test.ts
+++ b/apps/editor/src/features/simulation/waveform-interaction.test.ts
@@ -1,8 +1,18 @@
 import { describe, expect, it } from "vitest";
-import { waveformTicks, waveformTickLabel } from "./waveform-interaction";
+import {
+  responsiveWaveformHeight,
+  waveformTicks,
+  waveformTickLabel,
+} from "./waveform-interaction";
 import { layoutAcPlot } from "./ac-response-plot";
 
 describe("waveform axes", () => {
+  it("grows docked plots with their panel without becoming unbounded", () => {
+    expect(responsiveWaveformHeight(400)).toBe(320);
+    expect(responsiveWaveformHeight(760)).toBe(395);
+    expect(responsiveWaveformHeight(1200)).toBe(440);
+  });
+
   it("adapts tick spacing to nanoseconds and a zoomed small signal", () => {
     expect(waveformTickLabel(1.8000005, 5e-7, "V")).not.toBe(
       waveformTickLabel(1.800001, 5e-7, "V"),

--- a/apps/editor/src/features/simulation/waveform-interaction.tsx
+++ b/apps/editor/src/features/simulation/waveform-interaction.tsx
@@ -21,6 +21,11 @@ export function useWaveformWidth() {
   return { ref, width };
 }
 
+/** Keep docked plots readable as the resizable Simulation workspace grows. */
+export function responsiveWaveformHeight(width: number): number {
+  return Math.round(Math.min(440, Math.max(320, width * 0.52)));
+}
+
 export interface WaveformPoint {
   x: number;
   y: number;

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -548,22 +548,22 @@
 .transient-quantity-group svg {
   width: 100%;
   height: auto;
-  color: var(--icm-text-muted);
-  font-size: 12px;
+  color: var(--icm-text);
+  font-size: 13px;
 }
 .transient-axis {
-  stroke: var(--icm-border-strong);
-  stroke-width: 1;
+  stroke: #667085;
+  stroke-width: 1.4;
 }
 .transient-trace {
   fill: none;
   stroke: currentColor;
-  stroke-width: 1.7;
+  stroke-width: 2.4;
   stroke-linejoin: round;
   vector-effect: non-scaling-stroke;
 }
 .transient-trace.ac-trace-selected {
-  stroke-width: 3;
+  stroke-width: 4;
 }
 .transient-quantity-group .ac-trace-hit {
   fill: none;
@@ -1187,13 +1187,13 @@
    solid blob instead of a curve. */
 .ac-response .ac-trace {
   fill: none;
-  stroke-width: 1.5;
+  stroke-width: 2.4;
   stroke-linejoin: round;
   pointer-events: none;
 }
 
 .ac-response .ac-trace.ac-trace-selected {
-  stroke-width: 3;
+  stroke-width: 4;
 }
 
 .ac-response .ac-trace-hit {
@@ -1206,7 +1206,7 @@
 
 .ac-response .ac-trace.ac-phase {
   stroke-dasharray: 3 2;
-  stroke-width: 1.2;
+  stroke-width: 2.1;
 }
 
 .ac-response .ac-cursor {
@@ -1218,20 +1218,21 @@
 
 .ac-response .ac-frame {
   fill: none;
-  stroke: var(--icm-border, #d5d9e0);
-  stroke-width: 1;
+  stroke: #667085;
+  stroke-width: 1.4;
 }
 
 .ac-response .ac-grid,
 .transient-results-explorer .ac-grid {
-  stroke: var(--icm-border-subtle, #eceff3);
-  stroke-width: 1;
+  stroke: #d0d5dd;
+  stroke-width: 1.1;
 }
 
 .ac-response .ac-axis-label,
 .transient-results-explorer .ac-axis-label {
-  font-size: 12px;
-  fill: var(--icm-text-muted, #667085);
+  font-size: 13px;
+  font-weight: 520;
+  fill: #344054;
   font-variant-numeric: tabular-nums;
 }
 


### PR DESCRIPTION
## Outcome
- defaults the resizable Simulation dock to 40% of the editor viewport
- moves the preference to a new storage key so the new default is visible to existing users
- grows docked AC and TRAN plots with panel width, from 320px up to 440px high
- strengthens trace, selected-trace, axis, grid and axis-label presentation

## Validation
- focused waveform unit tests: 19 passed
- TypeScript typecheck passed
- focused Simulation browser flows: 2 passed
- affected gate: 2704 unit/integration tests, 5 Simulation/Agent browser tests, and 134 main editor browser tests passed
- formatting, documentation/reference checks, Agent catalog and MCP distribution checks passed

Test-Impact: tests-updated