### PR TITLE
Add qualified SKY130 process corners

### DIFF
--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -13,7 +13,12 @@ const profile = JSON.parse(
     ),
     "utf8",
   ),
-) as { id: string; simulator: { version: string } };
+) as {
+  id: string;
+  displayName: string;
+  simulator: { version: string };
+  models: { library: { runtimePath: string } };
+};
 import { openMenu, downloadBytes } from "./editor-fixtures.js";
 import { parseProject } from "@icm/project-protocol";
 const ota = JSON.parse(
@@ -75,7 +80,17 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
         inputs: ["structured", "raw"],
         analyses: ["op", "dc", "ac", "tran"],
         parsedAnalyses: ["op", "dc", "ac", "tran"],
-        profiles: [{ id: profile.id, corners: ["tt"] }],
+        profiles: [
+          {
+            id: profile.id,
+            label: profile.displayName,
+            corners: ["tt", "ff", "ss", "fs", "sf"],
+          },
+        ],
+        modelLibrary: {
+          path: profile.models.library.runtimePath,
+          section: "tt",
+        },
         maxTimeoutMs: 120000,
         maxInputBytes: 1048576,
         cancel: true,
@@ -97,7 +112,13 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
   await expect(panel.getByLabel("Stop (Hz)")).toHaveValue("1000000000");
   await expect(panel.getByLabel("DC sweep source")).toHaveValue("VINP");
   await expect(panel.getByLabel("TRAN stop (s)")).toHaveValue("0.000004");
-  await expect(panel.getByLabel("Environment profile")).toHaveValue(profile.id);
+  await expect(
+    panel.getByText(profile.displayName, { exact: true }),
+  ).toBeVisible();
+  await expect(panel.getByLabel("Process corner")).toHaveValue("tt");
+  await panel.getByLabel("Process corner").selectOption("ff");
+  await expect(panel.getByLabel("Process corner")).toHaveValue("ff");
+  await panel.getByLabel("Process corner").selectOption("tt");
   await expect(
     panel.getByRole("button", { name: "Remove output" }),
   ).toHaveCount(4);
@@ -148,6 +169,7 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
   expect(deck).toMatch(/i\(v\.xdut\.vicmprb\d+\)/u);
   expect(deck).toMatch(/ac dec 10 1 (?:1000000000|1e\+?9)/i);
   expect(deck).toContain("dc VINP 0.88 0.92 0.005");
+  expect(deck).toContain(`.lib "${profile.models.library.runtimePath}" tt`);
   expect(deck).toContain("tran 2e-8 0.000004");
   expect(executions).toBe(0);
   await panel.getByRole("button", { name: "Minimize simulation" }).click();

--- a/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
@@ -42,9 +42,14 @@ describe("SpiceSimulationSurface workspace", () => {
       markup.indexOf('aria-label="Exit simulation"'),
     );
     expect(markup).toContain('class="simulation-minimize-glyph"');
-    expect(markup).toContain('<select name="profileId"');
+    expect(markup).toContain('class="simulation-environment-summary"');
+    expect(markup).toContain('<input type="hidden" name="profileId"');
     expect(markup).not.toContain("<datalist");
     expect(markup).toContain("sky130-core-continuous-ngspice46-v1");
+    expect(markup).toContain("SKY130 1.8 V · ngspice 46");
+    expect(markup).toContain("Process corner");
+    for (const corner of ["TT", "FF", "SS", "FS", "SF"])
+      expect(markup).toContain(`>${corner}</option>`);
     expect(markup).toContain('class="simulation-probe-control"');
     expect(markup).not.toContain('type="search"');
     expect(markup).not.toContain("Filter by Cell, instance, pin, or Net");

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -46,6 +46,8 @@ const RESULT_TABS = [
 const DEVELOPMENT_PROFILE_ID = import.meta.env.DEV
   ? "sky130-core-continuous-ngspice46-v1"
   : "";
+const DEVELOPMENT_PROFILE_LABEL = "SKY130 1.8 V · ngspice 46";
+const DEVELOPMENT_CORNERS = ["tt", "ff", "ss", "fs", "sf"] as const;
 type ResultTab = (typeof RESULT_TABS)[number][0];
 
 function preferredResultTab(run: Run): ResultTab {
@@ -1129,6 +1131,9 @@ function SetupEditor({
   const [profileId, setProfileId] = useState(
     saved?.environment.profileId ?? DEVELOPMENT_PROFILE_ID,
   );
+  const [corner, setCorner] = useState(
+    saved?.environment.corner ?? (DEVELOPMENT_PROFILE_ID ? "tt" : ""),
+  );
   const rawSaved = setup?.input.kind === "raw" ? setup.input : undefined;
   const [switchFromRaw, setSwitchFromRaw] = useState(false);
   const [pickCandidates, setPickCandidates] = useState<
@@ -1143,6 +1148,32 @@ function SetupEditor({
     )
       setProfileId(defaultProfileId);
   }, [capabilities?.profiles[0]?.id, profileId, saved?.environment.profileId]);
+  const advertisedProfiles =
+    capabilities?.profiles ??
+    (DEVELOPMENT_PROFILE_ID
+      ? [
+          {
+            id: DEVELOPMENT_PROFILE_ID,
+            label: DEVELOPMENT_PROFILE_LABEL,
+            corners: [...DEVELOPMENT_CORNERS],
+          },
+        ]
+      : []);
+  const selectedProfile = advertisedProfiles.find(
+    (profile) => profile.id === profileId,
+  );
+  const defaultCorner = selectedProfile?.corners[0] ?? "";
+  useEffect(() => {
+    if (!corner && !saved?.environment.corner && defaultCorner)
+      setCorner(defaultCorner);
+  }, [corner, defaultCorner, saved?.environment.corner]);
+  const profileUnavailable = !!profileId && !!capabilities && !selectedProfile;
+  const showProfilePicker = advertisedProfiles.length > 1 || profileUnavailable;
+  const environmentLabel =
+    selectedProfile?.label ??
+    (profileUnavailable
+      ? `${profileId} (unavailable)`
+      : "Loading environment…");
   const selectedDcSourceId = dcSources.some(
     (source) => source.id === dcSourceId,
   )
@@ -1379,40 +1410,66 @@ function SetupEditor({
             }}
           />
         </label>
-        <label>
-          Environment profile
-          <select
-            name="profileId"
-            required
-            value={profileId}
-            onChange={(event) => setProfileId(event.currentTarget.value)}
-          >
-            {!profileId ? (
-              <option value="" disabled>
-                {capabilities ? "No profiles available" : "Loading profiles…"}
-              </option>
-            ) : null}
-            {profileId &&
-            !capabilities?.profiles.some(
-              (profile) => profile.id === profileId,
-            ) ? (
-              <option value={profileId}>{profileId}</option>
-            ) : null}
-            {capabilities?.profiles.map((profile) => (
-              <option key={profile.id} value={profile.id}>
-                {profile.id}
-              </option>
-            ))}
-          </select>
-        </label>
+        {showProfilePicker ? (
+          <label>
+            Environment
+            <select
+              name="profileId"
+              required
+              value={profileId}
+              onChange={(event) => {
+                const nextId = event.currentTarget.value;
+                const nextProfile = advertisedProfiles.find(
+                  (profile) => profile.id === nextId,
+                );
+                setProfileId(nextId);
+                if (!nextProfile?.corners.includes(corner))
+                  setCorner(nextProfile?.corners[0] ?? "");
+              }}
+            >
+              {profileUnavailable ? (
+                <option value={profileId}>{profileId} (unavailable)</option>
+              ) : null}
+              {advertisedProfiles.map((profile) => (
+                <option key={profile.id} value={profile.id}>
+                  {profile.label ?? profile.id}
+                </option>
+              ))}
+            </select>
+          </label>
+        ) : (
+          <div className="simulation-environment-summary">
+            <span>Environment</span>
+            <strong>{environmentLabel}</strong>
+            <small>Managed automatically</small>
+            <input name="profileId" type="hidden" value={profileId} />
+          </div>
+        )}
         <div className="simulation-setup-group simulation-inline-fields columns-2">
           <label>
-            Corner
-            <input
+            Process corner
+            <select
               name="corner"
-              defaultValue={saved?.environment.corner ?? ""}
-              placeholder="Profile default"
-            />
+              value={corner}
+              onChange={(event) => setCorner(event.currentTarget.value)}
+              disabled={!selectedProfile}
+            >
+              {!corner ? (
+                <option value="">
+                  {selectedProfile ? "Profile default" : "Unavailable"}
+                </option>
+              ) : null}
+              {corner && !selectedProfile?.corners.includes(corner) ? (
+                <option value={corner}>
+                  {corner.toUpperCase()} (unavailable)
+                </option>
+              ) : null}
+              {selectedProfile?.corners.map((candidate) => (
+                <option key={candidate} value={candidate}>
+                  {candidate.toUpperCase()}
+                </option>
+              ))}
+            </select>
           </label>
           <label>
             Temperature (°C)

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -354,6 +354,25 @@
   margin: 6px 0;
   font-size: var(--icm-font-sm);
 }
+.simulation-environment-summary {
+  display: grid;
+  grid-template-columns: minmax(110px, 0.8fr) minmax(130px, 1.2fr) auto;
+  align-items: baseline;
+  gap: 8px;
+  margin: 6px 0;
+  font-size: var(--icm-font-sm);
+}
+.simulation-environment-summary > strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.simulation-environment-summary > small {
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+  white-space: nowrap;
+}
 .simulation-inline-fields {
   display: grid;
   gap: 8px;

--- a/containers/ngspice/hosted-sky130-profile.json
+++ b/containers/ngspice/hosted-sky130-profile.json
@@ -1,6 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "sky130-core-continuous-ngspice46-v1",
+  "displayName": "SKY130 1.8 V · ngspice 46",
   "sourceImage": "ghcr.io/arcadia-1/circuit-bench-sky130-ngspice@sha256:2da03dc7f1ead7ddc33f2f930a0487ae8618e51518009344584a98fca41a621d",
   "platform": "linux/x64",
   "simulator": {
@@ -14,7 +15,7 @@
     "library": {
       "directive": "lib",
       "runtimePath": "/opt/sky130/continuous/sky130.lib.spice",
-      "sections": ["tt"]
+      "sections": ["tt", "ff", "ss", "fs", "sf"]
     }
   },
   "startup": {
@@ -23,7 +24,7 @@
   },
   "qualifiedScope": {
     "devices": ["sky130_fd_pr__nfet_01v8", "sky130_fd_pr__pfet_01v8"],
-    "sections": ["tt"],
+    "sections": ["tt", "ff", "ss", "fs", "sf"],
     "analyses": ["op", "dc", "ac", "tran"]
   }
 }

--- a/containers/ngspice/profile-contract.test.mjs
+++ b/containers/ngspice/profile-contract.test.mjs
@@ -15,6 +15,7 @@ const dockerfile = await readFile(join(directory, "Dockerfile"), "utf8");
 describe("the hosted SKY130 Profile", () => {
   it("pins the exact base image, startup policy and runtime paths", () => {
     expect(profile.id).toBe("sky130-core-continuous-ngspice46-v1");
+    expect(profile.displayName).toBe("SKY130 1.8 V · ngspice 46");
     expect(dockerfile).toContain(`ARG BASE_IMAGE=${profile.sourceImage}`);
     expect(createHash("sha256").update(startup).digest("hex")).toBe(
       profile.startup.contentSha256,
@@ -28,14 +29,14 @@ describe("the hosted SKY130 Profile", () => {
     expect(profile.models.library).toEqual({
       directive: "lib",
       runtimePath: "/opt/sky130/continuous/sky130.lib.spice",
-      sections: ["tt"],
+      sections: ["tt", "ff", "ss", "fs", "sf"],
     });
   });
 
   it("qualifies only the scope backed by tracked hosted acceptance", () => {
     expect(profile.qualifiedScope).toEqual({
       devices: ["sky130_fd_pr__nfet_01v8", "sky130_fd_pr__pfet_01v8"],
-      sections: ["tt"],
+      sections: ["tt", "ff", "ss", "fs", "sf"],
       analyses: ["op", "dc", "ac", "tran"],
     });
   });

--- a/docs/user/analog-simulation.md
+++ b/docs/user/analog-simulation.md
@@ -38,8 +38,14 @@ same hierarchy, followed by the existing simulation configure operation.
 
 ## Setup, run and results
 
-Open **Setup**, create or select a named setup, choose its testbench Cell and advertised environment Profile,
-then set OP/DC/AC/TRAN, optional corner/temperature, and outputs. Voltage
+Open **Setup**, create or select a named setup, then set OP/DC/AC/TRAN,
+process corner, optional temperature, and outputs. The current SKY130
+environment offers TT, FF, SS, FS, and SF. New setups use TT. The runtime
+Profile is selected automatically and shown by a friendly environment name;
+its stable ID remains saved in the Project and visible to Agent/API clients for
+reproducibility. A Profile picker appears only when several compatible
+environments are advertised or a saved environment is no longer available.
+Voltage
 outputs may target a Net at the Testbench root or in a concrete DUT occurrence;
 current outputs may target circuit terminals. Each choice is written to the
 same occurrence-aware output contract that Agent authoring uses. Apply commits an

--- a/fixtures/simulation-acceptance/hosted-sky130-core-continuous-v1.json
+++ b/fixtures/simulation-acceptance/hosted-sky130-core-continuous-v1.json
@@ -12,6 +12,34 @@
     "directive": "lib",
     "section": "tt"
   },
+  "expectedCorners": {
+    "tt": {
+      "nfetCurrentA": -0.0002221772535699329,
+      "pfetSourceCurrentA": -7.065189762608948e-7
+    },
+    "ff": {
+      "nfetCurrentA": -0.0002526337154561964,
+      "pfetSourceCurrentA": -9.451994627332483e-7
+    },
+    "ss": {
+      "nfetCurrentA": -0.0001941105699482248,
+      "pfetSourceCurrentA": -5.279296240168208e-7
+    },
+    "fs": {
+      "nfetCurrentA": -0.000180956613662353,
+      "pfetSourceCurrentA": -0.000001648894668221379
+    },
+    "sf": {
+      "nfetCurrentA": -0.0002669450058923606,
+      "pfetSourceCurrentA": -2.990772873870395e-7
+    }
+  },
+  "cornerEvidence": {
+    "observedAt": "2026-09-07",
+    "executor": "operator-host",
+    "environmentFingerprint": "33c245e5df6dc12077b6a2e4ebf308777b0e9014fe9bfdafc3285c614688561d",
+    "absoluteTolerance": 1e-10
+  },
   "expectedProbes": {
     "v(vout)": { "value": 0.7589797395133877, "absoluteTolerance": 1e-8 },
     "v(ibias)": { "value": 0.6044031364286973, "absoluteTolerance": 1e-8 },

--- a/packages/simulation-service/src/contract.ts
+++ b/packages/simulation-service/src/contract.ts
@@ -187,6 +187,8 @@ export const CapabilitiesSchema = z.strictObject({
   profiles: z.array(
     z.strictObject({
       id: Id,
+      /** Human-facing name. Automation continues to select the stable id. */
+      label: z.string().min(1).max(128).optional(),
       corners: z.array(z.string()),
       /** Environment-owned files addressable by raw Project dependencies. */
       dependencies: z

--- a/packages/simulation-service/src/service.test.ts
+++ b/packages/simulation-service/src/service.test.ts
@@ -132,6 +132,46 @@ async function prepareRaw(f: ReturnType<typeof fixture>) {
   return { prepared, workspaceId: created.workspace.id };
 }
 describe("shared simulation lifecycle", () => {
+  it("prepares the corner selected by a structured setup", async () => {
+    const project = CircuitProjectSchema.parse(ota);
+    const setup = project.simulationSetups[0];
+    if (!setup || setup.input.kind !== "structured")
+      throw new Error("fixture has no structured setup");
+    setup.input.environment = { profileId: "test", corner: "ff" };
+    const f = fixture();
+    f.executor.capabilities = async () => ({
+      ...caps,
+      analyses: ["op", "dc", "ac", "tran"],
+      profiles: [{ id: "test", corners: ["tt", "ff"] }],
+      modelLibrary: { path: "/models/sky130.lib.spice", section: "tt" },
+    });
+    const service = new SimulationService(f.files, f.executor, () => project);
+    const prepared = unwrap(
+      await service.handle(
+        {
+          operation: "prepare",
+          source: {
+            kind: "project-setup",
+            setupId: setup.id,
+            expectedStructureRevision: project.structureRevision,
+          },
+        },
+        "prepare-ff",
+      ),
+      "prepared",
+    );
+    const artifact = prepared.artifacts.find(
+      (candidate) => candidate.name === "prepared.cir",
+    );
+    expect(artifact).toBeDefined();
+    expect(
+      await f.files.handle({ action: "artifact", artifactId: artifact!.id }),
+    ).toMatchObject({
+      ok: true,
+      text: expect.stringContaining('.lib "/models/sky130.lib.spice" ff'),
+    });
+  });
+
   it("prepares the explicitly addressed setup when a Project has several", async () => {
     const f = fixture();
     f.project.simulationSetups = ["A", "B"].map((name) => ({

--- a/packages/simulation-service/src/service.ts
+++ b/packages/simulation-service/src/service.ts
@@ -467,7 +467,12 @@ export class SimulationService {
             input,
             caps.modelLibrary &&
               deckNeedsModelLibrary(input.netlist + "\n" + input.testbench)
-              ? { directive: "lib", ...caps.modelLibrary }
+              ? {
+                  directive: "lib",
+                  path: caps.modelLibrary.path,
+                  section:
+                    input.environment.corner ?? caps.modelLibrary.section,
+                }
               : null,
           );
     const digest = await sha256(JSON.stringify(input));

--- a/packages/spice-run/src/environment-profile.test.ts
+++ b/packages/spice-run/src/environment-profile.test.ts
@@ -29,7 +29,7 @@ describe("hosted simulation Profile", () => {
     expect(HOSTED_SKY130_PROFILE.models.library).toMatchObject({
       directive: "lib",
       runtimePath: "/opt/sky130/continuous/sky130.lib.spice",
-      sections: ["tt"],
+      sections: ["tt", "ff", "ss", "fs", "sf"],
     });
     expect(HOSTED_SKY130_PROFILE.qualifiedScope.analyses).toEqual([
       "op",

--- a/packages/spice-run/src/environment-profile.ts
+++ b/packages/spice-run/src/environment-profile.ts
@@ -1,6 +1,8 @@
 export interface HostedSimulationProfile {
   readonly schemaVersion: 1;
   readonly id: string;
+  /** Human-facing name; the stable id remains the automation contract. */
+  readonly displayName?: string;
   readonly sourceImage: string;
   readonly platform: string;
   readonly simulator: {

--- a/scripts/preview-simulation-smoke.mjs
+++ b/scripts/preview-simulation-smoke.mjs
@@ -50,6 +50,20 @@ if (
     `Qualification ${qualification.fixtureId} uses a model selection outside Profile ${profile.id}.`,
   );
 }
+const qualificationCorners = Object.keys(qualification.expectedCorners ?? {});
+if (
+  qualificationCorners.length === 0 ||
+  qualificationCorners.some(
+    (corner) => !profile.qualifiedScope.sections.includes(corner),
+  ) ||
+  profile.qualifiedScope.sections.some(
+    (corner) => !qualificationCorners.includes(corner),
+  )
+) {
+  throw new Error(
+    `Qualification ${qualification.fixtureId} does not cover every declared Profile corner.`,
+  );
+}
 
 const EXECUTORS = ["operator-host"];
 const SHA256 = /^[0-9a-f]{64}$/u;
@@ -115,6 +129,34 @@ export const DIVIDER_DC_REQUEST = {
   ].join("\n"),
   timeoutMs: 30_000,
 };
+
+export function hostedSky130CornerRequest(corner) {
+  return {
+    netlist: [
+      ".subckt corner_pair gn dn gp sp dp",
+      "XMN dn gn 0 0 sky130_fd_pr__nfet_01v8 L=0.5 W=10",
+      "XMP dp gp sp sp sky130_fd_pr__pfet_01v8 L=0.5 W=10",
+      ".ends corner_pair",
+    ].join("\n"),
+    testbench: [
+      "VGN gn 0 0.9",
+      "VDN dn 0 1.8",
+      "VGP gp 0 0.9",
+      "VSP sp 0 1.8",
+      "VDP dp 0 0",
+      "XDUT gn dn gp sp dp corner_pair",
+      ".control",
+      "set filetype=ascii",
+      "op",
+      "write out.raw i(vdn) i(vsp)",
+      ".endc",
+      ".end",
+    ].join("\n"),
+    timeoutMs: 110_000,
+    inputRevision: `preview-sky130-corner-${corner}`,
+    environment: { profileId: profile.id, corner },
+  };
+}
 
 export async function compileHostedSky130Project() {
   const [{ compileStructuredSimulation }, { parseProject }] = await Promise.all(
@@ -754,6 +796,92 @@ export async function runHostedSky130Acceptance({
   );
 }
 
+export function validateHostedSky130CornerResult(
+  payload,
+  expectedTarget,
+  corner,
+) {
+  const expected = qualification.expectedCorners?.[corner];
+  if (!expected)
+    throw new Error(`No qualification evidence exists for ${corner}.`);
+  const result = object(payload, "simulation response");
+  if (object(result.execution, "execution metadata").target !== expectedTarget)
+    throw new Error(`${expectedTarget} did not execute corner ${corner}.`);
+  if (object(result.outcome, "simulation outcome").status !== "completed")
+    throw new Error(`${expectedTarget} did not complete corner ${corner}.`);
+  const metadata = object(result.metadata, "run metadata");
+  const configuration = object(
+    metadata.configuration,
+    "configuration metadata",
+  );
+  const modelLibrary = object(configuration.modelLibrary, "model selection");
+  if (
+    modelLibrary.directive !== profile.models.library.directive ||
+    modelLibrary.section !== corner
+  )
+    throw new Error(
+      `${expectedTarget} loaded ${String(modelLibrary.section)}, expected corner ${corner}.`,
+    );
+  const environment = object(metadata.environment, "environment metadata");
+  validatePinnedEnvironment(environment, expectedTarget);
+  if (
+    environment.fingerprint !==
+    qualification.cornerEvidence.environmentFingerprint
+  )
+    throw new Error(
+      `${expectedTarget} corner evidence came from a different environment.`,
+    );
+  const data = object(result.data, "parsed result data");
+  const operatingPoint = Array.isArray(data.analyses)
+    ? data.analyses.find((analysis) => analysis?.analysis === "op")
+    : null;
+  if (!operatingPoint || !Array.isArray(operatingPoint.probes))
+    throw new Error(`${expectedTarget} returned no OP result for ${corner}.`);
+  const readCurrent = (name) => {
+    const probe = operatingPoint.probes.find(
+      (candidate) => candidate?.name === name,
+    );
+    if (typeof probe?.value !== "number")
+      throw new Error(`${expectedTarget} returned no ${name} for ${corner}.`);
+    return probe.value;
+  };
+  const nfetCurrentA = readCurrent("i(vdn)");
+  const pfetSourceCurrentA = readCurrent("i(vsp)");
+  const tolerance = qualification.cornerEvidence.absoluteTolerance;
+  if (
+    Math.abs(nfetCurrentA - expected.nfetCurrentA) > tolerance ||
+    Math.abs(pfetSourceCurrentA - expected.pfetSourceCurrentA) > tolerance
+  )
+    throw new Error(
+      `${expectedTarget} returned unexpected ${corner} currents ` +
+        `(NFET=${nfetCurrentA}, PFET=${pfetSourceCurrentA}).`,
+    );
+  return { corner, nfetCurrentA, pfetSourceCurrentA };
+}
+
+export async function runHostedSky130CornerAcceptance({
+  baseUrl,
+  target,
+  corner,
+  fetchImpl = fetch,
+}) {
+  const response = await fetchImpl(new URL("/api/simulate", baseUrl), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      ...hostedSky130CornerRequest(corner),
+      executorTarget: target,
+    }),
+    signal: AbortSignal.timeout(120_000),
+  });
+  const payload = await response.json();
+  if (!response.ok)
+    throw new Error(
+      `[infrastructure:http-${response.status}] ${target} ${corner} corner qualification failed.`,
+    );
+  return validateHostedSky130CornerResult(payload, target, corner);
+}
+
 export async function runHostedSky130TransientAcceptance({
   baseUrl,
   target,
@@ -928,6 +1056,19 @@ async function main() {
     console.log(
       `${result.target}: SKY130 OTA TRAN ${result.pointCount} points passed`,
     );
+  }
+  for (const target of EXECUTORS) {
+    for (const corner of profile.qualifiedScope.sections) {
+      const result = await runHostedSky130CornerAcceptance({
+        baseUrl,
+        target,
+        corner,
+      });
+      console.log(
+        `${target}: SKY130 ${result.corner.toUpperCase()} corner passed ` +
+          `(NFET=${result.nfetCurrentA}, PFET=${result.pfetSourceCurrentA})`,
+      );
+    }
   }
   console.log(`Hosted SKY130 Profile ${profile.id}: qualified`);
 }

--- a/scripts/preview-simulation-smoke.test.mjs
+++ b/scripts/preview-simulation-smoke.test.mjs
@@ -3,13 +3,16 @@ import { describe, expect, it } from "vitest";
 import {
   compileHostedSky130Project,
   compileHostedSky130TransientProject,
+  hostedSky130CornerRequest,
   runHostedSky130Acceptance,
+  runHostedSky130CornerAcceptance,
   runHostedSky130TransientAcceptance,
   runPreviewSimulationSmoke,
   validateHostedSky130TransientResult,
   validateDcDividerResult,
   validateExecutorParity,
   validateHostedSky130Result,
+  validateHostedSky130CornerResult,
   validatePreviewSimulationResult,
 } from "./preview-simulation-smoke.mjs";
 
@@ -21,6 +24,8 @@ const MODEL_SHA =
   "0bf299f0e3e1616478203d370107865635fd08935bb1a9cf9db18efd31703100";
 const STARTUP_SHA =
   "5ad94681e17bba379ac84d01fe7773458b34f9bbd77c127a3738f1af47ad5634";
+const CORNER_ENVIRONMENT_SHA =
+  "33c245e5df6dc12077b6a2e4ebf308777b0e9014fe9bfdafc3285c614688561d";
 const EXPECTED_VECTORS = [
   { probeId: "probe-vout", vector: "v(vout)", quantity: "voltage" },
   { probeId: "probe-ibias", vector: "v(ibias)", quantity: "voltage" },
@@ -161,6 +166,35 @@ function modelResult(
       ],
     },
     ...overrides,
+  };
+}
+
+function cornerResult(target, corner = "ff") {
+  const base = result(target);
+  return {
+    ...base,
+    metadata: {
+      ...base.metadata,
+      input: { inputRevision: `preview-sky130-corner-${corner}` },
+      configuration: {
+        modelLibrary: { directive: "lib", section: corner },
+      },
+      environment: {
+        ...base.metadata.environment,
+        fingerprint: CORNER_ENVIRONMENT_SHA,
+      },
+    },
+    data: {
+      analyses: [
+        {
+          analysis: "op",
+          probes: [
+            { name: "i(vdn)", value: -0.0002526337154561964 },
+            { name: "i(vsp)", value: -9.451994627332483e-7 },
+          ],
+        },
+      ],
+    },
   };
 }
 
@@ -321,6 +355,46 @@ describe("the Preview dual-executor smoke", () => {
 });
 
 describe("the hosted SKY130 qualification", () => {
+  it("builds and validates the selected process-corner request", async () => {
+    expect(hostedSky130CornerRequest("ff")).toMatchObject({
+      environment: { profileId: PROFILE_ID, corner: "ff" },
+      inputRevision: "preview-sky130-corner-ff",
+    });
+    expect(
+      validateHostedSky130CornerResult(
+        cornerResult("operator-host"),
+        "operator-host",
+        "ff",
+      ),
+    ).toMatchObject({
+      corner: "ff",
+      nfetCurrentA: -0.0002526337154561964,
+    });
+
+    let submitted;
+    await runHostedSky130CornerAcceptance({
+      baseUrl: "https://preview.example",
+      target: "operator-host",
+      corner: "ff",
+      fetchImpl: async (_url, init) => {
+        submitted = JSON.parse(init.body);
+        return Response.json(cornerResult("operator-host"));
+      },
+    });
+    expect(submitted.environment).toEqual({
+      profileId: PROFILE_ID,
+      corner: "ff",
+    });
+  });
+
+  it("refuses process-corner numerical drift", () => {
+    const candidate = cornerResult("operator-host");
+    candidate.data.analyses[0].probes[0].value = -0.001;
+    expect(() =>
+      validateHostedSky130CornerResult(candidate, "operator-host", "ff"),
+    ).toThrow(/unexpected ff currents/u);
+  });
+
   it("accepts the model-backed OTA operating point", () => {
     expect(
       validateHostedSky130Result(

--- a/worker/simulation.test.ts
+++ b/worker/simulation.test.ts
@@ -79,6 +79,8 @@ describe("simulation route", () => {
       profiles: [
         {
           id: hostedSky130Profile.id,
+          label: hostedSky130Profile.displayName,
+          corners: hostedSky130Profile.qualifiedScope.sections,
           dependencies: [
             {
               id: hostedSky130Profile.models.id,
@@ -364,6 +366,46 @@ describe("simulation route", () => {
     expect(seen.deck).toContain('.lib "/models/sky130.lib.spice" ff');
   });
 
+  it("uses a qualified corner selected by the setup", async () => {
+    const seen: { deck?: string } = {};
+    const response = await routeSimulationRequest(
+      post({
+        netlist: NETLIST,
+        testbench: TESTBENCH,
+        environment: {
+          profileId: hostedSky130Profile.id,
+          corner: "sf",
+        },
+      }),
+      stubRunner(
+        { log: "", exitCode: 0, timedOut: false, durationMs: 5 },
+        seen,
+      ),
+    );
+    expect(response?.status).toBe(200);
+    expect(seen.deck).toContain(
+      '.lib "/opt/sky130/continuous/sky130.lib.spice" sf',
+    );
+  });
+
+  it("rejects a corner outside the qualified Profile", async () => {
+    const response = await routeSimulationRequest(
+      post({
+        netlist: NETLIST,
+        testbench: TESTBENCH,
+        environment: {
+          profileId: hostedSky130Profile.id,
+          corner: "mc",
+        },
+      }),
+      stubRunner({}),
+    );
+    expect(response?.status).toBe(400);
+    expect(await response!.json()).toMatchObject({
+      error: "simulation-profile-unavailable",
+    });
+  });
+
   it("returns input, configuration and environment identity with a result", async () => {
     const response = await routeSimulationRequest(
       post({
@@ -407,16 +449,16 @@ describe("simulation route", () => {
     });
   });
 
-  it("reports an invalid deployed section as environment configuration", async () => {
+  it("reports an unqualified deployed default corner as environment configuration", async () => {
     const env = stubRunner({});
-    env.SKY130_LIB_SECTION = "tt\n.end";
+    env.SKY130_LIB_SECTION = "mc";
     const response = await routeSimulationRequest(
       post({ netlist: NETLIST, testbench: TESTBENCH }),
       env,
     );
     expect(response?.status).toBe(503);
     expect((await response!.json()) as unknown).toMatchObject({
-      error: "simulation-environment-invalid",
+      error: "simulation-executor-configuration-invalid",
     });
   });
 

--- a/worker/simulation.ts
+++ b/worker/simulation.ts
@@ -289,6 +289,15 @@ export async function routeSimulationRequest(
   }
   const target = body.executorTarget ?? configuredDefault;
   const selected = runnerFor(env, runnerKey, target);
+  const defaultCorner = env.SKY130_LIB_SECTION ?? SKY130_LIBRARY_SECTION;
+  if (!hostedSky130Profile.qualifiedScope.sections.includes(defaultCorner))
+    return Response.json(
+      {
+        error: "simulation-executor-configuration-invalid",
+        message: `SKY130_LIB_SECTION does not name a qualified corner: ${defaultCorner}`,
+      },
+      { status: 503 },
+    );
   if (body.operation === "capabilities") {
     return Response.json({
       configured: !!selected,
@@ -298,7 +307,8 @@ export async function routeSimulationRequest(
       profiles: [
         {
           id: hostedSky130Profile.id,
-          corners: [env.SKY130_LIB_SECTION ?? SKY130_LIBRARY_SECTION],
+          label: hostedSky130Profile.displayName ?? hostedSky130Profile.id,
+          corners: hostedSky130Profile.qualifiedScope.sections,
           dependencies: [
             {
               id: hostedSky130Profile.models.id,
@@ -309,7 +319,7 @@ export async function routeSimulationRequest(
       ],
       modelLibrary: {
         path: env.SKY130_LIB_PATH ?? SKY130_LIBRARY_PATH,
-        section: env.SKY130_LIB_SECTION ?? SKY130_LIBRARY_SECTION,
+        section: defaultCorner,
       },
       maxTimeoutMs: 120000,
       maxInputBytes: MAX_INPUT_BYTES,
@@ -370,8 +380,10 @@ export async function routeSimulationRequest(
     body.environment &&
     (body.environment.profileId !== hostedSky130Profile.id ||
       (body.environment.corner !== undefined &&
-        body.environment.corner !==
-          (env.SKY130_LIB_SECTION ?? SKY130_LIBRARY_SECTION)))
+        (typeof body.environment.corner !== "string" ||
+          !hostedSky130Profile.qualifiedScope.sections.includes(
+            body.environment.corner,
+          ))))
   )
     return Response.json(
       { error: "simulation-profile-unavailable" },
@@ -447,7 +459,8 @@ export async function routeSimulationRequest(
       ? {
           directive: "lib",
           path: env.SKY130_LIB_PATH ?? SKY130_LIBRARY_PATH,
-          section: env.SKY130_LIB_SECTION ?? SKY130_LIBRARY_SECTION,
+          section:
+            (body.environment?.corner as string | undefined) ?? defaultCorner,
         }
       : null;
     // Raw input is already an executable deck: preserve its title, control


### PR DESCRIPTION
## Summary
- keep the hosted Profile automatic for ordinary users and show a friendly environment summary
- expose TT/FF/SS/FS/SF as a constrained process-corner choice and carry it through prepare and hosted deck composition
- qualify every advertised corner against the pinned operator environment and reject unqualified deployment defaults

## Validation
- pnpm gate:full
- 2,757 unit tests passed (28 skipped)
- 357 browser tests passed
- build, release, performance, visual/export golden, PWA, production and MCP smoke checks passed
- direct Preview evidence: TT/FF/SS/FS/SF core NMOS/PMOS OP and OTA OP/DC/AC/TRAN decks completed on environment fingerprint 33c245e5df6dc12077b6a2e4ebf308777b0e9014fe9bfdafc3285c614688561d

Test-Impact: tests-updated