### PR TITLE
Probe hierarchical current sources

### DIFF
--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -30,6 +30,25 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
   page,
 }) => {
   const project = parseProject(JSON.stringify(ota));
+  const dut = project.documents.find(
+    (document) => document.id === "document-ota-5t",
+  )!;
+  dut.instances.push({
+    id: "I_INTERNAL_PROBE",
+    symbolId: "current-source",
+    placement: null,
+    reference: "I1",
+    netlist: {
+      binding: { kind: "primitive", deviceClass: "current-source" },
+      parameters: { dc: "1u" },
+    },
+  });
+  dut.nets
+    .find((net) => net.id === "net-cell-pin-pvdd")!
+    .terminals.push({ instanceId: "I_INTERNAL_PROBE", pinName: "+" });
+  dut.nets
+    .find((net) => net.id === "net-dut-tail")!
+    .terminals.push({ instanceId: "I_INTERNAL_PROBE", pinName: "-" });
   const savedSetup = project.simulationSetups[0];
   expect(savedSetup?.input.kind).toBe("structured");
   if (savedSetup?.input.kind !== "structured")
@@ -98,9 +117,12 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
   await panel
     .getByLabel("Add current output")
     .selectOption({ label: "Testbench · VINP current" });
+  await panel
+    .getByLabel("Add current output")
+    .selectOption({ label: "XDUT · ota_5t · I1 current" });
   await expect(
     panel.getByRole("button", { name: "Remove output" }),
-  ).toHaveCount(6);
+  ).toHaveCount(7);
   await panel.getByRole("button", { name: "Apply setup" }).click();
   await panel.getByRole("button", { name: "Prepare deck" }).click();
   const deckDownload = page.waitForEvent("download");
@@ -119,6 +141,7 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
     "i(vinp)",
   ])
     expect(deck).toContain(vector);
+  expect(deck).toMatch(/i\(v\.xdut\.vicmprb\d+\)/u);
   expect(deck).toMatch(/ac dec 10 1 (?:1000000000|1e\+?9)/i);
   expect(executions).toBe(0);
   await panel.getByRole("button", { name: "Minimize simulation" }).click();
@@ -151,6 +174,14 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
         occurrence: [],
       },
     },
+    {
+      expression: {
+        kind: "current",
+        documentId: "document-ota-5t",
+        instanceId: "I_INTERNAL_PROBE",
+        occurrence: ["XDUT"],
+      },
+    },
   ]);
   await page.reload();
   await page.getByTestId("project-file").setInputFiles({
@@ -164,7 +195,7 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
   await panel.getByRole("button", { name: "Settings" }).click();
   await expect(
     panel.getByRole("button", { name: "Remove output" }),
-  ).toHaveCount(6);
+  ).toHaveCount(7);
   await expect(panel.getByLabel("Stop (Hz)")).toHaveValue("1000000000");
 });
 

