### PR TITLE
Simulation results: OP canvas, export, measurements, and comparison

### DIFF
--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -341,6 +341,7 @@ test("one Testbench persists several independently named setups", async ({
 test("human simulation uses saved setup, survives minimizing, recovers a bad input and exports results", async ({
   page,
 }) => {
+  test.setTimeout(90_000);
   const project = parseProject(JSON.stringify(ota));
   project.simulationSetups = [
     {
@@ -546,6 +547,11 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
     "0.500000",
   );
   await expect(panel.getByText("1 direct Net voltage")).toBeVisible();
+  const opMeasurements = panel.locator(
+    "details.simulation-measurement-results",
+  );
+  await expect(opMeasurements.locator("summary")).toContainText("1 value");
+  await expect(opMeasurements).not.toHaveAttribute("open", "");
   await panel.getByRole("button", { name: "Show on canvas" }).click();
   await expect(page.getByTestId("operating-point-badges")).toContainText(
     "500 mV",
@@ -553,6 +559,10 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   await panel.getByRole("button", { name: "Hide canvas values" }).click();
   await expect(page.getByTestId("operating-point-badges")).toHaveCount(0);
   await panel.getByRole("tab", { name: "Plot" }).click();
+  const plotMeasurements = panel.locator(
+    "details.simulation-measurement-results",
+  );
+  await expect(plotMeasurements.locator("summary")).toContainText("8 values");
   await expect(panel.locator(".spice-ac-plot svg")).toHaveCount(3);
   await expect(panel.locator('svg[aria-label="AC magnitude"]')).toBeVisible();
   await expect(panel.locator('svg[aria-label="AC phase"]')).toBeVisible();
@@ -593,6 +603,13 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   expect((await csvDownloadPromise).suggestedFilename()).toBe(
     "outputs-op-0.csv",
   );
+  const measurementDownloadPromise = page.waitForEvent("download");
+  await resultExport.getByRole("button", { name: "measurements.csv" }).click();
+  const measurementDownload = await measurementDownloadPromise;
+  expect(measurementDownload.suggestedFilename()).toBe("measurements.csv");
+  expect(readFileSync((await measurementDownload.path())!, "utf8")).toContain(
+    '"TRAN","Transient response","first-output","Time-weighted RMS"',
+  );
   resultExport.evaluate((element) => element.removeAttribute("open"));
   expect(
     await panel
@@ -606,7 +623,9 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
       .first()
       .evaluate((label) => getComputedStyle(label).fill),
   ).toBe("rgb(52, 64, 84)");
-  await expect(panel.getByText("first-output", { exact: true })).toHaveCount(2);
+  await expect(
+    panel.getByRole("button", { name: "Hide first-output" }),
+  ).toHaveCount(2);
   const magnitudePlot = panel
     .locator(".ac-plot-row")
     .filter({ hasText: "Magnitude" })
@@ -883,8 +902,12 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   );
   await panel.getByRole("button", { name: "Results" }).click();
   await panel.getByRole("tab", { name: "Plot" }).click();
-  await expect(panel.getByText("first-output", { exact: true })).toHaveCount(2);
-  await expect(panel.getByText("new-output", { exact: true })).toHaveCount(0);
+  await expect(
+    panel.getByRole("button", { name: "Hide first-output" }),
+  ).toHaveCount(2);
+  await expect(
+    panel.getByRole("button", { name: "Hide new-output" }),
+  ).toHaveCount(0);
   await panel.getByRole("button", { name: "Run", exact: true }).click();
   await expect.poll(() => executions).toBe(2);
   await expect(panel.getByRole("status")).toHaveText("finished · completed");
@@ -893,7 +916,9 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   await expect(
     transientShell.getByRole("button", { name: "Previous view" }),
   ).toBeDisabled();
-  await expect(panel.getByText("new-output", { exact: true })).toHaveCount(2);
+  await expect(
+    panel.getByRole("button", { name: "Hide new-output" }),
+  ).toHaveCount(2);
   pending = new Promise<void>((r) => {
     release = r;
   });

--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type WebSocketRoute } from "@playwright/test";
 import { readFileSync } from "node:fs";
+import { strFromU8, unzipSync } from "fflate";
 import {
   createSimulationEnvironmentMetadata,
   createSimulationInputMetadata,
@@ -562,6 +563,37 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
           ?.height ?? 0,
     )
     .toBeGreaterThan(300);
+  const resultExport = panel.locator("details.simulation-result-export");
+  await resultExport.locator("summary").click();
+  const svgBundlePromise = page.waitForEvent("download");
+  await resultExport
+    .getByRole("button", { name: "Visible plots · SVG" })
+    .click();
+  const svgBundle = await svgBundlePromise;
+  expect(svgBundle.suggestedFilename()).toBe("simulation-plots-svg.zip");
+  const svgEntries = unzipSync(readFileSync((await svgBundle.path())!));
+  expect(Object.keys(svgEntries)).toHaveLength(3);
+  const exportedSvg = strFromU8(Object.values(svgEntries)[0]!);
+  expect(exportedSvg).toContain('<?xml version="1.0"');
+  expect(exportedSvg).toContain('fill="white"');
+  expect(exportedSvg).not.toContain("ac-trace-hit");
+  const pngBundlePromise = page.waitForEvent("download");
+  await resultExport
+    .getByRole("button", { name: "Visible plots · PNG" })
+    .click();
+  const pngBundle = await pngBundlePromise;
+  expect(pngBundle.suggestedFilename()).toBe("simulation-plots-png.zip");
+  const pngEntries = unzipSync(readFileSync((await pngBundle.path())!));
+  expect(Object.keys(pngEntries)).toHaveLength(3);
+  expect([...Object.values(pngEntries)[0]!.slice(0, 8)]).toEqual([
+    137, 80, 78, 71, 13, 10, 26, 10,
+  ]);
+  const csvDownloadPromise = page.waitForEvent("download");
+  await resultExport.getByRole("button", { name: "outputs-op-0.csv" }).click();
+  expect((await csvDownloadPromise).suggestedFilename()).toBe(
+    "outputs-op-0.csv",
+  );
+  resultExport.evaluate((element) => element.removeAttribute("open"));
   expect(
     await panel
       .locator(".ac-response .ac-trace")

--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -544,6 +544,13 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   await expect(panel.getByRole("region", { name: "OP results" })).toContainText(
     "0.500000",
   );
+  await expect(panel.getByText("1 direct Net voltage")).toBeVisible();
+  await panel.getByRole("button", { name: "Show on canvas" }).click();
+  await expect(page.getByTestId("operating-point-badges")).toContainText(
+    "500 mV",
+  );
+  await panel.getByRole("button", { name: "Hide canvas values" }).click();
+  await expect(page.getByTestId("operating-point-badges")).toHaveCount(0);
   await panel.getByRole("tab", { name: "Plot" }).click();
   await expect(panel.locator(".spice-ac-plot svg")).toHaveCount(3);
   await expect(panel.locator('svg[aria-label="AC magnitude"]')).toBeVisible();

--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -611,6 +611,13 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
     '"TRAN","Transient response","first-output","Time-weighted RMS"',
   );
   resultExport.evaluate((element) => element.removeAttribute("open"));
+  await panel.getByRole("tab", { name: "Compare" }).click();
+  await expect(panel.getByText("Session only", { exact: false })).toBeVisible();
+  await panel.getByRole("button", { name: "Keep current" }).click();
+  await expect(
+    panel.getByRole("button", { name: "Current kept" }),
+  ).toBeDisabled();
+  await panel.getByRole("tab", { name: "Plot" }).click();
   expect(
     await panel
       .locator(".ac-response .ac-trace")
@@ -919,6 +926,16 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   await expect(
     panel.getByRole("button", { name: "Hide new-output" }),
   ).toHaveCount(2);
+  await panel.getByRole("tab", { name: "Compare" }).click();
+  const comparisonTable = panel.locator(".simulation-run-comparison-table");
+  await expect(comparisonTable.locator("thead th")).toHaveCount(3);
+  await expect(comparisonTable).toContainText("Current");
+  await expect(comparisonTable).toContainText("TRAN · Time-weighted RMS");
+  await expect(
+    comparisonTable.getByRole("button", {
+      name: "Remove E2E setup from comparison",
+    }),
+  ).toBeVisible();
   pending = new Promise<void>((r) => {
     release = r;
   });

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -107,10 +107,8 @@ import {
   type SpiceImportReport,
 } from "../features/editor-shell/editor-file-commands";
 import { EditorStatusbar } from "../features/editor-shell/editor-statusbar";
-import {
-  operatingPointLabels,
-  type OperatingPointDisplay,
-} from "../features/simulation/operating-point-labels";
+import { operatingPointLabels } from "../features/simulation/operating-point-labels";
+import type { OperatingPointCanvasProjection } from "../features/simulation/operating-point-projection";
 import {
   deriveSimulationProbeOptions,
   resolveSimulationVoltageProbeNetId,
@@ -1463,24 +1461,25 @@ export function App({
   );
   const [issuesFocusToken, setIssuesFocusToken] = useState(0);
   const [issuesSectionOpen, setIssuesSectionOpen] = useState(false);
-  /**
-   * The last DC operating point, kept in view state only. A simulation result
-   * is never persisted into the Project (ADR 0055), so it lives here and dies
-   * with the session rather than entering the document or the undo history.
-   *
-   * The setters have no caller yet by design, not by omission: the producer is
-   * the SPICE panel's run result, and the run route is still being built. This
-   * is the seam it attaches to — `_setOperatingPointVoltages(result.operating
-   * Point)` on success and `new Map()` on a new run. Do not delete it as dead
-   * code; deleting it would silently remove the canvas half of the feature.
-   * The leading underscore is what keeps `noUnusedLocals` from reading a
-   * reserved seam as dead code; drop it when the run route lands a caller.
-   */
-  const [operatingPointVoltages, _setOperatingPointVoltages] = useState<
-    ReadonlyMap<string, number>
-  >(() => new Map());
-  const [operatingPointDisplay, _setOperatingPointDisplay] =
-    useState<OperatingPointDisplay>("named");
+  /** Run results stay in session view state and never enter Project history. */
+  const [operatingPointProjection, setOperatingPointProjection] =
+    useState<OperatingPointCanvasProjection | null>(null);
+  const currentOccurrence = documentStack.map((frame) => frame.instanceId);
+  const operatingPointVoltages = useMemo(() => {
+    const values = new Map<string, number>();
+    for (const value of operatingPointProjection?.values ?? []) {
+      if (
+        value.documentId !== document.id ||
+        value.occurrence.length !== currentOccurrence.length ||
+        !value.occurrence.every(
+          (instanceId, index) => instanceId === currentOccurrence[index],
+        )
+      )
+        continue;
+      values.set(value.netId, value.volts);
+    }
+    return values;
+  }, [currentOccurrence, document.id, operatingPointProjection]);
   const operatingPointBadges = useMemo(
     () =>
       operatingPointVoltages.size === 0
@@ -1489,7 +1488,7 @@ export function App({
             document,
             resolver,
             voltages: operatingPointVoltages,
-            display: operatingPointDisplay,
+            display: operatingPointProjection?.display ?? "named",
             // "Pointed at" is whichever net the selected wire carries; the
             // highlight already tracks hover for the net-highlight overlay.
             selectedNetIds: selectedRouteId
@@ -1503,7 +1502,7 @@ export function App({
       document,
       resolver,
       operatingPointVoltages,
-      operatingPointDisplay,
+      operatingPointProjection?.display,
       selectedRouteId,
       highlightedNetId,
     ],
@@ -4959,6 +4958,7 @@ export function App({
               onFocusDiagnostic={(locator) =>
                 navigateToLocator(locator, `Located ${locator.kind}`)
               }
+              onOperatingPointProjection={setOperatingPointProjection}
               onFocusProbe={(probe, preparedRootDocumentId) => {
                 const targetDocument = project.documents.find(
                   (candidate) => candidate.id === probe.documentId,

--- a/apps/editor/src/features/simulation/operating-point-projection.test.ts
+++ b/apps/editor/src/features/simulation/operating-point-projection.test.ts
@@ -1,0 +1,134 @@
+import { createEmptyProject } from "@icm/model";
+import { describe, expect, it } from "vitest";
+
+import { deriveOperatingPointCanvasProjection } from "./operating-point-projection";
+
+describe("deriveOperatingPointCanvasProjection", () => {
+  it("maps only direct finite OP voltages through authored object anchors", () => {
+    const project = createEmptyProject("op-projection", "OP");
+    const document = project.documents[0]!;
+    document.nets.push({ id: "net-out", terminals: [] });
+    const voltage = {
+      id: "out-voltage",
+      label: "V(out)",
+      expression: {
+        kind: "voltage" as const,
+        documentId: document.id,
+        occurrence: [],
+        anchor: { kind: "base-net" as const, netId: "net-out" },
+      },
+    };
+    const projection = deriveOperatingPointCanvasProjection(
+      project,
+      document.id,
+      "revision-1",
+      {
+        schemaVersion: 1,
+        analyses: [
+          {
+            analysis: "op",
+            plotName: "Operating Point",
+            outputs: [
+              {
+                id: voltage.id,
+                label: voltage.label,
+                unit: "V",
+                values: [1.25],
+              },
+              {
+                id: "gain",
+                label: "Gain",
+                unit: "1",
+                values: [10],
+              },
+            ],
+          },
+          {
+            analysis: "tran",
+            plotName: "Transient",
+            domain: { name: "time", unit: "s", values: [0] },
+            outputs: [
+              {
+                id: voltage.id,
+                label: voltage.label,
+                unit: "V",
+                values: [9],
+              },
+            ],
+          },
+        ],
+        diagnostics: [],
+      },
+      [
+        voltage,
+        {
+          id: "gain",
+          label: "Gain",
+          expression: { kind: "constant", value: 10 },
+        },
+      ],
+      "named",
+    );
+
+    expect(projection).toEqual({
+      rootDocumentId: document.id,
+      inputRevision: "revision-1",
+      display: "named",
+      values: [
+        {
+          documentId: document.id,
+          occurrence: [],
+          netId: "net-out",
+          volts: 1.25,
+        },
+      ],
+    });
+  });
+
+  it("keeps repeated hierarchy occurrences distinct", () => {
+    const project = createEmptyProject("op-hierarchy", "Hierarchy");
+    const document = project.documents[0]!;
+    document.nets.push({ id: "net-child", terminals: [] });
+    const outputs = ["x1", "x2"].map((instanceId, index) => ({
+      id: `voltage-${instanceId}`,
+      label: instanceId,
+      expression: {
+        kind: "voltage" as const,
+        documentId: document.id,
+        occurrence: [instanceId],
+        anchor: { kind: "base-net" as const, netId: "net-child" },
+      },
+      value: index + 1,
+    }));
+    const projection = deriveOperatingPointCanvasProjection(
+      project,
+      document.id,
+      "revision-2",
+      {
+        schemaVersion: 1,
+        analyses: [
+          {
+            analysis: "op",
+            plotName: "Operating Point",
+            outputs: outputs.map((output) => ({
+              id: output.id,
+              label: output.label,
+              unit: "V",
+              values: [output.value],
+            })),
+          },
+        ],
+        diagnostics: [],
+      },
+      outputs,
+      "all",
+    );
+
+    expect(
+      projection.values.map((value) => [value.occurrence, value.volts]),
+    ).toEqual([
+      [["x1"], 1],
+      [["x2"], 2],
+    ]);
+  });
+});

--- a/apps/editor/src/features/simulation/operating-point-projection.ts
+++ b/apps/editor/src/features/simulation/operating-point-projection.ts
@@ -1,0 +1,74 @@
+import type { CircuitProject, SimulationOutputSpec } from "@icm/model";
+import type { SimulationOutputData } from "@icm/simulation-service/contract";
+
+import type { OperatingPointDisplay } from "./operating-point-labels";
+import { resolveSimulationVoltageProbeNetId } from "./simulation-probe-options";
+
+export interface OperatingPointCanvasValue {
+  readonly documentId: string;
+  /** Instance ids from the simulation root to this concrete Cell occurrence. */
+  readonly occurrence: readonly string[];
+  readonly netId: string;
+  readonly volts: number;
+}
+
+/**
+ * Session-only values that may be painted back onto the schematic.
+ *
+ * The mapping is deliberately based on authored voltage anchors. Raw ngspice
+ * names are never matched back to project objects after execution: that would
+ * collapse repeated hierarchy occurrences and turn a spelling coincidence
+ * into an electrical claim.
+ */
+export interface OperatingPointCanvasProjection {
+  readonly rootDocumentId: string;
+  readonly inputRevision: string;
+  readonly display: OperatingPointDisplay;
+  readonly values: readonly OperatingPointCanvasValue[];
+}
+
+export function deriveOperatingPointCanvasProjection(
+  project: CircuitProject,
+  rootDocumentId: string,
+  inputRevision: string,
+  data: SimulationOutputData | undefined,
+  outputs: readonly SimulationOutputSpec[],
+  display: OperatingPointDisplay,
+): OperatingPointCanvasProjection {
+  const authored = new Map(outputs.map((output) => [output.id, output]));
+  const values = new Map<string, OperatingPointCanvasValue>();
+  for (const analysis of data?.analyses ?? []) {
+    if (analysis.analysis !== "op") continue;
+    for (const result of analysis.outputs) {
+      const output = authored.get(result.id);
+      const expression = output?.expression;
+      const volts = result.values[0];
+      if (
+        expression?.kind !== "voltage" ||
+        result.unit !== "V" ||
+        volts === null ||
+        volts === undefined ||
+        !Number.isFinite(volts)
+      )
+        continue;
+      const netId = resolveSimulationVoltageProbeNetId(project, expression);
+      if (!netId) continue;
+      const occurrence = [...expression.occurrence];
+      values.set(
+        `${expression.documentId}\u0000${occurrence.join("\u0000")}\u0000${netId}`,
+        {
+          documentId: expression.documentId,
+          occurrence,
+          netId,
+          volts,
+        },
+      );
+    }
+  }
+  return {
+    rootDocumentId,
+    inputRevision,
+    display,
+    values: [...values.values()],
+  };
+}

--- a/apps/editor/src/features/simulation/simulation-measurement-results.test.tsx
+++ b/apps/editor/src/features/simulation/simulation-measurement-results.test.tsx
@@ -1,0 +1,55 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { SimulationMeasurementResults } from "./simulation-measurement-results";
+
+describe("SimulationMeasurementResults", () => {
+  const base = {
+    analysisIndex: 0,
+    analysis: "tran" as const,
+    plotName: "Transient",
+    outputId: "out",
+    outputLabel: "Vout",
+    unit: "V",
+  };
+
+  it("keeps successful detail compact behind a visible summary", () => {
+    const markup = renderToStaticMarkup(
+      <SimulationMeasurementResults
+        measurements={[
+          {
+            ...base,
+            id: "0:out:maximum",
+            metric: "maximum",
+            label: "Maximum",
+            status: "available",
+            value: 1.25,
+          },
+        ]}
+      />,
+    );
+    expect(markup).toContain("Measurements");
+    expect(markup).toContain("1 value");
+    expect(markup).not.toContain("<details open");
+  });
+
+  it("opens automatically so an unavailable measurement is not hidden", () => {
+    const markup = renderToStaticMarkup(
+      <SimulationMeasurementResults
+        measurements={[
+          {
+            ...base,
+            id: "0:out:time-rms",
+            metric: "time-rms",
+            label: "Time-weighted RMS",
+            status: "unavailable",
+            reason: "At least two samples are required",
+          },
+        ]}
+      />,
+    );
+    expect(markup).toContain('open=""');
+    expect(markup).toContain("1 unavailable");
+    expect(markup).toContain("At least two samples are required");
+  });
+});

--- a/apps/editor/src/features/simulation/simulation-measurement-results.tsx
+++ b/apps/editor/src/features/simulation/simulation-measurement-results.tsx
@@ -1,0 +1,94 @@
+import type { SimulationOutputData } from "@icm/simulation-service/contract";
+
+type Measurement = NonNullable<SimulationOutputData["measurements"]>[number];
+
+function formatMeasurement(value: number, unit: string): string {
+  const magnitude = Math.abs(value);
+  const scales = [
+    [1e9, "G"],
+    [1e6, "M"],
+    [1e3, "k"],
+    [1, ""],
+    [1e-3, "m"],
+    [1e-6, "µ"],
+    [1e-9, "n"],
+    [1e-12, "p"],
+  ] as const;
+  const scale =
+    value === 0
+      ? ([1, ""] as const)
+      : (scales.find(([factor]) => magnitude >= factor) ??
+        ([1e-15, "f"] as const));
+  const number = Number((value / scale[0]).toPrecision(5));
+  return `${number} ${scale[1]}${unit === "1" ? "" : unit}`.trim();
+}
+
+export function SimulationMeasurementResults({
+  measurements,
+}: {
+  measurements: readonly Measurement[];
+}) {
+  if (!measurements.length) return null;
+  const unavailable = measurements.filter(
+    (measurement) => measurement.status === "unavailable",
+  );
+  const availableCount = measurements.length - unavailable.length;
+  const groups = new Map<string, Measurement[]>();
+  for (const measurement of measurements) {
+    const key = `${measurement.analysisIndex}:${measurement.plotName}`;
+    groups.set(key, [...(groups.get(key) ?? []), measurement]);
+  }
+  return (
+    <details
+      className="simulation-measurement-results"
+      open={unavailable.length > 0}
+    >
+      <summary>
+        <span>
+          <strong>Measurements</strong>
+          <small>Automatic summaries from complete result data</small>
+        </span>
+        <span data-status={unavailable.length ? "attention" : "ready"}>
+          {availableCount} {availableCount === 1 ? "value" : "values"}
+          {unavailable.length ? ` · ${unavailable.length} unavailable` : ""}
+        </span>
+      </summary>
+      <div>
+        {[...groups.entries()].map(([key, group]) => (
+          <section key={key}>
+            <header>
+              <strong>{group[0]!.analysis.toUpperCase()}</strong>
+              <span>{group[0]!.plotName}</span>
+            </header>
+            <table>
+              <thead>
+                <tr>
+                  <th>Output</th>
+                  <th>Measurement</th>
+                  <th>Value</th>
+                </tr>
+              </thead>
+              <tbody>
+                {group.map((measurement) => (
+                  <tr key={measurement.id} data-status={measurement.status}>
+                    <td>{measurement.outputLabel}</td>
+                    <td>{measurement.label}</td>
+                    <td>
+                      {measurement.status === "available" ? (
+                        formatMeasurement(measurement.value, measurement.unit)
+                      ) : (
+                        <span title={measurement.reason}>
+                          Unavailable · {measurement.reason}
+                        </span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </section>
+        ))}
+      </div>
+    </details>
+  );
+}

--- a/apps/editor/src/features/simulation/simulation-output-results.tsx
+++ b/apps/editor/src/features/simulation/simulation-output-results.tsx
@@ -11,6 +11,7 @@ import type {
 
 import { AcResultsExplorer } from "./ac-results-explorer";
 import { TransientResultsExplorer } from "./transient-results-explorer";
+import { SimulationMeasurementResults } from "./simulation-measurement-results";
 
 function focusProbe(output: SimulationOutputSpec): SimulationProbeSpec | null {
   const dependency = simulationExpressionDependencies(output.expression)[0];
@@ -54,6 +55,9 @@ export function SimulationOutputResults({
   );
   const vectors = (ids: readonly string[]): Prepared["vectors"] =>
     ids.map((id) => ({ probeId: id, vector: id, quantity: "voltage" }));
+  const visibleAnalyses = new Set(
+    data.analyses.map((analysis) => analysis.analysis),
+  );
 
   return (
     <>
@@ -198,6 +202,11 @@ export function SimulationOutputResults({
           ))}
         </div>
       ) : null}
+      <SimulationMeasurementResults
+        measurements={(data.measurements ?? []).filter((measurement) =>
+          visibleAnalyses.has(measurement.analysis),
+        )}
+      />
     </>
   );
 }

--- a/apps/editor/src/features/simulation/simulation-plot-export.ts
+++ b/apps/editor/src/features/simulation/simulation-plot-export.ts
@@ -1,0 +1,175 @@
+import { strToU8, zipSync } from "fflate";
+
+export type SimulationPlotExportFormat = "svg" | "png";
+
+export interface SimulationPlotDownload {
+  readonly name: string;
+  readonly type: string;
+  readonly bytes: Uint8Array;
+  readonly plotCount: number;
+}
+
+const PRESENTATION_PROPERTIES = [
+  "color",
+  "fill",
+  "fill-opacity",
+  "stroke",
+  "stroke-width",
+  "stroke-linecap",
+  "stroke-linejoin",
+  "stroke-dasharray",
+  "opacity",
+  "font-family",
+  "font-size",
+  "font-style",
+  "font-weight",
+  "text-anchor",
+  "dominant-baseline",
+] as const;
+
+function safeName(value: string): string {
+  return (
+    value
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/gu, "-")
+      .replace(/^-+|-+$/gu, "") || "plot"
+  );
+}
+
+function dimensions(svg: SVGSVGElement): { width: number; height: number } {
+  const viewBox = svg.viewBox.baseVal;
+  if (viewBox.width > 0 && viewBox.height > 0)
+    return { width: viewBox.width, height: viewBox.height };
+  const bounds = svg.getBoundingClientRect();
+  return {
+    width: Math.max(1, Math.round(bounds.width || 760)),
+    height: Math.max(1, Math.round(bounds.height || 395)),
+  };
+}
+
+/** Serialize the currently visible plot with its computed presentation. */
+export function standaloneSimulationPlotSvg(svg: SVGSVGElement): string {
+  const clone = svg.cloneNode(true) as SVGSVGElement;
+  const sourceElements = [svg, ...svg.querySelectorAll<SVGElement>("*")];
+  const clonedElements = [clone, ...clone.querySelectorAll<SVGElement>("*")];
+  for (let index = 0; index < sourceElements.length; index++) {
+    const source = sourceElements[index];
+    const target = clonedElements[index];
+    if (!source || !target) continue;
+    const computed = getComputedStyle(source);
+    for (const property of PRESENTATION_PROPERTIES) {
+      const value = computed.getPropertyValue(property);
+      if (value) target.style.setProperty(property, value);
+    }
+  }
+  clone
+    .querySelectorAll(".ac-trace-hit, .ac-cursor-hit")
+    .forEach((element) => element.remove());
+  const size = dimensions(svg);
+  clone.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+  clone.setAttribute("width", String(size.width));
+  clone.setAttribute("height", String(size.height));
+  const background = document.createElementNS(
+    "http://www.w3.org/2000/svg",
+    "rect",
+  );
+  background.setAttribute("x", "0");
+  background.setAttribute("y", "0");
+  background.setAttribute("width", "100%");
+  background.setAttribute("height", "100%");
+  background.setAttribute("fill", "white");
+  clone.insertBefore(background, clone.firstChild);
+  return `<?xml version="1.0" encoding="UTF-8"?>\n${new XMLSerializer().serializeToString(clone)}`;
+}
+
+function loadSvgImage(svg: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    const url = URL.createObjectURL(
+      new Blob([svg], { type: "image/svg+xml;charset=utf-8" }),
+    );
+    image.onload = () => {
+      URL.revokeObjectURL(url);
+      resolve(image);
+    };
+    image.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error("The exported SVG could not be rasterized"));
+    };
+    image.src = url;
+  });
+}
+
+async function pngBytes(
+  svg: string,
+  width: number,
+  height: number,
+): Promise<Uint8Array> {
+  const image = await loadSvgImage(svg);
+  const scale = 2;
+  const canvas = document.createElement("canvas");
+  canvas.width = Math.ceil(width * scale);
+  canvas.height = Math.ceil(height * scale);
+  const context = canvas.getContext("2d");
+  if (!context) throw new Error("Canvas export is unavailable");
+  context.fillStyle = "white";
+  context.fillRect(0, 0, canvas.width, canvas.height);
+  context.scale(scale, scale);
+  context.drawImage(image, 0, 0, width, height);
+  const blob = await new Promise<Blob | null>((resolve) =>
+    canvas.toBlob(resolve, "image/png"),
+  );
+  if (!blob) throw new Error("The PNG encoder returned no data");
+  return new Uint8Array(await blob.arrayBuffer());
+}
+
+export async function buildVisibleSimulationPlotDownload(
+  root: HTMLElement,
+  format: SimulationPlotExportFormat,
+): Promise<SimulationPlotDownload | null> {
+  const plots = [...root.querySelectorAll<SVGSVGElement>("svg[role='img']")];
+  if (!plots.length) return null;
+  const entries: { name: string; bytes: Uint8Array }[] = [];
+  for (let index = 0; index < plots.length; index++) {
+    const plot = plots[index]!;
+    const label = plot.getAttribute("aria-label") ?? `Plot ${index + 1}`;
+    const name = `${String(index + 1).padStart(2, "0")}-${safeName(label)}.${format}`;
+    const svg = standaloneSimulationPlotSvg(plot);
+    const size = dimensions(plot);
+    entries.push({
+      name,
+      bytes:
+        format === "svg"
+          ? strToU8(svg)
+          : await pngBytes(svg, size.width, size.height),
+    });
+  }
+  if (entries.length === 1)
+    return {
+      name: entries[0]!.name,
+      type: format === "svg" ? "image/svg+xml" : "image/png",
+      bytes: entries[0]!.bytes,
+      plotCount: 1,
+    };
+  return {
+    name: `simulation-plots-${format}.zip`,
+    type: "application/zip",
+    bytes: zipSync(
+      Object.fromEntries(entries.map((entry) => [entry.name, entry.bytes])),
+      { level: 6, mtime: new Date("1980-01-01T00:00:00.000Z") },
+    ),
+    plotCount: entries.length,
+  };
+}
+
+export function downloadSimulationPlot(download: SimulationPlotDownload): void {
+  const url = URL.createObjectURL(
+    new Blob([download.bytes as BlobPart], { type: download.type }),
+  );
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = download.name;
+  anchor.click();
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}

--- a/apps/editor/src/features/simulation/simulation-run-comparison.test.tsx
+++ b/apps/editor/src/features/simulation/simulation-run-comparison.test.tsx
@@ -1,0 +1,58 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import {
+  SimulationRunComparison,
+  type SimulationComparisonRun,
+} from "./simulation-run-comparison";
+
+function run(
+  id: string,
+  label: string,
+  value: number,
+  current: boolean,
+): SimulationComparisonRun {
+  return {
+    id,
+    label,
+    inputRevision: `revision-${id}`,
+    environment: { profileId: "sky130", corner: "tt", temperatureC: 27 },
+    current,
+    measurements: [
+      {
+        id: `0:out:maximum:${id}`,
+        analysisIndex: 0,
+        analysis: "tran",
+        plotName: "Transient",
+        outputId: "out",
+        outputLabel: "Vout",
+        metric: "maximum",
+        label: "Maximum",
+        unit: "V",
+        status: "available",
+        value,
+      },
+    ],
+  };
+}
+
+describe("SimulationRunComparison", () => {
+  it("aligns measurements by stable output identity, analysis, metric and unit", () => {
+    const markup = renderToStaticMarkup(
+      <SimulationRunComparison
+        runs={[
+          run("before", "Before", 1, false),
+          run("after", "After", 1.2, true),
+        ]}
+        onRemove={() => undefined}
+      />,
+    );
+    expect(markup).toContain("Before");
+    expect(markup).toContain("After");
+    expect(markup).toContain("TRAN · Maximum");
+    expect(markup).toContain("1 V");
+    expect(markup).toContain("1.2 V");
+    expect(markup).toContain("Remove Before from comparison");
+    expect(markup).not.toContain("Remove After from comparison");
+  });
+});

--- a/apps/editor/src/features/simulation/simulation-run-comparison.tsx
+++ b/apps/editor/src/features/simulation/simulation-run-comparison.tsx
@@ -1,0 +1,120 @@
+import type {
+  Prepared,
+  SimulationOutputData,
+} from "@icm/simulation-service/contract";
+
+type Measurement = NonNullable<SimulationOutputData["measurements"]>[number];
+
+export interface SimulationComparisonRun {
+  readonly id: string;
+  readonly label: string;
+  readonly inputRevision: string;
+  readonly environment: Prepared["environment"];
+  readonly measurements: readonly Measurement[];
+  readonly current: boolean;
+}
+
+function condition(run: SimulationComparisonRun): string {
+  return [
+    run.environment.corner?.toUpperCase(),
+    run.environment.temperatureC === undefined
+      ? undefined
+      : `${run.environment.temperatureC} °C`,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+}
+
+function format(value: number, unit: string): string {
+  return `${Number(value.toPrecision(6))}${unit === "1" ? "" : ` ${unit}`}`;
+}
+
+export function SimulationRunComparison({
+  runs,
+  onRemove,
+}: {
+  runs: readonly SimulationComparisonRun[];
+  onRemove?(runId: string): void;
+}) {
+  if (!runs.length)
+    return (
+      <p className="simulation-empty-result">
+        Complete a structured run to compare its measurements.
+      </p>
+    );
+  const rows = new Map<string, Measurement>();
+  for (const run of runs)
+    for (const measurement of run.measurements)
+      rows.set(
+        `${measurement.analysis}\u0000${measurement.outputId}\u0000${measurement.metric}\u0000${measurement.unit}`,
+        measurement,
+      );
+  return (
+    <div className="simulation-run-comparison-table-wrap">
+      <table className="simulation-run-comparison-table">
+        <thead>
+          <tr>
+            <th>Measurement</th>
+            {runs.map((run) => (
+              <th key={run.id}>
+                <span>
+                  <strong>{run.label}</strong>
+                  <small>
+                    {condition(run) || run.environment.profileId}
+                    {run.current ? " · Current" : ""}
+                  </small>
+                </span>
+                {!run.current && onRemove ? (
+                  <button
+                    type="button"
+                    aria-label={`Remove ${run.label} from comparison`}
+                    onClick={() => onRemove(run.id)}
+                  >
+                    ×
+                  </button>
+                ) : null}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {[...rows.entries()].map(([key, row]) => (
+            <tr key={key}>
+              <th>
+                <strong>{row.outputLabel}</strong>
+                <small>
+                  {row.analysis.toUpperCase()} · {row.label}
+                </small>
+              </th>
+              {runs.map((run) => {
+                const item = run.measurements.find(
+                  (candidate) =>
+                    candidate.analysis === row.analysis &&
+                    candidate.outputId === row.outputId &&
+                    candidate.metric === row.metric &&
+                    candidate.unit === row.unit,
+                );
+                return (
+                  <td key={run.id}>
+                    {!item ? (
+                      <span className="simulation-comparison-missing">—</span>
+                    ) : item.status === "available" ? (
+                      format(item.value, item.unit)
+                    ) : (
+                      <span
+                        className="simulation-comparison-unavailable"
+                        title={item.reason}
+                      >
+                        Unavailable
+                      </span>
+                    )}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -25,6 +25,11 @@ import { DcResultsExplorer } from "./dc-results-explorer";
 import { TransientResultsExplorer } from "./transient-results-explorer";
 import { SimulationOutputResults } from "./simulation-output-results";
 import {
+  deriveOperatingPointCanvasProjection,
+  type OperatingPointCanvasProjection,
+} from "./operating-point-projection";
+import type { OperatingPointDisplay } from "./operating-point-labels";
+import {
   deriveSimulationProbeOptions,
   matchSimulationTerminalCurrentProbeOptions,
   matchSimulationVoltageProbeOptions,
@@ -120,6 +125,10 @@ export interface SpiceSimulationSurfaceProps {
     rootDocumentId?: string,
   ): void;
   onFocusDiagnostic?(locator: ObjectLocator): void;
+  /** Session-only OP values ready for exact object-addressed canvas display. */
+  onOperatingPointProjection?(
+    projection: OperatingPointCanvasProjection | null,
+  ): void;
 }
 
 export type SimulationSetupSaveResult =
@@ -200,6 +209,9 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
   const [artifactPreview, setArtifactPreview] =
     useState<SimulationArtifactContent>();
   const [artifactBusy, setArtifactBusy] = useState<string>();
+  const [canvasOpEnabled, setCanvasOpEnabled] = useState(false);
+  const [canvasOpDisplay, setCanvasOpDisplay] =
+    useState<OperatingPointDisplay>("named");
   const setupMenuRef = useRef<HTMLDetailsElement>(null);
   useEffect(() => {
     const closeSetupMenu = (event: PointerEvent): void => {
@@ -210,6 +222,9 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
     document.addEventListener("pointerdown", closeSetupMenu);
     return () => document.removeEventListener("pointerdown", closeSetupMenu);
   }, []);
+  const operatingPointProjectionRef = useRef(props.onOperatingPointProjection);
+  operatingPointProjectionRef.current = props.onOperatingPointProjection;
+  useEffect(() => () => operatingPointProjectionRef.current?.(null), []);
   const previousSetupId = useRef<string | null>(props.selectedSetupId);
   useEffect(() => {
     if (previousSetupId.current === props.selectedSetupId) return;
@@ -218,6 +233,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
     setRun(undefined);
     setProblem(undefined);
     setArtifactPreview(undefined);
+    props.onOperatingPointProjection?.(null);
     setResultsOpen(false);
     setSetupOpen(true);
   }, [props.selectedSetupId]);
@@ -249,6 +265,26 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
     } else if ("run" in reply) {
       setRun(reply.run);
       setProblem(undefined);
+      const presentation = preparedPresentations.current.get(
+        reply.run.preparedId,
+      );
+      if (
+        canvasOpEnabled &&
+        reply.run.state === "finished" &&
+        reply.run.inputStatus !== "changed" &&
+        presentation?.rootDocumentId
+      ) {
+        props.onOperatingPointProjection?.(
+          deriveOperatingPointCanvasProjection(
+            project,
+            presentation.rootDocumentId,
+            reply.run.inputRevision,
+            reply.run.outputData,
+            presentation.outputs,
+            canvasOpDisplay,
+          ),
+        );
+      } else props.onOperatingPointProjection?.(null);
       if (
         reply.run.result ||
         reply.run.error ||
@@ -302,6 +338,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
     lock.current = true;
     setBusy(true);
     setProblem(undefined);
+    props.onOperatingPointProjection?.(null);
     try {
       const reply = await session.handle({
         operation: "prepare",
@@ -439,6 +476,17 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
   const runPresentation = run
     ? preparedPresentations.current.get(run.preparedId)
     : undefined;
+  const canvasOpProjection =
+    run && runPresentation?.rootDocumentId
+      ? deriveOperatingPointCanvasProjection(
+          project,
+          runPresentation.rootDocumentId,
+          run.inputRevision,
+          run.outputData,
+          runPresentation.outputs,
+          canvasOpDisplay,
+        )
+      : undefined;
   const artifactCategories = ["Netlist", "Results", "Evidence", "Log", "Other"];
   const runPreparedArtifactIds = new Set(
     runPresentation?.prepared.artifacts.map((artifact) => artifact.id) ?? [],
@@ -883,6 +931,52 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
 
             {resultTab === "operating-point" ? (
               <div className="simulation-analysis-view">
+                <div className="simulation-op-canvas-controls">
+                  <button
+                    type="button"
+                    aria-pressed={canvasOpEnabled}
+                    disabled={
+                      !canvasOpProjection?.values.length ||
+                      run?.inputStatus === "changed"
+                    }
+                    onClick={() => {
+                      const enabled = !canvasOpEnabled;
+                      setCanvasOpEnabled(enabled);
+                      props.onOperatingPointProjection?.(
+                        enabled && canvasOpProjection
+                          ? canvasOpProjection
+                          : null,
+                      );
+                    }}
+                  >
+                    {canvasOpEnabled ? "Hide canvas values" : "Show on canvas"}
+                  </button>
+                  <label>
+                    Canvas labels
+                    <select
+                      value={canvasOpDisplay}
+                      disabled={!canvasOpEnabled}
+                      onChange={(event) => {
+                        const display = event.currentTarget
+                          .value as OperatingPointDisplay;
+                        setCanvasOpDisplay(display);
+                        if (canvasOpEnabled && canvasOpProjection)
+                          props.onOperatingPointProjection?.({
+                            ...canvasOpProjection,
+                            display,
+                          });
+                      }}
+                    >
+                      <option value="named">Named and focused</option>
+                      <option value="all">All collected</option>
+                    </select>
+                  </label>
+                  <span>
+                    {run?.inputStatus === "changed"
+                      ? "Paused: the circuit changed"
+                      : `${canvasOpProjection?.values.length ?? 0} direct Net voltage${canvasOpProjection?.values.length === 1 ? "" : "s"}`}
+                  </span>
+                </div>
                 {run?.outputData ? (
                   <SimulationOutputResults
                     resultKey={`${run.id}:op`}

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -50,10 +50,15 @@ import {
   downloadSimulationPlot,
   type SimulationPlotExportFormat,
 } from "./simulation-plot-export";
+import {
+  SimulationRunComparison,
+  type SimulationComparisonRun,
+} from "./simulation-run-comparison";
 
 const RESULT_TABS = [
   ["plot", "Plot"],
   ["operating-point", "Operating Point"],
+  ["compare", "Compare"],
   ["console", "Console"],
   ["files", "Files"],
 ] as const;
@@ -67,6 +72,7 @@ const DEVELOPMENT_PROFILE_ID = import.meta.env.DEV
 const DEVELOPMENT_PROFILE_LABEL = "SKY130 1.8 V · ngspice 46";
 const DEVELOPMENT_CORNERS = ["tt", "ff", "ss", "fs", "sf"] as const;
 const DEFAULT_SIMULATION_TEMPERATURE_C = 27;
+const MAX_COMPARISON_RUNS = 5;
 type ResultTab = (typeof RESULT_TABS)[number][0];
 
 function preferredResultTab(run: Run): ResultTab {
@@ -145,6 +151,7 @@ interface PreparedPresentation {
   readonly outputs: SimulationStructuredInput["outputs"];
   readonly analysisLabel: string;
   readonly rootDocumentId?: string;
+  readonly setupName: string;
 }
 
 function legacyProbe(output: SimulationOutputSpec): SimulationProbeSpec | null {
@@ -218,6 +225,9 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
   const [canvasOpDisplay, setCanvasOpDisplay] =
     useState<OperatingPointDisplay>("named");
   const resultsBodyRef = useRef<HTMLDivElement>(null);
+  const [retainedComparisonRuns, setRetainedComparisonRuns] = useState<
+    readonly SimulationComparisonRun[]
+  >([]);
   const setupMenuRef = useRef<HTMLDetailsElement>(null);
   useEffect(() => {
     const closeSetupMenu = (event: PointerEvent): void => {
@@ -368,6 +378,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
               : input?.kind === "raw"
                 ? "RAW"
                 : "",
+          setupName: selectedSetup?.name ?? "Simulation",
           ...(input?.kind === "structured"
             ? { rootDocumentId: input.rootDocumentId }
             : {}),
@@ -524,6 +535,36 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
           canvasOpDisplay,
         )
       : undefined;
+  const currentComparisonRun: SimulationComparisonRun | undefined =
+    run?.outputData?.measurements?.length && runPresentation
+      ? {
+          id: run.id,
+          label: runPresentation.setupName,
+          inputRevision: run.inputRevision,
+          environment: runPresentation.prepared.environment,
+          measurements: run.outputData.measurements,
+          current: true,
+        }
+      : undefined;
+  const comparisonRuns = [
+    ...retainedComparisonRuns.filter(
+      (candidate) => candidate.id !== currentComparisonRun?.id,
+    ),
+    ...(currentComparisonRun ? [currentComparisonRun] : []),
+  ];
+  const retainCurrentComparison = (): void => {
+    if (!currentComparisonRun) return;
+    setRetainedComparisonRuns((current) => {
+      if (current.some((candidate) => candidate.id === currentComparisonRun.id))
+        return current;
+      // Reserve one column for the next/current run.
+      if (current.length >= MAX_COMPARISON_RUNS - 1) return current;
+      return [
+        ...current,
+        structuredClone({ ...currentComparisonRun, current: false }),
+      ];
+    });
+  };
   const artifactCategories = ["Netlist", "Results", "Evidence", "Log", "Other"];
   const runPreparedArtifactIds = new Set(
     runPresentation?.prepared.artifacts.map((artifact) => artifact.id) ?? [],
@@ -1125,6 +1166,58 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
                     Run an operating-point analysis to see values.
                   </p>
                 ) : null}
+              </div>
+            ) : null}
+
+            {resultTab === "compare" ? (
+              <div className="simulation-comparison-view">
+                <header>
+                  <span>
+                    <strong>Run comparison</strong>
+                    <small>
+                      Session only · matches stable output and measurement IDs
+                    </small>
+                  </span>
+                  <button
+                    type="button"
+                    disabled={
+                      !currentComparisonRun ||
+                      retainedComparisonRuns.some(
+                        (candidate) => candidate.id === currentComparisonRun.id,
+                      ) ||
+                      retainedComparisonRuns.length >= MAX_COMPARISON_RUNS - 1
+                    }
+                    onClick={retainCurrentComparison}
+                  >
+                    {retainedComparisonRuns.some(
+                      (candidate) => candidate.id === currentComparisonRun?.id,
+                    )
+                      ? "Current kept"
+                      : "Keep current"}
+                  </button>
+                  {retainedComparisonRuns.length ? (
+                    <button
+                      type="button"
+                      onClick={() => setRetainedComparisonRuns([])}
+                    >
+                      Clear kept
+                    </button>
+                  ) : null}
+                </header>
+                {comparisonRuns.length < 2 && currentComparisonRun ? (
+                  <p className="simulation-comparison-hint">
+                    Keep this result, change the circuit or conditions, then run
+                    again to compare.
+                  </p>
+                ) : null}
+                <SimulationRunComparison
+                  runs={comparisonRuns}
+                  onRemove={(runId) =>
+                    setRetainedComparisonRuns((current) =>
+                      current.filter((candidate) => candidate.id !== runId),
+                    )
+                  }
+                />
               </div>
             ) : null}
 

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -45,6 +45,11 @@ import {
   simulationArtifactCategory,
   type SimulationArtifactContent,
 } from "./simulation-artifact-files";
+import {
+  buildVisibleSimulationPlotDownload,
+  downloadSimulationPlot,
+  type SimulationPlotExportFormat,
+} from "./simulation-plot-export";
 
 const RESULT_TABS = [
   ["plot", "Plot"],
@@ -212,6 +217,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
   const [canvasOpEnabled, setCanvasOpEnabled] = useState(false);
   const [canvasOpDisplay, setCanvasOpDisplay] =
     useState<OperatingPointDisplay>("named");
+  const resultsBodyRef = useRef<HTMLDivElement>(null);
   const setupMenuRef = useRef<HTMLDetailsElement>(null);
   useEffect(() => {
     const closeSetupMenu = (event: PointerEvent): void => {
@@ -432,6 +438,37 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
     anchor.click();
     setTimeout(() => URL.revokeObjectURL(url), 0);
   };
+  const exportVisiblePlots = async (format: SimulationPlotExportFormat) => {
+    if (!resultsBodyRef.current) return;
+    setArtifactBusy(`plots:${format}`);
+    try {
+      const result = await buildVisibleSimulationPlotDownload(
+        resultsBodyRef.current,
+        format,
+      );
+      if (!result) {
+        setProblem(
+          uiProblem(
+            "PLOT_EXPORT_UNAVAILABLE",
+            "Open Plot with at least one visible chart before exporting an image",
+          ),
+        );
+        return;
+      }
+      downloadSimulationPlot(result);
+    } catch (error) {
+      setProblem(
+        uiProblem(
+          "PLOT_EXPORT_FAILED",
+          error instanceof Error
+            ? error.message
+            : "The visible plot could not be exported",
+        ),
+      );
+    } finally {
+      setArtifactBusy(undefined);
+    }
+  };
   const running = run && ["running", "cancelling"].includes(run.state);
   const activeCell = project.documents.find(
     (candidate) => candidate.id === props.activeDocumentId,
@@ -515,6 +552,17 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
         ]
       : []),
   ].filter((group) => group.artifacts.length > 0);
+  const resultCsvArtifacts = run
+    ? (() => {
+        const csv = run.artifacts.filter((artifact) =>
+          artifact.name.toLowerCase().endsWith(".csv"),
+        );
+        const evaluated = csv.filter((artifact) =>
+          artifact.name.startsWith("outputs-"),
+        );
+        return evaluated.length ? evaluated : csv;
+      })()
+    : [];
   const analysisLabel = runPresentation?.analysisLabel;
   const presentationProbes =
     runPresentation?.outputs.flatMap((output) => {
@@ -826,8 +874,61 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
                 </button>
               ))}
             </div>
+            {run ? (
+              <details className="simulation-result-export">
+                <summary>Export</summary>
+                <div>
+                  {resultTab === "plot" ? (
+                    <>
+                      <button
+                        type="button"
+                        disabled={artifactBusy !== undefined}
+                        onClick={() => void exportVisiblePlots("svg")}
+                      >
+                        {artifactBusy === "plots:svg"
+                          ? "Preparing SVG…"
+                          : "Visible plots · SVG"}
+                      </button>
+                      <button
+                        type="button"
+                        disabled={artifactBusy !== undefined}
+                        onClick={() => void exportVisiblePlots("png")}
+                      >
+                        {artifactBusy === "plots:png"
+                          ? "Preparing PNG…"
+                          : "Visible plots · PNG"}
+                      </button>
+                    </>
+                  ) : null}
+                  {resultCsvArtifacts.length ? (
+                    <section>
+                      <small>Complete result data</small>
+                      {resultCsvArtifacts.map((artifact) => (
+                        <button
+                          key={artifact.id}
+                          type="button"
+                          disabled={artifactBusy !== undefined}
+                          onClick={() => void download(artifact)}
+                        >
+                          {artifact.name}
+                        </button>
+                      ))}
+                    </section>
+                  ) : null}
+                  <button
+                    type="button"
+                    disabled={
+                      artifactBusy !== undefined || run.artifacts.length === 0
+                    }
+                    onClick={() => void downloadBundle("run", run.artifacts)}
+                  >
+                    Complete run · ZIP
+                  </button>
+                </div>
+              </details>
+            ) : null}
           </header>
-          <div className="simulation-results-body">
+          <div ref={resultsBodyRef} className="simulation-results-body">
             {resultTab === "plot" ? (
               <div className="simulation-analysis-view">
                 {run?.outputData ? (

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -557,8 +557,10 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
         const csv = run.artifacts.filter((artifact) =>
           artifact.name.toLowerCase().endsWith(".csv"),
         );
-        const evaluated = csv.filter((artifact) =>
-          artifact.name.startsWith("outputs-"),
+        const evaluated = csv.filter(
+          (artifact) =>
+            artifact.name.startsWith("outputs-") ||
+            artifact.name === "measurements.csv",
         );
         return evaluated.length ? evaluated : csv;
       })()

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -653,6 +653,59 @@
   gap: 2px;
   overflow-x: auto;
 }
+.simulation-result-export {
+  position: relative;
+  margin-left: auto;
+}
+.simulation-result-export > summary {
+  min-width: 68px;
+  padding: 5px 9px;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  background: var(--icm-surface);
+  cursor: pointer;
+  font-size: var(--icm-font-xs);
+  list-style: none;
+  text-align: center;
+}
+.simulation-result-export > summary::-webkit-details-marker {
+  display: none;
+}
+.simulation-result-export > summary::after {
+  content: " ▾";
+  color: var(--icm-text-muted);
+}
+.simulation-result-export > div {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 5;
+  display: grid;
+  gap: 4px;
+  width: 210px;
+  padding: 7px;
+  border: 1px solid var(--icm-border-strong);
+  border-radius: var(--icm-radius-sm);
+  background: var(--icm-surface);
+  box-shadow: var(--icm-shadow-md);
+}
+.simulation-result-export section {
+  display: grid;
+  gap: 4px;
+  padding-top: 5px;
+  border-top: 1px solid var(--icm-border);
+}
+.simulation-result-export small {
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+}
+.simulation-result-export button {
+  width: 100%;
+  overflow: hidden;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .simulation-results-header [role="tab"] {
   min-height: 26px;
   padding: 3px 7px;

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -682,6 +682,29 @@
   margin: 0 0 8px;
   font-size: var(--icm-font-sm);
 }
+
+.simulation-op-canvas-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 0 0 12px;
+  padding: 8px 10px;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  background: var(--icm-surface-muted);
+}
+
+.simulation-op-canvas-controls label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.simulation-op-canvas-controls span {
+  margin-left: auto;
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+}
 .simulation-empty-result {
   display: grid;
   min-height: 110px;

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -825,6 +825,77 @@
 .simulation-measurement-results tr[data-status="unavailable"] td:last-child {
   color: var(--icm-danger);
 }
+.simulation-comparison-view > header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 10px;
+}
+.simulation-comparison-view > header > span {
+  display: grid;
+  margin-right: auto;
+}
+.simulation-comparison-view small,
+.simulation-comparison-hint {
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+}
+.simulation-comparison-hint {
+  margin: 0 0 10px;
+}
+.simulation-run-comparison-table-wrap {
+  overflow: auto;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+}
+.simulation-run-comparison-table {
+  width: 100%;
+  min-width: 520px;
+  border-collapse: collapse;
+  font-size: var(--icm-font-xs);
+}
+.simulation-run-comparison-table th,
+.simulation-run-comparison-table td {
+  min-width: 130px;
+  padding: 7px 9px;
+  border-right: 1px solid var(--icm-border);
+  border-bottom: 1px solid var(--icm-border);
+  text-align: left;
+  vertical-align: top;
+}
+.simulation-run-comparison-table thead th {
+  position: sticky;
+  top: 0;
+  background: var(--icm-surface-muted);
+}
+.simulation-run-comparison-table thead th:not(:first-child) {
+  padding-right: 30px;
+}
+.simulation-run-comparison-table thead th > span,
+.simulation-run-comparison-table tbody th {
+  display: grid;
+}
+.simulation-run-comparison-table thead button {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  min-width: 24px;
+  min-height: 24px;
+  padding: 0;
+}
+.simulation-run-comparison-table td:last-child,
+.simulation-run-comparison-table th:last-child {
+  border-right: 0;
+}
+.simulation-run-comparison-table tbody tr:last-child > * {
+  border-bottom: 0;
+}
+.simulation-comparison-missing {
+  color: var(--icm-text-muted);
+}
+.simulation-comparison-unavailable {
+  color: var(--icm-danger);
+}
 .simulation-empty-result {
   display: grid;
   min-height: 110px;

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -758,6 +758,73 @@
   color: var(--icm-text-muted);
   font-size: var(--icm-font-xs);
 }
+.simulation-measurement-results {
+  margin-top: 14px;
+  overflow: hidden;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  background: var(--icm-surface);
+}
+.simulation-measurement-results > summary {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-height: 42px;
+  padding: 7px 10px;
+  background: var(--icm-surface-muted);
+  cursor: pointer;
+  list-style: none;
+}
+.simulation-measurement-results > summary::-webkit-details-marker {
+  display: none;
+}
+.simulation-measurement-results > summary > span:first-child {
+  display: grid;
+}
+.simulation-measurement-results > summary > span:last-child {
+  margin-left: auto;
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+  white-space: nowrap;
+}
+.simulation-measurement-results > summary > span[data-status="attention"] {
+  color: var(--icm-danger);
+  font-weight: 650;
+}
+.simulation-measurement-results small {
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+}
+.simulation-measurement-results > div {
+  display: grid;
+  gap: 12px;
+  padding: 10px;
+}
+.simulation-measurement-results section > header {
+  display: flex;
+  gap: 7px;
+  margin-bottom: 5px;
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+}
+.simulation-measurement-results table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--icm-font-xs);
+}
+.simulation-measurement-results th,
+.simulation-measurement-results td {
+  padding: 5px 7px;
+  border-top: 1px solid var(--icm-border);
+  text-align: left;
+}
+.simulation-measurement-results th:last-child,
+.simulation-measurement-results td:last-child {
+  text-align: right;
+}
+.simulation-measurement-results tr[data-status="unavailable"] td:last-child {
+  color: var(--icm-danger);
+}
 .simulation-empty-result {
   display: grid;
   min-height: 110px;

--- a/docs/specs/simulation.md
+++ b/docs/specs/simulation.md
@@ -1002,7 +1002,11 @@ the same output browser, explicit plot tools, marker, expanded view, and
 back-annotation boundary; TRAN uses a linear time axis and does not revive
 Digital Simulation. The compact result export action produces standalone SVG
 or PNG from the visible plot state and downloads complete numeric CSV from File
-Resource artifacts, so displayed decimation is never presented as full data.
+Resource artifacts, so displayed decimation is never presented as full data. A
+browser session may retain a bounded set of completed structured results for
+comparison; rows align only by stable output id, analysis, metric, and unit,
+never by display label or array index. This first comparison view is session
+state, not Project or Cloud Project persistence.
 
 Recoverable problems use `{code,message,stage,recovery,diagnostics?}`. Ordinary
 compile errors, unavailable Profiles, simulator failures and busy responses do

--- a/docs/specs/simulation.md
+++ b/docs/specs/simulation.md
@@ -929,6 +929,15 @@ shape follows the analysis rather than one universal table:
 Values are written as the shortest decimal that reads back as the same double,
 so a round trip through the CSV loses nothing the rawfile carried.
 
+Structured evaluated outputs also carry conservative automatic measurements.
+OP contributes its scalar value; DC, AC, and TRAN contribute minimum, maximum,
+and span (complex AC outputs use magnitude); TRAN additionally contributes
+time-weighted mean and RMS over its actual, possibly nonuniform time samples.
+Each row is independently `available` or `unavailable` with a reason. A missing
+crossing or insufficient sample window must not become zero and must not change
+an otherwise completed Run into a failed Run. The service is the sole numerical
+owner: GUI, Agent responses, and `measurements.csv` consume the same rows.
+
 ## Rollout
 
 ### Agent resource implementation
@@ -985,9 +994,15 @@ second result store and does not claim an external model tree is embedded.
 The human Results view binds mappings and authored probe labels by the Run's
 own `preparedId`, never by the latest Setup or most recent Prepare. Historical
 numeric data remains viewable after the Project changes, while stale object
-locations are refused by normal locator resolution. AC and TRAN share the same
-output browser, explicit plot tools, marker, expanded view, and back-annotation
-boundary; TRAN uses a linear time axis and does not revive Digital Simulation.
+locations are refused by normal locator resolution. Direct OP Net-voltage
+outputs may be painted on the exact authored anchor and concrete hierarchy
+occurrence only while that input revision is current; raw node strings and
+derived expressions are not guessed back to Canvas objects. AC and TRAN share
+the same output browser, explicit plot tools, marker, expanded view, and
+back-annotation boundary; TRAN uses a linear time axis and does not revive
+Digital Simulation. The compact result export action produces standalone SVG
+or PNG from the visible plot state and downloads complete numeric CSV from File
+Resource artifacts, so displayed decimation is never presented as full data.
 
 Recoverable problems use `{code,message,stage,recovery,diagnostics?}`. Ordinary
 compile errors, unavailable Profiles, simulator failures and busy responses do

--- a/docs/user/analog-simulation.md
+++ b/docs/user/analog-simulation.md
@@ -83,6 +83,13 @@ unavailable without turning a successful simulator Run into a failure. The
 same typed rows are returned to Agent clients and exported as
 `measurements.csv`.
 
+**Compare** can keep up to five completed structured results in the current
+Simulation session and align their measurements by stable output identity,
+analysis, metric and unit. Keep a result, edit the circuit or conditions, run
+again, and inspect the current and retained columns. These comparison copies
+are intentionally transient: they are not hidden inside the Project or Cloud
+Project record, and closing the Project session clears them.
+
 Closing the drawer keeps a run alive. **Cancel run** asks the execution
 service to cancel; it is not simulated by hiding a spinner. Replacing the
 Project or closing its editor ends that browser-owned scope. Revoking an
@@ -93,8 +100,9 @@ are transient, not saved inside the Project.
 
 This is the B/C local-DUT and minimal human interface slice, not completion
 of all F1R/F5 requirements in the [v13 plan](../roadmap/simulation-vertical-integration-plan-v13.md).
-Cross-Project publication, structured TRAN and multi-run comparison remain
-outside this slice. Raw/Agent workflows retain their existing capabilities.
+Cross-Project publication, persistent result archives, and overlaid multi-run
+waveforms remain outside this slice. Raw/Agent workflows retain their existing
+capabilities.
 Browser regressions use a controlled executor
 to verify interaction/protocol behavior; they do **not** certify OTA numbers,
 model qualification or the separate real Preview acceptance journey.

--- a/docs/user/analog-simulation.md
+++ b/docs/user/analog-simulation.md
@@ -66,8 +66,13 @@ exact authored Net and hierarchy occurrence; choose named/focused Nets or all
 collected Nets. Derived expressions and raw node-name text are never guessed
 back onto canvas objects. Editing the Project pauses these labels until a new
 matching run completes. Console, diagnostics, input identity and downloadable
-deck/raw/CSV artifacts are available alongside the result. Bounded result
-previews are labelled; export the complete artifacts when needed.
+deck/raw/CSV artifacts are available alongside the result. The compact
+**Export** menu in Results downloads the visible Plot as standalone SVG or
+2× PNG (multiple visible charts are bundled), the complete authored-output
+CSV files, or the complete run ZIP. Image export follows the current viewport,
+trace visibility and markers; CSV remains the full numerical artifact.
+Bounded result previews are labelled; export the complete artifacts when
+needed.
 
 Closing the drawer keeps a run alive. **Cancel run** asks the execution
 service to cancel; it is not simulated by hiding a spinner. Replacing the

--- a/docs/user/analog-simulation.md
+++ b/docs/user/analog-simulation.md
@@ -60,11 +60,14 @@ does not run unapplied form edits. Input diagnostics leave the Project and
 session intact: correct the input and run again. Run failures keep available
 evidence and never automatically resubmit work.
 
-OP values and AC plots consume the shared structured result. Console,
-diagnostics, input identity and downloadable deck/raw/CSV artifacts are
-available alongside the result. Bounded result previews are labelled; export
-the complete artifacts when needed. Editing the Project marks older results
-as belonging to an earlier revision.
+OP values and AC plots consume the shared structured result. For direct Net
+voltage outputs, **Operating Point → Show on canvas** paints the value on the
+exact authored Net and hierarchy occurrence; choose named/focused Nets or all
+collected Nets. Derived expressions and raw node-name text are never guessed
+back onto canvas objects. Editing the Project pauses these labels until a new
+matching run completes. Console, diagnostics, input identity and downloadable
+deck/raw/CSV artifacts are available alongside the result. Bounded result
+previews are labelled; export the complete artifacts when needed.
 
 Closing the drawer keeps a run alive. **Cancel run** asks the execution
 service to cancel; it is not simulated by hiding a spinner. Replacing the

--- a/docs/user/analog-simulation.md
+++ b/docs/user/analog-simulation.md
@@ -74,6 +74,15 @@ trace visibility and markers; CSV remains the full numerical artifact.
 Bounded result previews are labelled; export the complete artifacts when
 needed.
 
+Each structured run also derives conservative automatic summaries from the
+complete evaluated outputs: OP value; DC/AC/TRAN minimum, maximum and span;
+and time-weighted TRAN mean/RMS. **Measurements** stays as one compact folded
+summary during normal review. If any metric lacks enough finite samples it
+opens automatically and shows the reason; that local metric remains
+unavailable without turning a successful simulator Run into a failure. The
+same typed rows are returned to Agent clients and exported as
+`measurements.csv`.
+
 Closing the drawer keeps a run alive. **Cancel run** asks the execution
 service to cancel; it is not simulated by hiding a spinner. Replacing the
 Project or closing its editor ends that browser-owned scope. Revoking an

--- a/packages/simulation-service/src/automatic-measurements.test.ts
+++ b/packages/simulation-service/src/automatic-measurements.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  automaticMeasurementsToCsv,
+  deriveAutomaticMeasurements,
+} from "./automatic-measurements.js";
+
+describe("automatic simulation measurements", () => {
+  it("uses time-weighted integration on a nonuniform transient grid", () => {
+    const measurements = deriveAutomaticMeasurements([
+      {
+        analysis: "tran",
+        plotName: "Transient",
+        domain: { name: "Time", unit: "s", values: [0, 1, 3] },
+        outputs: [
+          {
+            id: "out",
+            label: "Vout",
+            unit: "V",
+            values: [0, 2, 2],
+          },
+        ],
+      },
+    ]);
+
+    expect(
+      measurements.find((item) => item.metric === "time-mean"),
+    ).toMatchObject({ status: "available", value: 5 / 3, unit: "V" });
+    expect(
+      measurements.find((item) => item.metric === "time-rms"),
+    ).toMatchObject({ status: "available", value: Math.sqrt(10 / 3) });
+    expect(
+      measurements.find((item) => item.metric === "peak-to-peak"),
+    ).toMatchObject({ status: "available", value: 2 });
+  });
+
+  it("keeps an unavailable metric explicit without discarding other rows", () => {
+    const measurements = deriveAutomaticMeasurements([
+      {
+        analysis: "tran",
+        plotName: "Short",
+        domain: { name: "Time", unit: "s", values: [0] },
+        outputs: [{ id: "out", label: "Vout", unit: "V", values: [1] }],
+      },
+    ]);
+
+    expect(
+      measurements.find((item) => item.metric === "maximum"),
+    ).toMatchObject({ status: "available", value: 1 });
+    expect(
+      measurements.find((item) => item.metric === "time-rms"),
+    ).toMatchObject({
+      status: "unavailable",
+      reason: "At least two increasing finite time samples are required",
+    });
+    expect(automaticMeasurementsToCsv(measurements)).toContain(
+      '"unavailable","At least two increasing finite time samples are required"',
+    );
+  });
+
+  it("summarizes a complex AC output by magnitude", () => {
+    const measurements = deriveAutomaticMeasurements([
+      {
+        analysis: "ac",
+        plotName: "AC",
+        domain: { name: "Frequency", unit: "Hz", values: [1, 10] },
+        outputs: [
+          {
+            id: "out",
+            label: "Vout",
+            unit: "V",
+            values: [3, 0],
+            imaginary: [4, 2],
+          },
+        ],
+      },
+    ]);
+
+    expect(
+      measurements.map((item) => [
+        item.metric,
+        item.status === "available" ? item.value : undefined,
+      ]),
+    ).toEqual([
+      ["minimum", 2],
+      ["maximum", 5],
+      ["peak-to-peak", 3],
+    ]);
+  });
+});

--- a/packages/simulation-service/src/automatic-measurements.ts
+++ b/packages/simulation-service/src/automatic-measurements.ts
@@ -1,0 +1,236 @@
+import type { SimulationOutputData } from "./contract.js";
+
+type Analysis = SimulationOutputData["analyses"][number];
+type Measurement = NonNullable<SimulationOutputData["measurements"]>[number];
+type Metric = Measurement["metric"];
+
+interface SeriesSummary {
+  readonly minimum: number;
+  readonly maximum: number;
+  readonly peakToPeak: number;
+}
+
+function finiteSummary(
+  values: readonly (number | null)[],
+): SeriesSummary | null {
+  const finite = values.filter(
+    (value): value is number => value !== null && Number.isFinite(value),
+  );
+  if (!finite.length) return null;
+  const minimum = Math.min(...finite);
+  const maximum = Math.max(...finite);
+  return { minimum, maximum, peakToPeak: maximum - minimum };
+}
+
+function weightedMoment(
+  domain: readonly number[],
+  values: readonly (number | null)[],
+  square: boolean,
+): number | null {
+  let integral = 0;
+  let duration = 0;
+  for (let index = 1; index < Math.min(domain.length, values.length); index++) {
+    const x0 = domain[index - 1]!;
+    const x1 = domain[index]!;
+    const y0 = values[index - 1];
+    const y1 = values[index];
+    const delta = x1 - x0;
+    if (
+      y0 === null ||
+      y1 === null ||
+      y0 === undefined ||
+      y1 === undefined ||
+      !Number.isFinite(y0) ||
+      !Number.isFinite(y1) ||
+      !Number.isFinite(delta) ||
+      delta <= 0
+    )
+      continue;
+    integral +=
+      (((square ? y0 * y0 : y0) + (square ? y1 * y1 : y1)) / 2) * delta;
+    duration += delta;
+  }
+  if (duration <= 0) return null;
+  const moment = integral / duration;
+  return square ? Math.sqrt(Math.max(0, moment)) : moment;
+}
+
+function available(
+  analysisIndex: number,
+  analysis: Analysis,
+  output: Analysis["outputs"][number],
+  metric: Metric,
+  label: string,
+  value: number,
+): Measurement {
+  return {
+    id: `${analysisIndex}:${output.id}:${metric}`,
+    analysisIndex,
+    analysis: analysis.analysis,
+    plotName: analysis.plotName,
+    outputId: output.id,
+    outputLabel: output.label,
+    metric,
+    label,
+    unit: output.unit,
+    status: "available",
+    value,
+  };
+}
+
+function unavailable(
+  analysisIndex: number,
+  analysis: Analysis,
+  output: Analysis["outputs"][number],
+  metric: Metric,
+  label: string,
+  reason: string,
+): Measurement {
+  return {
+    id: `${analysisIndex}:${output.id}:${metric}`,
+    analysisIndex,
+    analysis: analysis.analysis,
+    plotName: analysis.plotName,
+    outputId: output.id,
+    outputLabel: output.label,
+    metric,
+    label,
+    unit: output.unit,
+    status: "unavailable",
+    reason,
+  };
+}
+
+function measurement(
+  analysisIndex: number,
+  analysis: Analysis,
+  output: Analysis["outputs"][number],
+  metric: Metric,
+  label: string,
+  value: number | null | undefined,
+  reason = "No finite samples are available",
+): Measurement {
+  return value !== null && value !== undefined && Number.isFinite(value)
+    ? available(analysisIndex, analysis, output, metric, label, value)
+    : unavailable(analysisIndex, analysis, output, metric, label, reason);
+}
+
+/**
+ * Conservative, setup-free summaries over the complete evaluated outputs.
+ * A metric failure remains local to its row and never changes Run status.
+ */
+export function deriveAutomaticMeasurements(
+  analyses: readonly Analysis[],
+): Measurement[] {
+  const result: Measurement[] = [];
+  analyses.forEach((analysis, analysisIndex) => {
+    for (const output of analysis.outputs) {
+      const values = output.imaginary
+        ? output.values.map((real, index) => {
+            const imaginary = output.imaginary?.[index];
+            return real === null ||
+              imaginary === null ||
+              imaginary === undefined
+              ? null
+              : Math.hypot(real, imaginary);
+          })
+        : output.values;
+      if (analysis.analysis === "op") {
+        result.push(
+          measurement(
+            analysisIndex,
+            analysis,
+            output,
+            "operating-point",
+            "Operating point",
+            values[0],
+          ),
+        );
+        continue;
+      }
+      const summary = finiteSummary(values);
+      result.push(
+        measurement(
+          analysisIndex,
+          analysis,
+          output,
+          "minimum",
+          output.imaginary ? "Minimum magnitude" : "Minimum",
+          summary?.minimum,
+        ),
+        measurement(
+          analysisIndex,
+          analysis,
+          output,
+          "maximum",
+          output.imaginary ? "Maximum magnitude" : "Maximum",
+          summary?.maximum,
+        ),
+        measurement(
+          analysisIndex,
+          analysis,
+          output,
+          "peak-to-peak",
+          output.imaginary ? "Magnitude span" : "Peak to peak",
+          summary?.peakToPeak,
+        ),
+      );
+      if (analysis.analysis !== "tran") continue;
+      const domain = analysis.domain?.values ?? [];
+      result.push(
+        measurement(
+          analysisIndex,
+          analysis,
+          output,
+          "time-mean",
+          "Time-weighted mean",
+          weightedMoment(domain, values, false),
+          "At least two increasing finite time samples are required",
+        ),
+        measurement(
+          analysisIndex,
+          analysis,
+          output,
+          "time-rms",
+          "Time-weighted RMS",
+          weightedMoment(domain, values, true),
+          "At least two increasing finite time samples are required",
+        ),
+      );
+    }
+  });
+  return result;
+}
+
+export function automaticMeasurementsToCsv(
+  measurements: readonly Measurement[],
+): string {
+  const quote = (value: string | number | undefined) =>
+    `"${String(value ?? "").replaceAll('"', '""')}"`;
+  return (
+    [
+      [
+        "Analysis",
+        "Plot",
+        "Output",
+        "Metric",
+        "Value",
+        "Unit",
+        "Status",
+        "Reason",
+      ],
+      ...measurements.map((item) => [
+        item.analysis.toUpperCase(),
+        item.plotName,
+        item.outputLabel,
+        item.label,
+        item.status === "available" ? item.value : "",
+        item.unit === "1" ? "" : item.unit,
+        item.status,
+        item.status === "unavailable" ? item.reason : "",
+      ]),
+    ]
+      .map((row) => row.map(quote).join(","))
+      .join("\n") + "\n"
+  );
+}

--- a/packages/simulation-service/src/contract.ts
+++ b/packages/simulation-service/src/contract.ts
@@ -137,9 +137,52 @@ export const EvaluatedAnalysisSchema = z.strictObject({
     .optional(),
   outputs: z.array(EvaluatedOutputSchema),
 });
+export const AutomaticMeasurementSchema = z.discriminatedUnion("status", [
+  z.strictObject({
+    id: Id,
+    analysisIndex: z.number().int().nonnegative(),
+    analysis: z.enum(["op", "dc", "ac", "tran"]),
+    plotName: z.string(),
+    outputId: Id,
+    outputLabel: z.string(),
+    metric: z.enum([
+      "operating-point",
+      "minimum",
+      "maximum",
+      "peak-to-peak",
+      "time-mean",
+      "time-rms",
+    ]),
+    label: z.string(),
+    unit: z.string(),
+    status: z.literal("available"),
+    value: z.number().finite(),
+  }),
+  z.strictObject({
+    id: Id,
+    analysisIndex: z.number().int().nonnegative(),
+    analysis: z.enum(["op", "dc", "ac", "tran"]),
+    plotName: z.string(),
+    outputId: Id,
+    outputLabel: z.string(),
+    metric: z.enum([
+      "operating-point",
+      "minimum",
+      "maximum",
+      "peak-to-peak",
+      "time-mean",
+      "time-rms",
+    ]),
+    label: z.string(),
+    unit: z.string(),
+    status: z.literal("unavailable"),
+    reason: z.string(),
+  }),
+]);
 export const SimulationOutputDataSchema = z.strictObject({
   schemaVersion: z.literal(1),
   analyses: z.array(EvaluatedAnalysisSchema),
+  measurements: z.array(AutomaticMeasurementSchema).optional(),
   diagnostics: z.array(
     z.strictObject({ outputId: Id, code: Id, message: z.string() }),
   ),

--- a/packages/simulation-service/src/index.ts
+++ b/packages/simulation-service/src/index.ts
@@ -4,3 +4,4 @@ export * from "./service.js";
 export * from "./hosted-executor.js";
 export * from "./result-volume.js";
 export * from "./output-evaluation.js";
+export * from "./automatic-measurements.js";

--- a/packages/simulation-service/src/output-evaluation.ts
+++ b/packages/simulation-service/src/output-evaluation.ts
@@ -6,6 +6,7 @@ import type {
 import type { SimulationResultData } from "@icm/spice-run";
 
 import type { SimulationOutputData } from "./contract.js";
+import { deriveAutomaticMeasurements } from "./automatic-measurements.js";
 
 interface ComplexSeries {
   readonly real: readonly (number | null)[];
@@ -224,10 +225,8 @@ export function evaluateSimulationOutputs(
   outputs: readonly CompiledSimulationOutput[],
 ): SimulationOutputData {
   const diagnostics: SimulationOutputData["diagnostics"] = [];
-  return {
-    schemaVersion: 1,
-    diagnostics,
-    analyses: data.analyses.map((analysis) => {
+  const analyses: SimulationOutputData["analyses"] = data.analyses.map(
+    (analysis) => {
       const acquisitions = sourceSeries(analysis, vectors);
       const pointCount =
         analysis.analysis === "op"
@@ -261,7 +260,11 @@ export function evaluateSimulationOutputs(
       });
       const domain =
         analysis.analysis === "ac"
-          ? { name: "Frequency", unit: "Hz", values: [...analysis.frequencyHz] }
+          ? {
+              name: "Frequency",
+              unit: "Hz",
+              values: [...analysis.frequencyHz],
+            }
           : analysis.analysis === "tran"
             ? { name: "Time", unit: "s", values: [...analysis.timeSeconds] }
             : analysis.analysis === "dc"
@@ -277,7 +280,13 @@ export function evaluateSimulationOutputs(
         ...(domain ? { domain } : {}),
         outputs: evaluated,
       };
-    }),
+    },
+  );
+  return {
+    schemaVersion: 1,
+    diagnostics,
+    analyses,
+    measurements: deriveAutomaticMeasurements(analyses),
   };
 }
 

--- a/packages/simulation-service/src/service.ts
+++ b/packages/simulation-service/src/service.ts
@@ -25,6 +25,7 @@ import {
   evaluateSimulationOutputs,
   simulationOutputAnalysisToCsv,
 } from "./output-evaluation.js";
+import { automaticMeasurementsToCsv } from "./automatic-measurements.js";
 
 export interface ExecutionInput {
   mode: "structured" | "raw";
@@ -677,6 +678,12 @@ export class SimulationService {
           `outputs-${analysis.analysis}-${i}.csv`,
           "text/csv",
           simulationOutputAnalysisToCsv(analysis),
+        );
+      if (run.view.outputData?.measurements?.length)
+        await artifact(
+          "measurements.csv",
+          "text/csv",
+          automaticMeasurementsToCsv(run.view.outputData.measurements),
         );
       const evidenceArtifacts = run.view.artifacts.map((item) => ({ ...item }));
       await artifact(


### PR DESCRIPTION
## Summary
- project direct OP Net voltages back onto exact Canvas objects and occurrences
- export visible plots as standalone SVG/2x PNG and full result CSV/ZIP
- derive typed automatic measurements once for GUI, Agent, and CSV
- compare up to five current-session runs without persisting result arrays in Projects

## Presentation and failure behavior
- measurements stay folded when healthy and open automatically when any row is unavailable
- plot/image export is contained in one compact Results menu
- stale/raw/derived values are never guessed back onto Canvas objects
- comparison matches stable output identity, analysis, metric, and unit

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
  - 2774 unit tests passed, 28 skipped
  - 6 Agent/Simulation browser tests passed
  - 134 Editor browser tests passed

Test-Impact: tests-updated