### PR TITLE
Qualify the four-analysis Agent simulation journey

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -144,7 +144,7 @@ jobs:
             exit 1
           fi
       # A divider checks the transport and the persisted OTA Project checks the
-      # product compiler plus OP/AC model evidence. Both run on the preview's
+      # product compiler plus OP/DC/AC/TRAN model evidence. Both run on the preview's
       # simulator host; a green status without numbers is not acceptance.
       - name: Run the preview's numerical and vertical simulation acceptance
         run: node scripts/preview-simulation-smoke.mjs "$PREVIEW_URL"

--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -73,8 +73,8 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
       json: {
         configured: true,
         inputs: ["structured", "raw"],
-        analyses: ["op", "ac", "tran"],
-        parsedAnalyses: ["op", "ac", "tran"],
+        analyses: ["op", "dc", "ac", "tran"],
+        parsedAnalyses: ["op", "dc", "ac", "tran"],
         profiles: [{ id: profile.id, corners: ["tt"] }],
         maxTimeoutMs: 120000,
         maxInputBytes: 1048576,
@@ -95,6 +95,8 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
   await panel.getByRole("button", { name: "Settings" }).click();
   await expect(panel.getByLabel("Testbench Cell")).toHaveCount(0);
   await expect(panel.getByLabel("Stop (Hz)")).toHaveValue("1000000000");
+  await expect(panel.getByLabel("DC sweep source")).toHaveValue("VINP");
+  await expect(panel.getByLabel("TRAN stop (s)")).toHaveValue("0.000004");
   await expect(panel.getByLabel("Environment profile")).toHaveValue(profile.id);
   await expect(
     panel.getByRole("button", { name: "Remove output" }),
@@ -145,6 +147,8 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
   expect(deck).toMatch(/i\(vicmprb\d+\)/u);
   expect(deck).toMatch(/i\(v\.xdut\.vicmprb\d+\)/u);
   expect(deck).toMatch(/ac dec 10 1 (?:1000000000|1e\+?9)/i);
+  expect(deck).toContain("dc VINP 0.88 0.92 0.005");
+  expect(deck).toContain("tran 2e-8 0.000004");
   expect(executions).toBe(0);
   await panel.getByRole("button", { name: "Minimize simulation" }).click();
   const saved = JSON.parse(
@@ -235,14 +239,14 @@ test("one Testbench persists several independently named setups", async ({
     .click();
   const panel = page.getByRole("region", { name: "Analog simulation" });
   const selector = panel.getByTitle("Simulation setup", { exact: true });
-  await expect(selector).toContainText("OTA OP and AC");
+  await expect(selector).toContainText("OTA OP, DC, AC, and TRAN");
   await selector.click();
   await panel.getByRole("button", { name: "New setup", exact: true }).click();
   await expect(selector).toContainText("Setup 2");
-  await panel.getByLabel("Setup name").fill("OTA OP and AC");
+  await panel.getByLabel("Setup name").fill("OTA OP, DC, AC, and TRAN");
   await panel.getByLabel("Setup name").press("Tab");
   await expect(panel.getByRole("alert")).toContainText(
-    "EDIT_PRECONDITION: Simulation setup name already exists: OTA OP and AC",
+    "EDIT_PRECONDITION: Simulation setup name already exists: OTA OP, DC, AC, and TRAN",
   );
   await panel.getByLabel("Setup name").fill("Bias search");
   await panel.getByRole("button", { name: "Apply setup" }).click();
@@ -256,7 +260,7 @@ test("one Testbench persists several independently named setups", async ({
   expect(saved.simulationSetups).toHaveLength(2);
   expect(
     saved.simulationSetups.map((setup: { name: string }) => setup.name),
-  ).toEqual(["OTA OP and AC", "Bias sweep"]);
+  ).toEqual(["OTA OP, DC, AC, and TRAN", "Bias sweep"]);
   expect(
     new Set(
       saved.simulationSetups.map(
@@ -274,7 +278,7 @@ test("one Testbench persists several independently named setups", async ({
   ).toBeVisible();
   await panel.getByRole("button", { name: "Delete Bias sweep" }).click();
   await panel.getByRole("button", { name: "Confirm", exact: true }).click();
-  await expect(selector).toContainText("OTA OP and AC");
+  await expect(selector).toContainText("OTA OP, DC, AC, and TRAN");
   await selector.click();
   await expect(
     panel.getByRole("button", { name: "Bias sweep", exact: true }),
@@ -283,7 +287,7 @@ test("one Testbench persists several independently named setups", async ({
     (await downloadBytes(page, "File", "Export Project File…")).toString(),
   );
   expect(afterDelete.simulationSetups).toHaveLength(1);
-  expect(afterDelete.simulationSetups[0].name).toBe("OTA OP and AC");
+  expect(afterDelete.simulationSetups[0].name).toBe("OTA OP, DC, AC, and TRAN");
 });
 
 test("human simulation uses saved setup, survives minimizing, recovers a bad input and exports results", async ({

--- a/apps/editor/src/examples/five-transistor-ota-sky130.icproj.json
+++ b/apps/editor/src/examples/five-transistor-ota-sky130.icproj.json
@@ -555,7 +555,15 @@
             },
             "parameters": {
               "acMagnitude": "1",
-              "dc": "0.9"
+              "dc": "0.9",
+              "delay": "1u",
+              "fall": "1n",
+              "high": "0.91",
+              "low": "0.9",
+              "period": "3u",
+              "rise": "1n",
+              "waveform": "pulse",
+              "width": "1u"
             }
           },
           "placement": {
@@ -856,7 +864,7 @@
         "grid": 10,
         "styleProfileId": "razavi-textbook-v1"
       },
-      "revision": 31,
+      "revision": 32,
       "routes": [
         {
           "id": "tb-gnd-vdd-route",
@@ -3018,7 +3026,7 @@
   "simulationSetups": [
     {
       "id": "simulation-setup-ota-op-ac",
-      "name": "OTA OP and AC",
+      "name": "OTA OP, DC, AC, and TRAN",
       "version": 2,
       "input": {
         "kind": "structured",
@@ -3028,11 +3036,23 @@
             "kind": "op"
           },
           {
+            "kind": "dc",
+            "sourceInstanceId": "VINP",
+            "startValue": 0.88,
+            "stopValue": 0.92,
+            "stepValue": 0.005
+          },
+          {
             "kind": "ac",
             "sweep": "dec",
             "points": 10,
             "startHz": 1,
             "stopHz": 1000000000
+          },
+          {
+            "kind": "tran",
+            "stepSeconds": 2e-8,
+            "stopSeconds": 0.000004
           }
         ],
         "outputs": [
@@ -3107,7 +3127,7 @@
     "files": [],
     "sourcePolicy": "copy"
   },
-  "structureRevision": 75,
+  "structureRevision": 76,
   "symbolLibrary": {
     "hash": "razavi-reference-v1",
     "id": "razavi-symbols",

--- a/apps/editor/src/examples/library-examples.test.ts
+++ b/apps/editor/src/examples/library-examples.test.ts
@@ -274,7 +274,7 @@ describe("the bundled five-transistor Sky130 OTA", () => {
     ).toBeGreaterThan(0);
   });
 
-  it("persists and compiles its OP and AC acceptance setup", async () => {
+  it("persists and compiles its four-analysis acceptance setup", async () => {
     const setup = project.simulationSetups[0];
     expect(setup).toBeDefined();
     expect(setup?.input.kind).toBe("structured");
@@ -283,11 +283,13 @@ describe("the bundled five-transistor Sky130 OTA", () => {
     expect(compiled.ok).toBe(true);
     if (!compiled.ok) return;
 
-    expect(compiled.request.analyses).toEqual(["op", "ac"]);
+    expect(compiled.request.analyses).toEqual(["op", "dc", "ac", "tran"]);
     expect(compiled.request.testbench).toContain("VINP");
     expect(compiled.request.testbench).toContain("AC 1 0");
     expect(compiled.request.testbench).toContain("op");
     expect(compiled.request.testbench).toContain("ac dec 10 1 1000000000");
+    expect(compiled.request.testbench).toContain("dc VINP 0.88 0.92 0.005");
+    expect(compiled.request.testbench).toContain("tran 2e-8 0.000004");
     expect(compiled.request.testbench).toContain("set appendwrite");
     expect(compiled.vectors).toEqual([
       { probeId: "probe-vout", vector: "v(vout)", quantity: "voltage" },

--- a/docs/specs/simulation.md
+++ b/docs/specs/simulation.md
@@ -72,9 +72,9 @@ Profile.
 
 The first qualified scope is deliberately narrow and factual: the continuous
 `sky130_fd_pr__nfet_01v8` and `sky130_fd_pr__pfet_01v8` wrappers, `tt`, and
-OP/AC/TRAN covered by the hosted model acceptance fixture. A separate
-independent-source divider smoke qualifies DC parsing and numerical sweep
-behavior on the same pinned runtime. TRAN qualification includes an ideal RC
+OP/DC/AC/TRAN covered by the hosted model acceptance fixture. A separate
+independent-source divider smoke gives DC parsing and numerical sweep behavior
+an exact closed-form check on the same pinned runtime. TRAN qualification includes an ideal RC
 step and a structured SKY130 OTA pulse response on the pinned ngspice 46
 environment. Adding another corner or device family extends this same Profile
 contract only after a model-backed fixture passes the hosted
@@ -404,11 +404,12 @@ into the Project, undo history, Gallery, or recovery copy.
 - `containers/ngspice/profile-contract.test.mjs` binds the Profile to the
   digest-pinned image and exact startup bytes. The Preview gate opens the
   tracked five-transistor OTA Project, compiles its persisted structured setup,
-  and sends that exact prepared OP+AC request through the operator-host
+  and sends that exact prepared OP/DC/AC/TRAN request through the operator-host
   executor. It requires the Profile identity and `tt` model selection, checks
-  all four compile-time probe bindings, compares four OP voltages, and compares
-  representative complex AC samples against the recorded qualification
-  fixture. Missing local ngspice never skips this hosted gate.
+  all four compile-time output bindings, compares four OP voltages, selected DC
+  transfer points, representative complex AC samples, and transient extrema
+  against the recorded qualification fixture. Missing local ngspice never
+  skips this hosted gate.
 - The pinned local authority pack under ignored `.reference-src/` demonstrates
   that ngspice 47 completes a Sky130 NFET operating-point deck with
   `.lib ... tt`, while top-level `.include` produces repeated subcircuit
@@ -477,12 +478,12 @@ a bare `write out.raw`, saving the whole plot rather than nothing.
 
 Vector names are produced here and never inferred from result text:
 
-| primitive acquisition                    | vector                   |
-| ---------------------------------------- | ------------------------ |
-| Net in the root                          | `v(mid)`                 |
-| Net under occurrence `X1`, `XI1`         | `v(x1.xi1.mid)`          |
-| terminal current in the root             | `i(vicmprb###)`          |
-| terminal current under `X1`, `XI1`       | `i(v.x1.xi1.vicmprb###)` |
+| primitive acquisition              | vector                   |
+| ---------------------------------- | ------------------------ |
+| Net in the root                    | `v(mid)`                 |
+| Net under occurrence `X1`, `XI1`   | `v(x1.xi1.mid)`          |
+| terminal current in the root       | `i(vicmprb###)`          |
+| terminal current under `X1`, `XI1` | `i(v.x1.xi1.vicmprb###)` |
 
 They are lower case because ngspice folds case on the way into the rawfile: a
 card may read `R1 IN MID 1k`, and `V(MidNode)` still comes back as
@@ -1036,7 +1037,7 @@ release. A deployment without the binding answers
 - `scripts/preview-simulation-smoke.mjs`: the bundled five-transistor OTA
   Project is the vertical acceptance asset. Its saved `SimulationSetup` is
   parsed and compiled by the production Project/netlist packages before the
-  generated OP+AC and structured TRAN requests reach Preview. The same gate
+  generated OP/DC/AC/TRAN request reaches Preview. The same gate
   also runs an ideal RC pulse deck. Returned input revisions, environment
   Profile, model corner, frequency/time axes, probe series, OP values,
   selected AC complex samples, and OTA transient extrema must agree with the

--- a/docs/user/analog-simulation.md
+++ b/docs/user/analog-simulation.md
@@ -7,11 +7,13 @@ canvas available; it is separate from the development-only Digital tool.
 ## Try it: the bundled five-transistor OTA
 
 The editor ships a Sky130 five-transistor OTA with its stimulus and a saved
-OP + AC setup. On the preview channel open
+OP + DC + AC + TRAN setup. On the preview channel open
 `https://analog-canvas-preview.tokenzhang.com/editor?example=five-transistor-ota-sky130`,
 press **Simulation**, then **Run**. The operating point returns
 v(vout) ≈ 0.75898 V, v(ibias) ≈ 0.60440 V, v(xdut.tail) ≈ 0.28487 V and
-v(xdut.nleft) ≈ 0.75898 V, and the AC sweep plots 1 Hz–1 GHz. The preview
+v(xdut.nleft) ≈ 0.75898 V. The DC sweep covers VINP from 0.88 V to 0.92 V,
+the AC sweep plots 1 Hz–1 GHz, and the transient source pulses VINP from
+0.90 V to 0.91 V. The preview
 deploy runs this same journey against the live simulator before it goes
 green, so those numbers are also its acceptance evidence. The Gallery panel
 lists published circuits, not bundled examples; the `?example=` link and
@@ -37,10 +39,10 @@ same hierarchy, followed by the existing simulation configure operation.
 ## Setup, run and results
 
 Open **Setup**, create or select a named setup, choose its testbench Cell and advertised environment Profile,
-then set OP/AC, optional corner/temperature, and probes. Voltage probes may
-target a Net at the Testbench root or in a concrete DUT occurrence; current
-probes may target voltage sources. Each choice is written to the same
-occurrence-aware probe contract that Agent authoring uses. Apply commits an
+then set OP/DC/AC/TRAN, optional corner/temperature, and outputs. Voltage
+outputs may target a Net at the Testbench root or in a concrete DUT occurrence;
+current outputs may target circuit terminals. Each choice is written to the
+same occurrence-aware output contract that Agent authoring uses. Apply commits an
 `upsert_simulation_setup` into the Project. One Testbench Cell may have several
 setups (for example bias search and AC response), while a different topology
 uses a different ordinary Testbench Cell. Saving/exporting and reopening the

--- a/fixtures/simulation-acceptance/hosted-sky130-core-continuous-v1.json
+++ b/fixtures/simulation-acceptance/hosted-sky130-core-continuous-v1.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 3,
-  "fixtureId": "ota-5t-structured-op-ac-tran-v1",
+  "fixtureId": "ota-5t-structured-op-dc-ac-tran-v2",
   "profileId": "sky130-core-continuous-ngspice46-v1",
-  "analyses": ["op", "ac", "tran"],
+  "analyses": ["op", "dc", "ac", "tran"],
   "inputs": {
     "project": "apps/editor/src/examples/five-transistor-ota-sky130.icproj.json",
     "netlist": "fixtures/simulation-acceptance/ota-5t.spi",
@@ -17,6 +17,31 @@
     "v(ibias)": { "value": 0.6044031364286973, "absoluteTolerance": 1e-8 },
     "v(xdut.tail)": { "value": 0.2848671983031419, "absoluteTolerance": 1e-8 },
     "v(xdut.nleft)": { "value": 0.7589797395214736, "absoluteTolerance": 1e-8 }
+  },
+  "expectedDc": {
+    "sourceInstanceId": "VINP",
+    "startValue": 0.88,
+    "stopValue": 0.92,
+    "stepValue": 0.005,
+    "pointCount": 9,
+    "sweepName": "v(v-sweep)",
+    "absoluteTolerance": 1e-8,
+    "probes": {
+      "v(vout)": {
+        "samples": [
+          { "index": 0, "value": 0.3052800375191325 },
+          { "index": 4, "value": 0.7589597733013465 },
+          { "index": 8, "value": 1.744078503303503 }
+        ]
+      },
+      "v(xdut.tail)": {
+        "samples": [
+          { "index": 0, "value": 0.2687226173951219 },
+          { "index": 4, "value": 0.2848672269272364 },
+          { "index": 8, "value": 0.2958758389498102 }
+        ]
+      }
+    }
   },
   "expectedAc": {
     "pointCount": 91,
@@ -73,7 +98,10 @@
     "source": {
       "instanceId": "VINP",
       "parameters": {
-        "low": "0.89",
+        "waveform": "pulse",
+        "dc": "0.9",
+        "acMagnitude": "1",
+        "low": "0.9",
         "high": "0.91",
         "delay": "1u",
         "rise": "1n",
@@ -87,10 +115,10 @@
     "timeAbsoluteTolerance": 1e-15,
     "probes": {
       "v(vout)": {
-        "first": 0.3342235191104477,
-        "minimum": 0.3342107447553537,
-        "maximum": 1.698172273444083,
-        "last": 0.3342235434776202,
+        "first": 0.7589797395133877,
+        "minimum": 0.75886248142361,
+        "maximum": 1.699250823009046,
+        "last": 0.7732444834989551,
         "absoluteTolerance": 1e-8
       }
     }

--- a/fixtures/simulation-acceptance/ota-5t-hosted.testbench.spice
+++ b/fixtures/simulation-acceptance/ota-5t-hosted.testbench.spice
@@ -1,5 +1,5 @@
 VDD vdd 0 DC 1.8
-VINP vinp 0 DC 0.9
+VINP vinp 0 DC 0.9 AC 1 0 PULSE(0.9 0.91 1u 1n 1n 1u 3u)
 VINN vinn 0 DC 0.9
 IBIAS vdd ibias DC 15u
 XDUT 0 ibias vdd vinn vinp vout ota_5t
@@ -7,6 +7,12 @@ CL vout 0 1p
 .control
 set filetype=ascii
 op
+write out.raw v(vout) v(ibias) v(xdut.tail) v(xdut.nleft)
+dc VINP 0.88 0.92 0.005
+write out.raw v(vout) v(ibias) v(xdut.tail) v(xdut.nleft)
+ac dec 10 1 1000000000
+write out.raw v(vout) v(ibias) v(xdut.tail) v(xdut.nleft)
+tran 2e-8 0.000004
 write out.raw v(vout) v(ibias) v(xdut.tail) v(xdut.nleft)
 .endc
 .end

--- a/scripts/preview-agent-simulation-journey.mjs
+++ b/scripts/preview-agent-simulation-journey.mjs
@@ -193,7 +193,36 @@ try {
     .filter({ hasText: "Connected" })
     .waitFor({ state: "visible", timeout: 30_000 });
 
-  const invalidSetup = structuredClone(setup);
+  const [contextReport, inspected, capabilityReply] = await Promise.all([
+    tool("get_context"),
+    tool("inspect", { target: { kind: "document" }, detail: "full" }),
+    tool("simulation", { request: { operation: "capabilities" } }),
+  ]);
+  const discoveredSetup = inspected.project?.simulationSetups?.find(
+    (candidate) => candidate.id === setup.id,
+  );
+  assert.deepEqual(
+    discoveredSetup,
+    setup,
+    "Agent inspection did not expose the complete authored Simulation setup",
+  );
+  const sourceReport = await tool("inspect", {
+    documentId: discoveredSetup.input.rootDocumentId,
+    target: { kind: "object", id: "VINP" },
+  });
+  assert.equal(
+    sourceReport.parameters?.waveform,
+    "pulse",
+    "Agent inspection did not expose the transient source intent",
+  );
+  assert.equal(capabilityReply.ok, true);
+  assert.deepEqual(
+    capabilityReply.capabilities.analyses,
+    ["op", "dc", "ac", "tran"],
+    "The deployed Profile does not advertise all four qualified analyses",
+  );
+
+  const invalidSetup = structuredClone(discoveredSetup);
   assert.equal(
     invalidSetup.input.kind,
     "structured",
@@ -232,7 +261,9 @@ try {
   assert.equal(refused.error.recovery, "fix-input");
 
   const restored = await tool("advanced_transact", {
-    structureEdits: [{ kind: "upsert_simulation_setup", setup }],
+    structureEdits: [
+      { kind: "upsert_simulation_setup", setup: discoveredSetup },
+    ],
   });
   assert.equal(restored.ok, true);
   const prepared = await tool("simulation", {
@@ -276,13 +307,16 @@ try {
   );
 
   const exports = [];
-  for (const name of ["out.raw", "result.json", "ac-1.csv"]) {
-    exports.push(
-      await exportArtifact(
-        finished.run.artifacts.find((artifact) => artifact.name === name),
-        name,
-      ),
-    );
+  const resultArtifacts = finished.run.artifacts
+    .filter(
+      (artifact) =>
+        artifact.name === "out.raw" ||
+        artifact.name === "result.json" ||
+        artifact.name.endsWith(".csv"),
+    )
+    .sort((left, right) => left.name.localeCompare(right.name));
+  for (const artifact of resultArtifacts) {
+    exports.push(await exportArtifact(artifact, artifact.name));
   }
   exports.push(
     await exportArtifact(
@@ -296,13 +330,74 @@ try {
   report.status = "passed";
   report.completedAt = new Date().toISOString();
   report.connection = { mode: connection.mode };
-  report.recoverableError = refused.error.code;
+  report.discovery = {
+    projectId: contextReport.projectId,
+    documentId: contextReport.documentId,
+    structureRevision: inspected.project?.structureRevision,
+    setup: {
+      id: discoveredSetup.id,
+      name: discoveredSetup.name,
+      rootDocumentId: discoveredSetup.input.rootDocumentId,
+      analyses: discoveredSetup.input.analyses,
+      outputs: discoveredSetup.input.outputs.map((output) => ({
+        id: output.id,
+        label: output.label,
+        expressionKind: output.expression.kind,
+      })),
+    },
+    source: {
+      id: sourceReport.id,
+      reference: sourceReport.reference,
+      parameters: sourceReport.parameters,
+    },
+    capabilities: {
+      inputs: capabilityReply.capabilities.inputs,
+      analyses: capabilityReply.capabilities.analyses,
+      parsedAnalyses: capabilityReply.capabilities.parsedAnalyses,
+      profiles: capabilityReply.capabilities.profiles,
+      maxTimeoutMs: capabilityReply.capabilities.maxTimeoutMs,
+      maxInputBytes: capabilityReply.capabilities.maxInputBytes,
+      maxOutputBytes: capabilityReply.capabilities.maxOutputBytes,
+      cancel: capabilityReply.capabilities.cancel,
+    },
+  };
+  report.recoverableError = {
+    code: refused.error.code,
+    stage: refused.error.stage,
+    recovery: refused.error.recovery,
+    diagnostics: refused.error.diagnostics,
+  };
+  report.prepared = {
+    id: prepared.prepared.id,
+    digest: prepared.prepared.digest,
+    inputRevision: prepared.prepared.inputRevision,
+    mode: prepared.prepared.mode,
+    environment: prepared.prepared.environment,
+    vectors: prepared.prepared.vectors,
+    warnings: prepared.prepared.warnings,
+    artifacts: prepared.prepared.artifacts,
+  };
   report.run = {
     state: finished.run.state,
     outcome: finished.run.result.outcome.status,
     profileId: finished.run.result.metadata.environment.profileId,
     environmentFingerprint: accepted.environmentFingerprint,
     inputRevision: prepared.prepared.inputRevision,
+    preparedId: prepared.prepared.id,
+    runId: finished.run.id,
+    analyses: finished.run.result.data?.analyses.map((analysis) => ({
+      kind: analysis.analysis,
+      plotName: analysis.plotName,
+      points:
+        analysis.analysis === "op"
+          ? 1
+          : analysis.analysis === "dc"
+            ? analysis.sweep.values.length
+            : analysis.analysis === "ac"
+              ? analysis.frequencyHz.length
+              : analysis.timeSeconds.length,
+      outputs: analysis.probes.map((probe) => probe.name),
+    })),
   };
   report.exports = exports;
   await tool("disconnect");

--- a/scripts/preview-simulation-smoke.mjs
+++ b/scripts/preview-simulation-smoke.mjs
@@ -566,6 +566,63 @@ export function validateHostedSky130Result(
     values[name] = probe.value;
   }
 
+  const dc = Array.isArray(data.analyses)
+    ? data.analyses.find(
+        (analysis) =>
+          typeof analysis === "object" &&
+          analysis !== null &&
+          analysis.analysis === "dc",
+      )
+    : null;
+  const expectedDc = qualification.expectedDc;
+  if (!dc || !Array.isArray(dc.sweep?.values) || !Array.isArray(dc.probes)) {
+    throw new Error(`${expectedTarget} returned no qualified DC result.`);
+  }
+  if (
+    dc.sweep.name !== expectedDc.sweepName ||
+    dc.sweep.values.length !== expectedDc.pointCount ||
+    Math.abs(dc.sweep.values[0] - expectedDc.startValue) >
+      expectedDc.absoluteTolerance ||
+    Math.abs(dc.sweep.values.at(-1) - expectedDc.stopValue) >
+      expectedDc.absoluteTolerance
+  ) {
+    throw new Error(`${expectedTarget} returned an unexpected OTA DC axis.`);
+  }
+  for (const binding of expectedVectors) {
+    const probe = dc.probes.find(
+      (candidate) => candidate?.name === binding.vector,
+    );
+    if (!probe || !Array.isArray(probe.value)) {
+      throw new Error(
+        `${expectedTarget} returned no DC series for ${binding.probeId} (${binding.vector}).`,
+      );
+    }
+    if (probe.value.length !== expectedDc.pointCount) {
+      throw new Error(
+        `${expectedTarget} returned an incomplete DC series for ${binding.vector}.`,
+      );
+    }
+  }
+  for (const [name, expected] of Object.entries(expectedDc.probes)) {
+    const probe = dc.probes.find((candidate) => candidate?.name === name);
+    if (!probe || !Array.isArray(probe.value)) {
+      throw new Error(
+        `${expectedTarget} returned no qualified DC series ${name}.`,
+      );
+    }
+    for (const sample of expected.samples) {
+      const actual = probe.value[sample.index];
+      if (
+        typeof actual !== "number" ||
+        Math.abs(actual - sample.value) > expectedDc.absoluteTolerance
+      ) {
+        throw new Error(
+          `${expectedTarget} solved ${name}[${sample.index}] as ${String(actual)}, expected ${sample.value} ± ${expectedDc.absoluteTolerance}.`,
+        );
+      }
+    }
+  }
+
   const ac = Array.isArray(data.analyses)
     ? data.analyses.find(
         (analysis) =>
@@ -645,6 +702,12 @@ export function validateHostedSky130Result(
       }
     }
   }
+  validateHostedSky130TransientResult(
+    payload,
+    expectedTarget,
+    expectedInputRevision,
+    expectedVectors,
+  );
   return {
     target: expectedTarget,
     fixtureId: qualification.fixtureId,

--- a/scripts/preview-simulation-smoke.test.mjs
+++ b/scripts/preview-simulation-smoke.test.mjs
@@ -97,6 +97,15 @@ function modelResult(
   }
   tail.real[60] = 0.4417357549275905;
   tail.imag[60] = -0.1070857397604748;
+  const dcValues = [
+    0.3052800375191325, 0.3169616386791885, 0.334216771353992,
+    0.3797013459856312, 0.7589597733013465, 1.388551981037926,
+    1.699385597389425, 1.730270358029663, 1.744078503303503,
+  ];
+  const tranValues = Array(232).fill(0.7589797395133877);
+  tranValues[1] = 0.75886248142361;
+  tranValues[2] = 1.699250823009046;
+  tranValues[231] = 0.7732444834989551;
   return {
     ...base,
     metadata: {
@@ -118,9 +127,36 @@ function modelResult(
           ],
         },
         {
+          analysis: "dc",
+          sweep: {
+            name: "v(v-sweep)",
+            values: [0.88, 0.885, 0.89, 0.895, 0.9, 0.905, 0.91, 0.915, 0.92],
+          },
+          probes: EXPECTED_VECTORS.map(({ vector }) => ({
+            name: vector,
+            value:
+              vector === "v(vout)"
+                ? dcValues
+                : vector === "v(xdut.tail)"
+                  ? [
+                      0.2687226173951219, 0.27, 0.275, 0.28, 0.2848672269272364,
+                      0.288, 0.291, 0.293, 0.2958758389498102,
+                    ]
+                  : Array(9).fill(0.5),
+          })),
+        },
+        {
           analysis: "ac",
           frequencyHz,
           probes: acProbes,
+        },
+        {
+          analysis: "tran",
+          timeSeconds: [...Array(231).fill(0), 4e-6],
+          probes: EXPECTED_VECTORS.map(({ vector }) => ({
+            name: vector,
+            value: vector === "v(vout)" ? tranValues : Array(232).fill(0.5),
+          })),
         },
       ],
     },
@@ -295,7 +331,7 @@ describe("the hosted SKY130 qualification", () => {
       ),
     ).toMatchObject({
       target: "cloudflare-container",
-      fixtureId: "ota-5t-structured-op-ac-tran-v1",
+      fixtureId: "ota-5t-structured-op-dc-ac-tran-v2",
       environmentFingerprint: SHA,
       values: { "v(vout)": 0.7589797395133877 },
     });
@@ -316,7 +352,7 @@ describe("the hosted SKY130 qualification", () => {
 
   it("refuses AC drift outside the recorded tolerance", () => {
     const candidate = modelResult("operator-host");
-    candidate.data.analyses[1].probes[0].real[60] = 13;
+    candidate.data.analyses[2].probes[0].real[60] = 13;
     expect(() =>
       validateHostedSky130Result(
         candidate,
@@ -325,6 +361,19 @@ describe("the hosted SKY130 qualification", () => {
         EXPECTED_VECTORS,
       ),
     ).toThrow(/solved v\(vout\)\[60\] as 13/u);
+  });
+
+  it("refuses DC drift outside the recorded tolerance", () => {
+    const candidate = modelResult("operator-host");
+    candidate.data.analyses[1].probes[0].value[4] = 0.9;
+    expect(() =>
+      validateHostedSky130Result(
+        candidate,
+        "operator-host",
+        "preview-sky130-operator-host",
+        EXPECTED_VECTORS,
+      ),
+    ).toThrow(/solved v\(vout\)\[4\] as 0\.9/u);
   });
 
   it("refuses a run that did not load the qualified corner", () => {
@@ -357,12 +406,12 @@ describe("the hosted SKY130 qualification", () => {
     expect(submitted.testbench).toContain("set appendwrite");
     expect(submitted.testbench).toContain("write out.raw v(vout)");
     expect(submitted.testbench).toContain("ac dec 10 1 1000000000");
-    expect(accepted.fixtureId).toBe("ota-5t-structured-op-ac-tran-v1");
-  });
+    expect(accepted.fixtureId).toBe("ota-5t-structured-op-dc-ac-tran-v2");
+  }, 15_000);
 
   it("compiles the persisted Project setup into the qualified request", async () => {
     const compiled = await compileHostedSky130Project();
-    expect(compiled.request.analyses).toEqual(["op", "ac"]);
+    expect(compiled.request.analyses).toEqual(["op", "dc", "ac", "tran"]);
     expect(compiled.vectors).toEqual(EXPECTED_VECTORS);
     expect(compiled.request.inputRevision).toMatch(/^[0-9a-f]{64}$/u);
   });
@@ -372,13 +421,13 @@ describe("the hosted SKY130 qualification", () => {
     expect(compiled.request.analyses).toEqual(["tran"]);
     expect(compiled.request.testbench).toContain("tran 2e-8 0.000004");
     expect(compiled.request.testbench).toContain(
-      "VINP vinp 0 PULSE(0.89 0.91 1u 1n 1n 1u 3u)",
+      "VINP vinp 0 DC 0.9 AC 1 0 PULSE(0.9 0.91 1u 1n 1n 1u 3u)",
     );
 
-    const values = Array(232).fill(0.3342235191104477);
-    values[1] = 0.3342107447553537;
-    values[2] = 1.698172273444083;
-    values[231] = 0.3342235434776202;
+    const values = Array(232).fill(0.7589797395133877);
+    values[1] = 0.75886248142361;
+    values[2] = 1.699250823009046;
+    values[231] = 0.7732444834989551;
     const payload = modelResult(
       "operator-host",
       {
@@ -410,10 +459,10 @@ describe("the hosted SKY130 qualification", () => {
   it("sends the structured transient slice through the selected executor", async () => {
     let submitted;
     const compiled = await compileHostedSky130TransientProject();
-    const values = Array(232).fill(0.3342235191104477);
-    values[1] = 0.3342107447553537;
-    values[2] = 1.698172273444083;
-    values[231] = 0.3342235434776202;
+    const values = Array(232).fill(0.7589797395133877);
+    values[1] = 0.75886248142361;
+    values[2] = 1.699250823009046;
+    values[231] = 0.7732444834989551;
     const accepted = await runHostedSky130TransientAcceptance({
       baseUrl: "https://preview.example",
       target: "operator-host",


### PR DESCRIPTION
## Summary
- upgrade the saved SKY130 OTA acceptance setup to OP, DC, AC, and TRAN with explicit pulse stimulus
- make the deployed Preview Agent journey discover its Testbench, capabilities, profile dependencies, vectors, artifacts, and recoverable compiler errors before running
- qualify DC and transient numerical evidence alongside the existing OP/AC evidence and export every result artifact

## Validation
- corepack pnpm gate:preflight -- --base origin/main
- corepack pnpm gate:full (2752 unit tests passed; 357 browser tests passed)
- real Preview Agent journey and Preview executor smoke against https://analog-canvas-preview.tokenzhang.com

## Iteration evidence
The first Preview run exposed a flat transient because the source had no time-domain waveform. The fixture now declares an explicit PULSE source. A second run exposed that Agent inspection must use the discovered Testbench root instead of the default DUT document; the journey now demonstrates and verifies that lookup explicitly.