### PR TITLE
feat(simulation): turn artifacts into a file workspace

### DIFF
--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -128,11 +128,14 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
   ).toHaveCount(7);
   await panel.getByRole("button", { name: "Apply setup" }).click();
   await panel.getByRole("button", { name: "Prepare deck" }).click();
-  await panel.getByLabel("Prepared files Netlist").locator("summary").click();
-  const deckDownload = page.waitForEvent("download");
+  await expect(panel.getByLabel("Prepare files")).toBeVisible();
   await panel
     .getByRole("button", { name: "prepared.cir", exact: true })
     .click();
+  const filePreview = panel.getByRole("region", { name: "File preview" });
+  await expect(filePreview).toContainText("prepared.cir");
+  const deckDownload = page.waitForEvent("download");
+  await filePreview.getByRole("button", { name: "Download" }).click();
   const stream = await (await deckDownload).createReadStream();
   let deck = "";
   for await (const chunk of stream!) deck += chunk.toString();
@@ -749,20 +752,29 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   });
   await waveformDialog.getByRole("button", { name: "Close plot" }).click();
   await panel.getByRole("tab", { name: "Files" }).click();
-  await panel.getByLabel("Last run Evidence").locator("summary").click();
+  await panel.getByLabel("Run Evidence").locator("summary").click();
   await expect(
-    panel.getByRole("button", { name: "evidence-manifest.json" }),
+    panel.getByRole("button", {
+      name: "evidence-manifest.json",
+      exact: true,
+    }),
   ).toBeVisible();
   const download = page.waitForEvent("download");
   await panel
-    .getByRole("button", { name: /\.csv$/ })
+    .getByRole("button", { name: /Download .*\.csv$/ })
     .first()
     .click();
   expect((await download).suggestedFilename()).toMatch(/\.csv$/);
-  await expect(panel.getByLabel("Last run Results")).toBeVisible();
+  await expect(panel.getByLabel("Run Results")).toBeVisible();
+  const bundleDownload = page.waitForEvent("download");
+  await panel
+    .getByLabel("Run files")
+    .getByRole("button", { name: "Download ZIP" })
+    .click();
+  expect((await bundleDownload).suggestedFilename()).toBe("simulation-run.zip");
   await panel.getByRole("button", { name: "Prepare deck" }).click();
-  await expect(panel.getByLabel("Prepared files Netlist")).toBeVisible();
-  await expect(panel.getByLabel("Last run Results")).toBeVisible();
+  await expect(panel.getByLabel("Prepare Netlist")).toBeVisible();
+  await expect(panel.getByLabel("Run Results")).toBeVisible();
   await expect(panel.getByText("Input identity", { exact: true })).toHaveCount(
     0,
   );

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -23,6 +23,7 @@
     "@icm/simulation": "workspace:*",
     "@icm/spice": "workspace:*",
     "@icm/symbols": "workspace:*",
+    "fflate": "0.8.3",
     "mathlive": "0.110.0",
     "react": "19.2.8",
     "react-dom": "19.2.8"

--- a/apps/editor/src/features/simulation/simulation-artifact-files.test.ts
+++ b/apps/editor/src/features/simulation/simulation-artifact-files.test.ts
@@ -1,0 +1,55 @@
+import { unzipSync, strFromU8 } from "fflate";
+import { describe, expect, it } from "vitest";
+import { SimulationFiles } from "@icm/simulation-service/files";
+
+import {
+  buildSimulationArtifactArchive,
+  formatSimulationArtifactPreview,
+  readSimulationArtifactPreview,
+  simulationArtifactCategory,
+} from "./simulation-artifact-files";
+
+describe("simulation artifact files", () => {
+  it("previews bounded text and formats complete JSON", async () => {
+    const files = new SimulationFiles();
+    const json = await files.put(
+      "result.json",
+      "application/json",
+      '{"status":"completed"}',
+    );
+    const jsonPreview = await readSimulationArtifactPreview(files, json);
+    expect(jsonPreview.ok).toBe(true);
+    if (!jsonPreview.ok) return;
+    expect(formatSimulationArtifactPreview(jsonPreview.content)).toBe(
+      '{\n  "status": "completed"\n}',
+    );
+
+    const raw = await files.put("out.raw", "text/plain", "x".repeat(70_000));
+    const rawPreview = await readSimulationArtifactPreview(files, raw);
+    expect(rawPreview.ok).toBe(true);
+    if (!rawPreview.ok) return;
+    expect(rawPreview.content.text).toHaveLength(65_536);
+    expect(rawPreview.content.truncated).toBe(true);
+  });
+
+  it("packages a group into category folders without changing artifacts", async () => {
+    const files = new SimulationFiles();
+    const deck = await files.put("prepared.cir", "text/plain", "V1 in 0 1\n");
+    const csv = await files.put(
+      "op-0.csv",
+      "text/csv",
+      "name,value\nV(out),1\n",
+    );
+
+    const archive = await buildSimulationArtifactArchive(files, [deck, csv]);
+    expect(archive.ok).toBe(true);
+    if (!archive.ok) return;
+    const entries = unzipSync(archive.bytes);
+    expect(strFromU8(entries["netlist/prepared.cir"]!)).toBe("V1 in 0 1\n");
+    expect(strFromU8(entries["results/op-0.csv"]!)).toBe(
+      "name,value\nV(out),1\n",
+    );
+    expect(simulationArtifactCategory(deck)).toBe("Netlist");
+    expect(simulationArtifactCategory(csv)).toBe("Results");
+  });
+});

