### PR TITLE
feat(simulation): compact the analysis workspace

### DIFF
--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -93,9 +93,7 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
     .click();
   const panel = page.getByRole("region", { name: "Analog simulation" });
   await panel.getByRole("button", { name: "Settings" }).click();
-  await expect(panel.getByLabel("Testbench Cell")).toHaveValue(
-    originalSetupInput.rootDocumentId,
-  );
+  await expect(panel.getByLabel("Testbench Cell")).toHaveCount(0);
   await expect(panel.getByLabel("Stop (Hz)")).toHaveValue("1000000000");
   await expect(panel.getByLabel("Environment profile")).toHaveValue(profile.id);
   await expect(
@@ -230,13 +228,11 @@ test("one Testbench persists several independently named setups", async ({
     .getByRole("button", { name: "Analog simulation", exact: true })
     .click();
   const panel = page.getByRole("region", { name: "Analog simulation" });
-  const selector = panel.getByRole("combobox", {
-    name: "Simulation setup",
-    exact: true,
-  });
-  await expect(selector).toHaveValue("simulation-setup-ota-op-ac");
+  const selector = panel.getByTitle("Simulation setup", { exact: true });
+  await expect(selector).toContainText("OTA OP and AC");
+  await selector.click();
   await panel.getByRole("button", { name: "New setup", exact: true }).click();
-  await expect(selector.locator("option")).toHaveCount(2);
+  await expect(selector).toContainText("Setup 2");
   await panel.getByLabel("Setup name").fill("Bias search");
   await panel.getByRole("button", { name: "Apply setup" }).click();
   await panel.getByLabel("Setup name").fill("Bias sweep");
@@ -259,10 +255,18 @@ test("one Testbench persists several independently named setups", async ({
     ),
   ).toEqual(new Set(["document-ota-5t-testbench"]));
 
-  await panel.getByRole("button", { name: "Delete setup" }).click();
-  await expect(selector).toHaveValue("simulation-setup-ota-op-ac");
+  await selector.click();
+  await panel.getByRole("button", { name: "Delete Bias sweep" }).click();
+  await panel.getByRole("button", { name: "Cancel", exact: true }).click();
   await expect(
-    selector.getByRole("option", { name: "Bias sweep" }),
+    panel.getByRole("button", { name: "Bias sweep", exact: true }),
+  ).toBeVisible();
+  await panel.getByRole("button", { name: "Delete Bias sweep" }).click();
+  await panel.getByRole("button", { name: "Confirm", exact: true }).click();
+  await expect(selector).toContainText("OTA OP and AC");
+  await selector.click();
+  await expect(
+    panel.getByRole("button", { name: "Bias sweep", exact: true }),
   ).toHaveCount(0);
   const afterDelete = JSON.parse(
     (await downloadBytes(page, "File", "Export Project File…")).toString(),
@@ -837,7 +841,12 @@ test("Simulation creates an ordinary testbench and offers the current Cell at th
   expect(saved.topDocumentId).toBe("document-main");
   expect(saved.simulationSetups).toEqual([]);
   await page.getByTestId("open-analog-simulation").click();
-  await expect(page.getByLabel("Testbench Cell")).toHaveValue(tb.id);
+  await expect(page.getByLabel("Testbench Cell")).toHaveCount(0);
+  await page.getByRole("button", { name: "Apply setup" }).click();
+  const configured = JSON.parse(
+    (await downloadBytes(page, "File", "Export Project File…")).toString(),
+  );
+  expect(configured.simulationSetups[0].input.rootDocumentId).toBe(tb.id);
   const simulationResize = page.getByTestId("simulation-resize-handle");
   const initialWidth = Number(
     await simulationResize.getAttribute("aria-valuenow"),

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -4741,13 +4741,12 @@ export function App({
                 const committed = commitStructure("remove-simulation-setup", [
                   { kind: "remove_simulation_setup", setupId },
                 ]);
-                if (committed) {
+                if (committed && activeSimulationSetupId === setupId) {
                   setActiveSimulationSetupId(null);
                   setSimulationDraftContext(null);
                 }
                 return committed;
               }}
-              onOpenCell={(id) => switchDocument(id)}
               pickNetsActive={simulationPickNetsActive}
               pickedNet={analogPickedNet}
               onPickNetsChange={setSimulationPickMode}

--- a/apps/editor/src/features/simulation/ac-response-plot.test.ts
+++ b/apps/editor/src/features/simulation/ac-response-plot.test.ts
@@ -37,10 +37,12 @@ describe("AC response plot", () => {
     const layout = layoutAcPlot([singlePole()], { width: 600, height: 300 })!;
     // The trace spans about -20 dB to 40 dB; the axis must contain it and
     // land on round gridlines rather than on the data's own extremes.
-    expect(layout.magnitude.min).toBeLessThanOrEqual(-20);
-    expect(layout.magnitude.max).toBeGreaterThanOrEqual(
+    expect(layout.magnitude.min).toBeLessThan(-20);
+    expect(layout.magnitude.max).toBeGreaterThan(
       singlePole().points[0]!.magnitudeDb,
     );
+    expect(layout.frequency.min).toBeLessThan(1);
+    expect(layout.frequency.max).toBeGreaterThan(1e6);
     expect(layout.magnitude.ticks).toContain(0);
   });
 
@@ -49,8 +51,8 @@ describe("AC response plot", () => {
     const left = layout.frequencyAt(layout.frame.x);
     const right = layout.frequencyAt(layout.frame.x + layout.frame.width);
 
-    expect(left).toBeCloseTo(1, 6);
-    expect(right).toBeCloseTo(1e6, 0);
+    expect(left).toBeLessThan(1);
+    expect(right).toBeGreaterThan(1e6);
     // Logarithmic, so the midpoint is the geometric mean, not the average.
     expect(
       layout.frequencyAt(layout.frame.x + layout.frame.width / 2),

--- a/apps/editor/src/features/simulation/ac-response-plot.ts
+++ b/apps/editor/src/features/simulation/ac-response-plot.ts
@@ -94,10 +94,17 @@ function niceDecades(min: number, max: number): number[] {
 function adaptiveAxis(
   range: readonly [number, number],
   height: number,
+  pad = true,
 ): AcPlotAxis {
-  const margin = Math.max(Math.abs(range[0]) * 0.05, 1);
-  const min = range[0] === range[1] ? range[0] - margin : range[0];
-  const max = range[0] === range[1] ? range[1] + margin : range[1];
+  const span = range[1] - range[0];
+  const margin =
+    range[0] === range[1]
+      ? Math.max(Math.abs(range[0]) * 0.05, 1)
+      : pad
+        ? span * 0.05
+        : 0;
+  const min = range[0] - margin;
+  const max = range[1] + margin;
   return { min, max, ticks: waveformTicks(min, max, height > 400 ? 10 : 5) };
 }
 
@@ -129,8 +136,12 @@ export function layoutAcPlot(
   };
   const dataMin = Math.min(...frequencies);
   const dataMax = Math.max(...frequencies);
-  const fMin = frequencyRange?.[0] ?? dataMin;
-  const fMax = frequencyRange?.[1] ?? dataMax;
+  const logPadding =
+    frequencyRange || dataMin === dataMax
+      ? 0
+      : (Math.log10(dataMax) - Math.log10(dataMin)) * 0.025;
+  const fMin = frequencyRange?.[0] ?? dataMin / 10 ** logPadding;
+  const fMax = frequencyRange?.[1] ?? dataMax * 10 ** logPadding;
   const decades = niceDecades(fMin, fMax).filter(
     (frequency) => frequency >= fMin && frequency <= fMax,
   );
@@ -147,8 +158,8 @@ export function layoutAcPlot(
               0,
           )
         : waveformTicks(fMin, fMax, 5),
-    min: frequencyRange ? fMin : niceDecades(dataMin, dataMax)[0]!,
-    max: frequencyRange ? fMax : niceDecades(dataMin, dataMax).at(-1)!,
+    min: fMin,
+    max: fMax,
   };
   const logMin = Math.log10(frequency.min);
   const logSpan = Math.log10(frequency.max) - logMin || 1;
@@ -162,12 +173,14 @@ export function layoutAcPlot(
         ? valueOverride.range
         : [Math.min(...magnitudes), Math.max(...magnitudes)],
       size.height,
+      valueOverride?.kind !== "magnitude",
     ),
     phase: adaptiveAxis(
       valueOverride?.kind === "phase"
         ? valueOverride.range
         : [Math.min(...phases), Math.max(...phases)],
       size.height,
+      valueOverride?.kind !== "phase",
     ),
     frequencyAt: (x: number) =>
       10 ** (logMin + ((x - frame.x) / frame.width) * logSpan),

--- a/apps/editor/src/features/simulation/ac-results-explorer.test.tsx
+++ b/apps/editor/src/features/simulation/ac-results-explorer.test.tsx
@@ -47,6 +47,9 @@ describe("AC Results Explorer", () => {
     );
 
     expect(markup).toContain("VOUT");
+    expect(markup).toContain("Voltage magnitude");
+    expect(markup).toContain("Voltage phase");
+    expect(markup).not.toContain("<h4>Voltage</h4>");
     expect(markup).toContain('aria-label="AC magnitude"');
     expect(markup).toContain('aria-label="AC phase"');
     expect(markup.match(/data-trace-index="0"/gu)).toHaveLength(2);

--- a/apps/editor/src/features/simulation/ac-results-explorer.tsx
+++ b/apps/editor/src/features/simulation/ac-results-explorer.tsx
@@ -346,7 +346,6 @@ export function AcResultsExplorer({
         );
         return (
           <section key={quantity} className="ac-quantity-group">
-            <h4>{groupLabel(quantity)}</h4>
             <div className="simulation-plot-layout">
               <WaveformTraceList
                 label={`${groupLabel(quantity)} outputs`}
@@ -363,7 +362,7 @@ export function AcResultsExplorer({
                   (["magnitude", "phase"] as const).map((kind) => (
                     <div key={kind} className="ac-plot-row">
                       <strong>
-                        {kind === "magnitude" ? "Magnitude" : "Phase"}
+                        {groupLabel(quantity)} {kind}
                       </strong>
                       {renderPlot({ quantity, kind }, visibleQuantityTraces)}
                     </div>

--- a/apps/editor/src/features/simulation/dc-results-explorer.test.tsx
+++ b/apps/editor/src/features/simulation/dc-results-explorer.test.tsx
@@ -45,6 +45,7 @@ describe("DcResultsExplorer", () => {
     expect(markup).toContain("3 points");
     expect(markup).toContain("Output");
     expect(markup).toContain("<polyline");
-    expect(markup).toContain("1V");
+    expect(markup).toContain("-50mV");
+    expect(markup).toContain("1.050V");
   });
 });

--- a/apps/editor/src/features/simulation/dc-results-explorer.tsx
+++ b/apps/editor/src/features/simulation/dc-results-explorer.tsx
@@ -24,7 +24,10 @@ function extent(values: readonly number[]): readonly [number, number] {
   if (!finite.length) return [-1, 1];
   const low = Math.min(...finite);
   const high = Math.max(...finite);
-  if (low !== high) return [low, high];
+  if (low !== high) {
+    const margin = (high - low) * 0.05;
+    return [low - margin, high + margin];
+  }
   const margin = Math.max(Math.abs(low) * 0.05, 1e-12);
   return [low - margin, high + margin];
 }
@@ -107,74 +110,79 @@ export function DcResultsExplorer({
         const yExtent = extent(group.flatMap((trace) => [...trace.values]));
         const unit = group.find((trace) => trace.unit)?.unit ?? "";
         return (
-          <div className="ac-plot-shell" key={quantity}>
-            <div className="spice-ac-plot">
-              <svg
-                role="img"
-                aria-label={`DC ${quantity}`}
-                viewBox={`0 0 ${PLOT.width} ${PLOT.height}`}
-              >
-                <line
-                  className="transient-axis"
-                  x1={PLOT.left}
-                  y1={PLOT.top}
-                  x2={PLOT.left}
-                  y2={PLOT.height - PLOT.bottom}
-                />
-                <line
-                  className="transient-axis"
-                  x1={PLOT.left}
-                  y1={PLOT.height - PLOT.bottom}
-                  x2={PLOT.width - PLOT.right}
-                  y2={PLOT.height - PLOT.bottom}
-                />
-                <text x={PLOT.left} y={PLOT.height - 8}>
-                  {compact(xExtent[0])}
-                  {analysis.sweep.unit ?? ""}
-                </text>
-                <text
-                  textAnchor="end"
-                  x={PLOT.width - PLOT.right}
-                  y={PLOT.height - 8}
+          <div className="ac-plot-row" key={quantity}>
+            <strong>
+              {quantity === "voltage" ? "Voltage" : "Current"} DC sweep
+            </strong>
+            <div className="ac-plot-shell">
+              <div className="spice-ac-plot">
+                <svg
+                  role="img"
+                  aria-label={`DC ${quantity}`}
+                  viewBox={`0 0 ${PLOT.width} ${PLOT.height}`}
                 >
-                  {compact(xExtent[1])}
-                  {analysis.sweep.unit ?? ""}
-                </text>
-                <text x={4} y={PLOT.top + 5}>
-                  {compact(yExtent[1])}
-                  {unit}
-                </text>
-                <text x={4} y={PLOT.height - PLOT.bottom}>
-                  {compact(yExtent[0])}
-                  {unit}
-                </text>
-                {group.map((trace) => (
-                  <polyline
-                    key={trace.id}
-                    className={`transient-trace ac-trace-${trace.index % 6}`}
-                    points={points(
-                      analysis.sweep.values,
-                      trace.values,
-                      xExtent,
-                      yExtent,
-                    )}
+                  <line
+                    className="transient-axis"
+                    x1={PLOT.left}
+                    y1={PLOT.top}
+                    x2={PLOT.left}
+                    y2={PLOT.height - PLOT.bottom}
                   />
+                  <line
+                    className="transient-axis"
+                    x1={PLOT.left}
+                    y1={PLOT.height - PLOT.bottom}
+                    x2={PLOT.width - PLOT.right}
+                    y2={PLOT.height - PLOT.bottom}
+                  />
+                  <text x={PLOT.left} y={PLOT.height - 8}>
+                    {compact(xExtent[0])}
+                    {analysis.sweep.unit ?? ""}
+                  </text>
+                  <text
+                    textAnchor="end"
+                    x={PLOT.width - PLOT.right}
+                    y={PLOT.height - 8}
+                  >
+                    {compact(xExtent[1])}
+                    {analysis.sweep.unit ?? ""}
+                  </text>
+                  <text x={4} y={PLOT.top + 5}>
+                    {compact(yExtent[1])}
+                    {unit}
+                  </text>
+                  <text x={4} y={PLOT.height - PLOT.bottom}>
+                    {compact(yExtent[0])}
+                    {unit}
+                  </text>
+                  {group.map((trace) => (
+                    <polyline
+                      key={trace.id}
+                      className={`transient-trace ac-trace-${trace.index % 6}`}
+                      points={points(
+                        analysis.sweep.values,
+                        trace.values,
+                        xExtent,
+                        yExtent,
+                      )}
+                    />
+                  ))}
+                </svg>
+              </div>
+              <div className="ac-trace-list">
+                {group.map((trace) => (
+                  <button
+                    key={trace.id}
+                    type="button"
+                    data-trace-index={trace.index}
+                    onClick={() =>
+                      trace.authored && onFocusProbe?.(trace.authored)
+                    }
+                  >
+                    {trace.label}
+                  </button>
                 ))}
-              </svg>
-            </div>
-            <div className="ac-trace-list">
-              {group.map((trace) => (
-                <button
-                  key={trace.id}
-                  type="button"
-                  data-trace-index={trace.index}
-                  onClick={() =>
-                    trace.authored && onFocusProbe?.(trace.authored)
-                  }
-                >
-                  {trace.label}
-                </button>
-              ))}
+              </div>
             </div>
           </div>
         );

--- a/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
@@ -22,7 +22,6 @@ describe("SpiceSimulationSurface workspace", () => {
         onExit={() => undefined}
         onSaveSetup={() => true}
         onDeleteSetup={() => true}
-        onOpenCell={() => undefined}
       />,
     );
 
@@ -30,7 +29,10 @@ describe("SpiceSimulationSurface workspace", () => {
     expect(markup).not.toContain('data-testid="simulation-cell-flow"');
     expect(markup).toContain("No DUT instance in this Cell");
     expect(markup).toContain("Edit → New Testbench Cell");
+    expect(markup).toContain('class="simulation-setup-menu"');
     expect(markup).toContain('aria-label="Simulation setup"');
+    expect(markup).toContain("New setup");
+    expect(markup).not.toContain("<label>Testbench Cell");
     expect(markup).toContain('aria-pressed="true">Settings');
     expect(markup).toContain('aria-pressed="false">Results');
     expect(markup).toContain('aria-label="Maximize simulation"');
@@ -125,14 +127,13 @@ describe("SpiceSimulationSurface workspace", () => {
         onExit={() => undefined}
         onSaveSetup={() => true}
         onDeleteSetup={() => true}
-        onOpenCell={() => undefined}
       />,
     );
     expect(markup).toContain("DC sweep source");
     expect(markup).toContain('aria-label="Simulation setup"');
     expect(markup).toContain("DC Sweep");
     expect(markup).toContain("AC Response");
-    expect(markup.match(/Delete setup/g)).toHaveLength(1);
+    expect(markup.match(/aria-label="Delete /g)).toHaveLength(2);
     expect(markup).toContain('name="setupName"');
     expect(markup).toContain("V1 · Voltage");
     expect(markup).toContain('name="dcStartValue"');
@@ -168,7 +169,6 @@ describe("SpiceSimulationSurface workspace", () => {
         onExit={() => undefined}
         onSaveSetup={() => true}
         onDeleteSetup={() => true}
-        onOpenCell={() => undefined}
       />,
     );
 
@@ -177,7 +177,7 @@ describe("SpiceSimulationSurface workspace", () => {
     expect(markup).toContain('aria-label="Restore simulation panel"');
     expect(markup).toContain("tb.cir");
     expect(markup).toContain("Switch to structured setup");
-    expect(markup.match(/Delete setup/g)).toHaveLength(1);
+    expect(markup.match(/aria-label="Delete /g)).toHaveLength(1);
     expect(markup).not.toContain("Add voltage probe");
     expect(markup).not.toContain("authored file(s)");
     expect(markup).not.toContain("Profile: raw-profile");

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -82,7 +82,6 @@ export interface SpiceSimulationSurfaceProps {
   onExit(): void;
   onSaveSetup(setup: ProjectSimulationSetup): boolean;
   onDeleteSetup(setupId: string): boolean;
-  onOpenCell(documentId: string): void;
   pickNetsActive?: boolean;
   pickedNet?: {
     readonly sequence: number;
@@ -169,6 +168,17 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
   const [resultsOpen, setResultsOpen] = useState(false);
   const [resultTab, setResultTab] = useState<ResultTab>("plot");
   const [exitConfirmationOpen, setExitConfirmationOpen] = useState(false);
+  const [deleteSetupId, setDeleteSetupId] = useState<string>();
+  const setupMenuRef = useRef<HTMLDetailsElement>(null);
+  useEffect(() => {
+    const closeSetupMenu = (event: PointerEvent): void => {
+      if (setupMenuRef.current?.contains(event.target as Node)) return;
+      setupMenuRef.current?.removeAttribute("open");
+      setDeleteSetupId(undefined);
+    };
+    document.addEventListener("pointerdown", closeSetupMenu);
+    return () => document.removeEventListener("pointerdown", closeSetupMenu);
+  }, []);
   const previousSetupId = useRef<string | null>(props.selectedSetupId);
   useEffect(() => {
     if (previousSetupId.current === props.selectedSetupId) return;
@@ -326,16 +336,6 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
   const activeCell = project.documents.find(
     (candidate) => candidate.id === props.activeDocumentId,
   );
-  const draftDut = project.documents.find(
-    (candidate) => candidate.id === props.draftContext?.dutDocumentId,
-  );
-  const savedRoot = project.documents.find(
-    (candidate) =>
-      candidate.id ===
-      (selectedSetup?.input.kind === "structured"
-        ? selectedSetup.input.rootDocumentId
-        : undefined),
-  );
   const hasDutInstance = Boolean(
     activeCell?.instances.some(
       (instance) => instance.netlist?.binding?.kind === "subcircuit",
@@ -410,6 +410,37 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
   const presentationLabels = Object.fromEntries(
     (runPresentation?.outputs ?? []).map((output) => [output.id, output.label]),
   );
+  const createSetup = (): void => {
+    const baseName = "Setup";
+    let suffix = project.simulationSetups.length + 1;
+    while (
+      project.simulationSetups.some(
+        (setup) => setup.name === `${baseName} ${suffix}`,
+      )
+    )
+      suffix++;
+    const created: ProjectSimulationSetup = {
+      id: `simulation-setup-${crypto.randomUUID()}`,
+      name: `${baseName} ${suffix}`,
+      version: 2,
+      input: selectedSetup
+        ? structuredClone(selectedSetup.input)
+        : {
+            kind: "structured",
+            rootDocumentId: props.activeDocumentId,
+            analyses: [{ kind: "op" }],
+            outputs: [],
+            environment: {
+              profileId:
+                capabilities?.profiles[0]?.id ?? DEVELOPMENT_PROFILE_ID,
+            },
+          },
+    };
+    if (props.onSaveSetup(created)) {
+      props.onSelectSetupId(created.id);
+      setupMenuRef.current?.removeAttribute("open");
+    }
+  };
   return (
     <section
       hidden={!open}
@@ -417,99 +448,98 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
       aria-label="Analog simulation"
       onKeyDown={(e) => {
         e.stopPropagation();
-        if (e.key === "Escape") props.onMinimize();
+        if (e.key !== "Escape") return;
+        if (setupMenuRef.current?.open) {
+          setupMenuRef.current.removeAttribute("open");
+          setDeleteSetupId(undefined);
+        } else props.onMinimize();
       }}
     >
       <header className="simulation-taskbar">
         <div className="simulation-brand">
           <strong>Simulation</strong>
+          <span
+            className={`simulation-status-chip simulation-status-${run?.state ?? (prepared ? "prepared" : "idle")}`}
+            role="status"
+          >
+            {dirty ? "Setup changed" : statusLabel}
+          </span>
         </div>
-        {draftDut || (savedRoot && savedRoot.id !== activeCell?.id) ? (
-          <div
-            className="simulation-cell-context"
-            data-testid="simulation-cell-flow"
-          >
-            {draftDut ? (
-              <button onClick={() => props.onOpenCell(draftDut.id)}>
-                <small>DUT</small>
-                {draftDut.name}
-              </button>
-            ) : null}
-            {savedRoot && savedRoot.id !== activeCell?.id ? (
-              <button onClick={() => props.onOpenCell(savedRoot.id)}>
-                <small>Setup root</small>
-                {savedRoot.name}
-              </button>
-            ) : null}
-          </div>
-        ) : null}
-        <span
-          className={`simulation-status-chip simulation-status-${run?.state ?? (prepared ? "prepared" : "idle")}`}
-          role="status"
-        >
-          {dirty ? "Setup changed" : statusLabel}
-        </span>
         <div className="simulation-task-actions">
-          <select
-            aria-label="Simulation setup"
-            value={selectedSetup?.id ?? ""}
-            disabled={dirty || busy || !!running}
-            onChange={(event) =>
-              props.onSelectSetupId(event.currentTarget.value)
-            }
-          >
-            {!selectedSetup ? <option value="">New setup</option> : null}
-            {project.simulationSetups.map((setup) => (
-              <option key={setup.id} value={setup.id}>
-                {setup.name}
-              </option>
-            ))}
-          </select>
-          <button
-            type="button"
-            disabled={dirty || busy || !!running}
-            onClick={() => {
-              const baseName = "Setup";
-              let suffix = project.simulationSetups.length + 1;
-              while (
-                project.simulationSetups.some(
-                  (setup) => setup.name === `${baseName} ${suffix}`,
-                )
-              )
-                suffix++;
-              const created: ProjectSimulationSetup = {
-                id: `simulation-setup-${crypto.randomUUID()}`,
-                name: `${baseName} ${suffix}`,
-                version: 2,
-                input: selectedSetup
-                  ? structuredClone(selectedSetup.input)
-                  : {
-                      kind: "structured",
-                      rootDocumentId: props.activeDocumentId,
-                      analyses: [{ kind: "op" }],
-                      outputs: [],
-                      environment: {
-                        profileId:
-                          capabilities?.profiles[0]?.id ??
-                          DEVELOPMENT_PROFILE_ID,
-                      },
-                    },
-              };
-              if (props.onSaveSetup(created)) props.onSelectSetupId(created.id);
+          <details
+            ref={setupMenuRef}
+            className="simulation-setup-menu"
+            onToggle={(event) => {
+              if (!event.currentTarget.open) setDeleteSetupId(undefined);
             }}
           >
-            New setup
-          </button>
-          <button
-            type="button"
-            disabled={busy || !!running || !selectedSetup}
-            onClick={() => {
-              if (selectedSetup && props.onDeleteSetup(selectedSetup.id))
-                setDirty(false);
-            }}
-          >
-            Delete setup
-          </button>
+            <summary aria-label="Simulation setup" title="Simulation setup">
+              <span>{selectedSetup?.name ?? "Setup"}</span>
+            </summary>
+            <div className="simulation-setup-menu-popover">
+              <button
+                type="button"
+                className="simulation-setup-menu-new"
+                disabled={dirty || busy || !!running}
+                onClick={createSetup}
+              >
+                New setup
+              </button>
+              {project.simulationSetups.map((setup) => (
+                <div
+                  key={setup.id}
+                  className="simulation-setup-menu-row"
+                  data-selected={setup.id === selectedSetup?.id}
+                >
+                  <button
+                    type="button"
+                    className="simulation-setup-menu-select"
+                    disabled={dirty || busy || !!running}
+                    onClick={() => {
+                      props.onSelectSetupId(setup.id);
+                      setupMenuRef.current?.removeAttribute("open");
+                    }}
+                  >
+                    {setup.name}
+                  </button>
+                  {deleteSetupId === setup.id ? (
+                    <span className="simulation-setup-delete-confirmation">
+                      <button
+                        type="button"
+                        className="simulation-setup-delete-confirm"
+                        disabled={busy || !!running}
+                        onClick={() => {
+                          if (props.onDeleteSetup(setup.id)) {
+                            if (setup.id === selectedSetup?.id) setDirty(false);
+                            setDeleteSetupId(undefined);
+                          }
+                        }}
+                      >
+                        Confirm
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setDeleteSetupId(undefined)}
+                      >
+                        Cancel
+                      </button>
+                    </span>
+                  ) : (
+                    <button
+                      type="button"
+                      className="simulation-setup-delete"
+                      aria-label={`Delete ${setup.name}`}
+                      title={`Delete ${setup.name}`}
+                      disabled={busy || !!running}
+                      onClick={() => setDeleteSetupId(setup.id)}
+                    >
+                      ×
+                    </button>
+                  )}
+                </div>
+              ))}
+            </div>
+          </details>
           <button
             type="button"
             className="simulation-settings-button"
@@ -551,11 +581,13 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
             </button>
           ) : selectedSetup ? (
             <button
-              className="simulation-primary-button"
+              className="simulation-primary-button simulation-run-button"
               disabled={busy || dirty}
               onClick={() => void execute(true)}
+              aria-label="Run"
+              title="Run"
             >
-              Run
+              ▶
             </button>
           ) : (
             <button
@@ -568,6 +600,8 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
               Set up
             </button>
           )}
+        </div>
+        <div className="simulation-window-actions">
           <button
             className="simulation-maximize-button"
             onClick={props.onToggleMaximized}
@@ -1015,9 +1049,8 @@ function SetupEditor({
   onProblem(value: Problem | undefined): void;
 }) {
   const saved = setup?.input.kind === "structured" ? setup.input : undefined;
-  const [rootId, setRootId] = useState(
-    saved?.rootDocumentId ?? draftContext?.rootDocumentId ?? activeDocumentId,
-  );
+  const rootId =
+    saved?.rootDocumentId ?? draftContext?.rootDocumentId ?? activeDocumentId;
   const [outputs, setOutputs] = useState(saved?.outputs ?? []);
   const [setupName, setSetupName] = useState(
     setup?.name ?? draftContext?.setupName ?? "Setup 1",
@@ -1110,7 +1143,7 @@ function SetupEditor({
       onProblem(
         uiProblem(
           "PROBE_TARGET_UNAVAILABLE",
-          "That Net is outside the selected Testbench occurrence. Choose it from the Output list or change the Testbench Cell.",
+          "That Net is outside this Setup's Testbench. Choose it from the Output list or create a Setup for the intended Testbench.",
         ),
       );
       return;
@@ -1292,17 +1325,6 @@ function SetupEditor({
               }
             }}
           />
-        </label>
-        <label>
-          Testbench Cell
-          <select value={rootId} onChange={(e) => setRootId(e.target.value)}>
-            {!root && <option value={rootId}>Missing: {rootId}</option>}
-            {project.documents.map((d) => (
-              <option key={d.id} value={d.id}>
-                {d.name}
-              </option>
-            ))}
-          </select>
         </label>
         <label>
           Environment profile

--- a/apps/editor/src/features/simulation/transient-results-explorer.test.tsx
+++ b/apps/editor/src/features/simulation/transient-results-explorer.test.tsx
@@ -21,6 +21,12 @@ describe("Transient Results Explorer", () => {
     expect(extent[1]).toBeCloseTo(1.89, 10);
   });
 
+  it("keeps changing waveforms away from the plot boundary", () => {
+    const extent = transientValueExtent([0, 1]);
+    expect(extent[0]).toBeCloseTo(-0.05);
+    expect(extent[1]).toBeCloseTo(1.05);
+  });
+
   it("retains the segment crossing a zoom window between solver samples", () => {
     expect(transientVisibleValues([0, 10], [0, 1], [4, 6])).toEqual([0.4, 0.6]);
     const points = transientPolylinePoints([0, 10], [0, 1], [0, 1], [4, 6]);
@@ -79,6 +85,8 @@ describe("Transient Results Explorer", () => {
 
     expect(markup).toContain("VOUT");
     expect(markup).toContain("IIN");
+    expect(markup).toContain("Voltage transient");
+    expect(markup).toContain("Current transient");
     expect(markup).toContain('aria-label="Hide VOUT"');
     expect(markup).toContain('aria-label="Hide IIN"');
     expect(markup).toContain('aria-pressed="true"');

--- a/apps/editor/src/features/simulation/transient-results-explorer.tsx
+++ b/apps/editor/src/features/simulation/transient-results-explorer.tsx
@@ -90,7 +90,10 @@ export function transientValueExtent(
   const center = (extent[0] + extent[1]) / 2;
   const magnitude = Math.max(Math.abs(extent[0]), Math.abs(extent[1]));
   const tolerance = Math.max(magnitude * 1e-9, 1e-12);
-  if (extent[1] - extent[0] > tolerance) return extent;
+  if (extent[1] - extent[0] > tolerance) {
+    const margin = (extent[1] - extent[0]) * 0.05;
+    return [extent[0] - margin, extent[1] + margin];
+  }
   const margin = Math.max(Math.abs(center) * 0.05, 1e-12);
   return [center - margin, center + margin];
 }
@@ -659,13 +662,6 @@ export function TransientResultsExplorer({
             key={quantity}
             className="transient-quantity-group ac-quantity-group"
           >
-            <h4>
-              {quantity === "voltage"
-                ? "Voltage"
-                : quantity === "current"
-                  ? "Current"
-                  : quantity}
-            </h4>
             <div className="simulation-plot-layout">
               <WaveformTraceList
                 label={`${analysisLabel} ${quantity} outputs`}
@@ -679,7 +675,17 @@ export function TransientResultsExplorer({
               />
               <div className="simulation-plot-stack">
                 {visibleQuantityTraces.length ? (
-                  plot(quantity, visibleQuantityTraces)
+                  <div className="ac-plot-row">
+                    <strong>
+                      {quantity === "voltage"
+                        ? "Voltage"
+                        : quantity === "current"
+                          ? "Current"
+                          : quantity}{" "}
+                      {analysisLabel.toLowerCase()}
+                    </strong>
+                    {plot(quantity, visibleQuantityTraces)}
+                  </div>
                 ) : (
                   <p className="simulation-empty-plot">Outputs hidden</p>
                 )}

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -40,81 +40,161 @@
 }
 
 .simulation-taskbar {
+  position: relative;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  grid-template-areas:
-    "brand status"
-    "actions actions";
-  align-items: center;
-  gap: 8px var(--icm-space-2);
-  padding: 12px;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 6px;
+  min-height: 44px;
+  padding: 6px 7px;
   border-bottom: 1px solid var(--icm-border);
   background: var(--icm-surface);
 }
-.simulation-taskbar:has(.simulation-cell-context) {
-  grid-template-areas:
-    "brand status"
-    "context context"
-    "actions actions";
-}
 .simulation-brand {
-  grid-area: brand;
   display: grid;
+  align-content: start;
+  gap: 2px;
+  min-width: 68px;
   line-height: 1.05;
 }
 .simulation-brand strong {
-  font-size: var(--icm-font-lg);
+  font-size: var(--icm-font-md);
 }
-.simulation-brand span,
-.simulation-taskbar small {
-  color: var(--icm-text-muted);
-  font-size: var(--icm-font-xs);
-}
-.simulation-cell-context,
 .simulation-task-actions {
   display: flex;
   align-items: center;
-  gap: 5px;
+  gap: 4px;
   min-width: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
 }
-.simulation-cell-context {
-  grid-area: context;
-  flex-wrap: wrap;
+.simulation-task-actions::-webkit-scrollbar {
+  display: none;
 }
-.simulation-task-actions {
-  grid-area: actions;
-  flex-wrap: wrap;
-  justify-self: stretch;
-}
-.simulation-cell-context button {
-  display: grid;
-  flex: 0 1 auto;
+.simulation-task-actions > button {
+  flex: 0 0 auto;
   min-width: 0;
-  padding: 3px 8px;
+  min-height: 28px;
+  padding: 3px 5px;
   border-color: var(--icm-border);
-  line-height: 1.05;
-  text-align: left;
+  font-size: var(--icm-font-xs);
 }
-.simulation-cell-context button:not(:last-child) {
-  max-width: 150px;
+.simulation-status-chip {
+  justify-self: start;
+  max-width: 84px;
+  overflow: hidden;
+  padding: 2px 6px;
+  border-radius: 999px;
+  border: 1px solid var(--icm-border);
+  color: var(--icm-text-muted);
+  background: var(--icm-surface-muted);
+  font-size: 9px;
+  line-height: 1.15;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
-.simulation-cell-context button {
+.simulation-setup-menu {
+  position: relative;
+  flex: 0 0 110px;
+  min-width: 0;
+}
+.simulation-setup-menu > summary {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  min-height: 28px;
+  padding: 3px 7px;
+  overflow: hidden;
+  border: 1px solid var(--icm-border-strong);
+  border-radius: var(--icm-radius-sm);
+  background: var(--icm-surface);
+  cursor: pointer;
+  font-size: var(--icm-font-xs);
+  list-style: none;
+}
+.simulation-setup-menu > summary::-webkit-details-marker {
+  display: none;
+}
+.simulation-setup-menu > summary::after {
+  content: "";
+  flex: 0 0 auto;
+  width: 0;
+  height: 0;
+  margin-left: auto;
+  border-top: 4px solid currentColor;
+  border-right: 3px solid transparent;
+  border-left: 3px solid transparent;
+  opacity: 0.55;
+}
+.simulation-setup-menu > summary > span {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.simulation-status-chip {
-  padding: 4px 8px;
-  border-radius: 999px;
+.simulation-setup-menu[open] > summary {
+  border-color: var(--icm-accent);
+}
+.simulation-setup-menu-popover {
+  position: absolute;
+  z-index: 12;
+  top: calc(100% + 4px);
+  left: 0;
+  display: grid;
+  width: 250px;
+  max-height: min(360px, 60vh);
+  padding: 4px;
+  overflow-y: auto;
+  border: 1px solid var(--icm-border-strong);
+  border-radius: var(--icm-radius-sm);
+  background: var(--icm-surface);
+  box-shadow: var(--icm-shadow-md);
+}
+.simulation-setup-menu-popover > button,
+.simulation-setup-menu-row {
+  min-height: 30px;
+}
+.simulation-setup-menu-new {
+  justify-self: stretch;
+  border-color: transparent !important;
+  text-align: left;
+}
+.simulation-setup-menu-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 3px;
+  align-items: center;
+  border-top: 1px solid var(--icm-border);
+}
+.simulation-setup-menu-row[data-selected="true"] {
   background: var(--icm-surface-muted);
-  font-size: var(--icm-font-xs);
+}
+.simulation-setup-menu-row button {
+  min-height: 28px;
+  border-color: transparent;
+}
+.simulation-setup-menu-select {
+  min-width: 0;
+  overflow: hidden;
+  text-align: left;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
-.simulation-status-chip {
-  grid-area: status;
-  justify-self: start;
-  color: var(--icm-text-muted);
-  border: 1px solid var(--icm-border);
+.simulation-setup-delete {
+  width: 28px;
+  padding: 0 !important;
+  color: var(--icm-text-muted) !important;
+}
+.simulation-setup-delete-confirmation {
+  display: flex;
+  gap: 2px;
+}
+.simulation-setup-delete-confirmation button {
+  padding: 2px 5px;
+  font-size: var(--icm-font-xs);
+}
+.simulation-setup-delete-confirm {
+  color: #b42318 !important;
 }
 .simulation-status-running,
 .simulation-status-cancelling {
@@ -132,19 +212,33 @@
   background: var(--icm-accent) !important;
   font-weight: 650;
 }
+.simulation-run-button {
+  width: 30px;
+  padding: 0 !important;
+}
 .simulation-stop-button {
   color: #b42318 !important;
   border-color: #fda29b !important;
 }
-.simulation-minimize-button {
-  margin-left: auto;
+.simulation-window-actions {
+  display: flex;
+  align-items: flex-start;
+  gap: 0;
 }
 .simulation-maximize-button,
 .simulation-minimize-button,
 .simulation-close-button {
-  width: 30px;
+  width: 23px;
+  min-height: 23px !important;
   padding: 0 !important;
-  font-size: 18px !important;
+  border-color: transparent !important;
+  border-radius: 3px !important;
+  font-size: 15px !important;
+  line-height: 1;
+}
+.simulation-close-button:hover {
+  color: #fff !important;
+  background: #d92d20 !important;
 }
 
 .spice-simulation-surface.maximized {
@@ -163,22 +257,10 @@
   margin-inline: auto;
 }
 
-@media (min-width: 1101px) {
-  .spice-simulation-surface.maximized .simulation-taskbar {
-    grid-template-columns: auto auto minmax(0, 1fr);
-    grid-template-areas: "brand status actions";
-  }
-
-  .spice-simulation-surface.maximized
-    .simulation-taskbar:has(.simulation-cell-context) {
-    grid-template-areas:
-      "brand status actions"
-      "context context context";
-  }
-
-  .spice-simulation-surface.maximized .simulation-task-actions {
-    justify-content: flex-end;
-  }
+.spice-simulation-surface.maximized .simulation-results-header {
+  box-sizing: border-box;
+  width: min(100%, 960px);
+  margin-inline: auto;
 }
 
 .simulation-workspace-notice {
@@ -462,6 +544,8 @@
   overflow-x: auto;
 }
 .simulation-results-header [role="tab"] {
+  min-height: 26px;
+  padding: 3px 7px;
   border-color: transparent;
   background: transparent;
   white-space: nowrap;
@@ -717,7 +801,7 @@
 .ac-results-explorer {
   position: relative;
   display: grid;
-  gap: 10px;
+  gap: 6px;
   min-width: 0;
 }
 .ac-results-explorer > header {
@@ -739,13 +823,13 @@
 .simulation-plot-layout {
   display: grid;
   grid-template-columns: minmax(74px, 108px) minmax(0, 1fr);
-  gap: 8px;
+  gap: 6px;
   align-items: start;
   min-width: 0;
 }
 .simulation-plot-stack {
   display: grid;
-  gap: 10px;
+  gap: 8px;
   min-width: 0;
 }
 .waveform-trace-list {
@@ -754,7 +838,7 @@
   display: grid;
   gap: 4px;
   min-width: 0;
-  padding-top: 21px;
+  padding-top: 20px;
 }
 .waveform-trace-toggle {
   width: 100%;
@@ -803,15 +887,8 @@
 }
 .ac-quantity-group {
   display: grid;
-  gap: 8px;
+  gap: 4px;
   min-width: 0;
-}
-.ac-quantity-group > h4 {
-  margin: 4px 0 0;
-  color: var(--icm-text-muted);
-  font-size: var(--icm-font-xs);
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
 }
 .ac-plot-row {
   display: grid;
@@ -819,13 +896,14 @@
   min-width: 0;
 }
 .ac-plot-row > strong {
+  padding-left: 2px;
   font-size: var(--icm-font-xs);
 }
 .spice-ac-plot.interactive {
   position: relative;
   min-width: 0;
-  border: 1px solid var(--icm-border);
-  border-radius: var(--icm-radius-sm);
+  border: 0;
+  border-radius: 0;
   background: #fff;
   cursor: crosshair;
   touch-action: none;
@@ -835,22 +913,35 @@
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 0;
+  overflow: hidden;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  background: #fff;
 }
 .ac-plot-toolbar {
   position: relative;
   order: -1;
-  align-self: flex-end;
+  align-self: stretch;
+  justify-content: flex-end;
   flex-wrap: wrap;
   display: flex;
   gap: 2px;
-  padding: 3px;
-  border: 1px solid var(--icm-border);
-  border-radius: var(--icm-radius-sm);
-  background: color-mix(in srgb, var(--icm-surface) 94%, transparent);
-  box-shadow: var(--icm-shadow-sm);
+  padding: 3px 4px;
+  border: 0;
+  border-bottom: 1px solid var(--icm-border);
+  border-radius: 0;
+  background: var(--icm-surface-muted);
+  box-shadow: none;
   opacity: 1;
   pointer-events: auto;
+}
+.ac-plot-shell > .ac-cursor-readout {
+  margin: 0;
+  border: 0;
+  border-top: 1px solid var(--icm-border);
+  border-radius: 0;
+  box-shadow: none;
 }
 .ac-plot-shell:hover .ac-plot-toolbar,
 .ac-plot-shell:focus-within .ac-plot-toolbar,
@@ -964,20 +1055,13 @@
 
 @media (max-width: 700px) {
   .simulation-taskbar {
-    grid-template-columns: minmax(0, 1fr) auto;
-    grid-template-areas:
-      "status status"
-      "actions actions";
+    grid-template-columns: auto minmax(0, 1fr) auto;
   }
-  .simulation-taskbar:has(.simulation-cell-context) {
-    grid-template-areas:
-      "context context"
-      "status status"
-      "actions actions";
+  .simulation-brand {
+    min-width: 68px;
   }
-  .simulation-brand,
-  .simulation-settings-button {
-    display: none;
+  .simulation-brand strong {
+    font-size: var(--icm-font-sm);
   }
   .simulation-plot-layout {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## Summary
- consolidate setup lifecycle, navigation, deck preparation, and run controls into one compact taskbar
- remove the duplicate Simulation Cell selector so Manage Cells remains the only Cell workspace control
- tighten result navigation and combine waveform controls with their plot frames
- add automatic AC, TRAN, and DC plot padding while preserving explicit user ranges

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
- 2749 unit tests passed (28 skipped)
- 6 simulation/Agent browser tests passed
- 134 manual Editor browser tests passed

Test-Impact: tests-updated