### PR TITLE
Focus the simulation workspace

### DIFF
--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -846,6 +846,22 @@ test("Simulation creates an ordinary testbench and offers the current Cell at th
     "aria-valuenow",
     String(initialWidth + 8),
   );
+  await page.getByRole("button", { name: "Maximize simulation" }).click();
+  await expect(page.locator(".app-workspace")).toHaveClass(
+    /simulation-maximized/,
+  );
+  await expect(page.getByTestId("schematic-canvas")).toBeHidden();
+  await expect(page.getByTestId("simulation-resize-handle")).toHaveCount(0);
+  const maximizedSetup = await page
+    .locator(".simulation-setup-panel form")
+    .boundingBox();
+  expect(maximizedSetup!.width).toBeLessThanOrEqual(960);
+  await page.getByRole("button", { name: "Restore simulation panel" }).click();
+  await expect(page.locator(".app-workspace")).not.toHaveClass(
+    /simulation-maximized/,
+  );
+  await expect(page.getByTestId("schematic-canvas")).toBeVisible();
+  await expect(page.getByTestId("simulation-resize-handle")).toBeVisible();
   await expect(page.getByTestId("library-toggle")).toBeDisabled();
   await expect(page.getByTestId("examples-toggle")).toBeDisabled();
   await page.getByRole("button", { name: "Minimize simulation" }).click();

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -737,11 +737,13 @@ export function App({
     [editorDocumentController, projectSessionId],
   );
   const [analogSimulationState, setAnalogSimulationState] = useState<
-    "closed" | "open" | "minimized"
+    "closed" | "open" | "maximized" | "minimized"
   >("closed");
   const simulationPropertiesOpenBeforeRef = useRef(false);
   const analogSimulationOpened = analogSimulationState !== "closed";
-  const analogSimulationOpen = analogSimulationState === "open";
+  const analogSimulationOpen =
+    analogSimulationState === "open" || analogSimulationState === "maximized";
+  const analogSimulationMaximized = analogSimulationState === "maximized";
   const humanSimulationSession = useMemo(
     () =>
       new BrowserSimulationSession({
@@ -765,6 +767,11 @@ export function App({
     setSimulationPickNetsActive(false);
     setAnalogSimulationState("minimized");
     setSelectionOpen(simulationPropertiesOpenBeforeRef.current);
+  };
+  const toggleAnalogSimulationMaximized = (): void => {
+    setAnalogSimulationState((current) =>
+      current === "maximized" ? "open" : "maximized",
+    );
   };
   const exitAnalogSimulation = (): void => {
     setSimulationPickNetsActive(false);
@@ -4685,7 +4692,9 @@ export function App({
       <div
         className={
           analogSimulationOpen
-            ? "app-workspace simulation-mode"
+            ? `app-workspace simulation-mode${
+                analogSimulationMaximized ? " simulation-maximized" : ""
+              }`
             : visibleLibraryPanelOpen
               ? "app-workspace"
               : "app-workspace library-collapsed"
@@ -4714,6 +4723,8 @@ export function App({
                 ? { draftContext: simulationDraftContext }
                 : {})}
               open={analogSimulationOpen}
+              maximized={analogSimulationMaximized}
+              onToggleMaximized={toggleAnalogSimulationMaximized}
               onMinimize={minimizeAnalogSimulation}
               onExit={exitAnalogSimulation}
               onSaveSetup={(setup) => {
@@ -4803,7 +4814,7 @@ export function App({
             />
           </Suspense>
         ) : null}
-        {analogSimulationOpen ? (
+        {analogSimulationOpen && !analogSimulationMaximized ? (
           <div
             className="simulation-resize-handle"
             role="separator"

--- a/apps/editor/src/app/editor-app-chrome.tsx
+++ b/apps/editor/src/app/editor-app-chrome.tsx
@@ -57,7 +57,7 @@ export interface EditorAppChromeProps {
   onOpenNetlistPreflight: () => void;
   agentAction: { label: string; execute: () => void } | null;
   simulationAction?: () => void;
-  simulationState?: "closed" | "open" | "minimized";
+  simulationState?: "closed" | "open" | "maximized" | "minimized";
   publishGalleryOpen: boolean;
   onPublishGallery: () => void;
   helpButtonRef: RefObject<HTMLButtonElement | null>;
@@ -323,7 +323,9 @@ export function EditorAppChrome({
                 type="button"
                 data-testid="open-analog-simulation"
                 aria-label="Analog simulation"
-                aria-pressed={simulationState === "open"}
+                aria-pressed={
+                  simulationState === "open" || simulationState === "maximized"
+                }
                 onClick={simulationAction}
               >
                 {simulationState === "minimized"

--- a/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
@@ -11,11 +11,13 @@ describe("SpiceSimulationSurface workspace", () => {
     const markup = renderToStaticMarkup(
       <SpiceSimulationSurface
         open
+        maximized={false}
         project={project}
         activeDocumentId={project.topDocumentId}
         selectedSetupId={null}
         onSelectSetupId={() => undefined}
         session={{} as BrowserSimulationSession}
+        onToggleMaximized={() => undefined}
         onMinimize={() => undefined}
         onExit={() => undefined}
         onSaveSetup={() => true}
@@ -26,11 +28,12 @@ describe("SpiceSimulationSurface workspace", () => {
 
     expect(markup).toContain('class="simulation-taskbar"');
     expect(markup).not.toContain('data-testid="simulation-cell-flow"');
-    expect(markup).toContain("This Cell has no DUT instance");
+    expect(markup).toContain("No DUT instance in this Cell");
     expect(markup).toContain("Edit → New Testbench Cell");
     expect(markup).toContain('aria-label="Simulation setup"');
     expect(markup).toContain('aria-pressed="true">Settings');
     expect(markup).toContain('aria-pressed="false">Results');
+    expect(markup).toContain('aria-label="Maximize simulation"');
     expect(markup).toContain('<select name="profileId"');
     expect(markup).not.toContain("<datalist");
     expect(markup).toContain("sky130-core-continuous-ngspice46-v1");
@@ -111,11 +114,13 @@ describe("SpiceSimulationSurface workspace", () => {
     const markup = renderToStaticMarkup(
       <SpiceSimulationSurface
         open
+        maximized={false}
         project={project}
         activeDocumentId={root.id}
         selectedSetupId="setup-dc"
         onSelectSetupId={() => undefined}
         session={{} as BrowserSimulationSession}
+        onToggleMaximized={() => undefined}
         onMinimize={() => undefined}
         onExit={() => undefined}
         onSaveSetup={() => true}
@@ -152,11 +157,13 @@ describe("SpiceSimulationSurface workspace", () => {
     const markup = renderToStaticMarkup(
       <SpiceSimulationSurface
         open
+        maximized
         project={project}
         activeDocumentId={project.topDocumentId}
         selectedSetupId="setup-raw"
         onSelectSetupId={() => undefined}
         session={{} as BrowserSimulationSession}
+        onToggleMaximized={() => undefined}
         onMinimize={() => undefined}
         onExit={() => undefined}
         onSaveSetup={() => true}
@@ -166,9 +173,13 @@ describe("SpiceSimulationSurface workspace", () => {
     );
 
     expect(markup).toContain("Raw setup");
+    expect(markup).toContain('class="spice-simulation-surface maximized"');
+    expect(markup).toContain('aria-label="Restore simulation panel"');
     expect(markup).toContain("tb.cir");
     expect(markup).toContain("Switch to structured setup");
     expect(markup.match(/Delete setup/g)).toHaveLength(1);
     expect(markup).not.toContain("Add voltage probe");
+    expect(markup).not.toContain("authored file(s)");
+    expect(markup).not.toContain("Profile: raw-profile");
   });
 });

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -65,6 +65,7 @@ function preferredResultTab(run: Run): ResultTab {
 
 export interface SpiceSimulationSurfaceProps {
   open: boolean;
+  maximized: boolean;
   project: CircuitProject;
   activeDocumentId: string;
   draftContext?: {
@@ -76,6 +77,7 @@ export interface SpiceSimulationSurfaceProps {
   selectedSetupId: string | null;
   onSelectSetupId(setupId: string): void;
   session: BrowserSimulationSession;
+  onToggleMaximized(): void;
   onMinimize(): void;
   onExit(): void;
   onSaveSetup(setup: ProjectSimulationSetup): boolean;
@@ -409,7 +411,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
   return (
     <section
       hidden={!open}
-      className="spice-simulation-surface"
+      className={`spice-simulation-surface${props.maximized ? " maximized" : ""}`}
       aria-label="Analog simulation"
       onKeyDown={(e) => {
         e.stopPropagation();
@@ -565,6 +567,22 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
             </button>
           )}
           <button
+            className="simulation-maximize-button"
+            onClick={props.onToggleMaximized}
+            aria-label={
+              props.maximized
+                ? "Restore simulation panel"
+                : "Maximize simulation"
+            }
+            title={
+              props.maximized
+                ? "Restore simulation panel"
+                : "Maximize simulation"
+            }
+          >
+            {props.maximized ? "↙" : "□"}
+          </button>
+          <button
             className="simulation-minimize-button"
             onClick={props.onMinimize}
             aria-label="Minimize simulation"
@@ -583,8 +601,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
 
       {!selectedSetup && !hasDutInstance ? (
         <p className="simulation-context-hint">
-          This Cell has no DUT instance. You can continue here, or use Edit →
-          New Testbench Cell before simulation.
+          No DUT instance in this Cell · Edit → New Testbench Cell if needed.
         </p>
       ) : null}
 
@@ -608,7 +625,6 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
 
       {attention ? (
         <div className="simulation-workspace-notice" role="alert">
-          <strong>Needs attention</strong>
           <span>{attentionSummary}</span>
           {activeProblem?.recovery === "retry-same-request" && run ? (
             <button
@@ -625,10 +641,6 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
       ) : capabilities?.configured === false ? (
         <div className="simulation-workspace-notice">
           Simulator not configured. You can still edit the Project and setup.
-        </div>
-      ) : dirty ? (
-        <div className="simulation-workspace-notice">
-          Apply setup changes before running.
         </div>
       ) : null}
 
@@ -1124,7 +1136,6 @@ function SetupEditor({
       <aside className="simulation-setup-panel" aria-label="Simulation setup">
         <header>
           <div>
-            <small>Simulation</small>
             <strong>Raw setup</strong>
           </div>
         </header>
@@ -1132,11 +1143,6 @@ function SetupEditor({
           <p>
             <strong>{rawSaved.entry}</strong>
           </p>
-          <p>
-            {rawSaved.files.length} authored file(s) ·{" "}
-            {rawSaved.dependencies.length} dependency declaration(s)
-          </p>
-          <p>Profile: {rawSaved.environment.profileId}</p>
           <button type="button" onClick={() => setSwitchFromRaw(true)}>
             Switch to structured setup…
           </button>
@@ -1148,8 +1154,7 @@ function SetupEditor({
     <aside className="simulation-setup-panel" aria-label="Simulation setup">
       <header>
         <div>
-          <small>Simulation</small>
-          <strong>Setup</strong>
+          <strong>Settings</strong>
         </div>
       </header>
       <form

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -139,11 +139,46 @@
 .simulation-minimize-button {
   margin-left: auto;
 }
+.simulation-maximize-button,
 .simulation-minimize-button,
 .simulation-close-button {
   width: 30px;
   padding: 0 !important;
   font-size: 18px !important;
+}
+
+.spice-simulation-surface.maximized {
+  border-right: 0;
+}
+
+.spice-simulation-surface.maximized .simulation-setup-panel form {
+  box-sizing: border-box;
+  width: min(100%, 960px);
+  margin-inline: auto;
+}
+
+.spice-simulation-surface.maximized .simulation-results-body > * {
+  box-sizing: border-box;
+  width: min(100%, 1440px);
+  margin-inline: auto;
+}
+
+@media (min-width: 1101px) {
+  .spice-simulation-surface.maximized .simulation-taskbar {
+    grid-template-columns: auto auto minmax(0, 1fr);
+    grid-template-areas: "brand status actions";
+  }
+
+  .spice-simulation-surface.maximized
+    .simulation-taskbar:has(.simulation-cell-context) {
+    grid-template-areas:
+      "brand status actions"
+      "context context context";
+  }
+
+  .spice-simulation-surface.maximized .simulation-task-actions {
+    justify-content: flex-end;
+  }
 }
 
 .simulation-workspace-notice {

--- a/apps/editor/src/styles/editor-workspace.css
+++ b/apps/editor/src/styles/editor-workspace.css
@@ -20,6 +20,17 @@
   transition: none;
 }
 
+.app-workspace.simulation-mode.simulation-maximized {
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-areas: "simulation";
+}
+
+.app-workspace.simulation-maximized .canvas-panel,
+.app-workspace.simulation-maximized .selection-dock,
+.app-workspace.simulation-maximized .simulation-resize-handle {
+  display: none;
+}
+
 /* Sits on the Library's right edge, overlapping the canvas by a few pixels so
    the grab target is comfortable without stealing layout width. */
 .library-resize-handle {
@@ -627,6 +638,11 @@
       auto;
     grid-template-areas: "simulation canvas props";
   }
+
+  .app-workspace.simulation-mode.simulation-maximized {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas: "simulation";
+  }
 }
 
 @media (max-width: 860px) {
@@ -648,6 +664,11 @@
   .app-workspace.simulation-mode {
     grid-template-columns: min(var(--icm-simulation-width), 62vw) minmax(0, 1fr);
     grid-template-areas: "simulation canvas";
+  }
+
+  .app-workspace.simulation-mode.simulation-maximized {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas: "simulation";
   }
 
   .app-workspace.library-collapsed .shapes-panel {


### PR DESCRIPTION
## Summary\n- add maximize, restore, and minimize states to the analog Simulation workspace\n- let maximized Simulation own the canvas area while constraining Settings and Results to readable widths\n- remove duplicated setup guidance and implementation-oriented Raw Setup details\n\n## Validation\n- pnpm gate:preflight -- --base origin/main\n- pnpm gate:affected -- --base origin/main\n- 2743 unit tests passed (27 skipped)\n- 6 Simulation/Agent browser tests passed\n- 134 manual Editor browser tests passed\n\nTest-Impact: tests-updated