### PR TITLE
feat(simulation): pick directed terminal currents

### DIFF
--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -144,12 +144,19 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
   await panel
     .getByLabel("Add voltage probe")
     .selectOption({ label: "XDUT · ota_5t · vinp" });
-  await panel.getByRole("button", { name: "Pick terminal" }).click();
+  await panel.getByRole("button", { name: "Pick current" }).click();
   await expect(page.locator(".schematic-canvas")).toHaveClass(
     /simulation-terminal-pick-active/u,
   );
-  await page.getByTestId("terminal-VINP-+").click({ force: true });
-  await panel.getByRole("button", { name: "Picking Terminals…" }).click();
+  await page.getByTestId("terminal-VINP-+").click();
+  await expect(
+    page.getByTestId("terminal-VINP-+-current-pick-marker"),
+  ).toHaveClass(/origin/u);
+  await expect(
+    page.getByTestId("terminal-VINP---current-pick-marker"),
+  ).toHaveClass(/partner/u);
+  await page.getByTestId("terminal-VINP--").click();
+  await panel.getByRole("button", { name: "Picking current…" }).click();
   await panel
     .getByLabel("Add current output")
     .selectOption({ label: "XDUT · ota_5t · I1.+ current" });

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -112,9 +112,14 @@ import {
   type OperatingPointDisplay,
 } from "../features/simulation/operating-point-labels";
 import {
+  deriveSimulationProbeOptions,
   resolveSimulationVoltageProbeNetId,
   simulationProbeHierarchyPath,
 } from "../features/simulation/simulation-probe-options";
+import {
+  sameSimulationOccurrence,
+  terminalCurrentDirectionPartners,
+} from "../features/simulation/terminal-current-pick";
 import { TimingSimulationPanel } from "../features/simulation/timing-simulation-panel";
 import { TIMING_UI_ENABLED } from "../features/simulation/timing-ui";
 import { updateComponentParameterValues } from "../features/component-insert/component-parameters";
