### PR TITLE
Fix Preview Agent journey after authored outputs migration

### DIFF
--- a/scripts/preview-agent-simulation-journey.mjs
+++ b/scripts/preview-agent-simulation-journey.mjs
@@ -194,7 +194,18 @@ try {
     .waitFor({ state: "visible", timeout: 30_000 });
 
   const invalidSetup = structuredClone(setup);
-  invalidSetup.input.probes[0].anchor = {
+  assert.equal(
+    invalidSetup.input.kind,
+    "structured",
+    "The acceptance setup must use structured simulation input",
+  );
+  const firstOutput = invalidSetup.input.outputs[0];
+  assert(firstOutput, "The acceptance setup has no authored output");
+  assert(
+    ["voltage", "current"].includes(firstOutput.expression.kind),
+    "The first acceptance output cannot be anchored to a circuit terminal",
+  );
+  firstOutput.expression.anchor = {
     kind: "terminal",
     instanceId: "missing-acceptance-instance",
     pinName: "out",

--- a/scripts/preview-workflow.test.mjs
+++ b/scripts/preview-workflow.test.mjs
@@ -9,6 +9,10 @@ import { describe, expect, it } from "vitest";
  */
 const preview = readFileSync(".github/workflows/deploy-preview.yml", "utf8");
 const production = readFileSync(".github/workflows/cloudflare.yml", "utf8");
+const agentJourney = readFileSync(
+  "scripts/preview-agent-simulation-journey.mjs",
+  "utf8",
+);
 
 describe("the preview deploy", () => {
   it("deploys the preview configuration file and nothing else", () => {
@@ -62,5 +66,11 @@ describe("the preview deploy", () => {
     expect(production).not.toContain("wrangler.preview.jsonc");
     expect(production).not.toContain("VITE_ICM_AGENT_UI: enabled");
     expect(production).not.toContain("preview-agent-simulation-journey.mjs");
+  });
+
+  it("injects its recoverable failure through the current authored-output contract", () => {
+    expect(agentJourney).toContain("invalidSetup.input.outputs[0]");
+    expect(agentJourney).toContain("firstOutput.expression.anchor");
+    expect(agentJourney).not.toContain("invalidSetup.input.probes");
   });
 });


### PR DESCRIPTION
## Summary
- inject the recoverable compile failure through the current authored-output expression contract
- replace the opaque undefined access with explicit fixture-contract assertions
- guard the Preview journey against reintroducing retired input.probes access

## Validation
- corepack pnpm test:local scripts/preview-workflow.test.mjs (5 passed)
- real public Preview Agent/MCP SKY130 OTA journey (passed; recoverable error, successful run, raw/result/CSV/deck exports)
- corepack pnpm gate:preflight -- --base origin/main
- corepack pnpm gate:affected -- --base origin/main (2740 passed, 26 skipped)

Test-Impact: tests-updated