--- a/apps/editor/src/features/simulation/simulation-artifact-files.ts
+++ b/apps/editor/src/features/simulation/simulation-artifact-files.ts
@@ -1,0 +1,132 @@
+import { strToU8, zipSync } from "fflate";
+import type { ArtifactRef, Problem } from "@icm/simulation-service/contract";
+import type { SimulationFiles } from "@icm/simulation-service/files";
+
+const PREVIEW_CHARS = 65_536;
+
+export interface SimulationArtifactContent {
+  readonly artifact: ArtifactRef;
+  readonly text: string;
+  readonly truncated: boolean;
+}
+
+type ArtifactReadResult =
+  | { readonly ok: true; readonly content: SimulationArtifactContent }
+  | { readonly ok: false; readonly error: Problem };
+
+export async function readSimulationArtifactPreview(
+  files: SimulationFiles,
+  artifact: ArtifactRef,
+): Promise<ArtifactReadResult> {
+  const result = await files.handle({
+    action: "artifact",
+    artifactId: artifact.id,
+    offset: 0,
+    maxChars: PREVIEW_CHARS,
+  });
+  if (!result.ok) return result;
+  if (!("text" in result))
+    return {
+      ok: false,
+      error: {
+        code: "ARTIFACT_READ_FAILED",
+        message: "The selected artifact did not return readable content",
+        stage: "export",
+        recovery: "not-retryable",
+      },
+    };
+  return {
+    ok: true,
+    content: {
+      artifact,
+      text: result.text,
+      truncated: result.nextOffset !== null,
+    },
+  };
+}
+
+export async function readSimulationArtifact(
+  files: SimulationFiles,
+  artifact: ArtifactRef,
+): Promise<ArtifactReadResult> {
+  let offset: number | null = 0;
+  let text = "";
+  while (offset !== null) {
+    const result = await files.handle({
+      action: "artifact",
+      artifactId: artifact.id,
+      offset,
+    });
+    if (!result.ok) return result;
+    if (!("text" in result))
+      return {
+        ok: false,
+        error: {
+          code: "ARTIFACT_READ_FAILED",
+          message: "The selected artifact did not return readable content",
+          stage: "export",
+          recovery: "not-retryable",
+        },
+      };
+    text += result.text;
+    offset = result.nextOffset;
+  }
+  return { ok: true, content: { artifact, text, truncated: false } };
+}
+
+export async function buildSimulationArtifactArchive(
+  files: SimulationFiles,
+  artifacts: readonly ArtifactRef[],
+): Promise<
+  | { readonly ok: true; readonly bytes: Uint8Array }
+  | { readonly ok: false; readonly error: Problem }
+> {
+  try {
+    const entries: Record<string, Uint8Array> = {};
+    for (const artifact of artifacts) {
+      const result = await readSimulationArtifact(files, artifact);
+      if (!result.ok) return result;
+      entries[
+        `${simulationArtifactCategory(artifact).toLowerCase()}/${artifact.name}`
+      ] = strToU8(result.content.text);
+    }
+    return {
+      ok: true,
+      bytes: zipSync(entries, {
+        level: 6,
+        mtime: new Date("1980-01-01T00:00:00.000Z"),
+      }),
+    };
+  } catch {
+    return {
+      ok: false,
+      error: {
+        code: "ARTIFACT_ARCHIVE_FAILED",
+        message: "The artifact bundle could not be created in this browser",
+        stage: "export",
+        recovery: "retry-after",
+      },
+    };
+  }
+}
+
+export function simulationArtifactCategory(artifact: ArtifactRef): string {
+  const name = artifact.name.toLocaleLowerCase();
+  if (name.endsWith(".cir") || name.endsWith(".spi")) return "Netlist";
+  if (name.endsWith(".raw") || name.endsWith(".csv")) return "Results";
+  if (name.endsWith(".json")) return "Evidence";
+  if (name.endsWith(".log") || name.endsWith(".txt")) return "Log";
+  return "Other";
+}
+
+export function formatSimulationArtifactPreview(
+  content: SimulationArtifactContent,
+): string {
+  if (!content.artifact.name.toLocaleLowerCase().endsWith(".json"))
+    return content.text;
+  try {
+    return JSON.stringify(JSON.parse(content.text), null, 2);
+  } catch {
+    return content.text;
+  }
+}

