### PR TITLE
Simplify simulation workspace controls

### DIFF
--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -221,6 +221,17 @@ test("one Testbench persists several independently named setups", async ({
       ),
     ),
   ).toEqual(new Set(["document-ota-5t-testbench"]));
+
+  await panel.getByRole("button", { name: "Delete setup" }).click();
+  await expect(selector).toHaveValue("simulation-setup-ota-op-ac");
+  await expect(
+    selector.getByRole("option", { name: "Bias search" }),
+  ).toHaveCount(0);
+  const afterDelete = JSON.parse(
+    (await downloadBytes(page, "File", "Export Project File…")).toString(),
+  );
+  expect(afterDelete.simulationSetups).toHaveLength(1);
+  expect(afterDelete.simulationSetups[0].name).toBe("OTA OP and AC");
 });
 
 test("human simulation uses saved setup, survives minimizing, recovers a bad input and exports results", async ({
@@ -524,7 +535,9 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   await page.mouse.move(
     transientBounds!.x + transientBounds!.width * 0.7,
     transientBounds!.y + transientBounds!.height * 0.7,
+    { steps: 5 },
   );
+  await expect(transientPlot.locator(".waveform-selection")).toBeVisible();
   await page.mouse.up();
   expect(toolbarBounds!.y + toolbarBounds!.height).toBeLessThanOrEqual(
     transientBounds!.y,
@@ -547,13 +560,15 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   const xDrag = (await transientPlot.boundingBox())!;
   await page.mouse.move(
     xDrag.x + xDrag.width * 0.3,
-    xDrag.y + xDrag.height * 0.5,
+    xDrag.y + xDrag.height * 0.3,
   );
   await page.mouse.down();
   await page.mouse.move(
     xDrag.x + xDrag.width * 0.7,
-    xDrag.y + xDrag.height * 0.5,
+    xDrag.y + xDrag.height * 0.7,
+    { steps: 5 },
   );
+  await expect(transientPlot.locator(".waveform-selection")).toBeVisible();
   await page.mouse.up();
   await expect(rightTimeLabel).not.toHaveText(fullTimeLabel ?? "");
   expect(
@@ -668,16 +683,12 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
     .first()
     .click();
   expect((await download).suggestedFilename()).toMatch(/\.csv$/);
-  const oldRunIdentity = await panel
-    .getByLabel("Run evidence")
-    .locator("small")
-    .innerText();
+  await expect(panel.getByLabel("Last run")).toBeVisible();
   await panel.getByRole("button", { name: "Prepare deck" }).click();
-  await expect(
-    panel.getByLabel("Prepared input").locator("small"),
-  ).not.toHaveText(oldRunIdentity.split(" / prepared ")[1]!);
-  await expect(panel.getByLabel("Run evidence").locator("small")).toHaveText(
-    oldRunIdentity,
+  await expect(panel.getByLabel("Prepared files")).toBeVisible();
+  await expect(panel.getByLabel("Last run")).toBeVisible();
+  await expect(panel.getByText("Input identity", { exact: true })).toHaveCount(
+    0,
   );
   expect(executions).toBe(1);
   await panel.getByRole("button", { name: "Settings" }).click();

--- a/apps/editor/src/features/simulation/simulation-probe-options.test.ts
+++ b/apps/editor/src/features/simulation/simulation-probe-options.test.ts
@@ -230,4 +230,55 @@ describe("simulation probe choices", () => {
     expect(options[0]?.label).toBe("Main · 0");
     expect(options[0]?.key).toContain(":logical:net-ground-a");
   });
+
+  it("omits a lone Cell Pin while keeping an interface Net with a circuit member", () => {
+    const project = createEmptyProject("project", "Project", "main");
+    const document = project.documents[0]!;
+    document.instances.push(
+      { id: "PIN_GHOST", symbolId: "port", placement: null },
+      { id: "PIN_IN", symbolId: "port", placement: null },
+      { id: "R1", symbolId: "resistor", reference: "R1", placement: null },
+    );
+    document.netlist = {
+      name: "main",
+      formalParameters: [],
+      terminals: [
+        {
+          id: "terminal-ghost",
+          name: "ghost",
+          netId: "net-ghost",
+          direction: "input",
+          interfaceInstanceIds: ["PIN_GHOST"],
+        },
+        {
+          id: "terminal-in",
+          name: "in",
+          netId: "net-in",
+          direction: "input",
+          interfaceInstanceIds: ["PIN_IN"],
+        },
+      ],
+    };
+    document.nets.push(
+      {
+        id: "net-ghost",
+        terminals: [{ instanceId: "PIN_GHOST", pinName: "P" }],
+      },
+      {
+        id: "net-in",
+        terminals: [
+          { instanceId: "PIN_IN", pinName: "P" },
+          { instanceId: "R1", pinName: "A" },
+        ],
+      },
+    );
+
+    const labels = deriveSimulationProbeOptions(
+      project,
+      document.id,
+    ).voltage.map((option) => option.label);
+
+    expect(labels.some((label) => label.includes("ghost"))).toBe(false);
+    expect(labels).toContain("Main · in");
+  });
 });

--- a/apps/editor/src/features/simulation/simulation-probe-options.ts
+++ b/apps/editor/src/features/simulation/simulation-probe-options.ts
@@ -161,6 +161,39 @@ function voltageAnchor(
   return route ? { kind: "route", routeId: route.id } : undefined;
 }
 
+/**
+ * A lone formal Cell Pin is an interface declaration, not a solved circuit
+ * node. It cannot produce a useful ngspice vector until the Net also contains
+ * another electrical member. Keep this simulation-only eligibility rule out
+ * of the persisted Net and Cell contracts.
+ */
+function hasMeasurableVoltageMember(
+  document: SchematicDocument,
+  baseNetIds: readonly string[],
+): boolean {
+  const ids = new Set(baseNetIds);
+  const interfaceInstanceIds = new Set(
+    (document.netlist?.terminals ?? []).flatMap(
+      (terminal) => terminal.interfaceInstanceIds,
+    ),
+  );
+  const terminals = document.nets.flatMap((net) =>
+    ids.has(net.id) ? net.terminals : [],
+  );
+  const globalSupply = document.connectivityEvidence.some(
+    (evidence) =>
+      ids.has(evidence.netId) &&
+      evidence.kind === "name-claim" &&
+      evidence.scope === "global" &&
+      (evidence.powerDomain === "vdd" || evidence.powerDomain === "ground"),
+  );
+  return (
+    globalSupply ||
+    terminals.length > 1 ||
+    terminals.some((terminal) => !interfaceInstanceIds.has(terminal.instanceId))
+  );
+}
+
 function logicalNetDisplayLabel(
   document: SchematicDocument,
   choice: {
@@ -254,6 +287,7 @@ export function deriveSimulationProbeOptions(
     // joined by the same scoped label (notably repeated Ground markers); the
     // user should not have to choose among indistinguishable aliases.
     for (const net of logicalNetChoices(document)) {
+      if (!hasMeasurableVoltageMember(document, net.baseNetIds)) continue;
       const anchor = voltageAnchor(document, net.baseNetIds);
       if (!anchor) continue;
       const target: VoltageProbeTarget = {

--- a/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
@@ -35,8 +35,8 @@ describe("SpiceSimulationSurface workspace", () => {
     expect(markup).not.toContain("<datalist");
     expect(markup).toContain("sky130-core-continuous-ngspice46-v1");
     expect(markup).toContain('class="simulation-probe-control"');
-    expect(markup).toContain('aria-label="Filter voltage targets"');
-    expect(markup).toContain("Filter by Cell, instance, pin, or Net");
+    expect(markup).not.toContain('type="search"');
+    expect(markup).not.toContain("Filter by Cell, instance, pin, or Net");
     expect(markup).toContain("Choose a Net");
     expect(markup).toContain("Pick on canvas");
     expect(markup).not.toContain("Pick voltage on canvas");
@@ -127,6 +127,7 @@ describe("SpiceSimulationSurface workspace", () => {
     expect(markup).toContain('aria-label="Simulation setup"');
     expect(markup).toContain("DC Sweep");
     expect(markup).toContain("AC Response");
+    expect(markup.match(/Delete setup/g)).toHaveLength(1);
     expect(markup).toContain('name="setupName"');
     expect(markup).toContain("V1 · Voltage");
     expect(markup).toContain('name="dcStartValue"');
@@ -167,6 +168,7 @@ describe("SpiceSimulationSurface workspace", () => {
     expect(markup).toContain("Raw setup");
     expect(markup).toContain("tb.cir");
     expect(markup).toContain("Switch to structured setup");
+    expect(markup.match(/Delete setup/g)).toHaveLength(1);
     expect(markup).not.toContain("Add voltage probe");
   });
 });

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -326,8 +326,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
     ...(prepared
       ? [
           {
-            label: "Prepared input",
-            identity: prepared.id,
+            label: "Prepared files",
             artifacts: prepared.artifacts,
           },
         ]
@@ -335,8 +334,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
     ...(run
       ? [
           {
-            label: "Run evidence",
-            identity: `${run.id} / prepared ${run.preparedId}`,
+            label: "Last run",
             artifacts: run.artifacts,
           },
         ]
@@ -476,6 +474,17 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
           </button>
           <button
             type="button"
+            disabled={busy || !!running || !selectedSetup}
+            onClick={() => {
+              if (selectedSetup && props.onDeleteSetup(selectedSetup.id))
+                setDirty(false);
+            }}
+          >
+            Delete setup
+          </button>
+          <button
+            type="button"
+            className="simulation-settings-button"
             aria-pressed={setupOpen}
             onClick={() => {
               setResultsOpen(false);
@@ -846,33 +855,22 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
 
             {resultTab === "files" ? (
               <div className="simulation-files-view">
-                {(run || prepared) && (
-                  <details>
-                    <summary>Input identity</summary>
-                    <pre>
-                      {prepared &&
-                        `Prepared ${prepared.id}\nInput ${prepared.inputRevision}\n`}
-                      {run &&
-                        `Run ${run.id}\nPrepared ${run.preparedId}\nInput ${run.inputRevision}`}
-                    </pre>
-                  </details>
-                )}
                 {artifactGroups.map((group) => (
                   <section key={group.label} aria-label={group.label}>
-                    <div>
-                      <strong>{group.label}</strong>
-                      <small>{group.identity}</small>
-                    </div>
-                    <div className="simulation-artifact-list">
+                    <h3>{group.label}</h3>
+                    <ul className="simulation-artifact-list">
                       {group.artifacts.map((artifact) => (
-                        <button
-                          key={artifact.id}
-                          onClick={() => void download(artifact)}
-                        >
-                          {artifact.name}
-                        </button>
+                        <li key={artifact.id}>
+                          <span>{simulationArtifactCategory(artifact)}</span>
+                          <button onClick={() => void download(artifact)}>
+                            {artifact.name}
+                          </button>
+                          <small>
+                            {formatArtifactSize(artifact.byteLength)}
+                          </small>
+                        </li>
                       ))}
-                    </div>
+                    </ul>
                   </section>
                 ))}
                 {artifactGroups.length === 0 ? (
@@ -964,7 +962,6 @@ function SetupEditor({
   draftContext,
   capabilities,
   onSaveSetup,
-  onDeleteSetup,
   setup,
   onDirty,
   onProblem,
@@ -1113,12 +1110,6 @@ function SetupEditor({
           <p>Profile: {rawSaved.environment.profileId}</p>
           <button type="button" onClick={() => setSwitchFromRaw(true)}>
             Switch to structured setup…
-          </button>
-          <button
-            type="button"
-            onClick={() => setup && onDeleteSetup(setup.id)}
-          >
-            Delete setup
           </button>
         </div>
       </aside>
@@ -1689,11 +1680,6 @@ function SetupEditor({
           ))}
         </ul>
         <button type="submit">Apply setup</button>
-        {setup && (
-          <button type="button" onClick={() => onDeleteSetup(setup.id)}>
-            Delete setup
-          </button>
-        )}
       </form>
     </aside>
   );
@@ -1800,54 +1786,47 @@ function ProbeSelect({
   onAdd(option: SimulationProbeOption): void;
   trailingAction?: ReactNode;
 }) {
-  const [query, setQuery] = useState("");
   const selectId = useId();
-  const visibleOptions = options.filter((option) =>
-    option.label.toLocaleLowerCase().includes(query.trim().toLocaleLowerCase()),
-  );
   return (
     <div className="simulation-probe-select">
       <label htmlFor={selectId}>{label}</label>
       <span className="simulation-probe-control">
-        <span className="simulation-probe-picker">
-          <input
-            type="search"
-            value={query}
-            aria-label={
-              label === "Add voltage probe"
-                ? "Filter voltage targets"
-                : "Filter current targets"
-            }
-            placeholder="Filter by Cell, instance, pin, or Net"
-            onChange={(event) => setQuery(event.currentTarget.value)}
-          />
-          <select
-            id={selectId}
-            value=""
-            onChange={(event) => {
-              const option = options.find(
-                (candidate) => candidate.key === event.target.value,
-              );
-              if (option) {
-                onAdd(option);
-                setQuery("");
-              }
-            }}
-          >
-            <option value="">{placeholder}</option>
-            {visibleOptions.map((option) => (
-              <option
-                key={option.key}
-                value={option.key}
-                disabled={selectedKeys.has(option.key)}
-              >
-                {option.label}
-              </option>
-            ))}
-          </select>
-        </span>
+        <select
+          id={selectId}
+          value=""
+          onChange={(event) => {
+            const option = options.find(
+              (candidate) => candidate.key === event.target.value,
+            );
+            if (option) onAdd(option);
+          }}
+        >
+          <option value="">{placeholder}</option>
+          {options.map((option) => (
+            <option
+              key={option.key}
+              value={option.key}
+              disabled={selectedKeys.has(option.key)}
+            >
+              {option.label}
+            </option>
+          ))}
+        </select>
         {trailingAction}
       </span>
     </div>
   );
+}
+
+function simulationArtifactCategory(artifact: ArtifactRef): string {
+  const name = artifact.name.toLocaleLowerCase();
+  if (name.endsWith(".cir") || name.endsWith(".spi")) return "Netlist";
+  if (name.endsWith(".raw") || name.endsWith(".csv")) return "Results";
+  if (name.endsWith(".log") || name.endsWith(".txt")) return "Log";
+  return "Other";
+}
+
+function formatArtifactSize(byteLength: number): string {
+  if (byteLength < 1024) return `${byteLength} B`;
+  return `${(byteLength / 1024).toFixed(byteLength < 10_240 ? 1 : 0)} KB`;
 }

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -352,13 +352,7 @@
   align-items: center;
   min-width: 0;
 }
-.simulation-probe-picker {
-  display: grid;
-  gap: 4px;
-  min-width: 0;
-}
-.simulation-probe-picker > input,
-.simulation-probe-picker > select {
+.simulation-probe-control > select {
   width: 100%;
   min-width: 0;
 }
@@ -484,25 +478,48 @@
 }
 .simulation-files-view {
   display: grid;
-  gap: 10px;
+  gap: 14px;
 }
 .simulation-files-view > section {
   display: grid;
-  grid-template-columns: minmax(160px, 1fr) minmax(220px, 2fr);
-  gap: 12px;
-  align-items: center;
-  padding: 10px;
-  border: 1px solid var(--icm-border);
-  border-radius: var(--icm-radius-sm);
+  gap: 6px;
 }
-.simulation-files-view > section > div:first-child {
-  display: grid;
-  gap: 3px;
+.simulation-files-view h3 {
+  margin: 0;
+  font-size: var(--icm-font-sm);
 }
 .simulation-artifact-list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
+  display: grid;
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  list-style: none;
+}
+.simulation-artifact-list li {
+  display: grid;
+  grid-template-columns: 72px minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  min-height: 38px;
+  padding: 5px 9px;
+  background: var(--icm-surface);
+}
+.simulation-artifact-list li + li {
+  border-top: 1px solid var(--icm-border);
+}
+.simulation-artifact-list li > span {
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+}
+.simulation-artifact-list button {
+  min-width: 0;
+  justify-self: start;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .spice-simulation-surface pre {
   white-space: pre-wrap;
@@ -864,14 +881,17 @@
       "actions actions";
   }
   .simulation-brand,
-  .simulation-task-actions > button:nth-child(3) {
+  .simulation-settings-button {
     display: none;
   }
   .simulation-result-summary {
     grid-template-columns: 1fr;
   }
-  .simulation-files-view > section {
-    grid-template-columns: 1fr;
+  .simulation-artifact-list li {
+    grid-template-columns: 62px minmax(0, 1fr);
+  }
+  .simulation-artifact-list small {
+    display: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- expose setup deletion beside setup creation and preserve the remaining setup selection
- replace internal run/input identities with categorized downloadable file rows
- remove redundant voltage/current probe filters
- exclude lone formal Cell Pins from voltage probe choices while retaining connected interfaces and global supplies

## Validation
- pnpm gate:affected -- --base origin/main (2725 unit tests passed, 26 skipped; 6 browser tests passed)
- pnpm gate:preflight -- --base origin/main static contracts passed; Test-Impact was rerun after commit and passed
- git diff --check origin/main...HEAD

Test-Impact: tests-updated