--- a/apps/editor/src/features/simulation/simulation-probe-options.test.ts
+++ b/apps/editor/src/features/simulation/simulation-probe-options.test.ts
@@ -12,8 +12,21 @@ import {
 } from "./simulation-probe-options";
 
 describe("simulation probe choices", () => {
-  it("keeps hierarchy occurrences and voltage-source currents addressable", () => {
+  it("keeps hierarchy occurrences and source currents addressable", () => {
     const project = CircuitProjectSchema.parse(fiveTransistorOtaSky130);
+    const dut = project.documents.find(
+      (document) => document.id === "document-ota-5t",
+    )!;
+    dut.instances.push({
+      id: "IINTERNAL",
+      symbolId: "current-source",
+      placement: null,
+      reference: "I1",
+      netlist: {
+        binding: { kind: "primitive", deviceClass: "current-source" },
+        parameters: { dc: "10u" },
+      },
+    });
     const options = deriveSimulationProbeOptions(
       project,
       "document-ota-5t-testbench",
@@ -36,11 +49,18 @@ describe("simulation probe choices", () => {
       },
     });
     expect(options.sourceCurrent.map((option) => option.label)).toEqual([
+      "XDUT · ota_5t · I1 current",
       "Testbench · VDD current",
       "Testbench · VINP current",
       "Testbench · VINN current",
       "Testbench · IBIAS current",
     ]);
+    expect(options.sourceCurrent[0]?.target).toEqual({
+      kind: "current",
+      documentId: "document-ota-5t",
+      instanceId: "IINTERNAL",
+      occurrence: ["XDUT"],
+    });
   });
 
   it("names an unnamed hierarchical Net by its terminal aliases", () => {
@@ -136,6 +156,47 @@ describe("simulation probe choices", () => {
         occurrence: ["XDUT2"],
       }).map((option) => option.target.occurrence),
     ).toEqual([["XDUT2"]]);
+  });
+
+  it("gives a hierarchical current source one choice per occurrence", () => {
+    const project = CircuitProjectSchema.parse(fiveTransistorOtaSky130);
+    const testbench = project.documents.find(
+      (document) => document.id === "document-ota-5t-testbench",
+    )!;
+    const dut = project.documents.find(
+      (document) => document.id === "document-ota-5t",
+    )!;
+    const first = testbench.instances.find(
+      (instance) => instance.id === "XDUT",
+    )!;
+    testbench.instances.push({
+      ...structuredClone(first),
+      id: "XDUT2",
+      reference: "XDUT2",
+    });
+    dut.instances.push({
+      id: "IINTERNAL",
+      symbolId: "current-source",
+      placement: null,
+      reference: "I1",
+      netlist: {
+        binding: { kind: "primitive", deviceClass: "current-source" },
+        parameters: { dc: "10u" },
+      },
+    });
+
+    const targets = deriveSimulationProbeOptions(
+      project,
+      testbench.id,
+    ).sourceCurrent.filter(
+      (option) => option.target.instanceId === "IINTERNAL",
+    );
+
+    expect(targets.map((option) => option.target.occurrence)).toEqual([
+      ["XDUT"],
+      ["XDUT2"],
+    ]);
+    expect(new Set(targets.map((option) => option.key)).size).toBe(2);
   });
 
   it("resolves an object anchor for canvas focus and matches its whole Logical Net", () => {

--- a/apps/editor/src/features/simulation/simulation-probe-options.ts
+++ b/apps/editor/src/features/simulation/simulation-probe-options.ts
@@ -307,7 +307,7 @@ export function deriveSimulationProbeOptions(
       if (
         (binding?.kind === "primitive" || binding?.kind === "model") &&
         (binding.deviceClass === "voltage-source" ||
-          (binding.deviceClass === "current-source" && occurrence.length === 0))
+          binding.deviceClass === "current-source")
       ) {
         const target: SourceCurrentProbeTarget = {
           kind: "current",

--- a/docs/specs/simulation.md
+++ b/docs/specs/simulation.md
@@ -473,12 +473,14 @@ a bare `write out.raw`, saving the whole plot rather than nothing.
 
 Vector names are produced here and never inferred from result text:
 
-| primitive acquisition            | vector            |
-| -------------------------------- | ----------------- |
-| Net in the root                  | `v(mid)`          |
-| Net under occurrence `X1`, `XI1` | `v(x1.xi1.mid)`   |
-| voltage source in the root       | `i(v1)`           |
-| voltage source under `X1`, `XI1` | `i(v.x1.xi1.vsi)` |
+| primitive acquisition                         | vector                   |
+| --------------------------------------------- | ------------------------ |
+| Net in the root                               | `v(mid)`                 |
+| Net under occurrence `X1`, `XI1`              | `v(x1.xi1.mid)`          |
+| voltage source in the root                    | `i(v1)`                  |
+| voltage source under `X1`, `XI1`              | `i(v.x1.xi1.vsi)`        |
+| current source in the root                    | `i(i1)`                  |
+| instrumented current source under `X1`, `XI1` | `i(v.x1.xi1.vicmprb###)` |
 
 They are lower case because ngspice folds case on the way into the rawfile: a
 card may read `R1 IN MID 1k`, and `V(MidNode)` still comes back as
@@ -489,17 +491,24 @@ time.
 
 A top-level independent current source is measured by compiler-generated
 `.probe I(<ref>)` instrumentation. ngspice inserts a zero-volt sense source and
-publishes `<ref>#branch`; result parsing normalises that vector to `i(<ref>)`.
-This is supported for OP, AC, and TRAN. The directive addresses only top-level
-devices, so a current source below the simulation root is rejected with a
-located diagnostic until hierarchical instrumentation is implemented. See the
-ngspice manual, section 11.6.5.1, “.probe — Insert current probes”. The other refusals are a missing
-root, a root that instantiates nothing, a probe naming a Document or concrete
-anchor that is not there, an occurrence that does not follow hierarchy
-Instances from the root or that reaches a different Document than the probe
-claims, an analysis kind this release does not compile, and a source-current
-probe on a device that is not a source. Each is a typed diagnostic carrying an
-occurrence-aware `ObjectLocator`, never a thrown error.
+publishes `<ref>#branch`; the rawfile records that vector as `i(<ref>)`. The
+directive addresses only top-level devices. For a selected current source
+below the simulation root, the compiler instead inserts a deterministic 0 V
+sense source in series inside the extracted Cell definition and writes its
+occurrence-qualified branch current. This instrumentation exists only in the
+prepared simulation artifact: it does not mutate the Project or ordinary
+structural export. Its positive direction matches the authored independent
+current source's first-to-second-node direction, so no result-side sign repair
+is applied. One instrumented Cell definition remains independently addressable
+through every concrete occurrence. Both forms are supported for OP, DC, AC,
+and TRAN. See the ngspice manual, section 11.6.5.1, “.probe — Insert current
+probes”. The other refusals are a missing root, a root that instantiates
+nothing, a probe naming a Document or concrete anchor that is not there, an
+occurrence that does not follow hierarchy Instances from the root or that
+reaches a different Document than the probe claims, an analysis kind this
+release does not compile, and a source-current probe on a device that is not a
+source. Each is a typed diagnostic carrying an occurrence-aware
+`ObjectLocator`, never a thrown error.
 
 `inputRevision` is the SHA-256 of the two compiled texts and a canonical
 serialization of the setup, computed with Web Crypto so the function stays

--- a/packages/netlist/src/simulation-compile.test.ts
+++ b/packages/netlist/src/simulation-compile.test.ts
@@ -284,6 +284,22 @@ function hierarchicalProject(): CircuitProject {
   return project;
 }
 
+function addHierarchicalCurrentSource(project: CircuitProject): void {
+  const child = project.documents.find((document) => document.id === "dut")!;
+  child.instances.push({
+    id: "inst-i1",
+    symbolId: "current-source",
+    placement: null,
+    reference: "I1",
+    netlist: {
+      binding: { kind: "primitive", deviceClass: "current-source" },
+      parameters: { dc: "1m" },
+    },
+  });
+  child.nets[0]!.terminals.push({ instanceId: "inst-i1", pinName: "+" });
+  child.nets[1]!.terminals.push({ instanceId: "inst-i1", pinName: "-" });
+}
+
 function setupWith(
   overrides: Partial<SimulationStructuredInput> & {
     probes?: Array<Record<string, unknown> & { id: string; kind: string }>;
@@ -1046,21 +1062,9 @@ describe("refusing a setup that cannot be simulated", () => {
     });
   });
 
-  it("reports a current-source probe below the simulation root", async () => {
+  it("instruments a current source below the simulation root", async () => {
     const project = hierarchicalProject();
-    const child = project.documents.find((document) => document.id === "dut")!;
-    child.instances.push({
-      id: "inst-i1",
-      symbolId: "current-source",
-      placement: null,
-      reference: "I1",
-      netlist: {
-        binding: { kind: "primitive", deviceClass: "current-source" },
-        parameters: { dc: "1m" },
-      },
-    });
-    child.nets[0]!.terminals.push({ instanceId: "inst-i1", pinName: "+" });
-    child.nets[1]!.terminals.push({ instanceId: "inst-i1", pinName: "-" });
+    addHierarchicalCurrentSource(project);
 
     const result = await compile(
       project,
@@ -1077,9 +1081,75 @@ describe("refusing a setup that cannot be simulated", () => {
       }),
     );
 
-    expect(result.ok).toBe(false);
-    expect(codes(result)).toEqual([
-      "SIMULATION_PROBE_CURRENT_SOURCE_HIERARCHY_UNSUPPORTED",
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.request.netlist).toContain(
+      "I1 A ICMPRB001 DC 1m\nVICMPRB001 ICMPRB001 OUT DC 0",
+    );
+    expect(result.request.testbench).toContain(
+      "write out.raw i(v.x1.vicmprb001)\n",
+    );
+    expect(result.request.testbench).not.toContain(".probe I(I1)");
+    expect(result.vectors).toEqual([
+      {
+        probeId: "probe-i1",
+        vector: "i(v.x1.vicmprb001)",
+        quantity: "current",
+      },
+    ]);
+  });
+
+  it("keeps repeated occurrences of one instrumented current source distinct", async () => {
+    const project = hierarchicalProject();
+    addHierarchicalCurrentSource(project);
+    const tb = project.documents.find((document) => document.id === "tb")!;
+    const x1 = tb.instances.find((instance) => instance.id === "inst-x1")!;
+    tb.instances.push({
+      ...structuredClone(x1),
+      id: "inst-x2",
+      reference: "X2",
+    });
+    tb.nets[0]!.terminals.push({ instanceId: "inst-x2", pinName: "A" });
+    tb.nets[1]!.terminals.push({ instanceId: "inst-x2", pinName: "B" });
+
+    const result = await compile(
+      project,
+      setupWith({
+        probes: [
+          {
+            id: "probe-i1-x1",
+            kind: "source-current",
+            documentId: "dut",
+            instanceId: "inst-i1",
+            occurrence: ["inst-x1"],
+          },
+          {
+            id: "probe-i1-x2",
+            kind: "source-current",
+            documentId: "dut",
+            instanceId: "inst-i1",
+            occurrence: ["inst-x2"],
+          },
+        ],
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(
+      result.request.netlist.match(/VICMPRB001 ICMPRB001 OUT DC 0/gu),
+    ).toHaveLength(1);
+    expect(result.vectors).toEqual([
+      {
+        probeId: "probe-i1-x1",
+        vector: "i(v.x1.vicmprb001)",
+        quantity: "current",
+      },
+      {
+        probeId: "probe-i1-x2",
+        vector: "i(v.x2.vicmprb001)",
+        quantity: "current",
+      },
     ]);
   });
 });
@@ -1166,6 +1236,57 @@ describe.skipIf(!ngspiceOnPath())("running a compiled deck", () => {
       expect(value("v(in)")).toBeCloseTo(1, 12);
       expect(value("v(mid)")).toBeCloseTo(0.5, 12);
       expect(value("i(v1)")).toBeCloseTo(-0.0005, 12);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("reads a selected hierarchical current source through compiler instrumentation", async () => {
+    const project = hierarchicalProject();
+    addHierarchicalCurrentSource(project);
+    const compiled = await compile(
+      project,
+      setupWith({
+        analyses: [{ kind: "op" }],
+        probes: [
+          {
+            id: "probe-i1",
+            kind: "source-current",
+            documentId: "dut",
+            instanceId: "inst-i1",
+            occurrence: ["inst-x1"],
+          },
+        ],
+      }),
+    );
+    expect(compiled.ok).toBe(true);
+    if (!compiled.ok) return;
+
+    const deck = buildSimulationDeck(
+      compiled.request as SimulationRequest,
+      null,
+    );
+    const directory = mkdtempSync(join(tmpdir(), "icm-hierarchy-current-"));
+    try {
+      writeFileSync(join(directory, "deck.cir"), deck, "utf8");
+      execFileSync("ngspice", ["-b", "deck.cir"], {
+        cwd: directory,
+        encoding: "utf8",
+      });
+      const reading = readSimulationData(
+        readFileSync(join(directory, "out.raw"), "utf8"),
+      );
+
+      expect(reading.status).toBe("read");
+      if (reading.status !== "read") return;
+      const operatingPoint = reading.data.analyses[0]!;
+      expect(operatingPoint.analysis).toBe("op");
+      if (operatingPoint.analysis !== "op") return;
+      expect(
+        operatingPoint.probes.find(
+          (probe) => probe.name === "i(v.x1.vicmprb001)",
+        )?.value,
+      ).toBeCloseTo(0.001, 12);
     } finally {
       rmSync(directory, { recursive: true, force: true });
     }

--- a/packages/netlist/src/simulation-compile.ts
+++ b/packages/netlist/src/simulation-compile.ts
@@ -56,11 +56,13 @@
  *
  * A top-level independent current source is instrumented with ngspice's
  * `.probe I(<ref>)`. ngspice inserts a zero-volt sense source and writes its
- * result as `<ref>#branch`; the rawfile reader normalises that spelling to the
- * public `i(<ref>)` vector used by voltage-source currents. The directive only
- * addresses top-level devices, so a current source inside a subcircuit remains
- * an explicit compile-time diagnostic rather than a probe that silently
- * returns no data.
+ * result as `<ref>#branch`; the rawfile records that as `i(<ref>)`.
+ *
+ * `.probe` only scans top-level devices. For a selected current source inside
+ * a subcircuit, this compiler therefore inserts its own zero-volt sense source
+ * into the extracted (ephemeral) Cell definition and reads that voltage
+ * source's occurrence-qualified branch current. The authored Project and the
+ * ordinary structural export are never changed.
  */
 
 import type {
@@ -77,7 +79,12 @@ import { resolveDocumentLogicalNets } from "@icm/derived";
 import type { SimulationAnalysis, SimulationRequest } from "@icm/spice-run";
 
 import { analyzeDesignNetlist } from "./extract.js";
-import type { DesignNetlistCell, NetlistDiagnostic } from "./ir.js";
+import type {
+  DesignNetlistCell,
+  DesignNetlistInstance,
+  DesignNetlistIR,
+  NetlistDiagnostic,
+} from "./ir.js";
 import { printSpiceCellInstances, printSpiceNetlist } from "./printers.js";
 
 /** The rawfile every compiled deck writes; the harness returns the one `.raw`. */
@@ -97,6 +104,15 @@ interface ResolvedSimulationProbe {
   readonly writeVector: string;
   /** Deck cards required to make the vector exist. */
   readonly instrumentationCards: readonly string[];
+  /** Ephemeral Cell instrumentation required before printing the netlist. */
+  readonly netlistInstrumentation?: HierarchicalCurrentInstrumentation;
+}
+
+interface HierarchicalCurrentInstrumentation {
+  readonly cellId: StableId;
+  readonly sourceInstanceId: StableId;
+  readonly senseReference: string;
+  readonly senseNode: string;
 }
 
 export type CompiledSimulationExpression =
@@ -397,6 +413,122 @@ function resolveOccurrence(
   return { document, cell, path, hierarchyPath };
 }
 
+function instrumentationKey(
+  instrumentation: Pick<
+    HierarchicalCurrentInstrumentation,
+    "cellId" | "sourceInstanceId"
+  >,
+): string {
+  return `${instrumentation.cellId}\u0000${instrumentation.sourceInstanceId}`;
+}
+
+/**
+ * Allocate names from the extracted Cell, not from output order. This makes
+ * the generated deck deterministic when an author reorders outputs and keeps
+ * compiler-owned names away from authored References and node names.
+ */
+function ensureHierarchicalCurrentInstrumentation(
+  cell: DesignNetlistCell,
+  source: DesignNetlistInstance,
+  instrumentations: Map<string, HierarchicalCurrentInstrumentation>,
+): HierarchicalCurrentInstrumentation {
+  const key = instrumentationKey({
+    cellId: cell.id,
+    sourceInstanceId: source.id,
+  });
+  const existing = instrumentations.get(key);
+  if (existing) return existing;
+
+  const references = new Set(
+    cell.instances.map((instance) => instance.reference.toLowerCase()),
+  );
+  const nodes = new Set([
+    ...cell.ports.map((port) => port.name.toLowerCase()),
+    ...cell.nets.map((net) => net.name.toLowerCase()),
+    ...cell.instances.flatMap((instance) =>
+      instance.nodes.map((node) => node.netName.toLowerCase()),
+    ),
+  ]);
+  for (const item of instrumentations.values()) {
+    if (item.cellId !== cell.id) continue;
+    references.add(item.senseReference.toLowerCase());
+    nodes.add(item.senseNode.toLowerCase());
+  }
+
+  let serial =
+    cell.instances.findIndex((instance) => instance.id === source.id) + 1;
+  while (true) {
+    const suffix = String(serial).padStart(3, "0");
+    const senseReference = `VICMPRB${suffix}`;
+    const senseNode = `ICMPRB${suffix}`;
+    if (
+      !references.has(senseReference.toLowerCase()) &&
+      !nodes.has(senseNode.toLowerCase())
+    ) {
+      const instrumentation = {
+        cellId: cell.id,
+        sourceInstanceId: source.id,
+        senseReference,
+        senseNode,
+      } satisfies HierarchicalCurrentInstrumentation;
+      instrumentations.set(key, instrumentation);
+      return instrumentation;
+    }
+    serial += 1;
+  }
+}
+
+/**
+ * Put a zero-volt source in series with each selected hierarchical current
+ * source. Its positive branch direction matches SPICE's current-source
+ * direction (first node to second node), so no result-side sign correction is
+ * needed.
+ */
+function instrumentHierarchicalCurrentSources(
+  ir: DesignNetlistIR,
+  instrumentations: ReadonlyMap<string, HierarchicalCurrentInstrumentation>,
+): DesignNetlistIR {
+  if (instrumentations.size === 0) return ir;
+  return {
+    ...ir,
+    cells: ir.cells.map((cell) => ({
+      ...cell,
+      instances: cell.instances.flatMap((instance) => {
+        const instrumentation = instrumentations.get(
+          instrumentationKey({
+            cellId: cell.id,
+            sourceInstanceId: instance.id,
+          }),
+        );
+        if (!instrumentation) return [instance];
+        const positive = instance.nodes[0]!;
+        const negative = instance.nodes[1]!;
+        return [
+          {
+            ...instance,
+            nodes: [
+              positive,
+              { ...negative, netName: instrumentation.senseNode },
+            ],
+          },
+          {
+            id: `${instance.id}:simulation-current-sense`,
+            reference: instrumentation.senseReference,
+            invocationKind: "primitive",
+            deviceClass: "voltage-source",
+            target: null,
+            nodes: [
+              { pinName: "+", netName: instrumentation.senseNode },
+              { pinName: "-", netName: negative.netName },
+            ],
+            parameters: [{ name: "dc", rawValue: "0" }],
+          },
+        ];
+      }),
+    })),
+  };
+}
+
 function netVoltageVector(
   measurement: Extract<SimulationExpression, { kind: "voltage" }>,
   acquisitionId: string,
@@ -481,6 +613,10 @@ function sourceCurrentVector(
   outputId: string,
   occurrence: ResolvedOccurrence,
   diagnostics: NetlistDiagnostic[],
+  hierarchicalCurrentInstrumentations: Map<
+    string,
+    HierarchicalCurrentInstrumentation
+  >,
 ): ResolvedSimulationProbe | null {
   const { document, cell, path, hierarchyPath } = occurrence;
   const instance = cell.instances.find(
@@ -500,21 +636,44 @@ function sourceCurrentVector(
   }
   if (instance.deviceClass === "current-source") {
     if (path.length > 0) {
-      diagnostics.push(
-        diagnostic(
-          "SIMULATION_PROBE_CURRENT_SOURCE_HIERARCHY_UNSUPPORTED",
-          document.id,
-          `Output ${outputId} measures current source ${instance.reference} inside a subcircuit; this ngspice instrumentation can address only a top-level source`,
-          locator(
+      if (instance.nodes.length !== 2) {
+        diagnostics.push(
+          diagnostic(
+            "SIMULATION_PROBE_CURRENT_SOURCE_TERMINALS_UNAVAILABLE",
             document.id,
-            hierarchyPath,
-            "instance",
-            measurement.instanceId,
+            `Output ${outputId} cannot instrument current source ${instance.reference}; its extracted card does not have two terminals`,
+            locator(
+              document.id,
+              hierarchyPath,
+              "instance",
+              measurement.instanceId,
+            ),
+            [measurement.instanceId],
           ),
-          [measurement.instanceId],
-        ),
+        );
+        return null;
+      }
+      const instrumentation = ensureHierarchicalCurrentInstrumentation(
+        cell,
+        instance,
+        hierarchicalCurrentInstrumentations,
       );
-      return null;
+      const senseName = [
+        "v",
+        ...path,
+        instrumentation.senseReference.toLowerCase(),
+      ].join(".");
+      const binding: CompiledSimulationVector = {
+        probeId: acquisitionId,
+        vector: `i(${senseName})`,
+        quantity: "current",
+      };
+      return {
+        binding,
+        writeVector: binding.vector,
+        instrumentationCards: [],
+        netlistInstrumentation: instrumentation,
+      };
     }
     const reference = instance.reference.toLowerCase();
     return {
@@ -691,6 +850,10 @@ export async function compileStructuredSimulation(
   const outputs: CompiledSimulationOutput[] = [];
   const writeVectors: string[] = [];
   const instrumentationCards: string[] = [];
+  const hierarchicalCurrentInstrumentations = new Map<
+    string,
+    HierarchicalCurrentInstrumentation
+  >();
   for (const output of input.outputs) {
     let leafIndex = 0;
     const compileExpression = (
@@ -711,7 +874,7 @@ export async function compileStructuredSimulation(
           expression === output.expression
             ? output.id
             : `${output.id}:input:${leafIndex++}`;
-        const resolved =
+        const resolved: ResolvedSimulationProbe | null =
           expression.kind === "voltage"
             ? (() => {
                 const vector = netVoltageVector(
@@ -735,6 +898,7 @@ export async function compileStructuredSimulation(
                 output.id,
                 occurrence,
                 diagnostics,
+                hierarchicalCurrentInstrumentations,
               );
         if (!resolved) return null;
         const identity = `${resolved.binding.quantity}\u0000${resolved.binding.vector}`;
@@ -748,6 +912,13 @@ export async function compileStructuredSimulation(
           vectors.push(acquisition);
           writeVectors.push(resolved.writeVector);
           instrumentationCards.push(...resolved.instrumentationCards);
+          if (resolved.netlistInstrumentation) {
+            const instrumentation = resolved.netlistInstrumentation;
+            hierarchicalCurrentInstrumentations.set(
+              instrumentationKey(instrumentation),
+              instrumentation,
+            );
+          }
         }
         return {
           kind: "acquisition",
@@ -780,9 +951,15 @@ export async function compileStructuredSimulation(
 
   // Every reached Cell but the root: the root is instantiated below, not
   // defined. `.global` declarations stay with the definitions.
+  const instrumentedIr = instrumentHierarchicalCurrentSources(
+    ir,
+    hierarchicalCurrentInstrumentations,
+  );
   const netlist = printSpiceNetlist({
-    ...ir,
-    cells: ir.cells.filter((cell) => cell.id !== ir.topCellId),
+    ...instrumentedIr,
+    cells: instrumentedIr.cells.filter(
+      (cell) => cell.id !== instrumentedIr.topCellId,
+    ),
   });
 
   // One `write` per analysis, so each plot reaches the rawfile; see the note


### PR DESCRIPTION
## Summary
- expose independent current sources at every concrete hierarchy occurrence in the Simulation picker
- instrument selected internal sources with deterministic zero-volt sense sources in the ephemeral prepared netlist
- preserve distinct vectors for repeated Cell occurrences without mutating the Project or structural export
- document and test the ngspice current-acquisition contract

## Validation
- \pnpm -C packages/netlist build\`n- focused simulation compiler and picker tests
- ngspice 47 numerical run: 31/31 compiler tests
- isolated GUI prepare/export/reload flow
- full static, unit, build, release/performance and production smoke passed locally

The initial full browser run lost its shared Vite server after an unrelated waveform assertion; the affected Simulation E2E passed in an isolated rerun on port 4174.

Test-Impact: tests-updated