### PR TITLE
feat(editor): organize properties with disclosures

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -194,6 +194,10 @@ test("returns a component to the Placement Tray and places the retained Instance
   ).toHaveCount(0);
 
   await page
+    .getByRole("region", { name: "Placement Tray" })
+    .locator(":scope > summary")
+    .click();
+  await page
     .getByRole("button", { name: "Place R1 · resistor from tray" })
     .click();
   await canvas.hover({ position: { x: 480, y: 260 } });

--- a/apps/editor/e2e/hierarchy.spec.ts
+++ b/apps/editor/e2e/hierarchy.spec.ts
@@ -550,6 +550,10 @@ test("returns a formal Cell Pin to the Tray without deleting its interface", asy
   await expect(page.getByTestId("hit-P1")).toHaveCount(0);
   await page
     .getByRole("region", { name: "Placement Tray" })
+    .locator(":scope > summary")
+    .click();
+  await page
+    .getByRole("region", { name: "Placement Tray" })
     .getByRole("button", { name: "Place all" })
     .click();
   await expect(page.getByTestId("hit-P1")).toBeVisible();

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -3243,6 +3243,12 @@ test("Properties offers no dead Reference controls for a schematic-only block", 
   await expect(properties.getByText("Symbol")).toBeVisible();
   await expect(referenceField).toHaveCount(0);
   await expect(parametersCard).toHaveCount(0);
+  await expect(
+    properties.locator('details[aria-label="Component appearance"]'),
+  ).not.toHaveAttribute("open", "");
+  await properties
+    .locator('details[aria-label="Component appearance"] > summary')
+    .click();
   await expect(properties.getByText("Line", { exact: true })).toBeVisible();
 
   // An ordinary device keeps both.
@@ -3279,8 +3285,13 @@ test("Properties toggles reference label visibility for one or many components",
     name: "Component properties",
   });
   await expect(
-    componentProperties.locator(":scope > .property-card"),
-  ).toHaveCount(5);
+    componentProperties.locator(":scope > .property-disclosure"),
+  ).toHaveCount(4);
+  await expect(
+    componentProperties.locator(
+      ':scope > details[aria-label="Component appearance"]',
+    ),
+  ).not.toHaveAttribute("open", "");
   await expect(
     componentProperties.getByText("Appearance", { exact: true }),
   ).toBeVisible();
