### PR TITLE
Support hierarchical and current-source simulation probes

### DIFF
--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -1049,7 +1049,10 @@ export function App({
   const [waveformPlacementPoint, setWaveformPlacementPoint] =
     useState<Point | null>(null);
   useEffect(() => {
-    setSimulationPickNetsActive(false);
+    // Net-pick is a hierarchy traversal mode: keep it armed while the author
+    // enters a DUT Cell, so an internal Net can be picked with its occurrence
+    // path intact. Closing/minimising Simulation still cancels it explicitly.
+    if (!analogSimulationOpen) setSimulationPickNetsActive(false);
     setSimulationHoverNetId(null);
     setSimulationSavedNetIds(new Set());
     setPendingWaveformPlacement(null);

--- a/apps/editor/src/features/simulation/simulation-probe-options.test.ts
+++ b/apps/editor/src/features/simulation/simulation-probe-options.test.ts
@@ -39,7 +39,32 @@ describe("simulation probe choices", () => {
       "Testbench · VDD current",
       "Testbench · VINP current",
       "Testbench · VINN current",
+      "Testbench · IBIAS current",
     ]);
+  });
+
+  it("names an unnamed hierarchical Net by its terminal aliases", () => {
+    const project = CircuitProjectSchema.parse(fiveTransistorOtaSky130);
+    const dut = project.documents.find(
+      (document) => document.id === "document-ota-5t",
+    )!;
+    const tail = dut.nets.find((net) => net.id === "net-dut-tail")!;
+    dut.connectivityEvidence = dut.connectivityEvidence.filter(
+      (evidence) => evidence.netId !== tail.id,
+    );
+
+    const option = deriveSimulationProbeOptions(
+      project,
+      "document-ota-5t-testbench",
+    ).voltage.find(
+      (candidate) =>
+        candidate.target.documentId === dut.id &&
+        candidate.target.anchor.kind === "terminal" &&
+        candidate.target.anchor.instanceId === "M5" &&
+        candidate.target.anchor.pinName === "D",
+    );
+
+    expect(option?.label).toBe("XDUT · ota_5t · XM5.D / XM1.S / XM2.S");
   });
 
   it("gives repeated calls of the same Cell different target identities", () => {

--- a/apps/editor/src/features/simulation/simulation-probe-options.ts
+++ b/apps/editor/src/features/simulation/simulation-probe-options.ts
@@ -135,6 +135,28 @@ function voltageAnchor(
   return route ? { kind: "route", routeId: route.id } : undefined;
 }
 
+function logicalNetDisplayName(
+  document: SchematicDocument,
+  baseNetIds: readonly string[],
+  fallback: string,
+): string {
+  const ids = new Set(baseNetIds);
+  const instances = new Map(
+    document.instances.map((instance) => [instance.id, instance]),
+  );
+  const aliases: string[] = [];
+  for (const net of document.nets) {
+    if (!ids.has(net.id)) continue;
+    for (const terminal of net.terminals) {
+      const instance = instances.get(terminal.instanceId);
+      const reference = instance?.reference ?? terminal.instanceId;
+      const alias = `${reference}.${terminal.pinName}`;
+      if (!aliases.includes(alias)) aliases.push(alias);
+    }
+  }
+  return aliases.length > 0 ? aliases.join(" / ") : fallback;
+}
+
 /**
  * Resolve the persisted occurrence ids into the same hierarchy frames used by
  * canvas navigation. This is presentation-only: probe identity remains the
@@ -211,7 +233,9 @@ export function deriveSimulationProbeOptions(
       };
       voltage.push({
         key: simulationProbeTargetKey(target),
-        label: `${prefix} · ${net.name ?? net.id}`,
+        label: `${prefix} · ${
+          net.name ?? logicalNetDisplayName(document, net.baseNetIds, net.id)
+        }`,
         target,
       });
     }
@@ -219,7 +243,8 @@ export function deriveSimulationProbeOptions(
       const binding = instance.netlist?.binding;
       if (
         (binding?.kind === "primitive" || binding?.kind === "model") &&
-        binding.deviceClass === "voltage-source"
+        (binding.deviceClass === "voltage-source" ||
+          (binding.deviceClass === "current-source" && occurrence.length === 0))
       ) {
         const target: SourceCurrentProbeTarget = {
           kind: "source-current",

--- a/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
@@ -35,6 +35,8 @@ describe("SpiceSimulationSurface workspace", () => {
     expect(markup).not.toContain("<datalist");
     expect(markup).toContain("sky130-core-continuous-ngspice46-v1");
     expect(markup).toContain('class="simulation-probe-control"');
+    expect(markup).toContain('aria-label="Filter voltage targets"');
+    expect(markup).toContain("Filter by Cell, instance, pin, or Net");
     expect(markup).toContain("Choose a Net");
     expect(markup).toContain("Pick on canvas");
     expect(markup).not.toContain("Pick voltage on canvas");

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useEffect, useId, useRef, useState, type ReactNode } from "react";
 import {
   type ObjectLocator,
   type ProjectSimulationSetup,
@@ -1430,7 +1430,7 @@ function SetupEditor({
         ) : null}
         <ProbeSelect
           label="Add current output"
-          placeholder="Choose a voltage-source branch"
+          placeholder="Choose a source current"
           options={probeOptions.sourceCurrent}
           probes={probes}
           onAdd={(option) => {
@@ -1535,32 +1535,54 @@ function ProbeSelect({
   trailingAction?: ReactNode;
 }) {
   const selected = new Set(probes.map(simulationProbeTargetKey));
+  const [query, setQuery] = useState("");
+  const selectId = useId();
+  const visibleOptions = options.filter((option) =>
+    option.label.toLocaleLowerCase().includes(query.trim().toLocaleLowerCase()),
+  );
   return (
-    <label className="simulation-probe-select">
-      <span>{label}</span>
+    <div className="simulation-probe-select">
+      <label htmlFor={selectId}>{label}</label>
       <span className="simulation-probe-control">
-        <select
-          value=""
-          onChange={(event) => {
-            const option = options.find(
-              (candidate) => candidate.key === event.target.value,
-            );
-            if (option) onAdd(option);
-          }}
-        >
-          <option value="">{placeholder}</option>
-          {options.map((option) => (
-            <option
-              key={option.key}
-              value={option.key}
-              disabled={selected.has(option.key)}
-            >
-              {option.label}
-            </option>
-          ))}
-        </select>
+        <span className="simulation-probe-picker">
+          <input
+            type="search"
+            value={query}
+            aria-label={
+              label === "Add voltage probe"
+                ? "Filter voltage targets"
+                : "Filter current targets"
+            }
+            placeholder="Filter by Cell, instance, pin, or Net"
+            onChange={(event) => setQuery(event.currentTarget.value)}
+          />
+          <select
+            id={selectId}
+            value=""
+            onChange={(event) => {
+              const option = options.find(
+                (candidate) => candidate.key === event.target.value,
+              );
+              if (option) {
+                onAdd(option);
+                setQuery("");
+              }
+            }}
+          >
+            <option value="">{placeholder}</option>
+            {visibleOptions.map((option) => (
+              <option
+                key={option.key}
+                value={option.key}
+                disabled={selected.has(option.key)}
+              >
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </span>
         {trailingAction}
       </span>
-    </label>
+    </div>
   );
 }

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -338,13 +338,28 @@
   justify-self: start;
 }
 .simulation-probe-select {
+  display: grid;
   grid-template-columns: minmax(110px, 0.8fr) minmax(130px, 1.2fr);
+  align-items: center;
+  gap: 8px;
+  margin: 6px 0;
+  font-size: var(--icm-font-sm);
 }
 .simulation-probe-control {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   gap: 6px;
   align-items: center;
+  min-width: 0;
+}
+.simulation-probe-picker {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+.simulation-probe-picker > input,
+.simulation-probe-picker > select {
+  width: 100%;
   min-width: 0;
 }
 .simulation-probe-control > button {

--- a/docs/specs/simulation.md
+++ b/docs/specs/simulation.md
@@ -444,10 +444,13 @@ occurrence path. Net names come from the Logical-Net resolver the printer
 already used, read back off the extracted Cell rather than derived a second
 time.
 
-An independent current source has no branch-current vector at all -- ngspice
-builds one for `V` sources and not for `I` sources, and `i(i1)` answers "not
-available" -- so a `source-current` probe on one is refused, with the advice
-to probe a series voltage source instead. The other refusals are a missing
+A top-level independent current source is measured by compiler-generated
+`.probe I(<ref>)` instrumentation. ngspice inserts a zero-volt sense source and
+publishes `<ref>#branch`; result parsing normalises that vector to `i(<ref>)`.
+This is supported for OP, AC, and TRAN. The directive addresses only top-level
+devices, so a current source below the simulation root is rejected with a
+located diagnostic until hierarchical instrumentation is implemented. See the
+ngspice manual, section 11.6.5.1, “.probe — Insert current probes”. The other refusals are a missing
 root, a root that instantiates nothing, a probe naming a Document or concrete
 anchor that is not there, an occurrence that does not follow hierarchy
 Instances from the root or that reaches a different Document than the probe

--- a/packages/netlist/src/simulation-compile.test.ts
+++ b/packages/netlist/src/simulation-compile.test.ts
@@ -923,7 +923,7 @@ describe("refusing a setup that cannot be simulated", () => {
     expect(codes(result)).toEqual(["SIMULATION_PROBE_NOT_A_SOURCE"]);
   });
 
-  it("refuses a source-current probe on an independent current source", async () => {
+  it("instruments a top-level independent current source", async () => {
     const project = dividerProject();
     const tb = project.documents[0]!;
     tb.instances.push({
@@ -954,9 +954,51 @@ describe("refusing a setup that cannot be simulated", () => {
       }),
     );
 
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.request.testbench).toContain("\n.probe I(I1)\n");
+    expect(result.request.testbench).toContain("write out.raw i1#branch\n");
+    expect(result.vectors).toContainEqual({
+      probeId: "probe-i1",
+      vector: "i(i1)",
+      quantity: "current",
+    });
+  });
+
+  it("reports a current-source probe below the simulation root", async () => {
+    const project = hierarchicalProject();
+    const child = project.documents.find((document) => document.id === "dut")!;
+    child.instances.push({
+      id: "inst-i1",
+      symbolId: "current-source",
+      placement: null,
+      reference: "I1",
+      netlist: {
+        binding: { kind: "primitive", deviceClass: "current-source" },
+        parameters: { dc: "1m" },
+      },
+    });
+    child.nets[0]!.terminals.push({ instanceId: "inst-i1", pinName: "+" });
+    child.nets[1]!.terminals.push({ instanceId: "inst-i1", pinName: "-" });
+
+    const result = await compile(
+      project,
+      setupWith({
+        probes: [
+          {
+            id: "probe-i1",
+            kind: "source-current",
+            documentId: "dut",
+            instanceId: "inst-i1",
+            occurrence: ["inst-x1"],
+          },
+        ],
+      }),
+    );
+
     expect(result.ok).toBe(false);
     expect(codes(result)).toEqual([
-      "SIMULATION_PROBE_SOURCE_HAS_NO_BRANCH_CURRENT",
+      "SIMULATION_PROBE_CURRENT_SOURCE_HIERARCHY_UNSUPPORTED",
     ]);
   });
 });

--- a/packages/netlist/src/simulation-compile.ts
+++ b/packages/netlist/src/simulation-compile.ts
@@ -54,10 +54,13 @@
  *   expansion prefixes the device's own type letter before the path, so
  *   `Vsi` under `X1`/`XI1` is `i(v.x1.xi1.vsi)`.
  *
- * An independent current source has no branch-current vector at all -- ngspice
- * builds one for `V` sources and not for `I` sources, and `i(i1)` answers
- * "not available". A `source-current` probe on one is refused here rather than
- * compiled into a name that cannot come back.
+ * A top-level independent current source is instrumented with ngspice's
+ * `.probe I(<ref>)`. ngspice inserts a zero-volt sense source and writes its
+ * result as `<ref>#branch`; the rawfile reader normalises that spelling to the
+ * public `i(<ref>)` vector used by voltage-source currents. The directive only
+ * addresses top-level devices, so a current source inside a subcircuit remains
+ * an explicit compile-time diagnostic rather than a probe that silently
+ * returns no data.
  */
 
 import type {
@@ -86,6 +89,14 @@ export interface CompiledSimulationVector {
   /** ngspice's own spelling, e.g. `v(mid)`, `v(x1.out)`, `i(v1)`. */
   readonly vector: string;
   readonly quantity: "voltage" | "current";
+}
+
+interface ResolvedSimulationProbe {
+  readonly binding: CompiledSimulationVector;
+  /** Expression passed to ngspice's `write`; it may differ from raw output. */
+  readonly writeVector: string;
+  /** Deck cards required to make the vector exist. */
+  readonly instrumentationCards: readonly string[];
 }
 
 export type CompiledSimulation =
@@ -465,7 +476,7 @@ function sourceCurrentVector(
   probe: Extract<SimulationProbeSpec, { kind: "source-current" }>,
   occurrence: ResolvedOccurrence,
   diagnostics: NetlistDiagnostic[],
-): CompiledSimulationVector | null {
+): ResolvedSimulationProbe | null {
   const { document, cell, path, hierarchyPath } = occurrence;
   const instance = cell.instances.find((item) => item.id === probe.instanceId);
   if (!instance) {
@@ -481,16 +492,28 @@ function sourceCurrentVector(
     return null;
   }
   if (instance.deviceClass === "current-source") {
-    diagnostics.push(
-      diagnostic(
-        "SIMULATION_PROBE_SOURCE_HAS_NO_BRANCH_CURRENT",
-        document.id,
-        `Probe ${probe.id} measures Instance ${instance.reference}, an independent current source; ngspice solves no branch current for one, so probe a series voltage source instead`,
-        locator(document.id, hierarchyPath, "instance", probe.instanceId),
-        [probe.instanceId],
-      ),
-    );
-    return null;
+    if (path.length > 0) {
+      diagnostics.push(
+        diagnostic(
+          "SIMULATION_PROBE_CURRENT_SOURCE_HIERARCHY_UNSUPPORTED",
+          document.id,
+          `Probe ${probe.id} measures current source ${instance.reference} inside a subcircuit; this ngspice instrumentation can address only a top-level source`,
+          locator(document.id, hierarchyPath, "instance", probe.instanceId),
+          [probe.instanceId],
+        ),
+      );
+      return null;
+    }
+    const reference = instance.reference.toLowerCase();
+    return {
+      binding: {
+        probeId: probe.id,
+        vector: `i(${reference})`,
+        quantity: "current",
+      },
+      writeVector: `${reference}#branch`,
+      instrumentationCards: [`.probe I(${instance.reference})`],
+    };
   }
   if (instance.deviceClass !== "voltage-source") {
     diagnostics.push(
@@ -511,7 +534,12 @@ function sourceCurrentVector(
   const name = path.length
     ? [reference.slice(0, 1), ...path, reference].join(".")
     : reference;
-  return { probeId: probe.id, vector: `i(${name})`, quantity: "current" };
+  const binding: CompiledSimulationVector = {
+    probeId: probe.id,
+    vector: `i(${name})`,
+    quantity: "current",
+  };
+  return { binding, writeVector: binding.vector, instrumentationCards: [] };
 }
 
 /**
@@ -644,6 +672,8 @@ export async function compileStructuredSimulation(
   );
   const cellsById = new Map(ir.cells.map((cell) => [cell.id, cell]));
   const vectors: CompiledSimulationVector[] = [];
+  const writeVectors: string[] = [];
+  const instrumentationCards: string[] = [];
   for (const probe of input.probes) {
     const occurrence = resolveOccurrence(
       probe,
@@ -653,11 +683,19 @@ export async function compileStructuredSimulation(
       diagnostics,
     );
     if (!occurrence) continue;
-    const vector =
-      probe.kind === "net-voltage"
-        ? netVoltageVector(probe, occurrence, diagnostics)
-        : sourceCurrentVector(probe, occurrence, diagnostics);
-    if (vector) vectors.push(vector);
+    if (probe.kind === "net-voltage") {
+      const vector = netVoltageVector(probe, occurrence, diagnostics);
+      if (vector) {
+        vectors.push(vector);
+        writeVectors.push(vector.vector);
+      }
+      continue;
+    }
+    const resolved = sourceCurrentVector(probe, occurrence, diagnostics);
+    if (!resolved) continue;
+    vectors.push(resolved.binding);
+    writeVectors.push(resolved.writeVector);
+    instrumentationCards.push(...resolved.instrumentationCards);
   }
 
   if (diagnostics.length) return { ok: false, diagnostics };
@@ -671,11 +709,12 @@ export async function compileStructuredSimulation(
 
   // One `write` per analysis, so each plot reaches the rawfile; see the note
   // at the top of this file for why `run` and a single `write` do not.
-  const written = [...new Set(vectors.map((item) => item.vector))];
+  const written = [...new Set(writeVectors)];
   const writeCard = [`write ${SIMULATION_RAWFILE_NAME}`, ...written].join(" ");
   const testbench = [
     `* Analog Canvas testbench for ${rootCell.name}`,
     ...rootCards,
+    ...new Set(instrumentationCards),
     ...(input.environment.temperatureC === undefined
       ? []
       : [`.temp ${spiceNumber(input.environment.temperatureC)}`]),


### PR DESCRIPTION
## Outcome
- keep simulation Net-pick active while entering a DUT Cell so internal Nets retain their occurrence path
- show unnamed hierarchical Nets through instance-pin aliases and add a local probe filter
- offer top-level independent current sources as outputs
- compile those currents through ngspice .probe I(ref) and normalize ef#branch results to i(ref)
- retain a located diagnostic for unsupported current sources below the simulation root

## Validation
- supplied OTA.icproj (3).json: X1.Vout, X1.IBias, X1.VDD, internal M5.D/M3.D, and I1 all compile
- live Preview ngspice 46 qualification: .probe I(I1) passed OP, AC, and TRAN
- pnpm ci:check: 2710 unit tests passed, build/release checks passed, 357 browser tests passed

Test-Impact: tests-updated