### PR TITLE
fix(simulation): restore compact shell controls

### DIFF
--- a/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
@@ -35,7 +35,13 @@ describe("SpiceSimulationSurface workspace", () => {
     expect(markup).not.toContain("<label>Testbench Cell");
     expect(markup).toContain('aria-pressed="true">Settings');
     expect(markup).toContain('aria-pressed="false">Results');
-    expect(markup).toContain('aria-label="Maximize simulation"');
+    expect(markup.indexOf('aria-label="Minimize simulation"')).toBeLessThan(
+      markup.indexOf('aria-label="Maximize simulation"'),
+    );
+    expect(markup.indexOf('aria-label="Maximize simulation"')).toBeLessThan(
+      markup.indexOf('aria-label="Exit simulation"'),
+    );
+    expect(markup).toContain('class="simulation-minimize-glyph"');
     expect(markup).toContain('<select name="profileId"');
     expect(markup).not.toContain("<datalist");
     expect(markup).toContain("sky130-core-continuous-ngspice46-v1");
@@ -49,6 +55,7 @@ describe("SpiceSimulationSurface workspace", () => {
     expect(markup).toContain(
       'class="simulation-setup-group simulation-analysis-row"',
     );
+    expect(markup).toContain('class="simulation-analysis-options"');
     expect(markup).toContain(
       'class="simulation-setup-group simulation-inline-fields columns-2"',
     );

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -614,6 +614,14 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
         </div>
         <div className="simulation-window-actions">
           <button
+            className="simulation-minimize-button"
+            onClick={props.onMinimize}
+            aria-label="Minimize simulation"
+            title="Minimize simulation"
+          >
+            <span className="simulation-minimize-glyph" aria-hidden="true" />
+          </button>
+          <button
             className="simulation-maximize-button"
             onClick={props.onToggleMaximized}
             aria-label={
@@ -628,13 +636,6 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
             }
           >
             {props.maximized ? "↙" : "□"}
-          </button>
-          <button
-            className="simulation-minimize-button"
-            onClick={props.onMinimize}
-            aria-label="Minimize simulation"
-          >
-            —
           </button>
           <button
             className="simulation-close-button"
@@ -1424,43 +1425,47 @@ function SetupEditor({
         </div>
         <fieldset className="simulation-setup-group simulation-analysis-row">
           <legend>Analyses</legend>
-          <label>
-            <input
-              name="dc"
-              type="checkbox"
-              checked={dcEnabled}
-              onChange={(event) => setDcEnabled(event.currentTarget.checked)}
-            />
-            DC
-          </label>
-          <label>
-            <input
-              name="op"
-              type="checkbox"
-              defaultChecked={
-                !saved || saved.analyses.some((a) => a.kind === "op")
-              }
-            />
-            OP
-          </label>
-          <label>
-            <input
-              name="ac"
-              type="checkbox"
-              checked={acEnabled}
-              onChange={(event) => setAcEnabled(event.currentTarget.checked)}
-            />
-            AC
-          </label>
-          <label>
-            <input
-              name="tran"
-              type="checkbox"
-              checked={tranEnabled}
-              onChange={(event) => setTranEnabled(event.currentTarget.checked)}
-            />
-            TRAN
-          </label>
+          <div className="simulation-analysis-options">
+            <label>
+              <input
+                name="dc"
+                type="checkbox"
+                checked={dcEnabled}
+                onChange={(event) => setDcEnabled(event.currentTarget.checked)}
+              />
+              DC
+            </label>
+            <label>
+              <input
+                name="op"
+                type="checkbox"
+                defaultChecked={
+                  !saved || saved.analyses.some((a) => a.kind === "op")
+                }
+              />
+              OP
+            </label>
+            <label>
+              <input
+                name="ac"
+                type="checkbox"
+                checked={acEnabled}
+                onChange={(event) => setAcEnabled(event.currentTarget.checked)}
+              />
+              AC
+            </label>
+            <label>
+              <input
+                name="tran"
+                type="checkbox"
+                checked={tranEnabled}
+                onChange={(event) =>
+                  setTranEnabled(event.currentTarget.checked)
+                }
+              />
+              TRAN
+            </label>
+          </div>
         </fieldset>
         {dcEnabled ? (
           <div className="simulation-setup-group simulation-analysis-settings">

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -65,11 +65,7 @@
   align-items: center;
   gap: 4px;
   min-width: 0;
-  overflow-x: auto;
-  scrollbar-width: none;
-}
-.simulation-task-actions::-webkit-scrollbar {
-  display: none;
+  overflow: visible;
 }
 .simulation-task-actions > button {
   flex: 0 0 auto;
@@ -236,6 +232,13 @@
   font-size: 15px !important;
   line-height: 1;
 }
+.simulation-minimize-glyph {
+  display: block;
+  width: 8px;
+  height: 1px;
+  margin: 0 auto;
+  background: currentColor;
+}
 .simulation-close-button:hover {
   color: #fff !important;
   background: #d92d20 !important;
@@ -384,23 +387,23 @@
   );
 }
 .simulation-analysis-row {
-  display: grid;
-  grid-template-columns: auto repeat(3, minmax(54px, 1fr));
-  gap: 6px;
-  align-items: center;
   min-width: 0;
   margin: 8px 0;
   padding: 7px 8px;
 }
 .simulation-analysis-row legend {
-  float: left;
-  margin-right: 4px;
+  padding: 0 3px;
   color: var(--icm-text-muted);
   font-size: var(--icm-font-xs);
 }
-.simulation-analysis-row > label {
+.simulation-analysis-options {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 6px;
+  min-width: 0;
+}
+.simulation-analysis-options > label {
   display: flex;
-  grid-template-columns: none;
   gap: 5px;
   justify-content: center;
   min-width: 0;


### PR DESCRIPTION
## Summary
- keep the Setup lifecycle menu visible outside the compact taskbar so create/select/confirmed delete remains usable
- order window controls as minimize, maximize, close and replace the long dash with a fixed short glyph
- keep DC, OP, AC, and TRAN in one explicit four-column analysis row

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
- 2750 unit tests passed (28 skipped)
- focused Setup lifecycle browser regression passed

Test-Impact: tests-updated