--- a/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
@@ -65,6 +65,7 @@ describe("SpiceSimulationSurface workspace", () => {
     expect(markup).not.toContain("Current Outputs target a measurable");
     expect(markup).not.toContain("<span>Preview</span>");
     expect(markup).not.toContain('class="simulation-results-dock"');
+    expect(markup).not.toContain('aria-label="File preview"');
   });
 
   it("edits a saved DC sweep with a root independent source", () => {

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -32,6 +32,14 @@ import {
   simulationProbeTargetKey,
   type SimulationProbeOption,
 } from "./simulation-probe-options";
+import {
+  buildSimulationArtifactArchive,
+  formatSimulationArtifactPreview,
+  readSimulationArtifact,
+  readSimulationArtifactPreview,
+  simulationArtifactCategory,
+  type SimulationArtifactContent,
+} from "./simulation-artifact-files";
 
 const RESULT_TABS = [
   ["plot", "Plot"],
@@ -184,6 +192,9 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
   const [resultTab, setResultTab] = useState<ResultTab>("plot");
   const [exitConfirmationOpen, setExitConfirmationOpen] = useState(false);
   const [deleteSetupId, setDeleteSetupId] = useState<string>();
+  const [artifactPreview, setArtifactPreview] =
+    useState<SimulationArtifactContent>();
+  const [artifactBusy, setArtifactBusy] = useState<string>();
   const setupMenuRef = useRef<HTMLDetailsElement>(null);
   useEffect(() => {
     const closeSetupMenu = (event: PointerEvent): void => {
@@ -201,6 +212,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
     setPrepared(undefined);
     setRun(undefined);
     setProblem(undefined);
+    setArtifactPreview(undefined);
     setResultsOpen(false);
     setSetupOpen(true);
   }, [props.selectedSetupId]);
@@ -244,6 +256,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
     } else if ("prepared" in reply) {
       setPrepared(reply.prepared);
       setProblem(undefined);
+      setArtifactPreview(undefined);
       setSetupOpen(false);
       setResultsOpen(true);
       setResultTab("files");
@@ -327,25 +340,55 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
     }
   };
   const download = async (artifact: ArtifactRef) => {
-    let offset: number | null = 0;
-    let text = "";
-    while (offset !== null) {
-      const chunk = await session.files.handle({
-        action: "artifact",
-        artifactId: artifact.id,
-        offset,
-      });
-      if (!chunk.ok) {
-        setProblem(chunk.error);
-        return;
-      }
-      if (!("text" in chunk)) return;
-      text += chunk.text;
-      offset = chunk.nextOffset;
+    setArtifactBusy(`download:${artifact.id}`);
+    const artifactResult = await readSimulationArtifact(
+      session.files,
+      artifact,
+    );
+    setArtifactBusy(undefined);
+    if (!artifactResult.ok) {
+      setProblem(artifactResult.error);
+      return;
     }
-    const result = downloadTextArtifact(text, artifact.name);
+    const result = downloadTextArtifact(
+      artifactResult.content.text,
+      artifact.name,
+    );
     if (result.status === "failed")
       setProblem(uiProblem("ARTIFACT_DOWNLOAD_FAILED", result.message));
+  };
+  const preview = async (artifact: ArtifactRef) => {
+    setArtifactBusy(`preview:${artifact.id}`);
+    const result = await readSimulationArtifactPreview(session.files, artifact);
+    setArtifactBusy(undefined);
+    if (!result.ok) {
+      setProblem(result.error);
+      return;
+    }
+    setArtifactPreview(result.content);
+  };
+  const downloadBundle = async (
+    key: "prepare" | "run",
+    artifacts: readonly ArtifactRef[],
+  ) => {
+    setArtifactBusy(`bundle:${key}`);
+    const result = await buildSimulationArtifactArchive(
+      session.files,
+      artifacts,
+    );
+    setArtifactBusy(undefined);
+    if (!result.ok) {
+      setProblem(result.error);
+      return;
+    }
+    const url = URL.createObjectURL(
+      new Blob([result.bytes as BlobPart], { type: "application/zip" }),
+    );
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `simulation-${key}.zip`;
+    anchor.click();
+    setTimeout(() => URL.revokeObjectURL(url), 0);
   };
   const running = run && ["running", "cancelling"].includes(run.state);
   const activeCell = project.documents.find(
@@ -355,33 +398,6 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
     activeCell?.instances.some(
       (instance) => instance.netlist?.binding?.kind === "subcircuit",
     ),
-  );
-  const artifactGroups = [
-    ...(prepared
-      ? [
-          {
-            label: "Prepared files",
-            artifacts: prepared.artifacts,
-          },
-        ]
-      : []),
-    ...(run
-      ? [
-          {
-            label: "Last run",
-            artifacts: run.artifacts,
-          },
-        ]
-      : []),
-  ];
-  const artifactCategories = ["Netlist", "Results", "Evidence", "Log", "Other"];
-  const artifactSections = artifactGroups.flatMap((group) =>
-    artifactCategories.flatMap((category) => {
-      const artifacts = group.artifacts.filter(
-        (artifact) => simulationArtifactCategory(artifact) === category,
-      );
-      return artifacts.length ? [{ ...group, category, artifacts }] : [];
-    }),
   );
   const statusLabel = busy
     ? "Preparing…"
@@ -418,6 +434,34 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
   const runPresentation = run
     ? preparedPresentations.current.get(run.preparedId)
     : undefined;
+  const artifactCategories = ["Netlist", "Results", "Evidence", "Log", "Other"];
+  const runPreparedArtifactIds = new Set(
+    runPresentation?.prepared.artifacts.map((artifact) => artifact.id) ?? [],
+  );
+  const artifactGroups = [
+    ...(prepared
+      ? [
+          {
+            key: "prepare" as const,
+            label: "Prepare",
+            description: "Compiled input",
+            artifacts: prepared.artifacts,
+          },
+        ]
+      : []),
+    ...(run
+      ? [
+          {
+            key: "run" as const,
+            label: "Run",
+            description: "Execution output",
+            artifacts: run.artifacts.filter(
+              (artifact) => !runPreparedArtifactIds.has(artifact.id),
+            ),
+          },
+        ]
+      : []),
+  ].filter((group) => group.artifacts.length > 0);
   const analysisLabel = runPresentation?.analysisLabel;
   const presentationProbes =
     runPresentation?.outputs.flatMap((output) => {
@@ -939,34 +983,138 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
             ) : null}
 
             {resultTab === "files" ? (
-              <div className="simulation-files-view">
-                {artifactSections.map((section) => (
-                  <details
-                    key={`${section.label}:${section.category}`}
-                    className="simulation-artifact-group"
-                    aria-label={`${section.label} ${section.category}`}
-                    open={section.category === "Results"}
+              <div
+                className={`simulation-files-view${artifactPreview ? " preview-open" : ""}`}
+              >
+                <div className="simulation-file-browser">
+                  {artifactGroups.map((group) => (
+                    <section
+                      key={group.key}
+                      className="simulation-artifact-group"
+                      aria-label={`${group.label} files`}
+                    >
+                      <header>
+                        <span>
+                          <strong>{group.label}</strong>
+                          <small>{group.description}</small>
+                        </span>
+                        <button
+                          type="button"
+                          disabled={artifactBusy !== undefined}
+                          onClick={() =>
+                            void downloadBundle(group.key, group.artifacts)
+                          }
+                        >
+                          {artifactBusy === `bundle:${group.key}`
+                            ? "Packing…"
+                            : "Download ZIP"}
+                        </button>
+                      </header>
+                      {artifactCategories.map((category) => {
+                        const artifacts = group.artifacts.filter(
+                          (artifact) =>
+                            simulationArtifactCategory(artifact) === category,
+                        );
+                        return artifacts.length ? (
+                          <details
+                            key={category}
+                            className="simulation-artifact-category"
+                            aria-label={`${group.label} ${category}`}
+                            open={
+                              category === "Results" || category === "Netlist"
+                            }
+                          >
+                            <summary>
+                              <strong>{category}</strong>
+                              <small>{artifacts.length}</small>
+                            </summary>
+                            <ul className="simulation-artifact-list">
+                              {artifacts.map((artifact) => (
+                                <li
+                                  key={artifact.id}
+                                  className={
+                                    artifactPreview?.artifact.id === artifact.id
+                                      ? "selected"
+                                      : undefined
+                                  }
+                                >
+                                  <button
+                                    type="button"
+                                    title={`Preview ${artifact.name}`}
+                                    disabled={artifactBusy !== undefined}
+                                    onClick={() => void preview(artifact)}
+                                  >
+                                    {artifactBusy === `preview:${artifact.id}`
+                                      ? "Opening…"
+                                      : artifact.name}
+                                  </button>
+                                  <small>
+                                    {formatArtifactSize(artifact.byteLength)}
+                                  </small>
+                                  <button
+                                    type="button"
+                                    className="simulation-artifact-download"
+                                    aria-label={`Download ${artifact.name}`}
+                                    title={`Download ${artifact.name}`}
+                                    disabled={artifactBusy !== undefined}
+                                    onClick={() => void download(artifact)}
+                                  >
+                                    ↓
+                                  </button>
+                                </li>
+                              ))}
+                            </ul>
+                          </details>
+                        ) : null;
+                      })}
+                    </section>
+                  ))}
+                </div>
+                {artifactPreview ? (
+                  <section
+                    className="simulation-artifact-preview"
+                    aria-label="File preview"
                   >
-                    <summary>
-                      <strong>{section.category}</strong>
-                      <span>{section.label}</span>
-                      <small>{section.artifacts.length}</small>
-                    </summary>
-                    <ul className="simulation-artifact-list">
-                      {section.artifacts.map((artifact) => (
-                        <li key={artifact.id}>
-                          <button onClick={() => void download(artifact)}>
-                            {artifact.name}
-                          </button>
-                          <small>
-                            {formatArtifactSize(artifact.byteLength)}
-                          </small>
-                        </li>
-                      ))}
-                    </ul>
-                  </details>
-                ))}
-                {artifactSections.length === 0 ? (
+                    <header>
+                      <span>
+                        <strong>{artifactPreview.artifact.name}</strong>
+                        <small>
+                          {formatArtifactSize(
+                            artifactPreview.artifact.byteLength,
+                          )}
+                        </small>
+                      </span>
+                      <span>
+                        <button
+                          type="button"
+                          disabled={artifactBusy !== undefined}
+                          onClick={() =>
+                            void download(artifactPreview.artifact)
+                          }
+                        >
+                          Download
+                        </button>
+                        <button
+                          type="button"
+                          aria-label="Close file preview"
+                          onClick={() => setArtifactPreview(undefined)}
+                        >
+                          ×
+                        </button>
+                      </span>
+                    </header>
+                    <pre>
+                      {formatSimulationArtifactPreview(artifactPreview)}
+                    </pre>
+                    {artifactPreview.truncated ? (
+                      <footer>
+                        Preview limited to the first 64 KB. Download for the
+                        complete file.
+                      </footer>
+                    ) : null}
+                  </section>
+                ) : null}
+                {artifactGroups.length === 0 ? (
                   <p className="simulation-empty-result">
                     Prepare a deck or run the simulation to create files.
                   </p>
@@ -1974,15 +2122,6 @@ function ProbeSelect({
       </span>
     </div>
   );
-}
-
-function simulationArtifactCategory(artifact: ArtifactRef): string {
-  const name = artifact.name.toLocaleLowerCase();
-  if (name.endsWith(".cir") || name.endsWith(".spi")) return "Netlist";
-  if (name.endsWith(".raw") || name.endsWith(".csv")) return "Results";
-  if (name.endsWith(".json")) return "Evidence";
-  if (name.endsWith(".log") || name.endsWith(".txt")) return "Log";
-  return "Other";
 }
 
 function formatArtifactSize(byteLength: number): string {

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -583,7 +583,17 @@
 }
 .simulation-files-view {
   display: grid;
-  gap: 8px;
+  gap: 10px;
+  min-height: 0;
+}
+.spice-simulation-surface.maximized .simulation-files-view.preview-open {
+  grid-template-columns: minmax(220px, 0.8fr) minmax(300px, 1.2fr);
+}
+.simulation-file-browser {
+  display: grid;
+  align-content: start;
+  gap: 10px;
+  min-width: 0;
 }
 .simulation-artifact-group {
   overflow: hidden;
@@ -591,22 +601,37 @@
   border-radius: var(--icm-radius-sm);
   background: var(--icm-surface);
 }
-.simulation-artifact-group > summary {
+.simulation-artifact-group > header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+  min-height: 42px;
+  padding: 6px 9px;
+  border-bottom: 1px solid var(--icm-border);
+  background: var(--icm-surface-muted);
+}
+.simulation-artifact-group > header > span,
+.simulation-artifact-preview > header > span:first-child {
   display: grid;
-  grid-template-columns: minmax(70px, auto) minmax(0, 1fr) auto;
+  min-width: 0;
+}
+.simulation-artifact-group > header button {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+.simulation-artifact-category > summary {
+  display: flex;
+  justify-content: space-between;
   gap: 8px;
   align-items: center;
-  min-height: 36px;
-  padding: 5px 9px;
+  min-height: 32px;
+  padding: 4px 9px;
   cursor: pointer;
   list-style-position: inside;
 }
-.simulation-artifact-group > summary span {
-  overflow: hidden;
-  color: var(--icm-text-muted);
-  font-size: var(--icm-font-xs);
-  text-overflow: ellipsis;
-  white-space: nowrap;
+.simulation-artifact-category + .simulation-artifact-category {
+  border-top: 1px solid var(--icm-border);
 }
 .simulation-artifact-list {
   display: grid;
@@ -621,12 +646,15 @@
 }
 .simulation-artifact-list li {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 10px;
+  grid-template-columns: minmax(0, 1fr) auto 28px;
+  gap: 7px;
   align-items: center;
   min-height: 38px;
   padding: 5px 9px;
   background: var(--icm-surface);
+}
+.simulation-artifact-list li.selected {
+  background: color-mix(in srgb, var(--icm-accent) 8%, var(--icm-surface));
 }
 .simulation-artifact-list li + li {
   border-top: 1px solid var(--icm-border);
@@ -637,6 +665,54 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+.simulation-artifact-list .simulation-artifact-download {
+  width: 28px;
+  min-width: 28px;
+  padding-inline: 0;
+  justify-self: end;
+}
+.simulation-artifact-preview {
+  display: grid;
+  grid-template-rows: auto minmax(220px, 1fr) auto;
+  min-width: 0;
+  min-height: 320px;
+  overflow: hidden;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  background: var(--icm-surface);
+}
+.simulation-artifact-preview > header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: center;
+  min-height: 42px;
+  padding: 6px 9px;
+  border-bottom: 1px solid var(--icm-border);
+  background: var(--icm-surface-muted);
+}
+.simulation-artifact-preview > header > span:last-child {
+  display: flex;
+  gap: 5px;
+}
+.simulation-artifact-preview > pre {
+  max-height: none;
+  margin: 0;
+  padding: 11px;
+  overflow: auto;
+  border: 0;
+  border-radius: 0;
+  background: var(--icm-surface);
+  font-size: var(--icm-font-xs);
+  line-height: 1.5;
+  white-space: pre;
+}
+.simulation-artifact-preview > footer {
+  padding: 6px 9px;
+  border-top: 1px solid var(--icm-border);
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
 }
 .spice-simulation-surface pre {
   white-space: pre-wrap;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       "@icm/symbols":
         specifier: workspace:*
         version: link:../../packages/symbols
+      fflate:
+        specifier: 0.8.3
+        version: 0.8.3
       mathlive:
         specifier: 0.110.0
         version: 0.110.0


### PR DESCRIPTION
## Summary
- organize Simulation files under Prepare and Run lifecycle groups without duplicated prepared artifacts
- add bounded in-page previews and direct artifact downloads
- add deterministic ZIP downloads for each lifecycle group

## Validation
- pnpm gate:full
- 2754 unit tests passed, 28 skipped
- 357/357 browser tests passed
- build, release, performance, visual/export golden, PWA and MCP smoke checks passed