### PR TITLE
Complete the five-transistor OTA simulation project

### DIFF
--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -262,6 +262,9 @@ test("one Testbench persists several independently named setups", async ({
   page,
 }) => {
   const project = parseProject(JSON.stringify(ota));
+  const existingSetupNames = project.simulationSetups.map(
+    (setup) => setup.name,
+  );
   await page.route("**/api/simulate", async (route) =>
     route.fulfill({
       json: {
@@ -290,7 +293,9 @@ test("one Testbench persists several independently named setups", async ({
   await expect(selector).toContainText("OTA OP, DC, AC, and TRAN");
   await selector.click();
   await panel.getByRole("button", { name: "New setup", exact: true }).click();
-  await expect(selector).toContainText("Setup 2");
+  await expect(selector).toContainText(
+    `Setup ${existingSetupNames.length + 1}`,
+  );
   await panel.getByLabel("Setup name").fill("OTA OP, DC, AC, and TRAN");
   await panel.getByLabel("Setup name").press("Tab");
   await expect(panel.getByRole("alert")).toContainText(
@@ -305,10 +310,10 @@ test("one Testbench persists several independently named setups", async ({
   const saved = JSON.parse(
     (await downloadBytes(page, "File", "Export Project File…")).toString(),
   );
-  expect(saved.simulationSetups).toHaveLength(2);
+  expect(saved.simulationSetups).toHaveLength(existingSetupNames.length + 1);
   expect(
     saved.simulationSetups.map((setup: { name: string }) => setup.name),
-  ).toEqual(["OTA OP, DC, AC, and TRAN", "Bias sweep"]);
+  ).toEqual([...existingSetupNames, "Bias sweep"]);
   expect(
     new Set(
       saved.simulationSetups.map(
@@ -334,8 +339,10 @@ test("one Testbench persists several independently named setups", async ({
   const afterDelete = JSON.parse(
     (await downloadBytes(page, "File", "Export Project File…")).toString(),
   );
-  expect(afterDelete.simulationSetups).toHaveLength(1);
-  expect(afterDelete.simulationSetups[0].name).toBe("OTA OP, DC, AC, and TRAN");
+  expect(afterDelete.simulationSetups).toHaveLength(existingSetupNames.length);
+  expect(
+    afterDelete.simulationSetups.map((setup: { name: string }) => setup.name),
+  ).toEqual(existingSetupNames);
 });
 
 test("human simulation uses saved setup, survives minimizing, recovers a bad input and exports results", async ({

--- a/apps/editor/src/examples/five-transistor-ota-sky130.icproj.json
+++ b/apps/editor/src/examples/five-transistor-ota-sky130.icproj.json
@@ -3119,6 +3119,375 @@
           "temperatureC": 27
         }
       }
+    },
+    {
+      "id": "simulation-setup-ota-bias-tt",
+      "name": "Bias point (TT)",
+      "version": 2,
+      "input": {
+        "kind": "structured",
+        "rootDocumentId": "document-ota-5t-testbench",
+        "analyses": [
+          {
+            "kind": "op"
+          }
+        ],
+        "outputs": [
+          {
+            "id": "probe-vout",
+            "label": "vout",
+            "expression": {
+              "kind": "voltage",
+              "documentId": "document-ota-5t-testbench",
+              "anchor": {
+                "kind": "terminal",
+                "instanceId": "XDUT",
+                "pinName": "vout"
+              },
+              "occurrence": []
+            }
+          },
+          {
+            "id": "probe-ibias",
+            "label": "ibias",
+            "expression": {
+              "kind": "voltage",
+              "documentId": "document-ota-5t-testbench",
+              "anchor": {
+                "kind": "terminal",
+                "instanceId": "IBIAS",
+                "pinName": "-"
+              },
+              "occurrence": []
+            }
+          },
+          {
+            "id": "probe-tail",
+            "label": "tail",
+            "expression": {
+              "kind": "voltage",
+              "documentId": "document-ota-5t",
+              "anchor": {
+                "kind": "terminal",
+                "instanceId": "M5",
+                "pinName": "D"
+              },
+              "occurrence": ["XDUT"]
+            }
+          },
+          {
+            "id": "probe-nleft",
+            "label": "nleft",
+            "expression": {
+              "kind": "voltage",
+              "documentId": "document-ota-5t",
+              "anchor": {
+                "kind": "terminal",
+                "instanceId": "M3",
+                "pinName": "D"
+              },
+              "occurrence": ["XDUT"]
+            }
+          },
+          {
+            "id": "probe-supply-current",
+            "label": "I_supply",
+            "expression": {
+              "kind": "negate",
+              "operand": {
+                "kind": "current",
+                "documentId": "document-ota-5t-testbench",
+                "instanceId": "VDD",
+                "pinName": "+",
+                "occurrence": []
+              }
+            }
+          }
+        ],
+        "environment": {
+          "profileId": "sky130-core-continuous-ngspice46-v1",
+          "corner": "tt",
+          "temperatureC": 27
+        }
+      }
+    },
+    {
+      "id": "simulation-setup-ota-dc-transfer-tt",
+      "name": "DC transfer (TT)",
+      "version": 2,
+      "input": {
+        "kind": "structured",
+        "rootDocumentId": "document-ota-5t-testbench",
+        "analyses": [
+          {
+            "kind": "dc",
+            "sourceInstanceId": "VINP",
+            "startValue": 0.86,
+            "stopValue": 0.94,
+            "stepValue": 0.001
+          }
+        ],
+        "outputs": [
+          {
+            "id": "probe-vout",
+            "label": "vout",
+            "expression": {
+              "kind": "voltage",
+              "documentId": "document-ota-5t-testbench",
+              "anchor": {
+                "kind": "terminal",
+                "instanceId": "XDUT",
+                "pinName": "vout"
+              },
+              "occurrence": []
+            }
+          },
+          {
+            "id": "probe-vinp",
+            "label": "vinp",
+            "expression": {
+              "kind": "voltage",
+              "documentId": "document-ota-5t-testbench",
+              "anchor": {
+                "kind": "terminal",
+                "instanceId": "VINP",
+                "pinName": "+"
+              },
+              "occurrence": []
+            }
+          },
+          {
+            "id": "probe-tail",
+            "label": "tail",
+            "expression": {
+              "kind": "voltage",
+              "documentId": "document-ota-5t",
+              "anchor": {
+                "kind": "terminal",
+                "instanceId": "M5",
+                "pinName": "D"
+              },
+              "occurrence": ["XDUT"]
+            }
+          }
+        ],
+        "environment": {
+          "profileId": "sky130-core-continuous-ngspice46-v1",
+          "corner": "tt",
+          "temperatureC": 27
+        }
+      }
+    },
+    {
+      "id": "simulation-setup-ota-ac-tt",
+      "name": "AC response (TT)",
+      "version": 2,
+      "input": {
+        "kind": "structured",
+        "rootDocumentId": "document-ota-5t-testbench",
+        "analyses": [
+          {
+            "kind": "ac",
+            "sweep": "dec",
+            "points": 40,
+            "startHz": 1,
+            "stopHz": 1000000000
+          }
+        ],
+        "outputs": [
+          {
+            "id": "probe-vout",
+            "label": "vout (A_v for AC=1 V)",
+            "expression": {
+              "kind": "voltage",
+              "documentId": "document-ota-5t-testbench",
+              "anchor": {
+                "kind": "terminal",
+                "instanceId": "XDUT",
+                "pinName": "vout"
+              },
+              "occurrence": []
+            }
+          },
+          {
+            "id": "probe-tail",
+            "label": "tail",
+            "expression": {
+              "kind": "voltage",
+              "documentId": "document-ota-5t",
+              "anchor": {
+                "kind": "terminal",
+                "instanceId": "M5",
+                "pinName": "D"
+              },
+              "occurrence": ["XDUT"]
+            }
+          }
+        ],
+        "environment": {
+          "profileId": "sky130-core-continuous-ngspice46-v1",
+          "corner": "tt",
+          "temperatureC": 27
+        }
+      }
+    },
+    {
+      "id": "simulation-setup-ota-ac-ff",
+      "name": "AC response (FF)",
+      "version": 2,
+      "input": {
+        "kind": "structured",
+        "rootDocumentId": "document-ota-5t-testbench",
+        "analyses": [
+          {
+            "kind": "ac",
+            "sweep": "dec",
+            "points": 40,
+            "startHz": 1,
+            "stopHz": 1000000000
+          }
+        ],
+        "outputs": [
+          {
+            "id": "probe-vout",
+            "label": "vout (A_v for AC=1 V)",
+            "expression": {
+              "kind": "voltage",
+              "documentId": "document-ota-5t-testbench",
+              "anchor": {
+                "kind": "terminal",
+                "instanceId": "XDUT",
+                "pinName": "vout"
+              },
+              "occurrence": []
+            }
+          },
+          {
+            "id": "probe-tail",
+            "label": "tail",
+            "expression": {
+              "kind": "voltage",
+              "documentId": "document-ota-5t",
+              "anchor": {
+                "kind": "terminal",
+                "instanceId": "M5",
+                "pinName": "D"
+              },
+              "occurrence": ["XDUT"]
+            }
+          }
+        ],
+        "environment": {
+          "profileId": "sky130-core-continuous-ngspice46-v1",
+          "corner": "ff",
+          "temperatureC": 27
+        }
+      }
+    },
+    {
+      "id": "simulation-setup-ota-ac-ss",
+      "name": "AC response (SS)",
+      "version": 2,
+      "input": {
+        "kind": "structured",
+        "rootDocumentId": "document-ota-5t-testbench",
+        "analyses": [
+          {
+            "kind": "ac",
+            "sweep": "dec",
+            "points": 40,
+            "startHz": 1,
+            "stopHz": 1000000000
+          }
+        ],
+        "outputs": [
+          {
+            "id": "probe-vout",
+            "label": "vout (A_v for AC=1 V)",
+            "expression": {
+              "kind": "voltage",
+              "documentId": "document-ota-5t-testbench",
+              "anchor": {
+                "kind": "terminal",
+                "instanceId": "XDUT",
+                "pinName": "vout"
+              },
+              "occurrence": []
+            }
+          },
+          {
+            "id": "probe-tail",
+            "label": "tail",
+            "expression": {
+              "kind": "voltage",
+              "documentId": "document-ota-5t",
+              "anchor": {
+                "kind": "terminal",
+                "instanceId": "M5",
+                "pinName": "D"
+              },
+              "occurrence": ["XDUT"]
+            }
+          }
+        ],
+        "environment": {
+          "profileId": "sky130-core-continuous-ngspice46-v1",
+          "corner": "ss",
+          "temperatureC": 27
+        }
+      }
+    },
+    {
+      "id": "simulation-setup-ota-tran-tt",
+      "name": "Transient step (TT)",
+      "version": 2,
+      "input": {
+        "kind": "structured",
+        "rootDocumentId": "document-ota-5t-testbench",
+        "analyses": [
+          {
+            "kind": "tran",
+            "stepSeconds": 1e-8,
+            "stopSeconds": 0.000006,
+            "maxStepSeconds": 1e-8
+          }
+        ],
+        "outputs": [
+          {
+            "id": "probe-vinp",
+            "label": "vinp",
+            "expression": {
+              "kind": "voltage",
+              "documentId": "document-ota-5t-testbench",
+              "anchor": {
+                "kind": "terminal",
+                "instanceId": "VINP",
+                "pinName": "+"
+              },
+              "occurrence": []
+            }
+          },
+          {
+            "id": "probe-vout",
+            "label": "vout",
+            "expression": {
+              "kind": "voltage",
+              "documentId": "document-ota-5t-testbench",
+              "anchor": {
+                "kind": "terminal",
+                "instanceId": "XDUT",
+                "pinName": "vout"
+              },
+              "occurrence": []
+            }
+          }
+        ],
+        "environment": {
+          "profileId": "sky130-core-continuous-ngspice46-v1",
+          "corner": "tt",
+          "temperatureC": 27
+        }
+      }
     }
   ],
   "source": {
@@ -3127,7 +3496,7 @@
     "files": [],
     "sourcePolicy": "copy"
   },
-  "structureRevision": 76,
+  "structureRevision": 82,
   "symbolLibrary": {
     "hash": "razavi-reference-v1",
     "id": "razavi-symbols",

--- a/apps/editor/src/examples/library-examples.test.ts
+++ b/apps/editor/src/examples/library-examples.test.ts
@@ -275,7 +275,9 @@ describe("the bundled five-transistor Sky130 OTA", () => {
   });
 
   it("persists and compiles its four-analysis acceptance setup", async () => {
-    const setup = project.simulationSetups[0];
+    const setup = project.simulationSetups.find(
+      (candidate) => candidate.id === "simulation-setup-ota-op-ac",
+    );
     expect(setup).toBeDefined();
     expect(setup?.input.kind).toBe("structured");
     if (setup?.input.kind !== "structured") return;
@@ -305,6 +307,36 @@ describe("the bundled five-transistor Sky130 OTA", () => {
         quantity: "voltage",
       },
     ]);
+  });
+
+  it("ships independently runnable bias, transfer, corner, and transient setups", async () => {
+    const expected = [
+      ["simulation-setup-ota-op-ac", "op,dc,ac,tran", "tt"],
+      ["simulation-setup-ota-bias-tt", "op", "tt"],
+      ["simulation-setup-ota-dc-transfer-tt", "dc", "tt"],
+      ["simulation-setup-ota-ac-tt", "ac", "tt"],
+      ["simulation-setup-ota-ac-ff", "ac", "ff"],
+      ["simulation-setup-ota-ac-ss", "ac", "ss"],
+      ["simulation-setup-ota-tran-tt", "tran", "tt"],
+    ] as const;
+
+    expect(
+      project.simulationSetups.map((setup) => [
+        setup.id,
+        setup.input.kind === "structured"
+          ? setup.input.analyses.map((analysis) => analysis.kind).join(",")
+          : setup.input.kind,
+        setup.input.environment.corner,
+      ]),
+    ).toEqual(expected);
+
+    for (const setup of project.simulationSetups) {
+      expect(setup.input.kind, setup.name).toBe("structured");
+      if (setup.input.kind !== "structured") continue;
+      expect(setup.input.rootDocumentId, setup.name).toBe(testbench.id);
+      const compiled = await compileStructuredSimulation(project, setup);
+      expect(compiled.ok, setup.name).toBe(true);
+    }
   });
 
   it("passes the Check-and-Save gates with no electrical rule issue", () => {

--- a/apps/editor/src/examples/library-examples.ts
+++ b/apps/editor/src/examples/library-examples.ts
@@ -51,7 +51,7 @@ export const libraryProjectExamples: readonly LibraryProjectExample[] = [
   {
     id: "five-transistor-ota-sky130",
     name: "Five-Transistor OTA (Sky130)",
-    description: "Textbook 5T OTA as a Cell, with its testbench",
+    description: "5T core, bias replica, complete testbench, and saved setups",
     project: bundledProject(fiveTransistorOtaSky130),
   },
 ];

--- a/docs/user/analog-simulation.md
+++ b/docs/user/analog-simulation.md
@@ -6,10 +6,15 @@ canvas available; it is separate from the development-only Digital tool.
 
 ## Try it: the bundled five-transistor OTA
 
-The editor ships a Sky130 five-transistor OTA with its stimulus and a saved
-OP + DC + AC + TRAN setup. On the preview channel open
+The editor ships a Sky130 five-transistor OTA core, its diode-connected bias
+replica, and a complete ordinary Testbench Cell. Its saved setup collection
+contains the qualified combined OP + DC + AC + TRAN run, a focused bias-point
+run with supply current, a denser DC transfer sweep, matching TT/FF/SS AC
+setups for comparison, and a two-cycle transient step run. On the preview
+channel open
 `https://analog-canvas-preview.tokenzhang.com/editor?example=five-transistor-ota-sky130`,
-press **Simulation**, then **Run**. The operating point returns
+press **Simulation**, then **Run** to execute the default qualified setup. The
+operating point returns
 v(vout) ≈ 0.75898 V, v(ibias) ≈ 0.60440 V, v(xdut.tail) ≈ 0.28487 V and
 v(xdut.nleft) ≈ 0.75898 V. The DC sweep covers VINP from 0.88 V to 0.92 V,
 the AC sweep plots 1 Hz–1 GHz, and the transient source pulses VINP from


### PR DESCRIPTION
## Summary
- keep the qualified OTA core and its diode-connected bias replica intact
- add focused bias, DC transfer, TT/FF/SS AC, and transient setups beside the combined acceptance setup
- document the bundled lab and make setup-lifecycle coverage independent of the fixture's initial setup count

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
  - 413 unit files passed; 1 skipped
  - 2775 tests passed; 28 skipped
  - 6 Agent/Simulation browser flows passed
- live Preview operator-host execution completed for all six added setups under environment fingerprint 33c245e5df6dc12077b6a2e4ebf308777b0e9014fe9bfdafc3285c614688561d
  - OP: 1 point / 5 probes
  - DC: 81 points / 3 probes
  - AC TT, FF, SS: 361 points / 2 probes each
  - TRAN: 652 points / 2 probes
