### PR TITLE
feat(simulation): reorganize result exploration

### DIFF
--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -103,6 +103,7 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
   ).toHaveCount(6);
   await panel.getByRole("button", { name: "Apply setup" }).click();
   await panel.getByRole("button", { name: "Prepare deck" }).click();
+  await panel.getByLabel("Prepared files Netlist").locator("summary").click();
   const deckDownload = page.waitForEvent("download");
   await panel
     .getByRole("button", { name: "prepared.cir", exact: true })
@@ -205,6 +206,9 @@ test("one Testbench persists several independently named setups", async ({
   await expect(selector.locator("option")).toHaveCount(2);
   await panel.getByLabel("Setup name").fill("Bias search");
   await panel.getByRole("button", { name: "Apply setup" }).click();
+  await panel.getByLabel("Setup name").fill("Bias sweep");
+  await panel.getByLabel("Setup name").press("Tab");
+  await expect(panel.getByRole("status")).not.toHaveText("Setup changed");
 
   const saved = JSON.parse(
     (await downloadBytes(page, "File", "Export Project File…")).toString(),
@@ -212,7 +216,7 @@ test("one Testbench persists several independently named setups", async ({
   expect(saved.simulationSetups).toHaveLength(2);
   expect(
     saved.simulationSetups.map((setup: { name: string }) => setup.name),
-  ).toEqual(["OTA OP and AC", "Bias search"]);
+  ).toEqual(["OTA OP and AC", "Bias sweep"]);
   expect(
     new Set(
       saved.simulationSetups.map(
@@ -225,7 +229,7 @@ test("one Testbench persists several independently named setups", async ({
   await panel.getByRole("button", { name: "Delete setup" }).click();
   await expect(selector).toHaveValue("simulation-setup-ota-op-ac");
   await expect(
-    selector.getByRole("option", { name: "Bias search" }),
+    selector.getByRole("option", { name: "Bias sweep" }),
   ).toHaveCount(0);
   const afterDelete = JSON.parse(
     (await downloadBytes(page, "File", "Export Project File…")).toString(),
@@ -422,6 +426,12 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   release();
   await page.getByTestId("open-analog-simulation").click();
   await expect(panel.getByRole("status")).toHaveText("finished · completed");
+  await expect(panel.getByRole("tab", { name: "Summary" })).toHaveCount(0);
+  await panel.getByRole("tab", { name: "Console" }).click();
+  await expect(panel.locator(".simulation-console-summary")).toContainText(
+    "finished · completed",
+  );
+  await expect(panel.locator(".simulation-console-view > pre")).toBeVisible();
   await panel.getByRole("tab", { name: "Operating Point" }).click();
   await expect(panel.getByRole("region", { name: "OP results" })).toContainText(
     "0.500000",
@@ -491,18 +501,13 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
     .locator("polyline[data-trace-id]")
     .evaluate((element) => {
       const line = element as SVGPolylineElement;
-      const point = line.points.getItem(
-        Math.floor(line.points.numberOfItems / 2),
-      );
+      const point = line.points.getItem(line.points.numberOfItems - 1);
       const screen = new DOMPoint(point.x, point.y).matrixTransform(
         line.getScreenCTM()!,
       );
       return { x: screen.x, y: screen.y };
     });
   await page.mouse.click(tracePoint.x, tracePoint.y);
-  await expect(
-    panel.locator(".simulation-output-browser > .selected"),
-  ).toHaveCount(1);
   await expect(page.getByTestId("net-highlight-overlay")).toBeVisible();
   await expect(
     panel.locator('svg[aria-label="Transient voltage"]'),
@@ -609,6 +614,24 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   await expect(fixedReadout).toContainText("ΔX:");
   await expect(fixedReadout).toContainText("ΔY");
   await expect(fixedReadout).toContainText("1/|Δt|");
+  await expect(transientPlot.locator("line.ac-cursor")).toHaveCount(4);
+  const markerA = transientPlot.locator('[data-marker="A"]').first();
+  const markerBounds = await markerA.boundingBox();
+  const markerTextBeforeDrag = await fixedReadout.textContent();
+  await page.mouse.move(
+    markerBounds!.x + markerBounds!.width / 2,
+    markerBounds!.y + markerBounds!.height / 2,
+  );
+  await page.mouse.down();
+  await page.mouse.move(
+    markerBounds!.x + transientBounds!.width * 0.6,
+    markerBounds!.y + 4,
+    {
+      steps: 4,
+    },
+  );
+  await page.mouse.up();
+  await expect(fixedReadout).not.toHaveText(markerTextBeforeDrag ?? "");
   const markersBeforeRemount = await fixedReadout.textContent();
   await transientShell
     .getByRole("button", { name: "Ranges", exact: true })
@@ -674,6 +697,7 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   });
   await waveformDialog.getByRole("button", { name: "Close plot" }).click();
   await panel.getByRole("tab", { name: "Files" }).click();
+  await panel.getByLabel("Last run Evidence").locator("summary").click();
   await expect(
     panel.getByRole("button", { name: "evidence-manifest.json" }),
   ).toBeVisible();
@@ -683,10 +707,10 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
     .first()
     .click();
   expect((await download).suggestedFilename()).toMatch(/\.csv$/);
-  await expect(panel.getByLabel("Last run")).toBeVisible();
+  await expect(panel.getByLabel("Last run Results")).toBeVisible();
   await panel.getByRole("button", { name: "Prepare deck" }).click();
-  await expect(panel.getByLabel("Prepared files")).toBeVisible();
-  await expect(panel.getByLabel("Last run")).toBeVisible();
+  await expect(panel.getByLabel("Prepared files Netlist")).toBeVisible();
+  await expect(panel.getByLabel("Last run Results")).toBeVisible();
   await expect(panel.getByText("Input identity", { exact: true })).toHaveCount(
     0,
   );

--- a/apps/editor/src/features/simulation/ac-response-plot.test.ts
+++ b/apps/editor/src/features/simulation/ac-response-plot.test.ts
@@ -114,6 +114,26 @@ describe("AC response plot", () => {
     expect(svg).toContain("ac-trace-selected");
   });
 
+  it("renders each measurement marker as a draggable x/y crosshair", () => {
+    const trace = { ...singlePole(), id: "probe-output" };
+    const svg = acResponseSvg(
+      [trace],
+      { width: 600, height: 300 },
+      {
+        kind: "magnitude",
+        selectedTraceId: trace.id,
+        cursorFrequency: 1e3,
+        cursorFrequencyB: 1e4,
+        showLegend: false,
+      },
+    )!;
+
+    expect(svg.match(/class="ac-cursor"/gu)).toHaveLength(4);
+    expect(svg.match(/data-marker="A"/gu)).toHaveLength(2);
+    expect(svg.match(/data-marker="B"/gu)).toHaveLength(2);
+    expect(svg.match(/class="ac-cursor-handle"/gu)).toHaveLength(2);
+  });
+
   it("declines to invent a plot when there is nothing to draw", () => {
     // A DC-only result, or a failed run, must not produce an empty frame that
     // looks like a measurement.

--- a/apps/editor/src/features/simulation/ac-response-plot.ts
+++ b/apps/editor/src/features/simulation/ac-response-plot.ts
@@ -229,6 +229,20 @@ function polyline(
     .join(" ");
 }
 
+function closestPoint(
+  points: readonly AcPoint[],
+  frequency: number,
+): AcPoint | undefined {
+  return points.reduce<AcPoint | undefined>((best, point) => {
+    if (point.frequency <= 0) return best;
+    if (!best) return point;
+    return Math.abs(Math.log(point.frequency / frequency)) <
+      Math.abs(Math.log(best.frequency / frequency))
+      ? point
+      : best;
+  }, undefined);
+}
+
 export function acResponseSvg(
   traces: readonly AcTrace[],
   size: AcPlotSize,
@@ -294,6 +308,10 @@ export function acResponseSvg(
           })
           .join("")
       : "";
+  const cursorTrace =
+    traces.find(
+      (trace) => (trace.id ?? trace.label) === options.selectedTraceId,
+    ) ?? traces[0];
   const cursor = ([options.cursorFrequency, options.cursorFrequencyB] as const)
     .map((frequency, index) => {
       if (
@@ -303,7 +321,20 @@ export function acResponseSvg(
       )
         return "";
       const x = project.x(frequency).toFixed(2);
-      return `<g pointer-events="none"><line class="ac-cursor" style="stroke:${index === 0 ? "#175cd3" : "#c4320a"}" x1="${x}" y1="${frame.y}" x2="${x}" y2="${frame.y + frame.height}"/><text x="${Number(x) + 3}" y="${frame.y + 12}">${index === 0 ? "A" : "B"}</text></g>`;
+      const marker = index === 0 ? "A" : "B";
+      const color = marker === "A" ? "#175cd3" : "#c4320a";
+      const point = cursorTrace
+        ? closestPoint(cursorTrace.points, frequency)
+        : undefined;
+      const value =
+        point &&
+        (options.kind === "magnitude" ? point.magnitudeDb : point.phaseDeg);
+      const y = value === undefined ? undefined : axisY(value).toFixed(2);
+      const horizontal =
+        y === undefined
+          ? ""
+          : `<line class="ac-cursor" style="stroke:${color}" x1="${frame.x}" y1="${y}" x2="${frame.x + frame.width}" y2="${y}"/><line class="ac-cursor-hit" data-marker="${marker}" x1="${frame.x}" y1="${y}" x2="${frame.x + frame.width}" y2="${y}"/><circle class="ac-cursor-handle" style="stroke:${color}" cx="${x}" cy="${y}" r="4"/>`;
+      return `<g><line class="ac-cursor" style="stroke:${color}" x1="${x}" y1="${frame.y}" x2="${x}" y2="${frame.y + frame.height}"/><line class="ac-cursor-hit" data-marker="${marker}" x1="${x}" y1="${frame.y}" x2="${x}" y2="${frame.y + frame.height}"/>${horizontal}<text pointer-events="none" x="${Number(x) + 5}" y="${frame.y + 13}">${marker}</text></g>`;
     })
     .join("");
 

--- a/apps/editor/src/features/simulation/ac-results-explorer.tsx
+++ b/apps/editor/src/features/simulation/ac-results-explorer.tsx
@@ -6,6 +6,7 @@ import {
 } from "./waveform-interaction";
 import { useWaveformView } from "./waveform-view";
 import { WaveformTools, WaveformMeasurements } from "./waveform-tools";
+import { WaveformTraceList } from "./waveform-trace-list";
 import type { SimulationProbeSpec } from "@icm/model";
 import type { AcResult } from "@icm/spice-run";
 import type { Prepared } from "@icm/simulation-service/contract";
@@ -138,18 +139,14 @@ export function AcResultsExplorer({
     [analysis, groups, labels, probes, vectors],
   );
   const controller = useWaveformView(resultKey);
-  const { hidden, solo, selected, markers } = controller.state;
+  const { hidden, selected, markers } = controller.state;
   const setHidden = (value: SetStateAction<ReadonlySet<string>>) =>
     controller.set("hidden", value);
-  const setSolo = (value: SetStateAction<string | null>) =>
-    controller.set("solo", value);
   const setSelected = (value: string) => controller.set("selected", value);
   const frequencyRange = controller.view.x;
   const valueRanges = controller.view.y;
   const [expandedPlot, setExpandedPlot] = useState<ExpandedPlot | null>(null);
-  const visible = traces.filter(
-    (trace) => !hidden.has(trace.id) && (solo === null || solo === trace.id),
-  );
+  const visible = traces.filter((trace) => !hidden.has(trace.id));
   useEffect(() => {
     if (!expandedPlot) return;
     const close = (event: KeyboardEvent) => {
@@ -166,6 +163,17 @@ export function AcResultsExplorer({
     if (trace.probe) onFocusProbe?.(trace.probe);
   };
 
+  const toggleTrace = (traceId: string): void => {
+    const showing = hidden.has(traceId);
+    setHidden((current) => {
+      const next = new Set(current);
+      if (showing) next.delete(traceId);
+      else next.add(traceId);
+      return next;
+    });
+    if (showing) focusTrace(traceId);
+  };
+
   const renderPlot = (
     plot: ExpandedPlot,
     plotTraces: readonly OutputTrace[],
@@ -175,8 +183,8 @@ export function AcResultsExplorer({
       ? EXPANDED_PLOT_SIZE
       : {
           ...PLOT_SIZE,
-          width: measured.width,
-          height: responsiveWaveformHeight(measured.width),
+          width: Math.max(280, measured.width - 116),
+          height: responsiveWaveformHeight(Math.max(280, measured.width - 116)),
         };
     const valueRange = valueRanges[plot.quantity + plot.kind];
     const layout = layoutAcPlot(
@@ -259,6 +267,17 @@ export function AcResultsExplorer({
             if (trace?.points.length)
               controller.mark(closestPoint(trace.points, frequency).frequency);
           }}
+          onMoveMarker={(point, marker) => {
+            const frequency = frequencyAt(point.x);
+            const trace =
+              plotTraces.find((candidate) => candidate.id === selected) ??
+              plotTraces[0];
+            if (trace?.points.length)
+              controller.mark(
+                closestPoint(trace.points, frequency).frequency,
+                marker,
+              );
+          }}
           onOpen={() => !expanded && setExpandedPlot(plot)}
         >
           <div
@@ -318,74 +337,45 @@ export function AcResultsExplorer({
       <header>
         <strong>{analysis.plotName}</strong>
       </header>
-      <div
-        className="simulation-output-browser"
-        aria-label="Simulation outputs"
-      >
-        {traces.map((trace) => {
-          const isVisible = !hidden.has(trace.id);
-          return (
-            <div
-              key={trace.id}
-              className={selected === trace.id ? "selected" : undefined}
-            >
-              <button
-                type="button"
-                className={`simulation-output-swatch ac-trace-${(trace.colorIndex ?? 0) % 6}`}
-                aria-label={`${isVisible ? "Hide" : "Show"} ${trace.label}`}
-                aria-pressed={isVisible}
-                onClick={() => {
-                  setHidden((current) => {
-                    const next = new Set(current);
-                    if (next.has(trace.id)) next.delete(trace.id);
-                    else next.add(trace.id);
-                    return next;
-                  });
-                }}
-              />
-              <button
-                type="button"
-                className="simulation-output-name"
-                onClick={() => focusTrace(trace.id)}
-              >
-                <strong>{trace.label}</strong>
-                <small>
-                  {trace.quantity} · {trace.probe ? "linked" : trace.id}
-                </small>
-              </button>
-              <button
-                type="button"
-                aria-pressed={solo === trace.id}
-                onClick={() =>
-                  setSolo((current) => (current === trace.id ? null : trace.id))
-                }
-              >
-                Solo
-              </button>
-            </div>
-          );
-        })}
-      </div>
       {[...new Set(traces.map((trace) => trace.quantity))].map((quantity) => {
-        const quantityTraces = visible.filter(
+        const quantityTraces = traces.filter(
           (trace) => trace.quantity === quantity,
         );
-        if (quantityTraces.length === 0) return null;
+        const visibleQuantityTraces = quantityTraces.filter(
+          (trace) => !hidden.has(trace.id),
+        );
         return (
           <section key={quantity} className="ac-quantity-group">
             <h4>{groupLabel(quantity)}</h4>
-            {(["magnitude", "phase"] as const).map((kind) => (
-              <div key={kind} className="ac-plot-row">
-                <strong>{kind === "magnitude" ? "Magnitude" : "Phase"}</strong>
-                {renderPlot({ quantity, kind }, quantityTraces)}
+            <div className="simulation-plot-layout">
+              <WaveformTraceList
+                label={`${groupLabel(quantity)} outputs`}
+                traces={quantityTraces.map((trace) => ({
+                  id: trace.id,
+                  label: trace.label,
+                  colorIndex: trace.colorIndex ?? 0,
+                  visible: !hidden.has(trace.id),
+                }))}
+                onToggle={toggleTrace}
+              />
+              <div className="simulation-plot-stack">
+                {visibleQuantityTraces.length ? (
+                  (["magnitude", "phase"] as const).map((kind) => (
+                    <div key={kind} className="ac-plot-row">
+                      <strong>
+                        {kind === "magnitude" ? "Magnitude" : "Phase"}
+                      </strong>
+                      {renderPlot({ quantity, kind }, visibleQuantityTraces)}
+                    </div>
+                  ))
+                ) : (
+                  <p className="simulation-empty-plot">Outputs hidden</p>
+                )}
               </div>
-            ))}
+            </div>
           </section>
         );
       })}
-      {visible.length === 0 ? (
-        <p className="simulation-empty-result">All Outputs are hidden.</p>
-      ) : null}
       {expandedPlot ? (
         <div
           className="ac-plot-dialog-backdrop"
@@ -415,13 +405,35 @@ export function AcResultsExplorer({
                 ×
               </button>
             </header>
-            {renderPlot(
-              expandedPlot,
-              visible.filter(
-                (trace) => trace.quantity === expandedPlot.quantity,
-              ),
-              true,
-            )}
+            <div className="simulation-plot-layout expanded">
+              <WaveformTraceList
+                label={`${groupLabel(expandedPlot.quantity)} outputs`}
+                traces={traces
+                  .filter((trace) => trace.quantity === expandedPlot.quantity)
+                  .map((trace) => ({
+                    id: trace.id,
+                    label: trace.label,
+                    colorIndex: trace.colorIndex ?? 0,
+                    visible: !hidden.has(trace.id),
+                  }))}
+                onToggle={toggleTrace}
+              />
+              <div className="simulation-plot-stack">
+                {visible.some(
+                  (trace) => trace.quantity === expandedPlot.quantity,
+                ) ? (
+                  renderPlot(
+                    expandedPlot,
+                    visible.filter(
+                      (trace) => trace.quantity === expandedPlot.quantity,
+                    ),
+                    true,
+                  )
+                ) : (
+                  <p className="simulation-empty-plot">Outputs hidden</p>
+                )}
+              </div>
+            </div>
             {measurement(expandedPlot)}
           </section>
         </div>

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -33,7 +33,6 @@ import {
 } from "./simulation-probe-options";
 
 const RESULT_TABS = [
-  ["summary", "Summary"],
   ["plot", "Plot"],
   ["operating-point", "Operating Point"],
   ["console", "Console"],
@@ -47,6 +46,22 @@ const DEVELOPMENT_PROFILE_ID = import.meta.env.DEV
   ? "sky130-core-continuous-ngspice46-v1"
   : "";
 type ResultTab = (typeof RESULT_TABS)[number][0];
+
+function preferredResultTab(run: Run): ResultTab {
+  const analyses = run.outputData?.analyses ?? run.result?.data?.analyses ?? [];
+  if (
+    analyses.some(
+      (analysis) =>
+        analysis.analysis === "dc" ||
+        analysis.analysis === "ac" ||
+        analysis.analysis === "tran",
+    )
+  )
+    return "plot";
+  if (analyses.some((analysis) => analysis.analysis === "op"))
+    return "operating-point";
+  return "console";
+}
 
 export interface SpiceSimulationSurfaceProps {
   open: boolean;
@@ -148,7 +163,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
   const preparedPresentations = useRef(new Map<string, PreparedPresentation>());
   const [setupOpen, setSetupOpen] = useState(true);
   const [resultsOpen, setResultsOpen] = useState(false);
-  const [resultTab, setResultTab] = useState<ResultTab>("summary");
+  const [resultTab, setResultTab] = useState<ResultTab>("plot");
   const [exitConfirmationOpen, setExitConfirmationOpen] = useState(false);
   const previousSetupId = useRef<string | null>(props.selectedSetupId);
   useEffect(() => {
@@ -195,7 +210,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
       ) {
         setSetupOpen(false);
         setResultsOpen(true);
-        setResultTab("summary");
+        setResultTab(preferredResultTab(reply.run));
       }
     } else if ("prepared" in reply) {
       setPrepared(reply.prepared);
@@ -340,6 +355,15 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
         ]
       : []),
   ];
+  const artifactCategories = ["Netlist", "Results", "Evidence", "Log", "Other"];
+  const artifactSections = artifactGroups.flatMap((group) =>
+    artifactCategories.flatMap((category) => {
+      const artifacts = group.artifacts.filter(
+        (artifact) => simulationArtifactCategory(artifact) === category,
+      );
+      return artifacts.length ? [{ ...group, category, artifacts }] : [];
+    }),
+  );
   const statusLabel = busy
     ? "Preparing…"
     : run
@@ -610,9 +634,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
 
       {setupOpen ? (
         <SetupEditor
-          key={
-            JSON.stringify(selectedSetup) ?? `unsaved:${props.activeDocumentId}`
-          }
+          key={selectedSetup?.id ?? `unsaved:${props.activeDocumentId}`}
           {...props}
           setup={selectedSetup}
           capabilities={capabilities}
@@ -642,39 +664,6 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
             </div>
           </header>
           <div className="simulation-results-body">
-            {resultTab === "summary" ? (
-              <div className="simulation-result-summary">
-                <div>
-                  <small>Run state</small>
-                  <strong>{statusLabel}</strong>
-                </div>
-                <div>
-                  <small>Input</small>
-                  <strong>{run?.inputStatus ?? "current"}</strong>
-                </div>
-                <div>
-                  <small>Analyses</small>
-                  <strong>{analysisLabel || "Not configured"}</strong>
-                </div>
-                {run?.state === "lost" ? (
-                  <p>
-                    The executor response is unknown. This run was not
-                    automatically resubmitted; inspect its evidence before
-                    choosing a new run.
-                  </p>
-                ) : null}
-                {runPresentation?.prepared.warnings.map((warning, index) => (
-                  <p key={index}>{warning}</p>
-                ))}
-                {run?.resultPreview ? (
-                  <p>
-                    Result preview is bounded. Export artifacts for complete
-                    data.
-                  </p>
-                ) : null}
-              </div>
-            ) : null}
-
             {resultTab === "plot" ? (
               <div className="simulation-analysis-view">
                 {run?.outputData ? (
@@ -828,6 +817,35 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
 
             {resultTab === "console" ? (
               <div className="simulation-console-view">
+                <div className="simulation-console-summary">
+                  <span>
+                    <small>Run</small>
+                    <strong>{statusLabel}</strong>
+                  </span>
+                  <span>
+                    <small>Input</small>
+                    <strong>{run?.inputStatus ?? "current"}</strong>
+                  </span>
+                  <span>
+                    <small>Analyses</small>
+                    <strong>{analysisLabel || "Not configured"}</strong>
+                  </span>
+                </div>
+                {run?.state === "lost" ? (
+                  <p>
+                    The executor response is unknown. Inspect its evidence
+                    before starting another run.
+                  </p>
+                ) : null}
+                {runPresentation?.prepared.warnings.map((warning, index) => (
+                  <p key={index}>{warning}</p>
+                ))}
+                {run?.resultPreview ? (
+                  <p>
+                    The on-screen result is bounded; exported artifacts contain
+                    the complete data.
+                  </p>
+                ) : null}
                 {activeProblem ? (
                   <SimulationProblemView
                     problem={activeProblem}
@@ -855,13 +873,21 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
 
             {resultTab === "files" ? (
               <div className="simulation-files-view">
-                {artifactGroups.map((group) => (
-                  <section key={group.label} aria-label={group.label}>
-                    <h3>{group.label}</h3>
+                {artifactSections.map((section) => (
+                  <details
+                    key={`${section.label}:${section.category}`}
+                    className="simulation-artifact-group"
+                    aria-label={`${section.label} ${section.category}`}
+                    open={section.category === "Results"}
+                  >
+                    <summary>
+                      <strong>{section.category}</strong>
+                      <span>{section.label}</span>
+                      <small>{section.artifacts.length}</small>
+                    </summary>
                     <ul className="simulation-artifact-list">
-                      {group.artifacts.map((artifact) => (
+                      {section.artifacts.map((artifact) => (
                         <li key={artifact.id}>
-                          <span>{simulationArtifactCategory(artifact)}</span>
                           <button onClick={() => void download(artifact)}>
                             {artifact.name}
                           </button>
@@ -871,9 +897,9 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
                         </li>
                       ))}
                     </ul>
-                  </section>
+                  </details>
                 ))}
-                {artifactGroups.length === 0 ? (
+                {artifactSections.length === 0 ? (
                   <p className="simulation-empty-result">
                     Prepare a deck or run the simulation to create files.
                   </p>
@@ -979,6 +1005,9 @@ function SetupEditor({
     saved?.rootDocumentId ?? draftContext?.rootDocumentId ?? activeDocumentId,
   );
   const [outputs, setOutputs] = useState(saved?.outputs ?? []);
+  const [setupName, setSetupName] = useState(
+    setup?.name ?? draftContext?.setupName ?? "Setup 1",
+  );
   const [expressionText, setExpressionText] = useState("");
   const [expressionLabel, setExpressionLabel] = useState("");
   const [editingOutputId, setEditingOutputId] = useState<string>();
@@ -1124,7 +1153,12 @@ function SetupEditor({
         </div>
       </header>
       <form
-        onChange={() => onDirty(true)}
+        onChange={(event) => {
+          if (
+            (event.target as unknown as { name?: string }).name !== "setupName"
+          )
+            onDirty(true);
+        }}
         onSubmit={(event) => {
           event.preventDefault();
           const data = new FormData(event.currentTarget);
@@ -1224,7 +1258,32 @@ function SetupEditor({
           <input
             name="setupName"
             required
-            defaultValue={setup?.name ?? draftContext?.setupName ?? "Setup 1"}
+            value={setupName}
+            onChange={(event) => setSetupName(event.currentTarget.value)}
+            onBlur={() => {
+              const name = setupName.trim();
+              if (!setup || name === setup.name) return;
+              if (!name) {
+                setSetupName(setup.name);
+                onProblem(
+                  uiProblem(
+                    "SIMULATION_SETUP_INVALID",
+                    "Setup name is required.",
+                  ),
+                );
+                return;
+              }
+              if (onSaveSetup({ ...setup, name })) onProblem(undefined);
+              else {
+                setSetupName(setup.name);
+                onProblem(
+                  uiProblem(
+                    "SIMULATION_SETUP_RENAME_FAILED",
+                    "The setup name could not be saved.",
+                  ),
+                );
+              }
+            }}
           />
         </label>
         <label>
@@ -1822,6 +1881,7 @@ function simulationArtifactCategory(artifact: ArtifactRef): string {
   const name = artifact.name.toLocaleLowerCase();
   if (name.endsWith(".cir") || name.endsWith(".spi")) return "Netlist";
   if (name.endsWith(".raw") || name.endsWith(".csv")) return "Results";
+  if (name.endsWith(".json")) return "Evidence";
   if (name.endsWith(".log") || name.endsWith(".txt")) return "Log";
   return "Other";
 }

--- a/apps/editor/src/features/simulation/transient-results-explorer.test.tsx
+++ b/apps/editor/src/features/simulation/transient-results-explorer.test.tsx
@@ -78,6 +78,11 @@ describe("Transient Results Explorer", () => {
 
     expect(markup).toContain("VOUT");
     expect(markup).toContain("IIN");
+    expect(markup).toContain('aria-label="Hide VOUT"');
+    expect(markup).toContain('aria-label="Hide IIN"');
+    expect(markup).toContain('aria-pressed="true"');
+    expect(markup).not.toContain("Solo");
+    expect(markup).not.toContain("simulation-output-browser");
     expect(markup).toContain('aria-label="Transient voltage"');
     expect(markup).toContain('aria-label="Transient current"');
     expect(markup.match(/data-trace-index=/gu)).toHaveLength(2);

--- a/apps/editor/src/features/simulation/transient-results-explorer.tsx
+++ b/apps/editor/src/features/simulation/transient-results-explorer.tsx
@@ -14,6 +14,7 @@ import {
 } from "./waveform-interaction";
 import { useWaveformView } from "./waveform-view";
 import { WaveformTools, WaveformMeasurements } from "./waveform-tools";
+import { WaveformTraceList } from "./waveform-trace-list";
 import type { SimulationProbeSpec } from "@icm/model";
 import type { TransientResult } from "@icm/spice-run";
 import type { Prepared } from "@icm/simulation-service/contract";
@@ -219,18 +220,14 @@ export function TransientResultsExplorer({
     [analysis, groups, labels, probes, vectors],
   );
   const controller = useWaveformView(resultKey);
-  const { hidden, solo, selected, markers } = controller.state;
+  const { hidden, selected, markers } = controller.state;
   const setHidden = (value: SetStateAction<ReadonlySet<string>>) =>
     controller.set("hidden", value);
-  const setSolo = (value: React.SetStateAction<string | null>) =>
-    controller.set("solo", value);
   const setSelected = (value: string) => controller.set("selected", value);
   const timeRange = controller.view.x;
   const valueRanges = controller.view.y;
   const [expandedQuantity, setExpandedQuantity] = useState<string | null>(null);
-  const visible = traces.filter(
-    (trace) => !hidden.has(trace.id) && (solo === null || solo === trace.id),
-  );
+  const visible = traces.filter((trace) => !hidden.has(trace.id));
   const fullRange = finiteExtent(analysis.timeSeconds);
   const xFraction = (value: number, range: readonly [number, number]) =>
     logarithmicX
@@ -258,6 +255,17 @@ export function TransientResultsExplorer({
     if (trace.probe) onFocusProbe?.(trace.probe);
   };
 
+  const toggleTrace = (traceId: string): void => {
+    const showing = hidden.has(traceId);
+    setHidden((current) => {
+      const next = new Set(current);
+      if (showing) next.delete(traceId);
+      else next.add(traceId);
+      return next;
+    });
+    if (showing) focusTrace(traceId);
+  };
+
   const plot = (
     quantity: PlotQuantity,
     quantityTraces: readonly TransientTrace[],
@@ -267,8 +275,8 @@ export function TransientResultsExplorer({
       ? EXPANDED_PLOT
       : {
           ...PLOT,
-          width: measured.width,
-          height: responsiveWaveformHeight(measured.width),
+          width: Math.max(280, measured.width - 116),
+          height: responsiveWaveformHeight(Math.max(280, measured.width - 116)),
         };
     const range = timeRange ?? fullRange;
     const clipId = `${clipPrefix}-${quantity}-${expanded}`;
@@ -339,6 +347,15 @@ export function TransientResultsExplorer({
               analysis.timeSeconds[0] ?? time,
             );
             controller.mark(nearest);
+          }}
+          onMoveMarker={(point, marker) => {
+            const time = xAt(point.x, range);
+            const nearest = analysis.timeSeconds.reduce(
+              (best, value) =>
+                Math.abs(value - time) < Math.abs(best - time) ? value : best,
+              analysis.timeSeconds[0] ?? time,
+            );
+            controller.mark(nearest, marker);
           }}
           onOpen={() => !expanded && setExpandedQuantity(quantity)}
         >
@@ -491,11 +508,30 @@ export function TransientResultsExplorer({
                 geometry.left +
                 xFraction(time, range) *
                   (geometry.width - geometry.left - geometry.right);
+              const cursorTrace =
+                quantityTraces.find((trace) => trace.id === selected) ??
+                quantityTraces[0];
+              const sampleIndex = analysis.timeSeconds.reduce(
+                (best, value, index) =>
+                  Math.abs(value - time) <
+                  Math.abs((analysis.timeSeconds[best] ?? value) - time)
+                    ? index
+                    : best,
+                0,
+              );
+              const cursorValue = cursorTrace?.values[sampleIndex];
+              const y =
+                cursorValue === undefined
+                  ? undefined
+                  : geometry.top +
+                    ((extent[1] - cursorValue) / (extent[1] - extent[0])) *
+                      (geometry.height - geometry.top - geometry.bottom);
+              const color = name === "A" ? "#175cd3" : "#c4320a";
               return (
-                <g key={name} pointerEvents="none">
+                <g key={name}>
                   <line
                     className="ac-cursor"
-                    stroke={name === "A" ? "#175cd3" : "#c4320a"}
+                    stroke={color}
                     strokeWidth={1}
                     strokeDasharray="3 3"
                     x1={x}
@@ -503,7 +539,42 @@ export function TransientResultsExplorer({
                     y1={geometry.top}
                     y2={geometry.height - geometry.bottom}
                   />
-                  <text x={x + 3} y={geometry.top + 12}>
+                  <line
+                    className="ac-cursor-hit"
+                    data-marker={name}
+                    x1={x}
+                    x2={x}
+                    y1={geometry.top}
+                    y2={geometry.height - geometry.bottom}
+                  />
+                  {y === undefined ? null : (
+                    <>
+                      <line
+                        className="ac-cursor"
+                        stroke={color}
+                        x1={geometry.left}
+                        x2={geometry.width - geometry.right}
+                        y1={y}
+                        y2={y}
+                      />
+                      <line
+                        className="ac-cursor-hit"
+                        data-marker={name}
+                        x1={geometry.left}
+                        x2={geometry.width - geometry.right}
+                        y1={y}
+                        y2={y}
+                      />
+                      <circle
+                        className="ac-cursor-handle"
+                        stroke={color}
+                        cx={x}
+                        cy={y}
+                        r={4}
+                      />
+                    </>
+                  )}
+                  <text pointerEvents="none" x={x + 5} y={geometry.top + 13}>
                     {name}
                   </text>
                 </g>
@@ -576,59 +647,14 @@ export function TransientResultsExplorer({
           </small>
         </div>
       </header>
-      <div
-        className="simulation-output-browser"
-        aria-label={`${analysisLabel} outputs`}
-      >
-        {traces.map((trace) => {
-          const isVisible = !hidden.has(trace.id);
-          return (
-            <div
-              key={trace.id}
-              className={selected === trace.id ? "selected" : undefined}
-            >
-              <button
-                type="button"
-                className={`simulation-output-swatch ac-trace-${trace.colorIndex % 6}`}
-                aria-label={`${isVisible ? "Hide" : "Show"} ${trace.label}`}
-                aria-pressed={isVisible}
-                onClick={() =>
-                  setHidden((current) => {
-                    const next = new Set(current);
-                    if (next.has(trace.id)) next.delete(trace.id);
-                    else next.add(trace.id);
-                    return next;
-                  })
-                }
-              />
-              <button
-                type="button"
-                className="simulation-output-name"
-                onClick={() => focusTrace(trace.id)}
-              >
-                <strong>{trace.label}</strong>
-                <small>
-                  {trace.quantity} · {trace.probe ? "linked" : trace.id}
-                </small>
-              </button>
-              <button
-                type="button"
-                aria-pressed={solo === trace.id}
-                onClick={() =>
-                  setSolo((current) => (current === trace.id ? null : trace.id))
-                }
-              >
-                Solo
-              </button>
-            </div>
-          );
-        })}
-      </div>
       {[...new Set(traces.map((trace) => trace.quantity))].map((quantity) => {
-        const quantityTraces = visible.filter(
+        const quantityTraces = traces.filter(
           (trace) => trace.quantity === quantity,
         );
-        return quantityTraces.length ? (
+        const visibleQuantityTraces = quantityTraces.filter(
+          (trace) => !hidden.has(trace.id),
+        );
+        return (
           <section
             key={quantity}
             className="transient-quantity-group ac-quantity-group"
@@ -640,13 +666,28 @@ export function TransientResultsExplorer({
                   ? "Current"
                   : quantity}
             </h4>
-            {plot(quantity, quantityTraces)}
+            <div className="simulation-plot-layout">
+              <WaveformTraceList
+                label={`${analysisLabel} ${quantity} outputs`}
+                traces={quantityTraces.map((trace) => ({
+                  id: trace.id,
+                  label: trace.label,
+                  colorIndex: trace.colorIndex,
+                  visible: !hidden.has(trace.id),
+                }))}
+                onToggle={toggleTrace}
+              />
+              <div className="simulation-plot-stack">
+                {visibleQuantityTraces.length ? (
+                  plot(quantity, visibleQuantityTraces)
+                ) : (
+                  <p className="simulation-empty-plot">Outputs hidden</p>
+                )}
+              </div>
+            </div>
           </section>
-        ) : null;
+        );
       })}
-      {visible.length === 0 ? (
-        <p className="simulation-empty-result">All Outputs are hidden.</p>
-      ) : null}
       {expandedQuantity ? (
         <div
           className="ac-plot-dialog-backdrop"
@@ -675,11 +716,35 @@ export function TransientResultsExplorer({
                 ×
               </button>
             </header>
-            {plot(
-              expandedQuantity,
-              visible.filter((trace) => trace.quantity === expandedQuantity),
-              true,
-            )}
+            <div className="simulation-plot-layout expanded">
+              <WaveformTraceList
+                label={`${analysisLabel} ${expandedQuantity} outputs`}
+                traces={traces
+                  .filter((trace) => trace.quantity === expandedQuantity)
+                  .map((trace) => ({
+                    id: trace.id,
+                    label: trace.label,
+                    colorIndex: trace.colorIndex,
+                    visible: !hidden.has(trace.id),
+                  }))}
+                onToggle={toggleTrace}
+              />
+              <div className="simulation-plot-stack">
+                {visible.some(
+                  (trace) => trace.quantity === expandedQuantity,
+                ) ? (
+                  plot(
+                    expandedQuantity,
+                    visible.filter(
+                      (trace) => trace.quantity === expandedQuantity,
+                    ),
+                    true,
+                  )
+                ) : (
+                  <p className="simulation-empty-plot">Outputs hidden</p>
+                )}
+              </div>
+            </div>
             {measurement(expandedQuantity)}
           </section>
         </div>

--- a/apps/editor/src/features/simulation/waveform-interaction.tsx
+++ b/apps/editor/src/features/simulation/waveform-interaction.tsx
@@ -31,6 +31,8 @@ export interface WaveformPoint {
   y: number;
 }
 
+type WaveformMarker = "A" | "B";
+
 /** Pointer gestures share the SVG's transform, including letterboxing. */
 export function WaveformInteraction({
   children,
@@ -38,6 +40,7 @@ export function WaveformInteraction({
   onZoom,
   onPick,
   onPan,
+  onMoveMarker,
   onOpen,
   axes = "xy",
 }: {
@@ -46,6 +49,7 @@ export function WaveformInteraction({
   onZoom(start: WaveformPoint, end: WaveformPoint): void;
   onPick(point: WaveformPoint, traceId?: string): void;
   onPan(delta: WaveformPoint): void;
+  onMoveMarker?(point: WaveformPoint, marker: WaveformMarker): void;
   onOpen(): void;
   axes?: "xy" | "x" | "y";
 }) {
@@ -55,6 +59,7 @@ export function WaveformInteraction({
         clientX: number;
         clientY: number;
         pan: boolean;
+        marker?: WaveformMarker;
         traceId?: string;
       }
     | undefined
@@ -88,6 +93,7 @@ export function WaveformInteraction({
       tabIndex={0}
       aria-label="Waveform: drag to zoom, click to measure, Shift-drag to pan"
       title="Drag to zoom · Click to measure · Shift-drag to pan · Double-click to expand"
+      onDoubleClick={onOpen}
       onBlur={() => {
         lastPick.current = undefined;
       }}
@@ -105,11 +111,15 @@ export function WaveformInteraction({
         const traceId = (event.target as Element)
           .closest("[data-trace-id]")
           ?.getAttribute("data-trace-id");
+        const marker = (event.target as Element)
+          .closest("[data-marker]")
+          ?.getAttribute("data-marker");
         drag.current = {
           start,
           clientX: event.clientX,
           clientY: event.clientY,
           pan: event.shiftKey,
+          ...(marker === "A" || marker === "B" ? { marker } : {}),
           ...(traceId ? { traceId } : {}),
         };
         event.currentTarget.focus();
@@ -118,6 +128,11 @@ export function WaveformInteraction({
       }}
       onPointerMove={(event) => {
         const start = drag.current;
+        if (start?.marker) {
+          const point = pointAt(event);
+          if (point) onMoveMarker?.(point, start.marker);
+          return;
+        }
         if (
           !start ||
           start.pan ||
@@ -167,6 +182,19 @@ export function WaveformInteraction({
         if (event.currentTarget.hasPointerCapture(event.pointerId))
           event.currentTarget.releasePointerCapture(event.pointerId);
         if (!start || !end) return;
+        if (start.marker) {
+          const previous = lastPick.current;
+          if (
+            previous &&
+            event.timeStamp - previous.time < 450 &&
+            Math.hypot(event.clientX - previous.x, event.clientY - previous.y) <
+              5
+          ) {
+            lastPick.current = undefined;
+            onOpen();
+          } else onMoveMarker?.(end, start.marker);
+          return;
+        }
         if (
           Math.hypot(
             event.clientX - start.clientX,

--- a/apps/editor/src/features/simulation/waveform-trace-list.tsx
+++ b/apps/editor/src/features/simulation/waveform-trace-list.tsx
@@ -1,0 +1,38 @@
+export interface WaveformTraceChoice {
+  readonly id: string;
+  readonly label: string;
+  readonly colorIndex: number;
+  readonly visible: boolean;
+}
+
+/**
+ * A compact plot-side legend. Visibility is the only button state: pressed
+ * means the authored Output is drawn, and pressing it again hides the trace.
+ */
+export function WaveformTraceList({
+  traces,
+  label,
+  onToggle,
+}: {
+  traces: readonly WaveformTraceChoice[];
+  label: string;
+  onToggle(traceId: string): void;
+}) {
+  return (
+    <div className="waveform-trace-list" role="group" aria-label={label}>
+      {traces.map((trace) => (
+        <button
+          key={trace.id}
+          type="button"
+          className={`waveform-trace-toggle ac-trace-${trace.colorIndex % 6}`}
+          aria-label={`${trace.visible ? "Hide" : "Show"} ${trace.label}`}
+          aria-pressed={trace.visible}
+          title={trace.label}
+          onClick={() => onToggle(trace.id)}
+        >
+          {trace.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/editor/src/features/simulation/waveform-view.ts
+++ b/apps/editor/src/features/simulation/waveform-view.ts
@@ -14,7 +14,6 @@ export interface WaveformState {
   markers: Partial<Record<MarkerName, number>>;
   activeMarker: MarkerName;
   hidden: ReadonlySet<string>;
-  solo: string | null;
   selected: string | null;
 }
 export function initialWaveformState(): WaveformState {
@@ -25,7 +24,6 @@ export function initialWaveformState(): WaveformState {
     markers: {},
     activeMarker: "A",
     hidden: new Set(),
-    solo: null,
     selected: null,
   };
 }
@@ -98,10 +96,13 @@ export function useWaveformView(resultKey?: string) {
       update((current) => commitWaveformView(current, view)),
     travel: (delta: number) =>
       update((current) => travelWaveformView(current, delta)),
-    mark: (x: number) =>
+    mark: (x: number, marker?: MarkerName) =>
       update((current) => ({
         ...current,
-        markers: { ...current.markers, [current.activeMarker]: x },
+        markers: {
+          ...current.markers,
+          [marker ?? current.activeMarker]: x,
+        },
       })),
   };
 }

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -442,26 +442,9 @@
   padding: 12px;
   overflow: auto;
 }
-.simulation-result-summary {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(120px, 1fr));
-  gap: var(--icm-space-2);
-}
-.simulation-result-summary > div {
-  display: grid;
-  gap: 3px;
-  padding: 10px;
-  border: 1px solid var(--icm-border);
-  border-radius: var(--icm-radius-sm);
-  background: var(--icm-surface-muted);
-}
-.simulation-result-summary small,
 .simulation-files-view small {
   color: var(--icm-text-muted);
   font-size: var(--icm-font-xs);
-}
-.simulation-result-summary > p {
-  grid-column: 1 / -1;
 }
 .simulation-analysis-view section {
   min-width: 0;
@@ -478,15 +461,30 @@
 }
 .simulation-files-view {
   display: grid;
-  gap: 14px;
+  gap: 8px;
 }
-.simulation-files-view > section {
+.simulation-artifact-group {
+  overflow: hidden;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  background: var(--icm-surface);
+}
+.simulation-artifact-group > summary {
   display: grid;
-  gap: 6px;
+  grid-template-columns: minmax(70px, auto) minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: center;
+  min-height: 36px;
+  padding: 5px 9px;
+  cursor: pointer;
+  list-style-position: inside;
 }
-.simulation-files-view h3 {
-  margin: 0;
-  font-size: var(--icm-font-sm);
+.simulation-artifact-group > summary span {
+  overflow: hidden;
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .simulation-artifact-list {
   display: grid;
@@ -494,13 +492,14 @@
   margin: 0;
   padding: 0;
   overflow: hidden;
-  border: 1px solid var(--icm-border);
-  border-radius: var(--icm-radius-sm);
+  border: 0;
+  border-top: 1px solid var(--icm-border);
+  border-radius: 0;
   list-style: none;
 }
 .simulation-artifact-list li {
   display: grid;
-  grid-template-columns: 72px minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr) auto;
   gap: 10px;
   align-items: center;
   min-height: 38px;
@@ -509,10 +508,6 @@
 }
 .simulation-artifact-list li + li {
   border-top: 1px solid var(--icm-border);
-}
-.simulation-artifact-list li > span {
-  color: var(--icm-text-muted);
-  font-size: var(--icm-font-xs);
 }
 .simulation-artifact-list button {
   min-width: 0;
@@ -526,6 +521,39 @@
   overflow-wrap: anywhere;
   max-height: 260px;
   overflow: auto;
+}
+.simulation-console-view {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  height: 100%;
+  min-height: 0;
+}
+.simulation-console-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.simulation-console-summary > span {
+  display: flex;
+  gap: 5px;
+  align-items: baseline;
+  padding: 4px 7px;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  background: var(--icm-surface-muted);
+}
+.simulation-console-summary small {
+  color: var(--icm-text-muted);
+}
+.simulation-console-view > p {
+  margin: 0;
+}
+.simulation-console-view > pre {
+  flex: 1 1 auto;
+  min-height: 240px;
+  max-height: none;
+  margin: 0;
 }
 .simulation-problem {
   display: grid;
@@ -673,55 +701,70 @@
 .ac-results-explorer > header button {
   margin-left: auto;
 }
-.simulation-output-browser {
+.simulation-plot-layout {
+  display: grid;
+  grid-template-columns: minmax(74px, 108px) minmax(0, 1fr);
+  gap: 8px;
+  align-items: start;
+  min-width: 0;
+}
+.simulation-plot-stack {
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+}
+.waveform-trace-list {
+  position: sticky;
+  top: 0;
   display: grid;
   gap: 4px;
-}
-.simulation-output-browser > div {
-  display: grid;
-  grid-template-columns: 22px minmax(0, 1fr) auto;
-  gap: 5px;
-  align-items: center;
-  padding: 3px;
-  border: 1px solid transparent;
-  border-radius: var(--icm-radius-sm);
-}
-.simulation-output-browser > div.selected {
-  border-color: var(--icm-accent);
-  background: var(--icm-surface-muted);
-}
-.simulation-output-browser button {
-  min-height: 26px;
-  padding: 3px 7px;
-}
-.simulation-output-browser .simulation-output-swatch {
-  width: 18px;
-  min-height: 18px;
-  padding: 0;
-  border: 4px solid currentColor;
-  border-radius: 50%;
-  background: currentColor;
-}
-.simulation-output-swatch[aria-pressed="false"] {
-  background: transparent;
-  opacity: 0.45;
-}
-.simulation-output-name {
-  display: grid;
   min-width: 0;
-  border-color: transparent !important;
-  background: transparent !important;
-  text-align: left;
+  padding-top: 21px;
 }
-.simulation-output-name strong,
-.simulation-output-name small {
+.waveform-trace-toggle {
+  width: 100%;
+  min-height: 27px;
+  padding: 3px 7px;
   overflow: hidden;
+  border-left: 4px solid currentColor;
+  background: transparent;
+  color: var(--icm-text-muted);
+  text-align: left;
   text-overflow: ellipsis;
   white-space: nowrap;
+  opacity: 0.5;
 }
-.simulation-output-name small {
+.waveform-trace-toggle[aria-pressed="true"] {
+  background: color-mix(in srgb, currentColor 9%, var(--icm-surface));
+  font-weight: 650;
+  opacity: 1;
+}
+.waveform-trace-toggle.ac-trace-0 {
+  color: #175cd3;
+}
+.waveform-trace-toggle.ac-trace-1 {
+  color: #b54708;
+}
+.waveform-trace-toggle.ac-trace-2 {
+  color: #067647;
+}
+.waveform-trace-toggle.ac-trace-3 {
+  color: #6941c6;
+}
+.waveform-trace-toggle.ac-trace-4 {
+  color: #b42318;
+}
+.waveform-trace-toggle.ac-trace-5 {
+  color: #026aa2;
+}
+.simulation-empty-plot {
+  display: grid;
+  min-height: 180px;
+  margin: 21px 0 0;
+  place-items: center;
+  border: 1px dashed var(--icm-border);
+  border-radius: var(--icm-radius-sm);
   color: var(--icm-text-muted);
-  font-size: var(--icm-font-xs);
 }
 .ac-quantity-group {
   display: grid;
@@ -803,7 +846,7 @@
 }
 .ac-plot-dialog {
   display: grid;
-  grid-template-rows: auto minmax(0, 1fr);
+  grid-template-rows: auto minmax(0, 1fr) auto;
   width: min(1400px, 92vw);
   height: min(820px, 92vh);
   min-width: 0;
@@ -813,6 +856,23 @@
   border-radius: var(--icm-radius-md);
   background: var(--icm-surface);
   box-shadow: var(--icm-shadow-md);
+}
+.ac-plot-dialog > .simulation-plot-layout {
+  height: 100%;
+  min-height: 0;
+  padding: 8px;
+  overflow: hidden;
+}
+.ac-plot-dialog > .simulation-plot-layout .waveform-trace-list {
+  padding-top: 43px;
+}
+.ac-plot-dialog > .simulation-plot-layout .simulation-plot-stack {
+  grid-template-rows: minmax(0, 1fr);
+  height: 100%;
+  min-height: 0;
+}
+.ac-plot-dialog > .simulation-plot-layout .ac-plot-shell.expanded {
+  height: 100%;
 }
 .ac-plot-dialog > header {
   display: flex;
@@ -884,11 +944,21 @@
   .simulation-settings-button {
     display: none;
   }
-  .simulation-result-summary {
+  .simulation-plot-layout {
     grid-template-columns: 1fr;
   }
+  .waveform-trace-list {
+    position: static;
+    display: flex;
+    flex-wrap: wrap;
+    padding-top: 0;
+  }
+  .waveform-trace-toggle {
+    width: auto;
+    max-width: 140px;
+  }
   .simulation-artifact-list li {
-    grid-template-columns: 62px minmax(0, 1fr);
+    grid-template-columns: minmax(0, 1fr) auto;
   }
   .simulation-artifact-list small {
     display: none;
@@ -1259,10 +1329,24 @@
   stroke-width: 2.1;
 }
 
-.ac-response .ac-cursor {
+.ac-response .ac-cursor,
+.transient-results-explorer .ac-cursor {
   stroke: #101828;
   stroke-width: 1;
   stroke-dasharray: 2 2;
+  pointer-events: none;
+}
+
+.ac-cursor-hit {
+  stroke: transparent;
+  stroke-width: 12;
+  pointer-events: stroke;
+  cursor: move;
+}
+
+.ac-cursor-handle {
+  fill: #fff;
+  stroke-width: 2;
   pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary
- move voltage/current trace visibility controls beside each plot and remove the separate Solo/output browser
- add draggable A/B crosshairs with sampled Y guides while preserving back-annotation and expanded plots
- replace Summary with a full-height Console, group Files into collapsible categories, and treat setup renames as metadata

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
- 405 unit test files / 2741 tests passed
- 6 selected Agent/Simulation browser tests passed

Test-Impact: tests-updated