### PR TITLE
Fix simulation setup apply lifecycle

### DIFF
--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -201,6 +201,9 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
     panel.getByRole("button", { name: "Remove output" }),
   ).toHaveCount(7);
   await expect(panel.getByLabel("Stop (Hz)")).toHaveValue("1000000000");
+  await panel.getByRole("button", { name: "Apply setup" }).click();
+  await expect(panel.getByRole("alert")).toHaveCount(0);
+  await expect(panel.getByRole("status")).not.toHaveText("Setup changed");
 });
 
 test("one Testbench persists several independently named setups", async ({
@@ -236,6 +239,11 @@ test("one Testbench persists several independently named setups", async ({
   await selector.click();
   await panel.getByRole("button", { name: "New setup", exact: true }).click();
   await expect(selector).toContainText("Setup 2");
+  await panel.getByLabel("Setup name").fill("OTA OP and AC");
+  await panel.getByLabel("Setup name").press("Tab");
+  await expect(panel.getByRole("alert")).toContainText(
+    "EDIT_PRECONDITION: Simulation setup name already exists: OTA OP and AC",
+  );
   await panel.getByLabel("Setup name").fill("Bias search");
   await panel.getByRole("button", { name: "Apply setup" }).click();
   await panel.getByLabel("Setup name").fill("Bias sweep");

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -610,7 +610,7 @@ export function App({
     setNewTestbenchDutId(null);
     setSimulationDraftContext(null);
     setActiveSimulationSetupId(null);
-  }, [project.id]);
+  }, [projectSessionId]);
   const [canvasContextMenu, setCanvasContextMenu] = useState<{
     x: number;
     y: number;
@@ -963,7 +963,7 @@ export function App({
     beginSelectionMove: beginSelectionMoveInteraction,
     cancelInteraction,
   } = useInteractionState<SchematicClipboard>();
-  const { commitStructure, transact, transactConnectivity } =
+  const { commitStructure, transactStructure, transact, transactConnectivity } =
     createEditorTransactionCommands({
       project,
       document,
@@ -1088,6 +1088,11 @@ export function App({
     setPendingWaveformPlacement(null);
     setWaveformPlacementPoint(null);
   }, [document.id]);
+  useEffect(() => {
+    setSimulationPickModeState(null);
+    setAnalogPickedNet(null);
+    setAnalogPickedTerminal(null);
+  }, [projectSessionId]);
   const routeCounter = useRef(0);
   const canvasDragSessionRef = useRef<CanvasDragSession | null>(null);
   /**
@@ -4763,14 +4768,46 @@ export function App({
               onMinimize={minimizeAnalogSimulation}
               onExit={exitAnalogSimulation}
               onSaveSetup={(setup) => {
-                const committed = commitStructure("upsert-simulation-setup", [
+                const result = transactStructure("upsert-simulation-setup", [
                   { kind: "upsert_simulation_setup", setup },
                 ]);
-                if (committed) {
+                if (result.ok) {
                   setSimulationDraftContext(null);
                   setActiveSimulationSetupId(setup.id);
+                  setStatus(
+                    result.applied
+                      ? `Updated simulation setup ${setup.name}`
+                      : `Simulation setup ${setup.name} is already up to date`,
+                  );
+                  return {
+                    status: result.applied ? "applied" : "unchanged",
+                  };
                 }
-                return committed;
+                const firstDiagnostic = result.diagnostics[0];
+                const message =
+                  firstDiagnostic?.message ?? result.error.message;
+                setStatus(`${result.error.code}: ${message}`);
+                return {
+                  status: "rejected",
+                  problem: {
+                    code: result.error.code,
+                    message,
+                    stage: "input",
+                    recovery: "fix-input",
+                    ...(result.diagnostics.length
+                      ? {
+                          diagnostics: result.diagnostics.map((diagnostic) => ({
+                            code: diagnostic.code,
+                            message: diagnostic.message,
+                            severity: diagnostic.severity,
+                            ...(diagnostic.path?.length
+                              ? { field: diagnostic.path.join(".") }
+                              : {}),
+                          })),
+                        }
+                      : {}),
+                  },
+                };
               }}
               onDeleteSetup={(setupId) => {
                 const committed = commitStructure("remove-simulation-setup", [

--- a/apps/editor/src/app/editor-transaction-commands.test.ts
+++ b/apps/editor/src/app/editor-transaction-commands.test.ts
@@ -59,6 +59,44 @@ describe("editor transaction commands", () => {
     );
   });
 
+  it("preserves a legal structural no-op for callers that distinguish unchanged", () => {
+    const input = dependencies();
+    const unchanged = {
+      ok: true as const,
+      applied: false,
+      structureRevision: 0,
+      proposedStructureRevision: 0,
+      project: input.project,
+      proposedProject: input.project,
+      changedDocumentIds: [],
+      documentResults: [],
+      diagnostics: [],
+    };
+    input.dispatchProjectTransaction.mockReturnValue(unchanged);
+    const commands = createEditorTransactionCommands(input);
+
+    expect(
+      commands.transactStructure("upsert-simulation-setup", [
+        {
+          kind: "upsert_simulation_setup",
+          setup: {
+            id: "setup-1",
+            name: "OP",
+            version: 2,
+            input: {
+              kind: "structured",
+              rootDocumentId: input.document.id,
+              analyses: [{ kind: "op" }],
+              outputs: [],
+              environment: { profileId: "profile" },
+            },
+          },
+        },
+      ]),
+    ).toBe(unchanged);
+    expect(input.setStatus).not.toHaveBeenCalled();
+  });
+
   it("cancels an unrelated transient tool after a successful commit", () => {
     const input = dependencies();
     input.getCurrentInteractionKind.mockReturnValue("copy-placement");

--- a/apps/editor/src/app/editor-transaction-commands.ts
+++ b/apps/editor/src/app/editor-transaction-commands.ts
@@ -79,12 +79,12 @@ export function createEditorTransactionCommands({
   cancelAllTransientInteraction,
   setStatus,
 }: EditorTransactionCommandDependencies) {
-  const commitStructure = (
+  const transactStructure = (
     transactionId: string,
     edits: ProjectStructureEdit[],
     activeDocumentId = document.id,
-  ): boolean => {
-    const result = dispatchProjectTransaction(
+  ): ProjectTransactionResult =>
+    dispatchProjectTransaction(
       {
         transactionId,
         projectId: project.id,
@@ -94,6 +94,13 @@ export function createEditorTransactionCommands({
       },
       activeDocumentId,
     );
+
+  const commitStructure = (
+    transactionId: string,
+    edits: ProjectStructureEdit[],
+    activeDocumentId = document.id,
+  ): boolean => {
+    const result = transactStructure(transactionId, edits, activeDocumentId);
     if (result.ok && result.applied) return true;
     const message = result.ok
       ? "The structural transaction made no change"
@@ -199,5 +206,10 @@ export function createEditorTransactionCommands({
     return transact([...gate.edits], options);
   };
 
-  return { commitStructure, transact, transactConnectivity };
+  return {
+    commitStructure,
+    transactStructure,
+    transact,
+    transactConnectivity,
+  };
 }

--- a/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
@@ -20,7 +20,7 @@ describe("SpiceSimulationSurface workspace", () => {
         onToggleMaximized={() => undefined}
         onMinimize={() => undefined}
         onExit={() => undefined}
-        onSaveSetup={() => true}
+        onSaveSetup={() => ({ status: "applied" })}
         onDeleteSetup={() => true}
       />,
     );
@@ -125,7 +125,7 @@ describe("SpiceSimulationSurface workspace", () => {
         onToggleMaximized={() => undefined}
         onMinimize={() => undefined}
         onExit={() => undefined}
-        onSaveSetup={() => true}
+        onSaveSetup={() => ({ status: "applied" })}
         onDeleteSetup={() => true}
       />,
     );
@@ -167,7 +167,7 @@ describe("SpiceSimulationSurface workspace", () => {
         onToggleMaximized={() => undefined}
         onMinimize={() => undefined}
         onExit={() => undefined}
-        onSaveSetup={() => true}
+        onSaveSetup={() => ({ status: "applied" })}
         onDeleteSetup={() => true}
       />,
     );

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -81,7 +81,7 @@ export interface SpiceSimulationSurfaceProps {
   onToggleMaximized(): void;
   onMinimize(): void;
   onExit(): void;
-  onSaveSetup(setup: ProjectSimulationSetup): boolean;
+  onSaveSetup(setup: ProjectSimulationSetup): SimulationSetupSaveResult;
   onDeleteSetup(setupId: string): boolean;
   pickNetsActive?: boolean;
   pickedNet?: {
@@ -108,6 +108,10 @@ export interface SpiceSimulationSurfaceProps {
   ): void;
   onFocusDiagnostic?(locator: ObjectLocator): void;
 }
+
+export type SimulationSetupSaveResult =
+  | { readonly status: "applied" | "unchanged" }
+  | { readonly status: "rejected"; readonly problem: Problem };
 
 interface PreparedPresentation {
   readonly prepared: Prepared;
@@ -407,7 +411,9 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
       ? "Simulation service is unavailable in this environment."
       : /probe/i.test(problemSearchText)
         ? "The probe selection needs attention. Open Console for details."
-        : "Simulation needs attention. Open Console for details."
+        : activeProblem.stage === "input"
+          ? `${activeProblem.code}: ${activeProblem.message}`
+          : "Simulation needs attention. Open Console for details."
     : staleMessage;
   const runPresentation = run
     ? preparedPresentations.current.get(run.preparedId)
@@ -447,10 +453,11 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
             },
           },
     };
-    if (props.onSaveSetup(created)) {
+    const result = props.onSaveSetup(created);
+    if (result.status !== "rejected") {
       props.onSelectSetupId(created.id);
       setupMenuRef.current?.removeAttribute("open");
-    }
+    } else setProblem(result.problem);
   };
   return (
     <section
@@ -1331,16 +1338,15 @@ function SetupEditor({
             setup?.id ??
             draftContext?.setupId ??
             `simulation-setup-${crypto.randomUUID()}`;
-          if (onSaveSetup({ id: setupId, name: setupName, ...parsed.data })) {
+          const result = onSaveSetup({
+            id: setupId,
+            name: setupName,
+            ...parsed.data,
+          });
+          if (result.status !== "rejected") {
             onDirty(false);
             onProblem(undefined);
-          } else
-            onProblem(
-              uiProblem(
-                "SIMULATION_SETUP_NOT_APPLIED",
-                "Setup was not applied. See the editor status; your draft is retained.",
-              ),
-            );
+          } else onProblem(result.problem);
         }}
       >
         <label>
@@ -1363,15 +1369,11 @@ function SetupEditor({
                 );
                 return;
               }
-              if (onSaveSetup({ ...setup, name })) onProblem(undefined);
+              const result = onSaveSetup({ ...setup, name });
+              if (result.status !== "rejected") onProblem(undefined);
               else {
                 setSetupName(setup.name);
-                onProblem(
-                  uiProblem(
-                    "SIMULATION_SETUP_RENAME_FAILED",
-                    "The setup name could not be saved.",
-                  ),
-                );
+                onProblem(result.problem);
               }
             }}
           />


### PR DESCRIPTION
## Summary
- treat idempotent simulation setup saves as successful unchanged outcomes
- preserve exact transaction diagnostics for rejected setup edits
- reset simulation draft and picker state by project session identity

## Validation
- pnpm ci:static
- pnpm test:local apps/editor/src/app/editor-transaction-commands.test.ts apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
- focused gent-simulation regression (2 tests)
- pnpm gate:preflight -- --base main
- pnpm gate:affected -- --base main (2751 unit tests; 154 browser tests)

Test-Impact: tests-updated