@@ -3364,6 +3375,9 @@ test("Properties keeps component and Annotation text colors independent", async 
   const label = page.locator('[data-object-id="instance-label-R1"]');
   const secondLabel = page.locator('[data-object-id="instance-label-R2"]');
 
+  await properties
+    .locator('details[aria-label="Component appearance"] > summary')
+    .click();
   await properties.getByRole("button", { name: "Use Red for line" }).click();
   await properties
     .getByRole("button", { name: "Use Blue for background" })
@@ -3381,6 +3395,9 @@ test("Properties keeps component and Annotation text colors independent", async 
   await expect(
     properties.getByRole("region", { name: "Text properties" }),
   ).toBeVisible();
+  await properties
+    .locator('details[aria-label="Text appearance"] > summary')
+    .click();
   await expect(properties.getByLabel("Text color hex value")).toHaveText(
     "Automatic",
   );
@@ -3406,6 +3423,9 @@ test("Properties keeps component and Annotation text colors independent", async 
   await page
     .getByTestId("annotation-hit-instance-label-R2")
     .click({ force: true });
+  await properties
+    .locator('details[aria-label="Text appearance"] > summary')
+    .click();
   await page.clock.runFor(300);
   await page.clock.resume();
   await expect(label).toHaveAttribute("fill", "#2563eb");
@@ -3417,6 +3437,9 @@ test("Properties keeps component and Annotation text colors independent", async 
   await page
     .getByTestId("annotation-hit-instance-label-R1")
     .click({ force: true });
+  await properties
+    .locator('details[aria-label="Text appearance"] > summary')
+    .click();
   await properties.locator("summary", { hasText: /^RGB$/u }).click();
   await properties.getByLabel("Text color red").fill("12");
   const resetTextColor = properties.getByRole("button", {
@@ -4527,6 +4550,10 @@ R7 IN OUT 10k
   await expect(page.getByTestId("status")).toContainText(
     "Imported 1 Documents",
   );
+  await page
+    .getByRole("region", { name: "Placement Tray" })
+    .locator(":scope > summary")
+    .click();
   await page
     .getByRole("region", { name: "Placement Tray" })
     .getByRole("button", { name: "Place all" })

--- a/apps/editor/src/features/component-insert/placement-tray-panel.test.tsx
+++ b/apps/editor/src/features/component-insert/placement-tray-panel.test.tsx
@@ -1,0 +1,37 @@
+import { createEmptyDocument } from "@icm/model";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { PlacementTrayPanel } from "./placement-tray-panel";
+
+describe("placement tray panel", () => {
+  it("keeps retained instances available behind a collapsed count summary", () => {
+    const document = createEmptyDocument("cell", "Cell");
+    const instance: (typeof document.instances)[number] = {
+      id: "R1",
+      symbolId: "resistor",
+      placement: null,
+      reference: "R1",
+    };
+    const markup = renderToStaticMarkup(
+      <PlacementTrayPanel
+        document={document}
+        unplaced={[instance]}
+        returnablePlaced={[]}
+        onPlaceAll={vi.fn()}
+        onReturnAll={vi.fn()}
+        onSelect={vi.fn()}
+        onPlace={vi.fn()}
+      />,
+    );
+
+    const tray = markup.match(
+      /<details[^>]*aria-label="Placement Tray"[^>]*>/u,
+    )?.[0];
+    expect(tray).toBeDefined();
+    expect(tray).toContain('role="region"');
+    expect(tray).not.toContain('open=""');
+    expect(markup).toContain('aria-label="1 retained Instance"');
+    expect(markup).toContain("R1 · resistor");
+  });
+});

--- a/apps/editor/src/features/component-insert/placement-tray-panel.tsx
+++ b/apps/editor/src/features/component-insert/placement-tray-panel.tsx
@@ -1,5 +1,7 @@
 import type { SchematicDocument } from "@icm/model";
 
+import { PropertyDisclosure } from "../properties/property-disclosure";
+
 type Instance = SchematicDocument["instances"][number];
 
 export function placementTrayIdentity(
@@ -31,12 +33,9 @@ export function PlacementTrayPanel({
   onPlace: (instanceId: string) => void;
 }) {
   return (
-    <section
-      className="context-actions placement-tray"
-      aria-label="Placement Tray"
-    >
-      <div className="placement-tray-heading">
-        <h2>Placement Tray</h2>
+    <PropertyDisclosure
+      title="Placement Tray"
+      summary={
         <span
           className="placement-tray-count"
           aria-label={`${unplaced.length} retained ${
@@ -45,7 +44,11 @@ export function PlacementTrayPanel({
         >
           {unplaced.length}
         </span>
-      </div>
+      }
+      className="context-actions placement-tray"
+      ariaLabel="Placement Tray"
+      role="region"
+    >
       <div className="component-mirror-row">
         <button
           type="button"
@@ -97,6 +100,6 @@ export function PlacementTrayPanel({
           })}
         </div>
       ) : null}
-    </section>
+    </PropertyDisclosure>
   );
 }

--- a/apps/editor/src/features/properties/annotation-color-properties.test.tsx
+++ b/apps/editor/src/features/properties/annotation-color-properties.test.tsx
@@ -30,6 +30,11 @@ describe("annotation color properties", () => {
     );
 
     expect(markup).toContain('aria-label="Text properties"');
+    const appearance = markup.match(
+      /<details[^>]*aria-label="Text appearance"[^>]*>/u,
+    )?.[0];
+    expect(appearance).toBeDefined();
+    expect(appearance).not.toContain('open=""');
     expect(markup).toContain('aria-label="Text color hex value">Automatic');
     expect(markup).toContain(
       'aria-label="Text color picker" type="color" value="#dc2626"',

--- a/apps/editor/src/features/properties/annotation-color-properties.tsx
+++ b/apps/editor/src/features/properties/annotation-color-properties.tsx
@@ -1,6 +1,7 @@
 import type { Annotation } from "@icm/model";
 
 import { ColorOverrideControl } from "./color-override-control";
+import { PropertyDisclosure } from "./property-disclosure";
 
 export function AnnotationColorProperties({
   annotation,
@@ -16,8 +17,7 @@ export function AnnotationColorProperties({
       className="property-section annotation-text-properties"
       aria-label="Text properties"
     >
-      <div className="property-card">
-        <div className="property-section-heading">Text</div>
+      <PropertyDisclosure title="Text appearance" ariaLabel="Text appearance">
         <ColorOverrideControl
           label="Text color"
           value={annotation.textColor}
@@ -27,7 +27,7 @@ export function AnnotationColorProperties({
           onChange={onChange}
         />
         <small>Auto uses the inherited text color.</small>
-      </div>
+      </PropertyDisclosure>
     </section>
   );
 }

--- a/apps/editor/src/features/properties/component-electrical-properties.test.tsx
+++ b/apps/editor/src/features/properties/component-electrical-properties.test.tsx
@@ -57,6 +57,9 @@ describe("component electrical properties", () => {
       />,
     );
     expect(markup).toContain("Finger width 1u");
+    expect(markup).toMatch(
+      /<details[^>]*aria-label="Component parameters and display"[^>]*open=""/u,
+    );
     expect(markup).toContain('aria-label="Additional parameter name 1"');
     expect(markup).toContain("Apply parameters");
     expect(markup).not.toContain("Component compatibility field");

--- a/apps/editor/src/features/properties/component-electrical-properties.tsx
+++ b/apps/editor/src/features/properties/component-electrical-properties.tsx
@@ -7,6 +7,7 @@ import { DisplayToggle } from "../component-insert/display-toggle";
 import type { ComponentParameter } from "../component-insert/component-parameters";
 import type { AdditionalParameterDraft } from "./additional-parameters";
 import { derivedFingerWidth } from "./finger-width";
+import { PropertyDisclosure } from "./property-disclosure";
 
 type Instance = SchematicDocument["instances"][number];
 const COMPACT_PARAMETER_LABELS = new Set(["W", "L", "NF"]);
@@ -147,11 +148,12 @@ export function ComponentElectricalProperties({
     return null;
   }
   return (
-    <div
-      className="property-card property-electrical-section"
-      aria-label="Component parameters and display"
+    <PropertyDisclosure
+      title="Parameters"
+      className="property-electrical-section"
+      ariaLabel="Component parameters and display"
+      defaultOpen
     >
-      <div className="property-section-heading">Parameters</div>
       <div className="component-parameter-grid">
         {primaryParameterRows.map((row) => (
           <div
@@ -319,6 +321,6 @@ export function ComponentElectricalProperties({
           </div>
         </details>
       ) : null}
-    </div>
+    </PropertyDisclosure>
   );
 }

--- a/apps/editor/src/features/properties/component-identity-properties.test.tsx
+++ b/apps/editor/src/features/properties/component-identity-properties.test.tsx
@@ -56,6 +56,9 @@ describe("component identity properties", () => {
       />,
     );
     expect(markup).toContain('aria-label="Supply name"');
+    expect(markup).toMatch(
+      /<details[^>]*aria-label="Component identity"[^>]*open=""/u,
+    );
     expect(markup).toContain('<option value="">None</option>');
     expect(markup).toContain("sky130_fd_pr__nfet_01v8");
     expect(markup).toContain("Custom…");

--- a/apps/editor/src/features/properties/component-identity-properties.tsx
+++ b/apps/editor/src/features/properties/component-identity-properties.tsx
@@ -5,6 +5,7 @@ import type { SchematicDocument } from "@icm/model";
 import { deviceDescriptor } from "@icm/devices";
 
 import type { CapacitorPlatePropertyRow } from "./capacitor-plate-properties";
+import { PropertyDisclosure } from "./property-disclosure";
 
 type Instance = SchematicDocument["instances"][number];
 
@@ -216,11 +217,12 @@ export function ComponentIdentityProperties({
   const reference = instance.reference ?? "";
   return (
     <>
-      <div
-        className="property-card property-identity-card"
-        aria-label="Component identity"
+      <PropertyDisclosure
+        title="Identity"
+        className="property-identity-card"
+        ariaLabel="Component identity"
+        defaultOpen
       >
-        <div className="property-section-heading">Identity</div>
         <dl className="component-readonly-fields">
           {portNet && !formalTerminalSelected ? (
             <div>
@@ -295,7 +297,7 @@ export function ComponentIdentityProperties({
             </div>
           ) : null}
         </dl>
-      </div>
+      </PropertyDisclosure>
       {capacitorPlateRows ? (
         <div
           className="property-card property-terminal-card"

--- a/apps/editor/src/features/properties/component-placement-properties.test.tsx
+++ b/apps/editor/src/features/properties/component-placement-properties.test.tsx
@@ -33,6 +33,9 @@ describe("component placement properties", () => {
         onDiscard={vi.fn()}
       />,
     );
+    expect(markup).toMatch(
+      /<details[^>]*aria-label="Component placement"[^>]*open=""/u,
+    );
     expect(markup).toContain('aria-label="Component geometry"');
     expect(markup).toContain("Swap + / − outputs");
     expect(markup).toContain("Discard changes");

--- a/apps/editor/src/features/properties/component-placement-properties.tsx
+++ b/apps/editor/src/features/properties/component-placement-properties.tsx
@@ -1,6 +1,7 @@
 import type { SchematicDocument } from "@icm/model";
 
 import { ToolIcon } from "../editor-shell/tool-icon";
+import { PropertyDisclosure } from "./property-disclosure";
 
 type Instance = SchematicDocument["instances"][number];
 
@@ -49,8 +50,12 @@ export function ComponentPlacementProperties({
         </div>
       ) : null}
       {instance.placement ? (
-        <div className="property-card property-placement-card">
-          <div className="property-section-heading">Placement</div>
+        <PropertyDisclosure
+          title="Placement"
+          className="property-placement-card"
+          ariaLabel="Component placement"
+          defaultOpen
+        >
           <div
             className="component-geometry-row property-placement-controls"
             aria-label="Component geometry"
@@ -151,7 +156,7 @@ export function ComponentPlacementProperties({
               ) : null}
             </div>
           ) : null}
-        </div>
+        </PropertyDisclosure>
       ) : null}
       {draftChanged ? (
         <button type="button" className="property-discard" onClick={onDiscard}>

--- a/apps/editor/src/features/properties/component-style-properties.test.tsx
+++ b/apps/editor/src/features/properties/component-style-properties.test.tsx
@@ -33,6 +33,11 @@ describe("component style properties", () => {
     );
 
     expect(markup).toContain("Appearance");
+    const appearance = markup.match(
+      /<details[^>]*aria-label="Component appearance"[^>]*>/u,
+    )?.[0];
+    expect(appearance).toBeDefined();
+    expect(appearance).not.toContain('open=""');
     expect(markup).toContain("<legend>Line</legend>");
     expect(markup).toContain("<legend>Background</legend>");
     expect(markup).not.toContain("Line / foreground");

--- a/apps/editor/src/features/properties/component-style-properties.tsx
+++ b/apps/editor/src/features/properties/component-style-properties.tsx
@@ -1,6 +1,7 @@
 import type { SchematicDocument } from "@icm/model";
 
 import { ColorOverrideControl } from "./color-override-control";
+import { PropertyDisclosure } from "./property-disclosure";
 
 type Instance = SchematicDocument["instances"][number];
 type InstanceStyleOverride = NonNullable<Instance["styleOverride"]>;
@@ -26,8 +27,11 @@ export function ComponentStyleProperties({
   };
 
   return (
-    <div className="property-card component-appearance-card">
-      <div className="property-section-heading">Appearance</div>
+    <PropertyDisclosure
+      title="Appearance"
+      ariaLabel="Component appearance"
+      className="component-appearance-card"
+    >
       <small>Colors apply to this component only.</small>
       <ColorOverrideControl
         label="Line"
@@ -42,6 +46,6 @@ export function ComponentStyleProperties({
         transparentDefault
         onChange={(value) => update("background", value)}
       />
-    </div>
+    </PropertyDisclosure>
   );
 }

--- a/apps/editor/src/features/properties/property-disclosure.tsx
+++ b/apps/editor/src/features/properties/property-disclosure.tsx
@@ -1,0 +1,38 @@
+import { useState, type ReactNode } from "react";
+
+export function PropertyDisclosure({
+  title,
+  summary,
+  defaultOpen = false,
+  ariaLabel,
+  role = "group",
+  className,
+  children,
+}: {
+  title: string;
+  summary?: ReactNode;
+  defaultOpen?: boolean;
+  ariaLabel?: string;
+  role?: "group" | "region";
+  className?: string;
+  children: ReactNode;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <details
+      className={["property-details", "property-disclosure", className]
+        .filter(Boolean)
+        .join(" ")}
+      aria-label={ariaLabel ?? title}
+      role={role}
+      open={open}
+      onToggle={(event) => setOpen(event.currentTarget.open)}
+    >
+      <summary>
+        <span>{title}</span>
+        {summary === undefined ? null : <small>{summary}</small>}
+      </summary>
+      <div className="property-disclosure-body">{children}</div>
+    </details>
+  );
+}

--- a/apps/editor/src/styles/editor-canvas.css
+++ b/apps/editor/src/styles/editor-canvas.css
@@ -1062,19 +1062,14 @@
 }
 
 .placement-tray {
-  display: grid;
-  gap: 0.5rem;
+  display: block;
+  padding-top: 0;
+  border-top: 0;
 }
 
-.placement-tray h2 {
-  margin: 0;
-}
-
-.placement-tray-heading {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--icm-space-2);
+.placement-tray > summary small {
+  padding: 0;
+  background: transparent;
 }
 
 .placement-tray-count {

--- a/apps/editor/src/styles/editor-properties.css
+++ b/apps/editor/src/styles/editor-properties.css
@@ -49,6 +49,7 @@
 }
 
 .property-card > small,
+.property-disclosure-body > small,
 .property-target-card label > small,
 .additional-parameters > small {
   color: var(--icm-text-muted);
@@ -152,6 +153,31 @@
 
 .property-details[open] summary {
   border-bottom: 1px solid var(--icm-border);
+}
+
+.property-disclosure > summary::before {
+  width: 0;
+  height: 0;
+  margin-right: var(--icm-space-2);
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  border-left: 6px solid var(--icm-text-muted);
+  content: "";
+  transition: transform 120ms ease;
+}
+
+.property-disclosure[open] > summary::before {
+  transform: rotate(90deg);
+}
+
+.property-disclosure > summary > span {
+  margin-right: auto;
+}
+
+.property-disclosure-body {
+  display: grid;
+  gap: 0.45rem;
+  padding: 0.65rem;
 }
 
 .additional-parameters {
@@ -456,7 +482,7 @@
   box-shadow: none;
 }
 
-.component-appearance-card > small {
+.component-appearance-card .property-disclosure-body > small {
   line-height: var(--icm-line);
 }
 


### PR DESCRIPTION
## Summary
- keep Identity, Parameters, and Placement open for routine editing
- collapse component/text appearance controls and Placement Tray by default
- preserve Placement Tray count and all existing editing behavior

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
  - 2760 unit tests passed (28 skipped)
  - 33 component-insert browser tests passed
  - 16 hierarchy browser tests passed
  - 134 editor browser tests passed

Test-Impact: tests-updated