### PR TITLE
feat(simulation): pick terminal currents on canvas

### DIFF
--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -114,9 +114,12 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
   await panel
     .getByLabel("Add voltage probe")
     .selectOption({ label: "XDUT · ota_5t · vinp" });
-  await panel
-    .getByLabel("Add current output")
-    .selectOption({ label: "Testbench · VINP.+ current" });
+  await panel.getByRole("button", { name: "Pick terminal" }).click();
+  await expect(page.locator(".schematic-canvas")).toHaveClass(
+    /simulation-terminal-pick-active/u,
+  );
+  await page.getByTestId("terminal-VINP-+").click({ force: true });
+  await panel.getByRole("button", { name: "Picking Terminals…" }).click();
   await panel
     .getByLabel("Add current output")
     .selectOption({ label: "XDUT · ota_5t · I1.+ current" });

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -764,7 +764,7 @@ export function App({
     setAnalogSimulationState("open");
   };
   const minimizeAnalogSimulation = (): void => {
-    setSimulationPickNetsActive(false);
+    setSimulationPickModeState(null);
     setAnalogSimulationState("minimized");
     setSelectionOpen(simulationPropertiesOpenBeforeRef.current);
   };
@@ -774,7 +774,7 @@ export function App({
     );
   };
   const exitAnalogSimulation = (): void => {
-    setSimulationPickNetsActive(false);
+    setSimulationPickModeState(null);
     void humanSimulationSession.clear();
     setAnalogSimulationState("closed");
     setSimulationDraftContext(null);
@@ -1049,8 +1049,12 @@ export function App({
   const [highlightedNetOrigin, setHighlightedNetOrigin] =
     useState<HighlightedNetOrigin | null>(null);
   const [simulationWindowOpen, setSimulationWindowOpen] = useState(false);
-  const [simulationPickNetsActive, setSimulationPickNetsActive] =
-    useState(false);
+  const [simulationPickMode, setSimulationPickModeState] = useState<
+    "net" | "terminal" | null
+  >(null);
+  const simulationPickNetsActive = simulationPickMode === "net";
+  const simulationPickTerminalsActive = simulationPickMode === "terminal";
+  const simulationPickActive = simulationPickMode !== null;
   const [simulationHoverNetId, setSimulationHoverNetId] = useState<
     string | null
   >(null);
@@ -1063,6 +1067,13 @@ export function App({
     netId: string;
     occurrence?: readonly string[];
   } | null>(null);
+  const [analogPickedTerminal, setAnalogPickedTerminal] = useState<{
+    sequence: number;
+    documentId: string;
+    instanceId: string;
+    pinName: string;
+    occurrence?: readonly string[];
+  } | null>(null);
   const [pendingWaveformPlacement, setPendingWaveformPlacement] =
     useState<PendingWaveformPlacement | null>(null);
   const [waveformPlacementPoint, setWaveformPlacementPoint] =
@@ -1071,7 +1082,7 @@ export function App({
     // Net-pick is a hierarchy traversal mode: keep it armed while the author
     // enters a DUT Cell, so an internal Net can be picked with its occurrence
     // path intact. Closing/minimising Simulation still cancels it explicitly.
-    if (!analogSimulationOpen) setSimulationPickNetsActive(false);
+    if (!analogSimulationOpen) setSimulationPickModeState(null);
     setSimulationHoverNetId(null);
     setSimulationSavedNetIds(new Set());
     setPendingWaveformPlacement(null);
@@ -1565,7 +1576,7 @@ export function App({
       documentStack,
       projectConnectivityIndex,
       simulationHoverNetId,
-      simulationPickNetsActive,
+      simulationPickMode,
     ],
   );
   const canonicalSimulationNetId = (netId: string): string | null => {
@@ -1573,6 +1584,17 @@ export function App({
       logicalNets.byBaseNetId.get(netId) ??
       logicalNets.groups.find((candidate) => candidate.id === netId);
     return group?.baseNetIds[0] ?? null;
+  };
+  const activeSimulationPickOccurrence = (): readonly string[] | undefined => {
+    const setupRootId =
+      activeSimulationSetup?.input.kind === "structured"
+        ? activeSimulationSetup.input.rootDocumentId
+        : undefined;
+    return documentStack.length > 0
+      ? documentStack.map((frame) => frame.instanceId)
+      : setupRootId === document.id
+        ? []
+        : undefined;
   };
   const toggleSimulationSavedNet = (netId: string): void => {
     const baseNetId = canonicalSimulationNetId(netId);
@@ -1582,16 +1604,7 @@ export function App({
     }
     const group = logicalNets.byBaseNetId.get(baseNetId);
     if (analogSimulationOpen) {
-      const setupRootId =
-        activeSimulationSetup?.input.kind === "structured"
-          ? activeSimulationSetup.input.rootDocumentId
-          : undefined;
-      const occurrence =
-        documentStack.length > 0
-          ? documentStack.map((frame) => frame.instanceId)
-          : setupRootId === document.id
-            ? []
-            : undefined;
+      const occurrence = activeSimulationPickOccurrence();
       setAnalogPickedNet((current) => ({
         sequence: (current?.sequence ?? 0) + 1,
         documentId: document.id,
@@ -1609,16 +1622,38 @@ export function App({
     });
     setStatus(`Toggled saved Net ${group?.name ?? baseNetId}`);
   };
-  const setSimulationPickMode = (active: boolean): void => {
-    if (active) activateTool("pointer");
-    setSimulationPickNetsActive(active);
-    if (!active) setSimulationHoverNetId(null);
+  const pickSimulationTerminal = (endpoint: WireSource): void => {
+    if (endpoint.endpoint.kind !== "terminal" || !analogSimulationOpen) return;
+    const terminal = endpoint.endpoint;
+    const occurrence = activeSimulationPickOccurrence();
+    setAnalogPickedTerminal((current) => ({
+      sequence: (current?.sequence ?? 0) + 1,
+      documentId: document.id,
+      instanceId: terminal.instanceId,
+      pinName: terminal.pinName,
+      ...(occurrence === undefined ? {} : { occurrence }),
+    }));
+    const reference =
+      document.instances.find((instance) => instance.id === terminal.instanceId)
+        ?.reference ?? terminal.instanceId;
+    setStatus(`Added terminal-current Output ${reference}.${terminal.pinName}`);
+  };
+  const setSimulationPickMode = (mode: "net" | "terminal" | null): void => {
+    if (mode) activateTool("pointer");
+    setSimulationPickModeState(mode);
+    if (mode !== "net") setSimulationHoverNetId(null);
     setStatus(
-      active
+      mode === "net"
         ? "Pick Nets: click a wire, label, junction, or connected pin · Esc exits"
-        : "Finished picking simulation Nets",
+        : mode === "terminal"
+          ? "Pick terminal current: click a connected device terminal · Esc exits"
+          : "Finished picking simulation Outputs",
     );
   };
+  const setSimulationNetPickMode = (active: boolean): void =>
+    setSimulationPickMode(active ? "net" : null);
+  const setSimulationTerminalPickMode = (active: boolean): void =>
+    setSimulationPickMode(active ? "terminal" : null);
   const {
     enabled: cellSymbolLayoutEnabled,
     layout: selectedCellSymbolLayout,
@@ -2658,7 +2693,7 @@ export function App({
       ),
       tool,
       cellSymbolLayoutEnabled,
-      simulationPickNetsActive,
+      simulationPickMode,
     },
     actions: {
       beginInstanceMove: beginMoveFromSelection,
@@ -3670,9 +3705,9 @@ export function App({
         setSearchOpen(true);
         return;
       }
-      if (event.key === "Escape" && simulationPickNetsActive) {
+      if (event.key === "Escape" && simulationPickActive) {
         event.preventDefault();
-        setSimulationPickMode(false);
+        setSimulationPickMode(null);
         return;
       }
       if (event.key === "Escape" && pendingWaveformPlacement) {
@@ -3844,7 +3879,7 @@ export function App({
     );
     uniqueSuffixCounter.current += 1;
     const groupId = `waveform-group-${uniqueSuffixCounter.current}`;
-    setSimulationPickMode(false);
+    setSimulationPickMode(null);
     setPendingWaveformPlacement({
       groupId,
       objects,
@@ -4005,7 +4040,7 @@ export function App({
         if (
           canvasContextMenuSuppressed.current ||
           canvasDragSessionRef.current !== null ||
-          simulationPickNetsActive ||
+          simulationPickActive ||
           target.closest('[data-testid="canvas-text-editor"]')
         )
           return;
@@ -4321,7 +4356,7 @@ export function App({
                   open: simulationWindowOpen,
                   onToggle: () => {
                     setSimulationWindowOpen((open) => {
-                      if (open) setSimulationPickMode(false);
+                      if (open) setSimulationPickMode(null);
                       return !open;
                     });
                   },
@@ -4750,7 +4785,10 @@ export function App({
               onOpenCell={(id) => switchDocument(id)}
               pickNetsActive={simulationPickNetsActive}
               pickedNet={analogPickedNet}
-              onPickNetsChange={setSimulationPickMode}
+              onPickNetsChange={setSimulationNetPickMode}
+              pickTerminalsActive={simulationPickTerminalsActive}
+              pickedTerminal={analogPickedTerminal}
+              onPickTerminalsChange={setSimulationTerminalPickMode}
               onFocusDiagnostic={(locator) =>
                 navigateToLocator(locator, `Located ${locator.kind}`)
               }
@@ -5519,6 +5557,9 @@ export function App({
             projectedMovePreviewDocument ? "semantic-move-preview" : "",
             panPreview ? "pan-mode" : "",
             simulationPickNetsActive ? "simulation-net-pick-active" : "",
+            simulationPickTerminalsActive
+              ? "simulation-terminal-pick-active"
+              : "",
           ]
             .filter(Boolean)
             .join(" ")}
@@ -5648,7 +5689,7 @@ export function App({
                 : null,
               wouldMoveIds,
               onInstanceClick: (instance, additive) => {
-                if (simulationPickNetsActive) return;
+                if (simulationPickActive) return;
                 if (suppressInstanceClick.current) {
                   suppressInstanceClick.current = false;
                   return;
@@ -5681,13 +5722,15 @@ export function App({
               onRoutePointerDown: (event, routeId) => {
                 // Reached only while a drawing tool is up: the pointer tool's
                 // presses are claimed and stopped by the capture-phase router.
-                if (simulationPickNetsActive) {
+                if (simulationPickActive) {
                   event.stopPropagation();
                   event.preventDefault();
-                  const route = document.routes.find(
-                    (candidate) => candidate.id === routeId,
-                  );
-                  if (route) toggleSimulationSavedNet(route.netId);
+                  if (simulationPickNetsActive) {
+                    const route = document.routes.find(
+                      (candidate) => candidate.id === routeId,
+                    );
+                    if (route) toggleSimulationSavedNet(route.netId);
+                  }
                   return;
                 }
                 handleRoutePointerDown(event, routeId);
@@ -5723,9 +5766,7 @@ export function App({
               document,
               endpoints: wiringEndpoints,
               tool,
-              selectedRoute: simulationPickNetsActive
-                ? undefined
-                : selectedRoute,
+              selectedRoute: simulationPickActive ? undefined : selectedRoute,
               selectedRouteSegmentIndex,
               selectedEndpoint,
               supplementalJunctionIds: supplementalSelection.junctionIds,
@@ -5761,8 +5802,8 @@ export function App({
               ),
               onRouteStretch: beginRouteStretch,
               onJunctionSelect: (candidate) => {
-                if (simulationPickNetsActive) {
-                  if (candidate.netId)
+                if (simulationPickActive) {
+                  if (simulationPickNetsActive && candidate.netId)
                     toggleSimulationSavedNet(candidate.netId);
                   return;
                 }
@@ -5779,10 +5820,12 @@ export function App({
                 setStatus(`Selected ${endpointTestId(candidate.endpoint)}`);
               },
               onWireEndpoint: (event, candidate) => {
-                if (simulationPickNetsActive) {
+                if (simulationPickActive) {
                   event.stopPropagation();
                   event.preventDefault();
-                  if (candidate.netId)
+                  if (simulationPickTerminalsActive)
+                    pickSimulationTerminal(candidate);
+                  else if (candidate.netId)
                     toggleSimulationSavedNet(candidate.netId);
                   return;
                 }
@@ -6001,9 +6044,9 @@ export function App({
           pickNetsActive={simulationPickNetsActive}
           onOpenChange={(open) => {
             setSimulationWindowOpen(open);
-            if (!open) setSimulationPickMode(false);
+            if (!open) setSimulationPickMode(null);
           }}
-          onPickNetsChange={setSimulationPickMode}
+          onPickNetsChange={setSimulationNetPickMode}
           onToggleSavedNet={toggleSimulationSavedNet}
           onSetSavedNets={(netIds) => setSimulationSavedNetIds(new Set(netIds))}
           onStatus={setStatus}

--- a/apps/editor/src/canvas/canvas-hit-controller.ts
+++ b/apps/editor/src/canvas/canvas-hit-controller.ts
@@ -26,8 +26,8 @@ export interface CanvasHitControllerDependencies {
     placementOwnsCanvas: boolean;
     tool: EditorTool;
     cellSymbolLayoutEnabled: boolean;
-    /** The Simulation panel is picking Nets; a press names a Net, nothing more. */
-    simulationPickNetsActive: boolean;
+    /** Which Simulation probe domain currently owns canvas presses. */
+    simulationPickMode: "net" | "terminal" | null;
   };
   actions: {
     beginInstanceMove: (
@@ -90,7 +90,7 @@ export function createCanvasHitController({
     placementOwnsCanvas,
     tool,
     cellSymbolLayoutEnabled,
-    simulationPickNetsActive,
+    simulationPickMode,
   },
   actions: {
     beginInstanceMove,
@@ -177,12 +177,12 @@ export function createCanvasHitController({
           event.altKey ? 1 : 0,
         )
       : null;
-    // The offer runs the verb, so it is withheld while Nets are being picked:
-    // a pick names a Net and must not rotate, copy, or delete what it names.
+    // The offer runs the verb, so it is withheld while a simulation probe is
+    // being picked: a pick must not rotate, copy, or delete what it names.
     const armedVerbConsumesHit =
       hit !== null &&
       hit.kind !== "handle" &&
-      !simulationPickNetsActive &&
+      simulationPickMode === null &&
       Boolean(consumeArmedVerb?.(hit.kind, hit.id));
     const compositeOwnsHit = Boolean(
       hit &&
@@ -214,7 +214,7 @@ export function createCanvasHitController({
         planSelectionMove(document, selection).previewObjectIds.length > 0,
       primaryInstanceId,
       armedVerbConsumesHit,
-      simulationPickNetsActive,
+      simulationPickMode,
     });
 
     // Only an action this dispatcher owns claims the press; everything else

--- a/apps/editor/src/canvas/pointer-down-router.test.ts
+++ b/apps/editor/src/canvas/pointer-down-router.test.ts
@@ -30,7 +30,7 @@ const facts = (
   compositeMovePlanHasPreview: false,
   primaryInstanceId: null,
   armedVerbConsumesHit: false,
-  simulationPickNetsActive: false,
+  simulationPickMode: null,
   ...overrides,
 });
 
@@ -59,7 +59,7 @@ describe("who owns one press on the canvas", () => {
     // and nothing is selected, moved, or handed to an armed verb meanwhile.
     // The label case is the one that was lost when its element handler went.
     const picking = {
-      simulationPickNetsActive: true,
+      simulationPickMode: "net" as const,
       armedVerbConsumesHit: true,
     };
     expect(
@@ -85,6 +85,28 @@ describe("who owns one press on the canvas", () => {
     expect(
       resolvePointerDownAction(facts({ ...picking, hit: null })).kind,
     ).toBe("ignore");
+  });
+
+  it("leaves only terminal hit circles active while picking terminal current", () => {
+    for (const hit of [
+      hitOf("instance", "M1"),
+      hitOf("route", "route-1"),
+      hitOf("junction", "j1"),
+      hitOf("annotation", "label-1"),
+    ]) {
+      expect(
+        resolvePointerDownAction(
+          facts({
+            simulationPickMode: "terminal",
+            armedVerbConsumesHit: true,
+            hit,
+          }),
+        ),
+      ).toEqual({
+        kind: "ignore",
+        reason: "picking terminals for simulation",
+      });
+    }
   });
 
   it("gives an Instance label no press of its own", () => {

--- a/apps/editor/src/canvas/pointer-down-router.ts
+++ b/apps/editor/src/canvas/pointer-down-router.ts
@@ -43,12 +43,8 @@ export interface PointerDownFacts {
   readonly primaryInstanceId: string | null;
   /** A verb (rotate/copy/move/delete) was armed before a target was picked. */
   readonly armedVerbConsumesHit: boolean;
-  /**
-   * The Simulation panel is picking Nets from the canvas. A press then names
-   * the Net under it and does nothing else: no selection, no drag, and no
-   * verb, however one was armed.
-   */
-  readonly simulationPickNetsActive: boolean;
+  /** The Simulation panel owns the canvas for one probe-picking domain. */
+  readonly simulationPickMode: "net" | "terminal" | null;
 }
 
 export type PointerDownAction =
@@ -124,7 +120,7 @@ export function resolvePointerDownAction(
   // alone, and so is a terminal pin, which carries no hit kind and keeps the
   // circle handler that picks it. This used to live on the label element
   // itself, which is how the label's pick was lost when that handler went.
-  if (facts.simulationPickNetsActive) {
+  if (facts.simulationPickMode === "net") {
     if (
       hit.kind === "route" ||
       hit.kind === "annotation" ||
@@ -133,6 +129,12 @@ export function resolvePointerDownAction(
       return { kind: "simulation-pick", hitKind: hit.kind, id: hit.id };
     }
     return { kind: "ignore", reason: "picking Nets for simulation" };
+  }
+  // Terminal circles own terminal-current picks in the endpoint layer. Scene
+  // objects must remain inert so clicking a part beside its pin cannot start
+  // a move while that terminal is being targeted.
+  if (facts.simulationPickMode === "terminal") {
+    return { kind: "ignore", reason: "picking terminals for simulation" };
   }
 
   // An armed verb owns the press: the pointed-at object is acted on rather

--- a/apps/editor/src/features/simulation/simulation-probe-options.test.ts
+++ b/apps/editor/src/features/simulation/simulation-probe-options.test.ts
@@ -4,6 +4,7 @@ import { CircuitProjectSchema, createEmptyProject } from "@icm/model";
 import fiveTransistorOtaSky130 from "../../examples/five-transistor-ota-sky130.icproj.json";
 import {
   deriveSimulationProbeOptions,
+  matchSimulationTerminalCurrentProbeOptions,
   matchSimulationVoltageProbeOptions,
   resolveSimulationVoltageProbeNetId,
   simulationProbeHierarchyPath,
@@ -218,6 +219,21 @@ describe("simulation probe choices", () => {
       ["XDUT2"],
     ]);
     expect(new Set(targets.map((option) => option.key)).size).toBe(2);
+    expect(
+      matchSimulationTerminalCurrentProbeOptions(targets, {
+        documentId: dut.id,
+        instanceId: "IINTERNAL",
+        pinName: "+",
+      }),
+    ).toHaveLength(2);
+    expect(
+      matchSimulationTerminalCurrentProbeOptions(targets, {
+        documentId: dut.id,
+        instanceId: "IINTERNAL",
+        pinName: "+",
+        occurrence: ["XDUT2"],
+      }).map((option) => option.target.occurrence),
+    ).toEqual([["XDUT2"]]);
   });
 
   it("resolves an object anchor for canvas focus and matches its whole Logical Net", () => {

--- a/apps/editor/src/features/simulation/simulation-probe-options.ts
+++ b/apps/editor/src/features/simulation/simulation-probe-options.ts
@@ -39,6 +39,13 @@ export interface PickedSimulationNet {
   readonly occurrence?: readonly string[];
 }
 
+export interface PickedSimulationTerminal {
+  readonly documentId: string;
+  readonly instanceId: string;
+  readonly pinName: string;
+  readonly occurrence?: readonly string[];
+}
+
 export function simulationProbeTargetKey(target: ProbeTarget): string {
   const occurrence = target.occurrence.join("/");
   if (target.kind === "current")
@@ -144,6 +151,28 @@ export function matchSimulationVoltageProbeOptions(
             (id, index) => id === picked.occurrence?.[index],
           ))) &&
       simulationVoltageProbeTargetsNet(project, candidate.target, picked.netId),
+  );
+}
+
+/**
+ * Match a visible terminal against the concrete current targets below the
+ * selected Testbench root. Definition-only picks deliberately retain every
+ * occurrence so the setup editor can ask which call the author meant.
+ */
+export function matchSimulationTerminalCurrentProbeOptions(
+  options: readonly SimulationProbeOption<TerminalCurrentProbeTarget>[],
+  picked: PickedSimulationTerminal,
+): readonly SimulationProbeOption<TerminalCurrentProbeTarget>[] {
+  return options.filter(
+    (candidate) =>
+      candidate.target.documentId === picked.documentId &&
+      candidate.target.instanceId === picked.instanceId &&
+      candidate.target.pinName === picked.pinName &&
+      (picked.occurrence === undefined ||
+        (candidate.target.occurrence.length === picked.occurrence.length &&
+          candidate.target.occurrence.every(
+            (id, index) => id === picked.occurrence?.[index],
+          ))),
   );
 }
 

--- a/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
@@ -42,7 +42,7 @@ describe("SpiceSimulationSurface workspace", () => {
     expect(markup).not.toContain("Filter by Cell, instance, pin, or Net");
     expect(markup).toContain("Choose a Net");
     expect(markup).toContain("Pick on canvas");
-    expect(markup).not.toContain("Pick voltage on canvas");
+    expect(markup).toContain("Pick terminal");
     expect(markup).toContain("Add current output");
     expect(markup).toContain(
       'class="simulation-setup-group simulation-analysis-row"',

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -26,6 +26,7 @@ import { TransientResultsExplorer } from "./transient-results-explorer";
 import { SimulationOutputResults } from "./simulation-output-results";
 import {
   deriveSimulationProbeOptions,
+  matchSimulationTerminalCurrentProbeOptions,
   matchSimulationVoltageProbeOptions,
   simulationProbeSelectionKey,
   simulationProbeTargetKey,
@@ -92,6 +93,16 @@ export interface SpiceSimulationSurfaceProps {
     readonly occurrence?: readonly string[];
   } | null;
   onPickNetsChange?(active: boolean): void;
+  pickTerminalsActive?: boolean;
+  pickedTerminal?: {
+    readonly sequence: number;
+    readonly documentId: string;
+    readonly instanceId: string;
+    readonly pinName: string;
+    /** Instance ids from the selected Testbench root to this Cell. */
+    readonly occurrence?: readonly string[];
+  } | null;
+  onPickTerminalsChange?(active: boolean): void;
   onFocusProbe?(
     probe: Extract<SimulationExpression, { kind: "voltage" | "current" }>,
     rootDocumentId?: string,
@@ -1008,6 +1019,9 @@ function SetupEditor({
   pickNetsActive,
   pickedNet,
   onPickNetsChange,
+  pickTerminalsActive,
+  pickedTerminal,
+  onPickTerminalsChange,
 }: SpiceSimulationSurfaceProps & {
   setup: ProjectSimulationSetup | undefined;
   capabilities: Capabilities | undefined;
@@ -1130,6 +1144,42 @@ function SetupEditor({
     setPickCandidates([]);
     onProblem(undefined);
   }, [pickedNet?.sequence]);
+  useEffect(() => {
+    if (!pickedTerminal) return;
+    const candidates = matchSimulationTerminalCurrentProbeOptions(
+      probeOptions.terminalCurrent,
+      pickedTerminal,
+    );
+    if (candidates.length > 1) {
+      setPickCandidates(candidates);
+      onProblem(undefined);
+      return;
+    }
+    const option = candidates[0];
+    if (!option) {
+      onProblem(
+        uiProblem(
+          "PROBE_TARGET_UNAVAILABLE",
+          "That terminal is not a connected current target in the selected Testbench occurrence.",
+        ),
+      );
+      return;
+    }
+    const key = simulationProbeSelectionKey(project, option.target);
+    if (
+      outputs.some(
+        (output) =>
+          (output.expression.kind === "voltage" ||
+            output.expression.kind === "current") &&
+          simulationProbeSelectionKey(project, output.expression) === key,
+      )
+    )
+      return;
+    setOutputs((current) => [...current, outputFromOption(option, current)]);
+    onDirty(true);
+    setPickCandidates([]);
+    onProblem(undefined);
+  }, [pickedTerminal?.sequence]);
   useEffect(() => {
     onDirty(false);
   }, []);
@@ -1558,7 +1608,7 @@ function SetupEditor({
         {pickCandidates.length > 1 ? (
           <fieldset
             className="simulation-setup-group"
-            aria-label="Choose Net occurrence"
+            aria-label="Choose probe occurrence"
           >
             <legend>Choose occurrence</legend>
             {pickCandidates.map((option) => (
@@ -1588,6 +1638,18 @@ function SetupEditor({
             setOutputs([...outputs, outputFromOption(option, outputs)]);
             onDirty(true);
           }}
+          trailingAction={
+            <button
+              type="button"
+              className={
+                pickTerminalsActive ? "simulation-pick-active" : undefined
+              }
+              aria-pressed={pickTerminalsActive}
+              onClick={() => onPickTerminalsChange?.(!pickTerminalsActive)}
+            >
+              {pickTerminalsActive ? "Picking Terminals…" : "Pick terminal"}
+            </button>
+          }
         />
         <small>Positive current enters the selected terminal.</small>
         <fieldset className="simulation-setup-group simulation-expression-editor">

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -1310,7 +1310,8 @@
 
 .schematic-canvas.simulation-net-pick-active .route-hit,
 .schematic-canvas.simulation-net-pick-active .endpoint-hit,
-.schematic-canvas.simulation-net-pick-active .annotation-text-hit {
+.schematic-canvas.simulation-net-pick-active .annotation-text-hit,
+.schematic-canvas.simulation-terminal-pick-active .endpoint-hit {
   cursor: crosshair;
 }
 
@@ -1318,7 +1319,8 @@
   stroke-width: 26;
 }
 
-.schematic-canvas.simulation-net-pick-active .endpoint-hit {
+.schematic-canvas.simulation-net-pick-active .endpoint-hit,
+.schematic-canvas.simulation-terminal-pick-active .endpoint-hit {
   r: 9px;
   fill: rgb(0 0 0 / 0.1%);
   pointer-events: all;

--- a/docs/specs/simulation.md
+++ b/docs/specs/simulation.md
@@ -503,7 +503,10 @@ instrumented Cell definition remains independently addressable through every
 concrete occurrence. Terminal currents are supported for OP, DC, AC, and
 TRAN. The editor offers connected, emitted terminals; stale authored outputs
 remain saved and preparation returns an occurrence-aware typed diagnostic
-rather than silently rebinding them. Other refusals include a missing root, a
+rather than silently rebinding them. The setup editor exposes the same target
+set through its list and through a canvas terminal picker; a canvas pick names
+the actual endpoint and preserves the Testbench occurrence instead of inferring
+current from the surrounding Net. Other refusals include a missing root, a
 root that instantiates nothing, an absent Instance or terminal, an invalid
 occurrence, and an unsupported analysis kind.
 


### PR DESCRIPTION
## Summary
- add a mutually exclusive terminal-current canvas picker beside the existing Net picker
- preserve exact terminal and hierarchy occurrence identity, with the existing occurrence chooser for ambiguous definition-level picks
- keep non-terminal canvas objects inert during terminal picking and document the shared target contract

## Validation
- pnpm ci:static
- pnpm test:local — 406 files, 2749 passed, 28 skipped
- isolated Playwright gent-simulation + web-agent-session — 6 passed
- isolated Playwright manual-editor — 134 passed
- isolated Playwright 	hin-target-hit — 1 passed

The aggregate local two-worker browser gate lost its shared Vite process; every selected spec passed against isolated single-worker servers.

Test-Impact: tests-updated