### PR TITLE
feat(simulation): measure terminal currents

### DIFF
--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -116,10 +116,10 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
     .selectOption({ label: "XDUT · ota_5t · vinp" });
   await panel
     .getByLabel("Add current output")
-    .selectOption({ label: "Testbench · VINP current" });
+    .selectOption({ label: "Testbench · VINP.+ current" });
   await panel
     .getByLabel("Add current output")
-    .selectOption({ label: "XDUT · ota_5t · I1 current" });
+    .selectOption({ label: "XDUT · ota_5t · I1.+ current" });
   await expect(
     panel.getByRole("button", { name: "Remove output" }),
   ).toHaveCount(7);
@@ -139,9 +139,9 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
     "v(xdut.tail)",
     "v(xdut.nleft)",
     "v(xdut.vinp)",
-    "i(vinp)",
   ])
     expect(deck).toContain(vector);
+  expect(deck).toMatch(/i\(vicmprb\d+\)/u);
   expect(deck).toMatch(/i\(v\.xdut\.vicmprb\d+\)/u);
   expect(deck).toMatch(/ac dec 10 1 (?:1000000000|1e\+?9)/i);
   expect(executions).toBe(0);
@@ -172,6 +172,7 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
         kind: "current",
         documentId: "document-ota-5t-testbench",
         instanceId: "VINP",
+        pinName: "+",
         occurrence: [],
       },
     },
@@ -180,6 +181,7 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
         kind: "current",
         documentId: "document-ota-5t",
         instanceId: "I_INTERNAL_PROBE",