@@ -1072,8 +1077,17 @@ export function App({
     documentId: string;
     instanceId: string;
     pinName: string;
+    directionPinName?: string;
     occurrence?: readonly string[];
   } | null>(null);
+  const [simulationTerminalPickStart, setSimulationTerminalPickStart] =
+    useState<{
+      documentId: string;
+      instanceId: string;
+      pinName: string;
+      partnerPinNames: readonly string[];
+      occurrence?: readonly string[];
+    } | null>(null);
   const [pendingWaveformPlacement, setPendingWaveformPlacement] =
     useState<PendingWaveformPlacement | null>(null);
   const [waveformPlacementPoint, setWaveformPlacementPoint] =
@@ -1083,6 +1097,7 @@ export function App({
     // enters a DUT Cell, so an internal Net can be picked with its occurrence
     // path intact. Closing/minimising Simulation still cancels it explicitly.
     if (!analogSimulationOpen) setSimulationPickModeState(null);
+    setSimulationTerminalPickStart(null);
     setSimulationHoverNetId(null);
     setSimulationSavedNetIds(new Set());
     setPendingWaveformPlacement(null);
@@ -1092,7 +1107,11 @@ export function App({
     setSimulationPickModeState(null);
     setAnalogPickedNet(null);
     setAnalogPickedTerminal(null);
+    setSimulationTerminalPickStart(null);
   }, [projectSessionId]);
+  useEffect(() => {
+    setSimulationTerminalPickStart(null);
+  }, [activeSimulationSetupId]);
   const routeCounter = useRef(0);
   const canvasDragSessionRef = useRef<CanvasDragSession | null>(null);
   /**
@@ -1590,17 +1609,59 @@ export function App({
       logicalNets.groups.find((candidate) => candidate.id === netId);
     return group?.baseNetIds[0] ?? null;
   };
-  const activeSimulationPickOccurrence = (): readonly string[] | undefined => {
-    const setupRootId =
-      activeSimulationSetup?.input.kind === "structured"
-        ? activeSimulationSetup.input.rootDocumentId
+  const simulationPickRootDocumentId =
+    activeSimulationSetup?.input.kind === "structured"
+      ? activeSimulationSetup.input.rootDocumentId
+      : simulationDraftContext?.setupId === activeSimulationSetupId
+        ? simulationDraftContext.rootDocumentId
         : undefined;
-    return documentStack.length > 0
+  const simulationPickOccurrence: readonly string[] | undefined =
+    documentStack.length > 0
       ? documentStack.map((frame) => frame.instanceId)
-      : setupRootId === document.id
+      : simulationPickRootDocumentId === document.id
         ? []
         : undefined;
-  };
+  const activeSimulationPickOccurrence = (): readonly string[] | undefined =>
+    simulationPickOccurrence;
+  const simulationCurrentProbeOptions = useMemo(
+    () =>
+      simulationPickRootDocumentId
+        ? deriveSimulationProbeOptions(project, simulationPickRootDocumentId)
+            .terminalCurrent
+        : [],
+    [project, simulationPickRootDocumentId],
+  );
+  const simulationCurrentTargetsInView = useMemo(
+    () =>
+      simulationCurrentProbeOptions.filter(
+        ({ target }) =>
+          target.documentId === document.id &&
+          (simulationPickOccurrence === undefined ||
+            sameSimulationOccurrence(
+              target.occurrence,
+              simulationPickOccurrence,
+            )),
+      ),
+    [document.id, simulationCurrentProbeOptions, simulationPickOccurrence],
+  );
+  const simulationCurrentPinNamesByInstance = useMemo(() => {
+    const result = new Map<string, string[]>();
+    for (const { target } of simulationCurrentTargetsInView) {
+      const pins = result.get(target.instanceId) ?? [];
+      if (!pins.includes(target.pinName)) pins.push(target.pinName);
+      result.set(target.instanceId, pins);
+    }
+    return result;
+  }, [simulationCurrentTargetsInView]);
+  const simulationCurrentEndpointKeys = useMemo(
+    () =>
+      new Set(
+        simulationCurrentTargetsInView.map(
+          ({ target }) => `${target.instanceId}\u0000${target.pinName}`,
+        ),
+      ),
+    [simulationCurrentTargetsInView],
+  );
   const toggleSimulationSavedNet = (netId: string): void => {
     const baseNetId = canonicalSimulationNetId(netId);
     if (!baseNetId) {
@@ -1631,27 +1692,97 @@ export function App({
     if (endpoint.endpoint.kind !== "terminal" || !analogSimulationOpen) return;
     const terminal = endpoint.endpoint;
     const occurrence = activeSimulationPickOccurrence();
-    setAnalogPickedTerminal((current) => ({
-      sequence: (current?.sequence ?? 0) + 1,
+    const referenceFor = (instanceId: string): string =>
+      document.instances.find((instance) => instance.id === instanceId)
+        ?.reference ?? instanceId;
+    const clickedKey = `${terminal.instanceId}\u0000${terminal.pinName}`;
+    if (!simulationCurrentEndpointKeys.has(clickedKey)) {
+      setStatus(
+        `${referenceFor(terminal.instanceId)}.${terminal.pinName} is not a measurable current terminal in this Testbench occurrence`,
+      );
+      return;
+    }
+    const commitPick = (
+      picked: {
+        documentId: string;
+        instanceId: string;
+        pinName: string;
+        occurrence?: readonly string[];
+      },
+      directionPinName?: string,
+    ): void => {
+      setAnalogPickedTerminal((current) => ({
+        sequence: (current?.sequence ?? 0) + 1,
+        ...picked,
+        ...(directionPinName ? { directionPinName } : {}),
+      }));
+      setSimulationTerminalPickStart(null);
+      const reference = referenceFor(picked.instanceId);
+      setStatus(
+        directionPinName
+          ? `Added current ${reference}.${picked.pinName} → ${reference}.${directionPinName} · positive current enters ${picked.pinName}`
+          : `Added terminal current ${reference}.${picked.pinName} · positive current enters the terminal`,
+      );
+    };
+    if (
+      simulationTerminalPickStart &&
+      simulationTerminalPickStart.documentId === document.id &&
+      simulationTerminalPickStart.instanceId === terminal.instanceId &&
+      sameSimulationOccurrence(
+        simulationTerminalPickStart.occurrence,
+        occurrence,
+      )
+    ) {
+      if (simulationTerminalPickStart.pinName === terminal.pinName) {
+        setSimulationTerminalPickStart(null);
+        setStatus("Current direction cancelled · choose the first terminal");
+        return;
+      }
+      if (
+        simulationTerminalPickStart.partnerPinNames.includes(terminal.pinName)
+      ) {
+        commitPick(simulationTerminalPickStart, terminal.pinName);
+        return;
+      }
+    }
+
+    const instance = document.instances.find(
+      (candidate) => candidate.id === terminal.instanceId,
+    );
+    const measurablePins =
+      simulationCurrentPinNamesByInstance.get(terminal.instanceId) ?? [];
+    const partnerPinNames = instance
+      ? terminalCurrentDirectionPartners(
+          instance,
+          terminal.pinName,
+          measurablePins,
+        )
+      : [];
+    const picked = {
       documentId: document.id,
       instanceId: terminal.instanceId,
       pinName: terminal.pinName,
       ...(occurrence === undefined ? {} : { occurrence }),
-    }));
-    const reference =
-      document.instances.find((instance) => instance.id === terminal.instanceId)
-        ?.reference ?? terminal.instanceId;
-    setStatus(`Added terminal-current Output ${reference}.${terminal.pinName}`);
+    };
+    if (partnerPinNames.length === 0) {
+      commitPick(picked);
+      return;
+    }
+    setSimulationTerminalPickStart({ ...picked, partnerPinNames });
+    setStatus(
+      `Current starts at ${referenceFor(terminal.instanceId)}.${terminal.pinName} · choose ${partnerPinNames.join(" or ")} to confirm direction`,
+    );
   };
   const setSimulationPickMode = (mode: "net" | "terminal" | null): void => {
     if (mode) activateTool("pointer");
     setSimulationPickModeState(mode);
+    if (mode !== "terminal") setSimulationTerminalPickStart(null);
     if (mode !== "net") setSimulationHoverNetId(null);
     setStatus(
       mode === "net"
         ? "Pick Nets: click a wire, label, junction, or connected pin · Esc exits"
         : mode === "terminal"
-          ? "Pick terminal current: click a connected device terminal · Esc exits"
+          ? "Pick current: choose a device terminal, then its direction · Esc exits"
           : "Finished picking simulation Outputs",
     );
   };
@@ -5800,13 +5931,41 @@ export function App({
             },
             endpoints: {
               document,
-              endpoints: wiringEndpoints,
+              endpoints: simulationPickTerminalsActive
+                ? wiringEndpoints.filter(
+                    (candidate) =>
+                      candidate.endpoint.kind === "terminal" &&
+                      simulationCurrentEndpointKeys.has(
+                        `${candidate.endpoint.instanceId}\u0000${candidate.endpoint.pinName}`,
+                      ),
+                  )
+                : wiringEndpoints,
               tool,
               selectedRoute: simulationPickActive ? undefined : selectedRoute,
               selectedRouteSegmentIndex,
               selectedEndpoint,
               supplementalJunctionIds: supplementalSelection.junctionIds,
               endpointLabel: endpointTestId,
+              ...(simulationPickTerminalsActive
+                ? {
+                    terminalPickState: (terminal: {
+                      kind: "terminal";
+                      instanceId: string;
+                      pinName: string;
+                    }) =>
+                      simulationTerminalPickStart?.instanceId ===
+                        terminal.instanceId &&
+                      simulationTerminalPickStart.pinName === terminal.pinName
+                        ? ("origin" as const)
+                        : simulationTerminalPickStart?.instanceId ===
+                              terminal.instanceId &&
+                            simulationTerminalPickStart.partnerPinNames.includes(
+                              terminal.pinName,
+                            )
+                          ? ("partner" as const)
+                          : ("candidate" as const),
+                  }
+                : {}),
               onEndpointActions: (candidate, clientX, clientY) => {
                 if (
                   candidate.endpoint.kind === "junction" &&

--- a/apps/editor/src/canvas/editor-canvas-hit-layer.test.tsx
+++ b/apps/editor/src/canvas/editor-canvas-hit-layer.test.tsx
@@ -127,6 +127,66 @@ describe("editor canvas hit layer", () => {
     expect(markup).toContain('class="endpoint-hit active"');
   });
 
+  it("renders explicit current-pick feedback independently of the hit circle", () => {
+    const document = createEmptyDocument("cell", "Cell");
+    const endpoint = {
+      kind: "terminal" as const,
+      instanceId: "M1",
+      pinName: "D",
+    };
+    const source = {
+      endpoint,
+      netId: "net",
+      connection: { contactPoint: { x: 10, y: 20 } },
+      preludeEdits: [],
+    } as unknown as WireSource;
+    const markup = renderToStaticMarkup(
+      <EditorCanvasHitLayer
+        selection={emptySelectionProps(document)}
+        endpoints={{
+          ...emptyEndpointProps(document),
+          endpoints: [source],
+          endpointLabel: () => "terminal-M1-D",
+          terminalPickState: () => "origin",
+        }}
+      />,
+    );
+    expect(markup).toContain('data-testid="terminal-M1-D-current-pick-marker"');
+    expect(markup).toContain('class="simulation-terminal-pick-marker origin"');
+    expect(markup).toContain('data-endpoint-kind="terminal"');
+  });
+
+  it("previews the direction from the first terminal to its partner", () => {
+    const document = createEmptyDocument("cell", "Cell");
+    const source = (pinName: string, x: number): WireSource =>
+      ({
+        endpoint: { kind: "terminal", instanceId: "M1", pinName },
+        netId: `net-${pinName}`,
+        connection: { contactPoint: { x, y: 20 } },
+        preludeEdits: [],
+      }) as unknown as WireSource;
+    const markup = renderToStaticMarkup(
+      <EditorCanvasHitLayer
+        selection={emptySelectionProps(document)}
+        endpoints={{
+          ...emptyEndpointProps(document),
+          endpoints: [source("D", 10), source("S", 50)],
+          endpointLabel: (endpoint) =>
+            endpoint.kind === "terminal"
+              ? `terminal-${endpoint.instanceId}-${endpoint.pinName}`
+              : "junction",
+          terminalPickState: (endpoint) =>
+            endpoint.pinName === "D" ? "origin" : "partner",
+        }}
+      />,
+    );
+    expect(markup).toContain(
+      'data-testid="simulation-terminal-direction-preview"',
+    );
+    expect(markup).toContain("<line");
+    expect(markup).toContain("<polygon");
+  });
+
   it("keeps endpoints between routes and annotations in hit order", () => {
     const document = createEmptyDocument("cell", "Cell");
     document.nets.push({ id: "net", terminals: [] });

--- a/apps/editor/src/canvas/editor-canvas-hit-layer.tsx
+++ b/apps/editor/src/canvas/editor-canvas-hit-layer.tsx
@@ -114,6 +114,9 @@ interface EndpointHitTargetProps {
   ) => void;
   onNetPointerEnter?: (netId: string) => void;
   onNetPointerLeave?: () => void;
+  terminalPickState?: (
+    endpoint: Extract<WireSource["endpoint"], { kind: "terminal" }>,
+  ) => "candidate" | "origin" | "partner";
 }
 
 export function EditorCanvasHitLayer({
@@ -311,6 +314,7 @@ function EndpointHitTargets({
   onWireEndpoint,
   onNetPointerEnter,
   onNetPointerLeave,
+  terminalPickState,
 }: EndpointHitTargetProps) {
   const selectedRouteEnd = selectedRoute ? routeEnd(selectedRoute) : null;
   // Which end of the selected wire an endpoint IS, by identity rather than by
@@ -334,7 +338,18 @@ function EndpointHitTargets({
           )
           .sort((left, right) => left.position.x - right.position.x) ?? [])
       : [];
-  return endpoints.map((candidate) => {
+  const pickEntries = endpoints.flatMap((candidate) => {
+    if (candidate.endpoint.kind !== "terminal" || !terminalPickState) return [];
+    return [
+      {
+        candidate,
+        state: terminalPickState(candidate.endpoint),
+      },
+    ];
+  });
+  const pickOrigin = pickEntries.find(({ state }) => state === "origin");
+  const pickPartners = pickEntries.filter(({ state }) => state === "partner");
+  const hitTargets = endpoints.map((candidate) => {
     const candidateJunctionId =
       candidate.endpoint.kind === "junction"
         ? candidate.endpoint.junctionId
@@ -357,6 +372,7 @@ function EndpointHitTargets({
       <circle
         key={`${candidate.netId}:${label}`}
         data-testid={label}
+        data-endpoint-kind={candidate.endpoint.kind}
         data-canvas-hit-kind={
           candidate.endpoint.kind === "junction" ? "junction" : undefined
         }
@@ -424,4 +440,65 @@ function EndpointHitTargets({
       />
     );
   });
+  return (
+    <>
+      {pickOrigin
+        ? pickPartners.map(({ candidate }) => (
+            <TerminalCurrentDirectionPreview
+              key={`current-direction-${endpointKey(candidate.endpoint)}`}
+              from={pickOrigin.candidate.connection.contactPoint}
+              to={candidate.connection.contactPoint}
+              arrowSize={endpointHitRadius * 1.6}
+            />
+          ))
+        : null}
+      {pickEntries.map(({ candidate, state }) => {
+        const label = endpointLabel(candidate.endpoint);
+        return (
+          <circle
+            key={`${label}-current-pick-marker`}
+            data-testid={`${label}-current-pick-marker`}
+            className={`simulation-terminal-pick-marker ${state}`}
+            cx={candidate.connection.contactPoint.x}
+            cy={candidate.connection.contactPoint.y}
+            r={endpointHitRadius}
+          />
+        );
+      })}
+      {hitTargets}
+    </>
+  );
+}
+
+function TerminalCurrentDirectionPreview({
+  from,
+  to,
+  arrowSize,
+}: {
+  from: { x: number; y: number };
+  to: { x: number; y: number };
+  arrowSize: number;
+}) {
+  const dx = to.x - from.x;
+  const dy = to.y - from.y;
+  const length = Math.hypot(dx, dy);
+  if (length === 0) return null;
+  const ux = dx / length;
+  const uy = dy / length;
+  const tip = { x: from.x + dx * 0.62, y: from.y + dy * 0.62 };
+  const base = { x: tip.x - ux * arrowSize, y: tip.y - uy * arrowSize };
+  const halfWidth = arrowSize * 0.56;
+  const left = { x: base.x - uy * halfWidth, y: base.y + ux * halfWidth };
+  const right = { x: base.x + uy * halfWidth, y: base.y - ux * halfWidth };
+  return (
+    <g
+      className="simulation-terminal-direction-preview"
+      data-testid="simulation-terminal-direction-preview"
+    >
+      <line x1={from.x} y1={from.y} x2={to.x} y2={to.y} />
+      <polygon
+        points={`${tip.x},${tip.y} ${left.x},${left.y} ${right.x},${right.y}`}
+      />
+    </g>
+  );
 }

--- a/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
@@ -66,7 +66,7 @@ describe("SpiceSimulationSurface workspace", () => {
     expect(markup).not.toContain("Filter by Cell, instance, pin, or Net");
     expect(markup).toContain("Choose a Net");
     expect(markup).toContain("Pick on canvas");
-    expect(markup).toContain("Pick terminal");
+    expect(markup).toContain("Pick current");
     expect(markup).toContain("Add current output");
     expect(markup).toContain('class="simulation-analysis-row"');
     expect(markup).toContain('class="simulation-analysis-options"');

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -109,6 +109,8 @@ export interface SpiceSimulationSurfaceProps {
     readonly documentId: string;
     readonly instanceId: string;
     readonly pinName: string;
+    /** Optional second click used only to present the authored direction. */
+    readonly directionPinName?: string;
     /** Instance ids from the selected Testbench root to this Cell. */
     readonly occurrence?: readonly string[];
   } | null;
@@ -1415,12 +1417,23 @@ function SetupEditor({
       probeOptions.terminalCurrent,
       pickedTerminal,
     );
-    if (candidates.length > 1) {
-      setPickCandidates(candidates);
+    const presentedCandidates = candidates.map((candidate) =>
+      pickedTerminal.directionPinName
+        ? {
+            ...candidate,
+            label: candidate.label.replace(
+              `${pickedTerminal.pinName} current`,
+              `${pickedTerminal.pinName}→${pickedTerminal.directionPinName} current`,
+            ),
+          }
+        : candidate,
+    );
+    if (presentedCandidates.length > 1) {
+      setPickCandidates(presentedCandidates);
       onProblem(undefined);
       return;
     }
-    const option = candidates[0];
+    const option = presentedCandidates[0];
     if (!option) {
       onProblem(
         uiProblem(
@@ -1438,8 +1451,15 @@ function SetupEditor({
             output.expression.kind === "current") &&
           simulationProbeSelectionKey(project, output.expression) === key,
       )
-    )
+    ) {
+      onProblem(
+        uiProblem(
+          "PROBE_TARGET_ALREADY_SELECTED",
+          "That terminal current is already present in this Setup.",
+        ),
+      );
       return;
+    }
     setOutputs((current) => [...current, outputFromOption(option, current)]);
     onDirty(true);
     setPickCandidates([]);
@@ -1953,11 +1973,11 @@ function SetupEditor({
                 aria-pressed={pickTerminalsActive}
                 onClick={() => onPickTerminalsChange?.(!pickTerminalsActive)}
               >
-                {pickTerminalsActive ? "Picking Terminals…" : "Pick terminal"}
+                {pickTerminalsActive ? "Picking current…" : "Pick current"}
               </button>
             }
           />
-          <small>Positive current enters the selected terminal.</small>
+          <small>First terminal sets the positive current direction.</small>
         </SimulationSettingsSection>
         <SimulationSettingsSection
           title="Output signals"

--- a/apps/editor/src/features/simulation/terminal-current-pick.test.ts
+++ b/apps/editor/src/features/simulation/terminal-current-pick.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import type { Instance } from "@icm/model";
+
+import {
+  sameSimulationOccurrence,
+  terminalCurrentDirectionPartners,
+} from "./terminal-current-pick";
+
+function instance(symbolId: string): Instance {
+  return {
+    id: "device",
+    symbolId,
+    reference: "X1",
+    placement: { position: { x: 0, y: 0 }, rotation: 0, mirror: "none" },
+  } as unknown as Instance;
+}
+
+describe("terminal current direction gesture", () => {
+  it("pairs only drain and source on a MOS device", () => {
+    const mos = instance("nmos");
+    expect(
+      terminalCurrentDirectionPartners(mos, "D", ["D", "G", "S", "B"]),
+    ).toEqual(["S"]);
+    expect(
+      terminalCurrentDirectionPartners(mos, "S", ["D", "G", "S", "B"]),
+    ).toEqual(["D"]);
+    expect(
+      terminalCurrentDirectionPartners(mos, "G", ["D", "G", "S", "B"]),
+    ).toEqual([]);
+  });
+
+  it("uses the other pin as direction for a two-terminal primitive", () => {
+    const source = instance("voltage-source");
+    expect(terminalCurrentDirectionPartners(source, "+", ["+", "-"])).toEqual([
+      "-",
+    ]);
+  });
+
+  it("does not invent a pair for a general multi-terminal instance", () => {
+    expect(
+      terminalCurrentDirectionPartners(instance("unknown"), "A", [
+        "A",
+        "B",
+        "C",
+      ]),
+    ).toEqual([]);
+  });
+
+  it("compares hierarchy occurrences without collapsing repeated cells", () => {
+    expect(sameSimulationOccurrence(["X1", "X2"], ["X1", "X2"])).toBe(true);
+    expect(sameSimulationOccurrence(["X1"], ["X2"])).toBe(false);
+    expect(sameSimulationOccurrence(undefined, [])).toBe(false);
+  });
+});

--- a/apps/editor/src/features/simulation/terminal-current-pick.ts
+++ b/apps/editor/src/features/simulation/terminal-current-pick.ts
@@ -1,0 +1,37 @@
+import { deviceDescriptor } from "@icm/devices";
+import type { Instance } from "@icm/model";
+
+/**
+ * Return the second terminals that make a directionally meaningful current
+ * gesture for the selected pin. The resulting measurement is still the
+ * current entering the first terminal; the second click only makes that
+ * direction explicit to the author.
+ */
+export function terminalCurrentDirectionPartners(
+  instance: Instance,
+  pinName: string,
+  measurablePinNames: readonly string[],
+): readonly string[] {
+  const measurable = new Set(measurablePinNames);
+  const descriptor = deviceDescriptor(instance.symbolId);
+  if (descriptor?.mosBulkClass) {
+    if (pinName === "D" && measurable.has("S")) return ["S"];
+    if (pinName === "S" && measurable.has("D")) return ["D"];
+    return [];
+  }
+
+  const unique = [...measurable];
+  if (unique.length !== 2 || !measurable.has(pinName)) return [];
+  return unique.filter((candidate) => candidate !== pinName);
+}
+
+export function sameSimulationOccurrence(
+  left: readonly string[] | undefined,
+  right: readonly string[] | undefined,
+): boolean {
+  if (left === undefined || right === undefined) return left === right;
+  return (
+    left.length === right.length &&
+    left.every((instanceId, index) => instanceId === right[index])
+  );
+}

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -1581,7 +1581,8 @@
 .schematic-canvas.simulation-net-pick-active .route-hit,
 .schematic-canvas.simulation-net-pick-active .endpoint-hit,
 .schematic-canvas.simulation-net-pick-active .annotation-text-hit,
-.schematic-canvas.simulation-terminal-pick-active .endpoint-hit {
+.schematic-canvas.simulation-terminal-pick-active
+  .endpoint-hit[data-endpoint-kind="terminal"] {
   cursor: crosshair;
 }
 
@@ -1590,10 +1591,55 @@
 }
 
 .schematic-canvas.simulation-net-pick-active .endpoint-hit,
-.schematic-canvas.simulation-terminal-pick-active .endpoint-hit {
+.schematic-canvas.simulation-terminal-pick-active
+  .endpoint-hit[data-endpoint-kind="terminal"] {
   r: 9px;
   fill: rgb(0 0 0 / 0.1%);
   pointer-events: all;
+}
+
+.simulation-terminal-pick-marker {
+  fill: var(--icm-surface);
+  stroke: var(--icm-accent);
+  stroke-width: 1.5;
+  vector-effect: non-scaling-stroke;
+  pointer-events: none;
+  opacity: 0.72;
+}
+
+.simulation-terminal-pick-marker.origin {
+  fill: var(--icm-accent);
+  stroke: var(--icm-accent);
+  opacity: 1;
+}
+
+.simulation-terminal-pick-marker.partner {
+  stroke-width: 2;
+  opacity: 1;
+}
+
+.simulation-terminal-direction-preview {
+  color: var(--icm-accent);
+  pointer-events: none;
+}
+
+.simulation-terminal-direction-preview line {
+  stroke: currentColor;
+  stroke-width: 1.5;
+  stroke-dasharray: 4 3;
+  vector-effect: non-scaling-stroke;
+  opacity: 0.78;
+}
+
+.simulation-terminal-direction-preview polygon {
+  fill: currentColor;
+  opacity: 0.92;
+}
+
+.simulation-terminal-pick-marker.candidate {
+  transition:
+    opacity 100ms ease,
+    stroke-width 100ms ease;
 }
 
 .schematic-canvas.waveform-placement-active {


### PR DESCRIPTION
## Summary
- replace opaque one-click current picking with a two-end direction gesture for MOS D-S and two-terminal devices
- expose only measurable terminals in the active Testbench occurrence and show candidate, origin, partner, and arrow feedback on canvas
- keep the canonical current contract terminal-based and return a recoverable diagnostic for duplicate Outputs

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
- manual GUI checks for voltage-source + to - and MOS D to S

Test-Impact: tests-updated