+        pinName: "+",
         occurrence: ["XDUT"],
       },
     },

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -4765,8 +4765,12 @@ export function App({
                 const targetExists =
                   probe.kind === "voltage"
                     ? voltageNetId !== undefined
-                    : targetDocument?.instances.some(
-                        (instance) => instance.id === probe.instanceId,
+                    : targetDocument?.nets.some((net) =>
+                        net.terminals.some(
+                          (terminal) =>
+                            terminal.instanceId === probe.instanceId &&
+                            terminal.pinName === probe.pinName,
+                        ),
                       ) === true;
                 if (!targetExists) {
                   setStatus(
@@ -4802,10 +4806,15 @@ export function App({
                         hierarchyPath,
                         kind: "instance",
                         objectId: probe.instanceId,
+                        endpoint: {
+                          kind: "terminal",
+                          instanceId: probe.instanceId,
+                          pinName: probe.pinName,
+                        },
                       },
                   probe.kind === "voltage"
                     ? `Located simulation Net ${voltageNetId}`
-                    : `Located simulation source ${probe.instanceId}`,
+                    : `Located simulation terminal ${probe.instanceId}.${probe.pinName}`,
                 );
                 // Back-annotation should not unexpectedly open the ordinary
                 // Properties dock over the simulation workspace.

--- a/apps/editor/src/examples/common-source-amplifier.icproj.json
+++ b/apps/editor/src/examples/common-source-amplifier.icproj.json
@@ -1344,7 +1344,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-main",
   "name": "New Circuit",
-  "schemaVersion": 43,
+  "schemaVersion": 44,
   "simulationSetups": [],
   "source": {
     "dialect": "none",

--- a/apps/editor/src/examples/current-mirror-loaded-differential-pair.icproj.json
+++ b/apps/editor/src/examples/current-mirror-loaded-differential-pair.icproj.json
@@ -1271,7 +1271,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-main",
   "name": "New Circuit",
-  "schemaVersion": 43,
+  "schemaVersion": 44,
   "simulationSetups": [],
   "source": {
     "dialect": "none",

--- a/apps/editor/src/examples/five-transistor-ota-sky130.icproj.json
+++ b/apps/editor/src/examples/five-transistor-ota-sky130.icproj.json
@@ -3014,7 +3014,7 @@
   ],
   "id": "project-five-transistor-ota-sky130",
   "name": "Five-Transistor OTA (Sky130)",
-  "schemaVersion": 43,
+  "schemaVersion": 44,
   "simulationSetups": [
     {
       "id": "simulation-setup-ota-op-ac",

--- a/apps/editor/src/examples/fully-differential-two-stage-op-amp.icproj.json
+++ b/apps/editor/src/examples/fully-differential-two-stage-op-amp.icproj.json
@@ -2487,7 +2487,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-main",
   "name": "New Circuit",
-  "schemaVersion": 43,
+  "schemaVersion": 44,
   "simulationSetups": [],
   "source": {
     "dialect": "none",

--- a/apps/editor/src/examples/two-stage-op-amp.icproj.json
+++ b/apps/editor/src/examples/two-stage-op-amp.icproj.json
@@ -778,7 +778,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-main",
   "name": "New Circuit",
-  "schemaVersion": 43,
+  "schemaVersion": 44,
   "simulationSetups": [],
   "source": {
     "dialect": "none",

--- a/apps/editor/src/features/simulation/simulation-output-results.tsx
+++ b/apps/editor/src/features/simulation/simulation-output-results.tsx
@@ -25,9 +25,10 @@ function focusProbe(output: SimulationOutputSpec): SimulationProbeSpec | null {
       }
     : {
         id: output.id,
-        kind: "source-current",
+        kind: "terminal-current",
         documentId: dependency.documentId,
         instanceId: dependency.instanceId,
+        pinName: dependency.pinName,
         occurrence: [...dependency.occurrence],
       };
 }

--- a/apps/editor/src/features/simulation/simulation-probe-options.test.ts
+++ b/apps/editor/src/features/simulation/simulation-probe-options.test.ts
@@ -12,7 +12,7 @@ import {
 } from "./simulation-probe-options";
 
 describe("simulation probe choices", () => {
-  it("keeps hierarchy occurrences and source currents addressable", () => {
+  it("keeps hierarchy occurrences and terminal currents addressable", () => {
     const project = CircuitProjectSchema.parse(fiveTransistorOtaSky130);
     const dut = project.documents.find(
       (document) => document.id === "document-ota-5t",
@@ -27,6 +27,8 @@ describe("simulation probe choices", () => {
         parameters: { dc: "10u" },
       },
     });
+    dut.nets[0]!.terminals.push({ instanceId: "IINTERNAL", pinName: "+" });
+    dut.nets[1]!.terminals.push({ instanceId: "IINTERNAL", pinName: "-" });
     const options = deriveSimulationProbeOptions(
       project,
       "document-ota-5t-testbench",
@@ -48,19 +50,34 @@ describe("simulation probe choices", () => {
         occurrence: ["XDUT"],
       },
     });
-    expect(options.sourceCurrent.map((option) => option.label)).toEqual([
-      "XDUT · ota_5t · I1 current",
-      "Testbench · VDD current",
-      "Testbench · VINP current",
-      "Testbench · VINN current",
-      "Testbench · IBIAS current",
-    ]);
-    expect(options.sourceCurrent[0]?.target).toEqual({
+    expect(
+      options.terminalCurrent
+        .filter((option) => option.target.instanceId === "IINTERNAL")
+        .map((option) => option.label),
+    ).toEqual(["XDUT · ota_5t · I1.+ current", "XDUT · ota_5t · I1.- current"]);
+    expect(
+      options.terminalCurrent.find(
+        (option) =>
+          option.target.instanceId === "IINTERNAL" &&
+          option.target.pinName === "+",
+      )?.target,
+    ).toEqual({
       kind: "current",
       documentId: "document-ota-5t",
       instanceId: "IINTERNAL",
+      pinName: "+",
       occurrence: ["XDUT"],
     });
+    expect(
+      options.terminalCurrent
+        .filter((option) => option.target.instanceId === "M5")
+        .map((option) => option.target.pinName),
+    ).toEqual(["D", "G", "S", "B"]);
+    expect(
+      options.terminalCurrent
+        .filter((option) => option.target.instanceId === "XDUT")
+        .map((option) => option.target.pinName),
+    ).toEqual(["vss", "ibias", "vdd", "vinn", "vinp", "vout"]);
   });
 
   it("names an unnamed hierarchical Net by its terminal aliases", () => {
@@ -184,12 +201,16 @@ describe("simulation probe choices", () => {
         parameters: { dc: "10u" },
       },
     });
+    dut.nets[0]!.terminals.push({ instanceId: "IINTERNAL", pinName: "+" });
+    dut.nets[1]!.terminals.push({ instanceId: "IINTERNAL", pinName: "-" });
 
     const targets = deriveSimulationProbeOptions(
       project,
       testbench.id,
-    ).sourceCurrent.filter(
-      (option) => option.target.instanceId === "IINTERNAL",
+    ).terminalCurrent.filter(
+      (option) =>
+        option.target.instanceId === "IINTERNAL" &&
+        option.target.pinName === "+",
     );
 
     expect(targets.map((option) => option.target.occurrence)).toEqual([

--- a/apps/editor/src/features/simulation/simulation-probe-options.ts
+++ b/apps/editor/src/features/simulation/simulation-probe-options.ts
@@ -1,10 +1,12 @@
 import type {
   CircuitProject,
+  Instance,
   SchematicDocument,
   SimulationExpression,
   SimulationVoltageProbeAnchor,
 } from "@icm/model";
 import { resolveDocumentLogicalNets, type HierarchyFrame } from "@icm/derived";
+import { deviceDescriptor } from "@icm/devices";
 
 import { logicalNetChoices } from "../logical-net-choices";
 
@@ -12,11 +14,11 @@ export type VoltageProbeTarget = Extract<
   SimulationExpression,
   { kind: "voltage" }
 >;
-export type SourceCurrentProbeTarget = Extract<
+export type TerminalCurrentProbeTarget = Extract<
   SimulationExpression,
   { kind: "current" }
 >;
-type ProbeTarget = VoltageProbeTarget | SourceCurrentProbeTarget;
+type ProbeTarget = VoltageProbeTarget | TerminalCurrentProbeTarget;
 
 export interface SimulationProbeOption<
   Target extends ProbeTarget = ProbeTarget,
@@ -28,7 +30,7 @@ export interface SimulationProbeOption<
 
 export interface SimulationProbeOptions {
   readonly voltage: readonly SimulationProbeOption<VoltageProbeTarget>[];
-  readonly sourceCurrent: readonly SimulationProbeOption<SourceCurrentProbeTarget>[];
+  readonly terminalCurrent: readonly SimulationProbeOption<TerminalCurrentProbeTarget>[];
 }
 
 export interface PickedSimulationNet {
@@ -40,7 +42,7 @@ export interface PickedSimulationNet {
 export function simulationProbeTargetKey(target: ProbeTarget): string {
   const occurrence = target.occurrence.join("/");
   if (target.kind === "current")
-    return `current:${occurrence}:${target.documentId}:${target.instanceId}`;
+    return `current:${occurrence}:${target.documentId}:${target.instanceId}:${target.pinName}`;
   const anchor = target.anchor;
   const anchorKey =
     anchor.kind === "terminal"
@@ -222,6 +224,45 @@ function logicalNetDisplayLabel(
   return aliases.length > 0 ? aliases.join(" / ") : choice.label;
 }
 
+function terminalCurrentPinNames(
+  project: CircuitProject,
+  document: SchematicDocument,
+  instance: Instance,
+): readonly string[] {
+  const connected = new Set(
+    document.nets.flatMap((net) =>
+      net.terminals.flatMap((terminal) =>
+        terminal.instanceId === instance.id ? [terminal.pinName] : [],
+      ),
+    ),
+  );
+  const binding = instance.netlist?.binding;
+  if (
+    !binding ||
+    binding.kind === "unresolved-subcircuit" ||
+    ((binding.kind === "primitive" || binding.kind === "model") &&
+      binding.deviceClass === "net-marker")
+  )
+    return [];
+  let ordered: readonly string[] = [];
+  if (binding?.kind === "primitive" || binding?.kind === "model")
+    ordered = deviceDescriptor(instance.symbolId)?.pinOrder ?? [];
+  else if (binding?.kind === "subcircuit")
+    ordered =
+      project.documents
+        .find((candidate) => candidate.id === binding.childDocumentId)
+        ?.netlist?.terminals.map((terminal) => terminal.name) ?? [];
+  else if (binding?.kind === "external-subcircuit")
+    ordered =
+      project.externalSubcircuitDefinitions
+        .find((definition) => definition.id === binding.definitionId)
+        ?.terminals.map((terminal) => terminal.name) ?? [];
+  return [...ordered, ...connected].filter(
+    (pinName, index, all) =>
+      connected.has(pinName) && all.indexOf(pinName) === index,
+  );
+}
+
 /**
  * Resolve the persisted occurrence ids into the same hierarchy frames used by
  * canvas navigation. This is presentation-only: probe identity remains the
@@ -271,8 +312,9 @@ export function deriveSimulationProbeOptions(
   );
   const root = documents.get(rootDocumentId);
   const voltage: SimulationProbeOption<VoltageProbeTarget>[] = [];
-  const sourceCurrent: SimulationProbeOption<SourceCurrentProbeTarget>[] = [];
-  if (!root) return { voltage, sourceCurrent };
+  const terminalCurrent: SimulationProbeOption<TerminalCurrentProbeTarget>[] =
+    [];
+  if (!root) return { voltage, terminalCurrent };
 
   const visit = (
     document: SchematicDocument,
@@ -304,20 +346,21 @@ export function deriveSimulationProbeOptions(
     }
     for (const instance of document.instances) {
       const binding = instance.netlist?.binding;
-      if (
-        (binding?.kind === "primitive" || binding?.kind === "model") &&
-        (binding.deviceClass === "voltage-source" ||
-          binding.deviceClass === "current-source")
-      ) {
-        const target: SourceCurrentProbeTarget = {
+      for (const pinName of terminalCurrentPinNames(
+        project,
+        document,
+        instance,
+      )) {
+        const target: TerminalCurrentProbeTarget = {
           kind: "current",
           documentId: document.id,
           instanceId: instance.id,
+          pinName,
           occurrence: [...occurrence],
         };
-        sourceCurrent.push({
+        terminalCurrent.push({
           key: simulationProbeTargetKey(target),
-          label: `${prefix} · ${instance.reference ?? instance.id} current`,
+          label: `${prefix} · ${instance.reference ?? instance.id}.${pinName} current`,
           target,
         });
       }
@@ -333,5 +376,5 @@ export function deriveSimulationProbeOptions(
     }
   };
   visit(root, [], [], new Set([root.id]));
-  return { voltage, sourceCurrent };
+  return { voltage, terminalCurrent };
 }

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -119,9 +119,10 @@ function legacyProbe(output: SimulationOutputSpec): SimulationProbeSpec | null {
   if (expression.kind === "current")
     return {
       id: output.id,
-      kind: "source-current",
+      kind: "terminal-current",
       documentId: expression.documentId,
       instanceId: expression.instanceId,
+      pinName: expression.pinName,
       occurrence: [...expression.occurrence],
     };
   return null;
@@ -141,6 +142,7 @@ function expressionFromLegacyProbe(
         kind: "current",
         documentId: probe.documentId,
         instanceId: probe.instanceId,
+        pinName: probe.pinName,
         occurrence: [...probe.occurrence],
       };
 }
@@ -1044,7 +1046,7 @@ function SetupEditor({
   const probeLabels = new Map<string, string>();
   for (const option of [
     ...probeOptions.voltage,
-    ...probeOptions.sourceCurrent,
+    ...probeOptions.terminalCurrent,
   ]) {
     // The option key is Logical-Net scoped for selection deduplication, while
     // a persisted output keeps its durable object anchor. Both identities
@@ -1579,14 +1581,15 @@ function SetupEditor({
         ) : null}
         <ProbeSelect
           label="Add current output"
-          placeholder="Choose a source current"
-          options={probeOptions.sourceCurrent}
+          placeholder="Choose a terminal current"
+          options={probeOptions.terminalCurrent}
           selectedKeys={selectedProbeKeys}
           onAdd={(option) => {
             setOutputs([...outputs, outputFromOption(option, outputs)]);
             onDirty(true);
           }}
         />
+        <small>Positive current enters the selected terminal.</small>
         <fieldset className="simulation-setup-group simulation-expression-editor">
           <legend>Derived expression</legend>
           <div className="simulation-inline-fields columns-2">

--- a/apps/editor/src/features/simulation/transient-results-explorer.test.tsx
+++ b/apps/editor/src/features/simulation/transient-results-explorer.test.tsx
@@ -66,9 +66,10 @@ describe("Transient Results Explorer", () => {
           },
           {
             id: "probe-v1",
-            kind: "source-current",
+            kind: "terminal-current",
             documentId: "tb",
             instanceId: "V1",
+            pinName: "+",
             occurrence: [],
           },
         ]}

--- a/docs/overall-product-plan.md
+++ b/docs/overall-product-plan.md
@@ -68,7 +68,7 @@ revision, lock, or transaction invariants.
   ordered hierarchy interface rather than another Net-label mechanism.
 - Routes describe visible geometry; they may stretch locally during movement
   without changing logical connectivity.
-- A Project's canonical content is schema-43 JSON. Explicit Save updates one
+- A Project's canonical content is schema-44 JSON. Explicit Save updates one
   stable private Cloud Project; `.icproj.json` is portable interchange, and
   browser recovery is an origin-local, non-authoritative copy.
 - Visual variants may change presentation but never remove electrical terminal

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -444,8 +444,8 @@ Open, demo load, restore, and human-approved staged import replace the entire
 Project through one replacement boundary; they are not Edit Engine
 transactions. Replacement cancels pending recovery for the outgoing Project
 and terminates its Agent session. A complete Project covered by the schema
-24→43 upgrade chain may be upgraded at the read boundary and then enters the
-editor only as schema-43; migrated files are marked as needing save.
+24→44 upgrade chain may be upgraded at the read boundary and then enters the
+editor only as schema-44; migrated files are marked as needing save.
 
 Selection, viewport, active tool, previews, Agent tokens, and approval UI are
 transient and never enter Project JSON. Recovery is scheduled only after a

--- a/docs/specs/persistence-and-recovery.md
+++ b/docs/specs/persistence-and-recovery.md
@@ -5,13 +5,13 @@ Status: `accepted`
 Primary owner: Worker Cloud Project storage, `packages/project-protocol`, and
 the editor document lifecycle
 
-Project content uses canonical schema-43 JSON. A private Cloud Project is the
+Project content uses canonical schema-44 JSON. A private Cloud Project is the
 formal saved resource; `.icproj.json` is portable import/export and backup.
 The current-only model in `packages/model` validates the normalized shape;
 `packages/project-protocol` owns parsing, compatibility diagnostics,
 and canonical serialization. Persistence validates the complete current schema
-before import or Cloud Save. The explicit schema 24→43 chain upgrades supported
-historical files; serialization always writes schema 43. The 32→33 adapter
+before import or Cloud Save. The explicit schema 24→44 chain upgrades supported
+historical files; serialization always writes schema 44. The 32→33 adapter
 rejects ownerless Net equivalence instead of guessing replacement electrical
 semantics, and the 33→34 adapter removes hidden electrical name authority while
 preserving source spelling as provenance. The 34→35 adapter unifies parallel
@@ -26,7 +26,7 @@ dependency declarations as the setup's mutually exclusive second input form.
 Versions outside the implemented chain are rejected.
 
 Recovery state is a non-authoritative browser safety copy. It may restore a
-complete schema-43 Project or a supported historical record that validates
+complete schema-44 Project or a supported historical record that validates
 after the chained upgrade, associated with a recorded working-copy session.
 Corrupt, incompatible, or partial recovery data is discarded or retained as raw
 data without changing the live Project. User-saved Library examples are the

--- a/docs/specs/project-file-format.md
+++ b/docs/specs/project-file-format.md
@@ -2,14 +2,14 @@
 
 Status: `accepted`
 
-Current Project schema: `43`
+Current Project schema: `44`
 
 Primary owners: `packages/model` (current shape) and
 `packages/project-protocol` (file boundary)
 
 An `.icproj.json` file is canonical JSON for one complete `CircuitProject`.
 `@icm/project-protocol` exposes `parseProject`. The file boundary accepts every
-schema covered by its explicit 24→43 upgrade chain. Schema 32 added optional
+schema covered by its explicit 24→44 upgrade chain. Schema 32 added optional
 presentation-only `Annotation.textColor`; schema 33 removes ownerless
 `explicit-equivalence` connectivity. The 32→33 adapter advances the version
 stamp only when that retired record is absent. If one exists, it rejects at the
@@ -47,8 +47,11 @@ named `simulationSetups` collection; the 41→42 adapter preserves one authored
 setup with a deterministic ID/name and maps absence to an empty collection.
 Schema 43 replaces primitive probes with named outputs and bounded expression
 trees; the 42→43 adapter preserves each target as a leaf output and derives an
-initial human-readable label. The public file boundary supplies only schema 43
-in memory and writes only schema 43; versions older than 24 or newer than 43
+initial human-readable label. Schema 44 makes terminal identity explicit for
+current expressions; the 43→44 adapter preserves the previously supported
+independent-source sign by selecting its `+` terminal. The public file boundary
+supplies only schema 44 in
+memory and writes only schema 44; versions older than 24 or newer than 44
 are rejected.
 
 ## Current authorities
@@ -134,7 +137,7 @@ are rejected.
 
 ```text
 import text -> parse JSON -> require Project schema 24 through 43
--> converge to schema 43 -> strict schema-43 validation -> install unbound
+-> converge to schema 44 -> strict schema-44 validation -> install unbound
 export -> strict validation -> canonical key ordering -> Blob download
 ```
 
@@ -158,7 +161,7 @@ open, and recovery remain exact.
 Canonical serialization ends with one newline and is byte-stable across
 serialize/parse/serialize. The current corpus is listed in
 `fixtures/projects/compatibility-corpus.json`; its accepted entries must all be
-already canonical Project schema 43. The rejected corpus names expected
+already canonical Project schema 44. The rejected corpus names expected
 validation failures.
 
 Viewport, selection, undo history, canvas overlays, Agent credentials,

--- a/docs/specs/schematic-model.md
+++ b/docs/specs/schematic-model.md
@@ -5,7 +5,7 @@ Status: `accepted`
 Primary owner: `packages/model`
 
 The Project contains Documents; each Document owns revisioned electrical,
-geometric, and presentation facts. The current model is strict schema 43 and has
+geometric, and presentation facts. The current model is strict schema 44 and has
 no compatibility shape.
 
 ## Coordinate domains
@@ -193,8 +193,8 @@ ordinary Schematic edits inside one Project structural transaction. The
 Project's `structureRevision` protects this cross-Document boundary and the
 editor records it as one undoable structural commit.
 
-Persistence writes only schema 43. The reader carries every schema in its
-explicit 24→43 upgrade chain forward, then supplies the current model only; no
+Persistence writes only schema 44. The reader carries every schema in its
+explicit 24→44 upgrade chain forward, then supplies the current model only; no
 compatibility shape enters runtime electrical derivation. The 32→33 step
 rejects ownerless equivalence rather than guessing replacement connectivity.
 The 33→34 step converts hidden imported names into non-electrical hints or

--- a/docs/specs/simulation.md
+++ b/docs/specs/simulation.md
@@ -203,6 +203,9 @@ collection. Schema 43 replaces primitive probes with named outputs and a
 bounded expression AST. The 42→43 adapter wraps every old probe as an
 equivalent voltage/current leaf expression and derives its initial authored
 label from the Logical Net, formal Cell port, or endpoint/Instance identity.
+Schema 44 makes a current expression terminal-specific. The 43→44 adapter
+maps every previously supported independent-source current to its `+`
+terminal, preserving ngspice's positive source-current convention.
 
 ```ts
 interface ProjectSimulationSetup {
@@ -272,6 +275,7 @@ type SimulationExpression =
       kind: "current";
       documentId: StableId;
       instanceId: StableId;
+      pinName: string; // current entering this concrete Instance terminal
       occurrence: StableId[];
     }
   | { kind: "constant"; value: number }
@@ -473,14 +477,12 @@ a bare `write out.raw`, saving the whole plot rather than nothing.
 
 Vector names are produced here and never inferred from result text:
 
-| primitive acquisition                         | vector                   |
-| --------------------------------------------- | ------------------------ |
-| Net in the root                               | `v(mid)`                 |
-| Net under occurrence `X1`, `XI1`              | `v(x1.xi1.mid)`          |
-| voltage source in the root                    | `i(v1)`                  |
-| voltage source under `X1`, `XI1`              | `i(v.x1.xi1.vsi)`        |
-| current source in the root                    | `i(i1)`                  |
-| instrumented current source under `X1`, `XI1` | `i(v.x1.xi1.vicmprb###)` |
+| primitive acquisition                    | vector                   |
+| ---------------------------------------- | ------------------------ |
+| Net in the root                          | `v(mid)`                 |
+| Net under occurrence `X1`, `XI1`         | `v(x1.xi1.mid)`          |
+| terminal current in the root             | `i(vicmprb###)`          |
+| terminal current under `X1`, `XI1`       | `i(v.x1.xi1.vicmprb###)` |
 
 They are lower case because ngspice folds case on the way into the rawfile: a
 card may read `R1 IN MID 1k`, and `V(MidNode)` still comes back as
@@ -489,26 +491,21 @@ occurrence path. Net names come from the Logical-Net resolver the printer
 already used, read back off the extracted Cell rather than derived a second
 time.
 
-A top-level independent current source is measured by compiler-generated
-`.probe I(<ref>)` instrumentation. ngspice inserts a zero-volt sense source and
-publishes `<ref>#branch`; the rawfile records that vector as `i(<ref>)`. The
-directive addresses only top-level devices. For a selected current source
-below the simulation root, the compiler instead inserts a deterministic 0 V
-sense source in series inside the extracted Cell definition and writes its
-occurrence-qualified branch current. This instrumentation exists only in the
-prepared simulation artifact: it does not mutate the Project or ordinary
-structural export. Its positive direction matches the authored independent
-current source's first-to-second-node direction, so no result-side sign repair
-is applied. One instrumented Cell definition remains independently addressable
-through every concrete occurrence. Both forms are supported for OP, DC, AC,
-and TRAN. See the ngspice manual, section 11.6.5.1, “.probe — Insert current
-probes”. The other refusals are a missing root, a root that instantiates
-nothing, a probe naming a Document or concrete anchor that is not there, an
-occurrence that does not follow hierarchy Instances from the root or that
-reaches a different Document than the probe claims, an analysis kind this
-release does not compile, and a source-current probe on a device that is not a
-source. Each is a typed diagnostic carrying an occurrence-aware
-`ObjectLocator`, never a thrown error.
+A terminal-current output names an Instance and one of its extracted
+terminals. The compiler inserts a deterministic 0 V sense source between that
+terminal and its external Net, then reads the source branch current. Positive
+current always means current entering the selected terminal. The same rule
+therefore covers passive devices, MOS/BJT terminals, independent sources, and
+Cell instance ports without depending on device- or model-specific ngspice
+internal vectors. Instrumentation exists only in the prepared simulation
+artifact: it does not mutate the Project or ordinary structural export. One
+instrumented Cell definition remains independently addressable through every
+concrete occurrence. Terminal currents are supported for OP, DC, AC, and
+TRAN. The editor offers connected, emitted terminals; stale authored outputs
+remain saved and preparation returns an occurrence-aware typed diagnostic
+rather than silently rebinding them. Other refusals include a missing root, a
+root that instantiates nothing, an absent Instance or terminal, an invalid
+occurrence, and an unsupported analysis kind.
 
 `inputRevision` is the SHA-256 of the two compiled texts and a canonical
 serialization of the setup, computed with Web Crypto so the function stays

--- a/docs/user/project-compatibility.md
+++ b/docs/user/project-compatibility.md
@@ -1,6 +1,6 @@
 # Project File Compatibility
 
-The released Project schema version is `43`. It retains schematic-only
+The released Project schema version is `44`. It retains schematic-only
 hierarchy integrity, a Project structural revision, stable formal Cell ports,
 and definition-level Cell symbol presentation. It also has one typed Instance
 netlist authority, formal Cell parameters, and Project-local external

--- a/fixtures/projects/instance-value-display/project.icproj.json
+++ b/fixtures/projects/instance-value-display/project.icproj.json
@@ -1075,7 +1075,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "instance-value-display",
   "name": "Instance Value Display",
-  "schemaVersion": 43,
+  "schemaVersion": 44,
   "simulationSetups": [],
   "source": {
     "dialect": "none",

--- a/fixtures/projects/minimal/project.icproj.json
+++ b/fixtures/projects/minimal/project.icproj.json
@@ -32,7 +32,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-minimal",
   "name": "Minimal Project",
-  "schemaVersion": 43,
+  "schemaVersion": 44,
   "simulationSetups": [],
   "source": {
     "dialect": "none",

--- a/fixtures/projects/phase-1-manual/project.icproj.json
+++ b/fixtures/projects/phase-1-manual/project.icproj.json
@@ -58,7 +58,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-phase-1-manual",
   "name": "Phase 1 Manual Editor",
-  "schemaVersion": 43,
+  "schemaVersion": 44,
   "simulationSetups": [],
   "source": {
     "dialect": "none",

--- a/fixtures/projects/phase-3-routing/project.icproj.json
+++ b/fixtures/projects/phase-3-routing/project.icproj.json
@@ -170,7 +170,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-routing",
   "name": "Phase 3 Routing Demo",
-  "schemaVersion": 43,
+  "schemaVersion": 44,
   "simulationSetups": [],
   "source": {
     "dialect": "none",

--- a/fixtures/projects/phase-5-dense-analog/project.icproj.json
+++ b/fixtures/projects/phase-5-dense-analog/project.icproj.json
@@ -421,7 +421,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-phase-5-dense-analog",
   "name": "Current Differential Stage",
-  "schemaVersion": 43,
+  "schemaVersion": 44,
   "simulationSetups": [],
   "source": {
     "dialect": "none",

--- a/fixtures/projects/rejected-missing-top/project.icproj.json
+++ b/fixtures/projects/rejected-missing-top/project.icproj.json
@@ -32,7 +32,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-rejected",
   "name": "Rejected",
-  "schemaVersion": 43,
+  "schemaVersion": 44,
   "simulationSetups": [],
   "source": {
     "dialect": "none",

--- a/packages/model/src/schema.test.ts
+++ b/packages/model/src/schema.test.ts
@@ -836,6 +836,7 @@ describe("SimulationSetup schema", () => {
               kind: "current",
               documentId: "ota",
               instanceId: "I1",
+              pinName: "+",
               occurrence: ["X1"],
             },
           },

--- a/packages/model/src/schema/common.ts
+++ b/packages/model/src/schema/common.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-export const CURRENT_PROJECT_SCHEMA_VERSION = 43;
+export const CURRENT_PROJECT_SCHEMA_VERSION = 44;
 
 export const StableIdSchema = z.string().min(1).max(256);
 /** Strict persisted/presentation hex color token. Format: `#RRGGBB`. */

--- a/packages/model/src/schema/instance-style.test.ts
+++ b/packages/model/src/schema/instance-style.test.ts
@@ -150,12 +150,12 @@ describe("SignalFlowParametersSchema", () => {
 });
 
 describe("CircuitProject schema version", () => {
-  it("current schema version is 43", () => {
-    expect(CURRENT_PROJECT_SCHEMA_VERSION).toBe(43);
+  it("current schema version is 44", () => {
+    expect(CURRENT_PROJECT_SCHEMA_VERSION).toBe(44);
   });
 
-  it("createEmptyProject produces schema version 43", () => {
-    expect(createEmptyProject("test", "Test").schemaVersion).toBe(43);
+  it("createEmptyProject produces schema version 44", () => {
+    expect(createEmptyProject("test", "Test").schemaVersion).toBe(44);
   });
 
   it("validates style and Signal Flow metadata together", () => {

--- a/packages/model/src/schema/simulation.ts
+++ b/packages/model/src/schema/simulation.ts
@@ -110,6 +110,8 @@ const SimulationCurrentExpressionSchema = z.strictObject({
   kind: z.literal("current"),
   documentId: StableIdSchema,
   instanceId: StableIdSchema,
+  /** Current entering this concrete Instance terminal. */
+  pinName: z.string().min(1).max(128),
   occurrence: SimulationProbeOccurrenceSchema,
 });
 

--- a/packages/model/src/schema/types.ts
+++ b/packages/model/src/schema/types.ts
@@ -123,7 +123,7 @@ export type SimulationProbeSpec =
       Extract<Schema.SimulationExpression, { kind: "voltage" }>,
       "kind"
     >)
-  | ({ id: StableId; kind: "source-current" } & Omit<
+  | ({ id: StableId; kind: "terminal-current" } & Omit<
       Extract<Schema.SimulationExpression, { kind: "current" }>,
       "kind"
     >);

--- a/packages/netlist/src/simulation-compile.test.ts
+++ b/packages/netlist/src/simulation-compile.test.ts
@@ -179,6 +179,7 @@ const DIVIDER_SETUP: SimulationStructuredSetup = {
           kind: "current",
           documentId: "tb",
           instanceId: "inst-v1",
+          pinName: "+",
           occurrence: [],
         },
       },
@@ -359,14 +360,15 @@ describe("compiling a structured simulation setup", () => {
         "* Analog Canvas testbench for divider_tb",
         "R1 IN MID 1k",
         "R2 MID 0 1k",
-        "V1 IN 0 DC 1 AC 1 0",
+        "V1 ICMPRB005 0 DC 1 AC 1 0",
+        "VICMPRB005 IN ICMPRB005 DC 0",
         ".control",
         "set filetype=ascii",
         "set appendwrite",
         "op",
-        "write out.raw v(mid) v(in) i(v1)",
+        "write out.raw v(mid) v(in) i(vicmprb005)",
         "ac dec 2 1 100",
-        "write out.raw v(mid) v(in) i(v1)",
+        "write out.raw v(mid) v(in) i(vicmprb005)",
         ".endc",
         ".end",
         "",
@@ -378,7 +380,11 @@ describe("compiling a structured simulation setup", () => {
     expect(result.vectors).toEqual([
       { probeId: "probe-mid", vector: "v(mid)", quantity: "voltage" },
       { probeId: "probe-in", vector: "v(in)", quantity: "voltage" },
-      { probeId: "probe-v1", vector: "i(v1)", quantity: "current" },
+      {
+        probeId: "probe-v1",
+        vector: "i(vicmprb005)",
+        quantity: "current",
+      },
     ]);
     expect(result.diagnostics).toEqual([]);
   });
@@ -567,7 +573,7 @@ describe("compiling a structured simulation setup", () => {
     ]);
   });
 
-  it("names a source current inside an occurrence with its device type letter", async () => {
+  it("instruments a selected terminal inside an occurrence", async () => {
     const project = hierarchicalProject();
     const dut = project.documents.find((item) => item.id === "dut")!;
     dut.instances.push(voltageSource("dut-vs", "VSENSE", { dc: "0" }));
@@ -587,9 +593,10 @@ describe("compiling a structured simulation setup", () => {
         probes: [
           {
             id: "probe-sense",
-            kind: "source-current",
+            kind: "terminal-current",
             documentId: "dut",
             instanceId: "dut-vs",
+            pinName: "+",
             occurrence: ["inst-x1"],
           },
         ],
@@ -599,8 +606,15 @@ describe("compiling a structured simulation setup", () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.vectors).toEqual([
-      { probeId: "probe-sense", vector: "i(v.x1.vsense)", quantity: "current" },
+      {
+        probeId: "probe-sense",
+        vector: "i(v.x1.vicmprb005)",
+        quantity: "current",
+      },
     ]);
+    expect(result.request.netlist).toContain(
+      "VSENSE ICMPRB005 SENSE DC 0\nVICMPRB005 SENSE ICMPRB005 DC 0",
+    );
   });
 
   it("declares a global Net with the definitions, ahead of the testbench", async () => {
@@ -901,9 +915,10 @@ describe("refusing a setup that cannot be simulated", () => {
         probes: [
           {
             id: "probe-lost",
-            kind: "source-current",
+            kind: "terminal-current",
             documentId: "tb",
             instanceId: "no-such-instance",
+            pinName: "+",
             occurrence: [],
           },
         ],
@@ -912,6 +927,40 @@ describe("refusing a setup that cannot be simulated", () => {
 
     expect(result.ok).toBe(false);
     expect(codes(result)).toEqual(["SIMULATION_PROBE_UNKNOWN_INSTANCE"]);
+  });
+
+  it("reports a current output naming a terminal the Instance does not hold", async () => {
+    const result = await compile(
+      dividerProject(),
+      setupWith({
+        probes: [
+          {
+            id: "probe-lost-terminal",
+            kind: "terminal-current",
+            documentId: "tb",
+            instanceId: "inst-r1",
+            pinName: "D",
+            occurrence: [],
+          },
+        ],
+      }),
+    );
+
+    expect(result.ok).toBe(false);
+    expect(codes(result)).toEqual(["SIMULATION_PROBE_UNKNOWN_TERMINAL"]);
+    expect(result.ok === false && result.diagnostics[0]!.primary).toMatchObject(
+      {
+        documentId: "tb",
+        hierarchyPath: [],
+        kind: "instance",
+        objectId: "inst-r1",
+        endpoint: {
+          kind: "terminal",
+          instanceId: "inst-r1",
+          pinName: "D",
+        },
+      },
+    );
   });
 
   it("reports an occurrence step that is not a hierarchy Instance", async () => {
@@ -1000,24 +1049,67 @@ describe("refusing a setup that cannot be simulated", () => {
     );
   });
 
-  it("reports a source-current probe on an Instance that is not a source", async () => {
+  it("instruments a passive-device terminal", async () => {
     const result = await compile(
       dividerProject(),
       setupWith({
         probes: [
           {
             id: "probe-r1",
-            kind: "source-current",
+            kind: "terminal-current",
             documentId: "tb",
             instanceId: "inst-r1",
+            pinName: "1",
             occurrence: [],
           },
         ],
       }),
     );
 
-    expect(result.ok).toBe(false);
-    expect(codes(result)).toEqual(["SIMULATION_PROBE_NOT_A_SOURCE"]);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.request.testbench).toContain(
+      "R1 ICMPRB001 MID 1k\nVICMPRB001 IN ICMPRB001 DC 0",
+    );
+    expect(result.vectors).toEqual([
+      {
+        probeId: "probe-r1",
+        vector: "i(vicmprb001)",
+        quantity: "current",
+      },
+    ]);
+  });
+
+  it("instruments a hierarchical Cell instance port", async () => {
+    const result = await compile(
+      hierarchicalProject(),
+      setupWith({
+        analyses: [{ kind: "op" }],
+        probes: [
+          {
+            id: "probe-x1-a",
+            kind: "terminal-current",
+            documentId: "tb",
+            instanceId: "inst-x1",
+            pinName: "A",
+            occurrence: [],
+          },
+        ],
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.request.testbench).toContain(
+      "X1 ICMPRB003 0 dut\nVICMPRB003 IN ICMPRB003 DC 0",
+    );
+    expect(result.vectors).toEqual([
+      {
+        probeId: "probe-x1-a",
+        vector: "i(vicmprb003)",
+        quantity: "current",
+      },
+    ]);
   });
 
   it("instruments a top-level independent current source", async () => {
@@ -1042,9 +1134,10 @@ describe("refusing a setup that cannot be simulated", () => {
         probes: [
           {
             id: "probe-i1",
-            kind: "source-current",
+            kind: "terminal-current",
             documentId: "tb",
             instanceId: "inst-i1",
+            pinName: "+",
             occurrence: [],
           },
         ],
@@ -1053,11 +1146,13 @@ describe("refusing a setup that cannot be simulated", () => {
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.request.testbench).toContain("\n.probe I(I1)\n");
-    expect(result.request.testbench).toContain("write out.raw i1#branch\n");
+    expect(result.request.testbench).toContain(
+      "I1 ICMPRB001 0 DC 1m\nVICMPRB001 MID ICMPRB001 DC 0",
+    );
+    expect(result.request.testbench).toContain("write out.raw i(vicmprb001)\n");
     expect(result.vectors).toContainEqual({
       probeId: "probe-i1",
-      vector: "i(i1)",
+      vector: "i(vicmprb001)",
       quantity: "current",
     });
   });
@@ -1072,9 +1167,10 @@ describe("refusing a setup that cannot be simulated", () => {
         probes: [
           {
             id: "probe-i1",
-            kind: "source-current",
+            kind: "terminal-current",
             documentId: "dut",
             instanceId: "inst-i1",
+            pinName: "+",
             occurrence: ["inst-x1"],
           },
         ],
@@ -1084,7 +1180,7 @@ describe("refusing a setup that cannot be simulated", () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.request.netlist).toContain(
-      "I1 A ICMPRB001 DC 1m\nVICMPRB001 ICMPRB001 OUT DC 0",
+      "I1 ICMPRB001 OUT DC 1m\nVICMPRB001 A ICMPRB001 DC 0",
     );
     expect(result.request.testbench).toContain(
       "write out.raw i(v.x1.vicmprb001)\n",
@@ -1118,16 +1214,18 @@ describe("refusing a setup that cannot be simulated", () => {
         probes: [
           {
             id: "probe-i1-x1",
-            kind: "source-current",
+            kind: "terminal-current",
             documentId: "dut",
             instanceId: "inst-i1",
+            pinName: "+",
             occurrence: ["inst-x1"],
           },
           {
             id: "probe-i1-x2",
-            kind: "source-current",
+            kind: "terminal-current",
             documentId: "dut",
             instanceId: "inst-i1",
+            pinName: "+",
             occurrence: ["inst-x2"],
           },
         ],
@@ -1137,7 +1235,7 @@ describe("refusing a setup that cannot be simulated", () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(
-      result.request.netlist.match(/VICMPRB001 ICMPRB001 OUT DC 0/gu),
+      result.request.netlist.match(/VICMPRB001 A ICMPRB001 DC 0/gu),
     ).toHaveLength(1);
     expect(result.vectors).toEqual([
       {
@@ -1193,6 +1291,63 @@ function ngspiceOnPath(): boolean {
 
 /** Skips cleanly where ngspice is absent; the hosted gate never skips. */
 describe.skipIf(!ngspiceOnPath())("running a compiled deck", () => {
+  it("reports opposite entering currents at a two-terminal device", async () => {
+    const compiled = await compile(
+      dividerProject(),
+      setupWith({
+        analyses: [{ kind: "op" }],
+        probes: [
+          {
+            id: "probe-r1-1",
+            kind: "terminal-current",
+            documentId: "tb",
+            instanceId: "inst-r1",
+            pinName: "1",
+            occurrence: [],
+          },
+          {
+            id: "probe-r1-2",
+            kind: "terminal-current",
+            documentId: "tb",
+            instanceId: "inst-r1",
+            pinName: "2",
+            occurrence: [],
+          },
+        ],
+      }),
+    );
+    expect(compiled.ok).toBe(true);
+    if (!compiled.ok) return;
+
+    const directory = mkdtempSync(join(tmpdir(), "icm-terminal-current-"));
+    try {
+      writeFileSync(
+        join(directory, "deck.cir"),
+        buildSimulationDeck(compiled.request as SimulationRequest, null),
+        "utf8",
+      );
+      execFileSync("ngspice", ["-b", "deck.cir"], {
+        cwd: directory,
+        encoding: "utf8",
+      });
+      const reading = readSimulationData(
+        readFileSync(join(directory, "out.raw"), "utf8"),
+      );
+      expect(reading.status).toBe("read");
+      if (reading.status !== "read") return;
+      const operatingPoint = reading.data.analyses[0]!;
+      expect(operatingPoint.analysis).toBe("op");
+      if (operatingPoint.analysis !== "op") return;
+      const probes = operatingPoint.probes;
+      const value = (name: string) =>
+        probes.find((probe) => probe.name === name)!.value;
+      expect(value("i(vicmprb003)")).toBeCloseTo(0.0005, 12);
+      expect(value("i(vicmprb004)")).toBeCloseTo(-0.0005, 12);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
   it("returns the divider's operating point under every emitted vector", async () => {
     const compiled = await compile(dividerProject(), DIVIDER_SETUP);
     expect(compiled.ok).toBe(true);
@@ -1235,7 +1390,7 @@ describe.skipIf(!ngspiceOnPath())("running a compiled deck", () => {
       // 1 V across two equal resistors, and 1 V / 2 kOhm out of the source.
       expect(value("v(in)")).toBeCloseTo(1, 12);
       expect(value("v(mid)")).toBeCloseTo(0.5, 12);
-      expect(value("i(v1)")).toBeCloseTo(-0.0005, 12);
+      expect(value("i(vicmprb005)")).toBeCloseTo(-0.0005, 12);
     } finally {
       rmSync(directory, { recursive: true, force: true });
     }
@@ -1251,9 +1406,10 @@ describe.skipIf(!ngspiceOnPath())("running a compiled deck", () => {
         probes: [
           {
             id: "probe-i1",
-            kind: "source-current",
+            kind: "terminal-current",
             documentId: "dut",
             instanceId: "inst-i1",
+            pinName: "+",
             occurrence: ["inst-x1"],
           },
         ],

--- a/packages/netlist/src/simulation-compile.ts
+++ b/packages/netlist/src/simulation-compile.ts
@@ -49,20 +49,13 @@
  *   the way into the rawfile, so `V(MidNode)` comes back as `v(midnode)`;
  * - a Net inside a hierarchy occurrence prints `v(<x1>.<x2>.<net>)`, one
  *   lowercased Instance reference per occurrence step;
- * - a voltage source in the root prints `i(<ref>)`, e.g. `i(v1)`;
- * - a voltage source inside an occurrence prints `i(v.<x1>.<x2>.<ref>)`: the
- *   expansion prefixes the device's own type letter before the path, so
- *   `Vsi` under `X1`/`XI1` is `i(v.x1.xi1.vsi)`.
+ * - current entering any selected Instance terminal is measured through a
+ *   compiler-owned zero-volt source inserted in series with that terminal;
+ * - a root sense source prints `i(vicmprb###)`, while one inside an occurrence
+ *   prints `i(v.<x1>.<x2>.vicmprb###)`.
  *
- * A top-level independent current source is instrumented with ngspice's
- * `.probe I(<ref>)`. ngspice inserts a zero-volt sense source and writes its
- * result as `<ref>#branch`; the rawfile records that as `i(<ref>)`.
- *
- * `.probe` only scans top-level devices. For a selected current source inside
- * a subcircuit, this compiler therefore inserts its own zero-volt sense source
- * into the extracted (ephemeral) Cell definition and reads that voltage
- * source's occurrence-qualified branch current. The authored Project and the
- * ordinary structural export are never changed.
+ * Instrumentation is applied only to the extracted, ephemeral simulation IR.
+ * The authored Project and ordinary structural export are never changed.
  */
 
 import type {
@@ -102,15 +95,14 @@ interface ResolvedSimulationProbe {
   readonly binding: CompiledSimulationVector;
   /** Expression passed to ngspice's `write`; it may differ from raw output. */
   readonly writeVector: string;
-  /** Deck cards required to make the vector exist. */
-  readonly instrumentationCards: readonly string[];
   /** Ephemeral Cell instrumentation required before printing the netlist. */
-  readonly netlistInstrumentation?: HierarchicalCurrentInstrumentation;
+  readonly netlistInstrumentation?: TerminalCurrentInstrumentation;
 }
 
-interface HierarchicalCurrentInstrumentation {
+interface TerminalCurrentInstrumentation {
   readonly cellId: StableId;
-  readonly sourceInstanceId: StableId;
+  readonly instanceId: StableId;
+  readonly pinName: string;
   readonly senseReference: string;
   readonly senseNode: string;
 }
@@ -415,11 +407,11 @@ function resolveOccurrence(
 
 function instrumentationKey(
   instrumentation: Pick<
-    HierarchicalCurrentInstrumentation,
-    "cellId" | "sourceInstanceId"
+    TerminalCurrentInstrumentation,
+    "cellId" | "instanceId" | "pinName"
   >,
 ): string {
-  return `${instrumentation.cellId}\u0000${instrumentation.sourceInstanceId}`;
+  return `${instrumentation.cellId}\u0000${instrumentation.instanceId}\u0000${instrumentation.pinName}`;
 }
 
 /**
@@ -427,14 +419,16 @@ function instrumentationKey(
  * the generated deck deterministic when an author reorders outputs and keeps
  * compiler-owned names away from authored References and node names.
  */
-function ensureHierarchicalCurrentInstrumentation(
+function ensureTerminalCurrentInstrumentation(
   cell: DesignNetlistCell,
-  source: DesignNetlistInstance,
-  instrumentations: Map<string, HierarchicalCurrentInstrumentation>,
-): HierarchicalCurrentInstrumentation {
+  instance: DesignNetlistInstance,
+  pinName: string,
+  instrumentations: Map<string, TerminalCurrentInstrumentation>,
+): TerminalCurrentInstrumentation {
   const key = instrumentationKey({
     cellId: cell.id,
-    sourceInstanceId: source.id,
+    instanceId: instance.id,
+    pinName,
   });
   const existing = instrumentations.get(key);
   if (existing) return existing;
@@ -455,8 +449,16 @@ function ensureHierarchicalCurrentInstrumentation(
     nodes.add(item.senseNode.toLowerCase());
   }
 
+  const instanceIndex = cell.instances.findIndex(
+    (candidate) => candidate.id === instance.id,
+  );
+  const pinIndex = instance.nodes.findIndex((node) => node.pinName === pinName);
   let serial =
-    cell.instances.findIndex((instance) => instance.id === source.id) + 1;
+    cell.instances
+      .slice(0, Math.max(0, instanceIndex))
+      .reduce((total, candidate) => total + candidate.nodes.length, 0) +
+    Math.max(0, pinIndex) +
+    1;
   while (true) {
     const suffix = String(serial).padStart(3, "0");
     const senseReference = `VICMPRB${suffix}`;
@@ -467,10 +469,11 @@ function ensureHierarchicalCurrentInstrumentation(
     ) {
       const instrumentation = {
         cellId: cell.id,
-        sourceInstanceId: source.id,
+        instanceId: instance.id,
+        pinName,
         senseReference,
         senseNode,
-      } satisfies HierarchicalCurrentInstrumentation;
+      } satisfies TerminalCurrentInstrumentation;
       instrumentations.set(key, instrumentation);
       return instrumentation;
     }
@@ -479,14 +482,13 @@ function ensureHierarchicalCurrentInstrumentation(
 }
 
 /**
- * Put a zero-volt source in series with each selected hierarchical current
- * source. Its positive branch direction matches SPICE's current-source
- * direction (first node to second node), so no result-side sign correction is
- * needed.
+ * Put a zero-volt source in series with each selected terminal. The source's
+ * positive node is the external Net and its negative node is the private sense
+ * node, so ngspice's positive branch current is current entering the terminal.
  */
-function instrumentHierarchicalCurrentSources(
+function instrumentTerminalCurrents(
   ir: DesignNetlistIR,
-  instrumentations: ReadonlyMap<string, HierarchicalCurrentInstrumentation>,
+  instrumentations: ReadonlyMap<string, TerminalCurrentInstrumentation>,
 ): DesignNetlistIR {
   if (instrumentations.size === 0) return ir;
   return {
@@ -494,35 +496,41 @@ function instrumentHierarchicalCurrentSources(
     cells: ir.cells.map((cell) => ({
       ...cell,
       instances: cell.instances.flatMap((instance) => {
-        const instrumentation = instrumentations.get(
-          instrumentationKey({
-            cellId: cell.id,
-            sourceInstanceId: instance.id,
-          }),
-        );
-        if (!instrumentation) return [instance];
-        const positive = instance.nodes[0]!;
-        const negative = instance.nodes[1]!;
+        const selected = instance.nodes.flatMap((node) => {
+          const instrumentation = instrumentations.get(
+            instrumentationKey({
+              cellId: cell.id,
+              instanceId: instance.id,
+              pinName: node.pinName,
+            }),
+          );
+          return instrumentation ? [{ node, instrumentation }] : [];
+        });
+        if (selected.length === 0) return [instance];
         return [
           {
             ...instance,
-            nodes: [
-              positive,
-              { ...negative, netName: instrumentation.senseNode },
-            ],
+            nodes: instance.nodes.map((node) => {
+              const selectedNode = selected.find(
+                (item) => item.node.pinName === node.pinName,
+              );
+              return selectedNode
+                ? { ...node, netName: selectedNode.instrumentation.senseNode }
+                : node;
+            }),
           },
-          {
-            id: `${instance.id}:simulation-current-sense`,
+          ...selected.map(({ node, instrumentation }) => ({
+            id: `${instance.id}:simulation-current-sense:${instrumentation.senseReference}`,
             reference: instrumentation.senseReference,
-            invocationKind: "primitive",
-            deviceClass: "voltage-source",
+            invocationKind: "primitive" as const,
+            deviceClass: "voltage-source" as const,
             target: null,
             nodes: [
-              { pinName: "+", netName: instrumentation.senseNode },
-              { pinName: "-", netName: negative.netName },
+              { pinName: "+", netName: node.netName },
+              { pinName: "-", netName: instrumentation.senseNode },
             ],
             parameters: [{ name: "dc", rawValue: "0" }],
-          },
+          })),
         ];
       }),
     })),
@@ -607,16 +615,13 @@ function netVoltageVector(
   };
 }
 
-function sourceCurrentVector(
+function terminalCurrentVector(
   measurement: Extract<SimulationExpression, { kind: "current" }>,
   acquisitionId: string,
   outputId: string,
   occurrence: ResolvedOccurrence,
   diagnostics: NetlistDiagnostic[],
-  hierarchicalCurrentInstrumentations: Map<
-    string,
-    HierarchicalCurrentInstrumentation
-  >,
+  terminalCurrentInstrumentations: Map<string, TerminalCurrentInstrumentation>,
 ): ResolvedSimulationProbe | null {
   const { document, cell, path, hierarchyPath } = occurrence;
   const instance = cell.instances.find(
@@ -634,83 +639,52 @@ function sourceCurrentVector(
     );
     return null;
   }
-  if (instance.deviceClass === "current-source") {
-    if (path.length > 0) {
-      if (instance.nodes.length !== 2) {
-        diagnostics.push(
-          diagnostic(
-            "SIMULATION_PROBE_CURRENT_SOURCE_TERMINALS_UNAVAILABLE",
-            document.id,
-            `Output ${outputId} cannot instrument current source ${instance.reference}; its extracted card does not have two terminals`,
-            locator(
-              document.id,
-              hierarchyPath,
-              "instance",
-              measurement.instanceId,
-            ),
-            [measurement.instanceId],
-          ),
-        );
-        return null;
-      }
-      const instrumentation = ensureHierarchicalCurrentInstrumentation(
-        cell,
-        instance,
-        hierarchicalCurrentInstrumentations,
-      );
-      const senseName = [
-        "v",
-        ...path,
-        instrumentation.senseReference.toLowerCase(),
-      ].join(".");
-      const binding: CompiledSimulationVector = {
-        probeId: acquisitionId,
-        vector: `i(${senseName})`,
-        quantity: "current",
-      };
-      return {
-        binding,
-        writeVector: binding.vector,
-        instrumentationCards: [],
-        netlistInstrumentation: instrumentation,
-      };
-    }
-    const reference = instance.reference.toLowerCase();
-    return {
-      binding: {
-        probeId: acquisitionId,
-        vector: `i(${reference})`,
-        quantity: "current",
-      },
-      writeVector: `${reference}#branch`,
-      instrumentationCards: [`.probe I(${instance.reference})`],
-    };
-  }
-  if (instance.deviceClass !== "voltage-source") {
+  const terminal = instance.nodes.find(
+    (node) => node.pinName === measurement.pinName,
+  );
+  if (!terminal) {
     diagnostics.push(
       diagnostic(
-        "SIMULATION_PROBE_NOT_A_SOURCE",
+        "SIMULATION_PROBE_UNKNOWN_TERMINAL",
         document.id,
-        `Output ${outputId} measures source current on Instance ${instance.reference}, which is a ${instance.deviceClass}`,
-        locator(document.id, hierarchyPath, "instance", measurement.instanceId),
+        `Output ${outputId} references unknown terminal ${instance.reference}.${measurement.pinName}`,
+        {
+          ...locator(
+            document.id,
+            hierarchyPath,
+            "instance",
+            measurement.instanceId,
+          ),
+          endpoint: {
+            kind: "terminal",
+            instanceId: measurement.instanceId,
+            pinName: measurement.pinName,
+          },
+        },
         [measurement.instanceId],
       ),
     );
     return null;
   }
-  const reference = instance.reference.toLowerCase();
-  // Inside a subcircuit the expanded device carries its own type letter before
-  // the occurrence path: `Vsi` under `X1`/`XI1` is `v.x1.xi1.vsi`. At the top
-  // level the reference stands alone.
+  const instrumentation = ensureTerminalCurrentInstrumentation(
+    cell,
+    instance,
+    terminal.pinName,
+    terminalCurrentInstrumentations,
+  );
   const name = path.length
-    ? [reference.slice(0, 1), ...path, reference].join(".")
-    : reference;
+    ? ["v", ...path, instrumentation.senseReference.toLowerCase()].join(".")
+    : instrumentation.senseReference.toLowerCase();
   const binding: CompiledSimulationVector = {
     probeId: acquisitionId,
     vector: `i(${name})`,
     quantity: "current",
   };
-  return { binding, writeVector: binding.vector, instrumentationCards: [] };
+  return {
+    binding,
+    writeVector: binding.vector,
+    netlistInstrumentation: instrumentation,
+  };
 }
 
 /**
@@ -849,10 +823,9 @@ export async function compileStructuredSimulation(
   >();
   const outputs: CompiledSimulationOutput[] = [];
   const writeVectors: string[] = [];
-  const instrumentationCards: string[] = [];
-  const hierarchicalCurrentInstrumentations = new Map<
+  const terminalCurrentInstrumentations = new Map<
     string,
-    HierarchicalCurrentInstrumentation
+    TerminalCurrentInstrumentation
   >();
   for (const output of input.outputs) {
     let leafIndex = 0;
@@ -888,17 +861,16 @@ export async function compileStructuredSimulation(
                   ? {
                       binding: vector,
                       writeVector: vector.vector,
-                      instrumentationCards: [] as readonly string[],
                     }
                   : null;
               })()
-            : sourceCurrentVector(
+            : terminalCurrentVector(
                 expression,
                 candidateId,
                 output.id,
                 occurrence,
                 diagnostics,
-                hierarchicalCurrentInstrumentations,
+                terminalCurrentInstrumentations,
               );
         if (!resolved) return null;
         const identity = `${resolved.binding.quantity}\u0000${resolved.binding.vector}`;
@@ -911,10 +883,9 @@ export async function compileStructuredSimulation(
           });
           vectors.push(acquisition);
           writeVectors.push(resolved.writeVector);
-          instrumentationCards.push(...resolved.instrumentationCards);
           if (resolved.netlistInstrumentation) {
             const instrumentation = resolved.netlistInstrumentation;
-            hierarchicalCurrentInstrumentations.set(
+            terminalCurrentInstrumentations.set(
               instrumentationKey(instrumentation),
               instrumentation,
             );
@@ -951,10 +922,13 @@ export async function compileStructuredSimulation(
 
   // Every reached Cell but the root: the root is instantiated below, not
   // defined. `.global` declarations stay with the definitions.
-  const instrumentedIr = instrumentHierarchicalCurrentSources(
+  const instrumentedIr = instrumentTerminalCurrents(
     ir,
-    hierarchicalCurrentInstrumentations,
+    terminalCurrentInstrumentations,
   );
+  const instrumentedRoot = instrumentedIr.cells.find(
+    (cell) => cell.id === instrumentedIr.topCellId,
+  )!;
   const netlist = printSpiceNetlist({
     ...instrumentedIr,
     cells: instrumentedIr.cells.filter(
@@ -968,8 +942,7 @@ export async function compileStructuredSimulation(
   const writeCard = [`write ${SIMULATION_RAWFILE_NAME}`, ...written].join(" ");
   const testbench = [
     `* Analog Canvas testbench for ${rootCell.name}`,
-    ...rootCards,
-    ...new Set(instrumentationCards),
+    ...printSpiceCellInstances(instrumentedRoot),
     ...(input.environment.temperatureC === undefined
       ? []
       : [`.temp ${spiceNumber(input.environment.temperatureC)}`]),

--- a/packages/project-protocol/src/dc-sweep-migration.test.ts
+++ b/packages/project-protocol/src/dc-sweep-migration.test.ts
@@ -22,7 +22,7 @@ describe("schema 40 to 41", () => {
     const result = parseProjectWithMetadata(
       JSON.stringify({ ...current, schemaVersion: 40 }),
     );
-    expect(result.project.schemaVersion).toBe(43);
+    expect(result.project.schemaVersion).toBe(44);
     expect(result.sourceSchemaVersion).toBe(40);
     expect(result.migrated).toBe(true);
   });

--- a/packages/project-protocol/src/instance-style-migration.test.ts
+++ b/packages/project-protocol/src/instance-style-migration.test.ts
@@ -37,6 +37,7 @@ import { upgradeSchema39To40 } from "./transforms/simulation-probe-anchor.js";
 import { upgradeSchema40To41 } from "./transforms/dc-sweep.js";
 import { upgradeSchema41To42 } from "./transforms/simulation-setup-collection.js";
 import { upgradeSchema42To43 } from "./transforms/simulation-outputs.js";
+import { upgradeSchema43To44 } from "./transforms/terminal-current.js";
 
 describe("schema migrations through hidden Net-name retirement", () => {
   it("keeps each retained historical transform independently usable", () => {
@@ -58,6 +59,7 @@ describe("schema migrations through hidden Net-name retirement", () => {
     const v41 = upgradeSchema40To41(v40);
     const v42 = upgradeSchema41To42(v41);
     const v43 = upgradeSchema42To43(v42);
+    const v44 = upgradeSchema43To44(v43);
 
     expect(v29.schemaVersion).toBe(29);
     expect(v30.schemaVersion).toBe(30);
@@ -73,7 +75,8 @@ describe("schema migrations through hidden Net-name retirement", () => {
     expect(v40.schemaVersion).toBe(40);
     expect(v41.schemaVersion).toBe(41);
     expect(v42.schemaVersion).toBe(42);
-    expect(v43.schemaVersion).toBe(CURRENT_PROJECT_SCHEMA_VERSION);
+    expect(v43.schemaVersion).toBe(43);
+    expect(v44.schemaVersion).toBe(CURRENT_PROJECT_SCHEMA_VERSION);
   });
 
   it("reports non-rewriting 28→29 through 32→33 upgrades as unchanged", () => {

--- a/packages/project-protocol/src/load.ts
+++ b/packages/project-protocol/src/load.ts
@@ -31,6 +31,7 @@ import {
   upgradeSchema40To41,
   upgradeSchema41To42,
   upgradeSchema42To43,
+  upgradeSchema43To44,
 } from "./previous-to-current.js";
 import { repairBoundFormatOverrides } from "./transforms/bound-format-override.js";
 import { repairLegacyReviewedExternalReferences } from "./transforms/reviewed-external-reference.js";
@@ -64,6 +65,7 @@ const UPGRADE_CHAIN: ReadonlyArray<
   upgradeSchema40To41,
   upgradeSchema41To42,
   upgradeSchema42To43,
+  upgradeSchema43To44,
 ];
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/project-protocol/src/persistence.test.ts
+++ b/packages/project-protocol/src/persistence.test.ts
@@ -400,7 +400,7 @@ describe("Project persistence", () => {
 
   it("rejects schemas outside the supported chain window", () => {
     const project = createEmptyProject("project-test", "Test Project");
-    for (const schemaVersion of [1, 22, 23, 44, 99]) {
+    for (const schemaVersion of [1, 22, 23, 45, 99]) {
       expect(() =>
         parseProject(JSON.stringify({ ...project, schemaVersion })),
       ).toThrow(

--- a/packages/project-protocol/src/previous-to-current.ts
+++ b/packages/project-protocol/src/previous-to-current.ts
@@ -155,3 +155,11 @@ export type {
   Schema42To43MigrationReport,
   Schema42To43MigrationResult,
 } from "./transforms/simulation-outputs.js";
+export {
+  upgradeSchema43To44,
+  upgradeSchema43To44WithReport,
+} from "./transforms/terminal-current.js";
+export type {
+  Schema43To44MigrationReport,
+  Schema43To44MigrationResult,
+} from "./transforms/terminal-current.js";

--- a/packages/project-protocol/src/simulation-outputs-migration.test.ts
+++ b/packages/project-protocol/src/simulation-outputs-migration.test.ts
@@ -191,13 +191,19 @@ describe("schema 42 to 43 simulation outputs", () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.sourceSchemaVersion).toBe(42);
-    expect(result.project.schemaVersion).toBe(43);
+    expect(result.project.schemaVersion).toBe(44);
     expect(result.project.simulationSetups).toHaveLength(2);
     expect(result.project.simulationSetups[0]).toMatchObject({
       version: 2,
       input: {
         kind: "structured",
-        outputs: [{ label: "VOUT_P" }, { label: "VOUT_current" }],
+        outputs: [
+          { label: "VOUT_P" },
+          {
+            label: "VOUT_current",
+            expression: { kind: "current", pinName: "+" },
+          },
+        ],
       },
     });
   });

--- a/packages/project-protocol/src/simulation-probe-anchor-migration.test.ts
+++ b/packages/project-protocol/src/simulation-probe-anchor-migration.test.ts
@@ -89,7 +89,7 @@ describe("schema 39 to 40 simulation probe anchors", () => {
       sourceSchemaVersion: 39,
       migrated: true,
       project: {
-        schemaVersion: 43,
+        schemaVersion: 44,
         simulationSetups: [
           {
             input: {

--- a/packages/project-protocol/src/simulation-setup-collection-migration.test.ts
+++ b/packages/project-protocol/src/simulation-setup-collection-migration.test.ts
@@ -51,7 +51,7 @@ describe("schema 41 to 42 named simulation setup migration", () => {
       ok: true,
       sourceSchemaVersion: 41,
       migrated: true,
-      project: { schemaVersion: 43, simulationSetups: [] },
+      project: { schemaVersion: 44, simulationSetups: [] },
     });
   });
 });

--- a/packages/project-protocol/src/terminal-current-migration.test.ts
+++ b/packages/project-protocol/src/terminal-current-migration.test.ts
@@ -1,0 +1,88 @@
+import { createEmptyProject } from "@icm/model";
+import { describe, expect, it } from "vitest";
+
+import { parseProjectWithMetadata } from "./load.js";
+import { upgradeSchema43To44WithReport } from "./previous-to-current.js";
+
+describe("schema 43 to 44 terminal-current migration", () => {
+  it("adds the source-positive terminal to every current expression", () => {
+    const project = createEmptyProject("project", "Project");
+    const raw = {
+      ...project,
+      schemaVersion: 43,
+      simulationSetups: [
+        {
+          id: "setup",
+          name: "Setup",
+          version: 2,
+          input: {
+            kind: "structured",
+            rootDocumentId: project.topDocumentId,
+            analyses: [{ kind: "op" }],
+            outputs: [
+              {
+                id: "direct",
+                label: "Direct",
+                expression: {
+                  kind: "current",
+                  documentId: project.topDocumentId,
+                  instanceId: "V1",
+                  occurrence: [],
+                },
+              },
+              {
+                id: "derived",
+                label: "Derived",
+                expression: {
+                  kind: "negate",
+                  operand: {
+                    kind: "current",
+                    documentId: project.topDocumentId,
+                    instanceId: "I1",
+                    occurrence: [],
+                  },
+                },
+              },
+            ],
+            environment: { profileId: "profile" },
+          },
+        },
+      ],
+    };
+
+    const migrated = upgradeSchema43To44WithReport(raw);
+
+    expect(migrated.project.schemaVersion).toBe(44);
+    expect(migrated.report).toEqual({
+      changed: true,
+      migratedOutputIds: ["direct", "derived"],
+    });
+    const outputs = (
+      migrated.project.simulationSetups as Array<{
+        input: { outputs: Array<{ expression: unknown }> };
+      }>
+    )[0]!.input.outputs;
+    expect(outputs).toMatchObject([
+      { expression: { kind: "current", pinName: "+" } },
+      {
+        expression: {
+          kind: "negate",
+          operand: { kind: "current", pinName: "+" },
+        },
+      },
+    ]);
+  });
+
+  it("loads a schema-43 setup through the public compatibility boundary", () => {
+    const project = createEmptyProject("project", "Project");
+    const raw = structuredClone(project) as unknown as Record<string, unknown>;
+    raw.schemaVersion = 43;
+    raw.simulationSetups = [];
+
+    const result = parseProjectWithMetadata(JSON.stringify(raw));
+
+    expect(result.sourceSchemaVersion).toBe(43);
+    expect(result.migrated).toBe(true);
+    expect(result.project.schemaVersion).toBe(44);
+  });
+});

--- a/packages/project-protocol/src/transforms/terminal-current.ts
+++ b/packages/project-protocol/src/transforms/terminal-current.ts
@@ -1,0 +1,67 @@
+function record(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+export interface Schema43To44MigrationReport {
+  readonly changed: boolean;
+  readonly migratedOutputIds: readonly string[];
+}
+
+export interface Schema43To44MigrationResult {
+  readonly project: Record<string, unknown>;
+  readonly report: Schema43To44MigrationReport;
+}
+
+function migrateExpression(value: unknown, changed: { value: boolean }): void {
+  const expression = record(value);
+  if (!expression) return;
+  if (expression.kind === "current" && typeof expression.pinName !== "string") {
+    // Schema 43 could author current outputs only for independent sources.
+    // Both built-in source descriptors use `+` as their first terminal, and
+    // ngspice's source-current sign is current entering that terminal.
+    expression.pinName = "+";
+    changed.value = true;
+    return;
+  }
+  if ("operand" in expression) migrateExpression(expression.operand, changed);
+  if ("left" in expression) migrateExpression(expression.left, changed);
+  if ("right" in expression) migrateExpression(expression.right, changed);
+}
+
+/** Add the terminal identity omitted by schema-43 source-current outputs. */
+export function upgradeSchema43To44WithReport(
+  raw: Record<string, unknown>,
+): Schema43To44MigrationResult {
+  const project = structuredClone(raw);
+  const changed = { value: false };
+  const migratedOutputIds: string[] = [];
+  const setups = Array.isArray(project.simulationSetups)
+    ? project.simulationSetups
+    : [];
+  for (const setupValue of setups) {
+    const input = record(record(setupValue)?.input);
+    if (input?.kind !== "structured" || !Array.isArray(input.outputs)) continue;
+    for (const outputValue of input.outputs) {
+      const output = record(outputValue);
+      if (!output) continue;
+      const outputChanged = { value: false };
+      migrateExpression(output.expression, outputChanged);
+      if (outputChanged.value && typeof output.id === "string")
+        migratedOutputIds.push(output.id);
+      changed.value ||= outputChanged.value;
+    }
+  }
+  project.schemaVersion = 44;
+  return {
+    project,
+    report: { changed: changed.value, migratedOutputIds },
+  };
+}
+
+export function upgradeSchema43To44(
+  raw: Record<string, unknown>,
+): Record<string, unknown> {
+  return upgradeSchema43To44WithReport(raw).project;
+}

--- a/worker/gallery-do.ts
+++ b/worker/gallery-do.ts
@@ -38,6 +38,7 @@ import {
   upgradeSchema40To41WithReport,
   upgradeSchema41To42WithReport,
   upgradeSchema42To43WithReport,
+  upgradeSchema43To44WithReport,
 } from "@icm/project-protocol";
 import {
   CURRENT_PROJECT_SCHEMA_VERSION,
@@ -1559,7 +1560,8 @@ export class GalleryDO {
         | ReturnType<typeof upgradeSchema39To40WithReport>["report"]
         | ReturnType<typeof upgradeSchema40To41WithReport>["report"]
         | ReturnType<typeof upgradeSchema41To42WithReport>["report"]
-        | ReturnType<typeof upgradeSchema42To43WithReport>["report"];
+        | ReturnType<typeof upgradeSchema42To43WithReport>["report"]
+        | ReturnType<typeof upgradeSchema43To44WithReport>["report"];
     }> = [];
     for (const source of sources) {
       const versions: Record<string, number> = {};
@@ -1713,6 +1715,15 @@ export class GalleryDO {
           }
           if (lifted.schemaVersion === 42) {
             const migration = upgradeSchema42To43WithReport(lifted);
+            lifted = migration.project;
+            migrationReports.push({
+              table: source.table,
+              id: row.id,
+              report: migration.report,
+            });
+          }
+          if (lifted.schemaVersion === 43) {
+            const migration = upgradeSchema43To44WithReport(lifted);
             lifted = migration.project;
             migrationReports.push({
               table: source.table,


### PR DESCRIPTION
## Summary
- replace source-only current probes with terminal-specific current expressions and migrate schema 43 projects to schema 44
- enumerate connected primitive, model, source, MOS/BJT, and hierarchical Cell terminals in the Simulation UI
- compile terminal current measurements through ephemeral 0 V sense sources without mutating the Project or exported DUT
- define current polarity as positive into the selected terminal and preserve occurrence-aware hierarchical vectors
- update Gallery maintenance reserialization for schema 44

## Validation
- `pnpm ci:check` (2748 unit tests passed, 28 skipped; 357 browser tests passed; builds, goldens, release and performance checks passed)
- focused terminal-current/model/protocol/editor tests after rebase (14 passed)
- focused qualified OTA browser flow after rebase (1 passed)
- `pnpm gate:preflight -- --base origin/main`
- `git diff --check`

## Notes
The ngspice numeric terminal-polarity regression runs when ngspice is available and remains skipped in the local environment otherwise; the deterministic compile assertions and full repository gate passed locally.