### PR TITLE
Fix bounded preview simulation result hydration

### DIFF
--- a/packages/simulation-service/src/run-receipt.test.ts
+++ b/packages/simulation-service/src/run-receipt.test.ts
@@ -37,3 +37,87 @@ it("bounds derived arrays even when there is no large raw result", () => {
   );
   expect(run.outputData!.analyses[0]!.outputs[0]!.values).toHaveLength(100000);
 });
+
+it("bounds a run when raw and derived results only exceed the budget together", () => {
+  const values = Array(2000).fill(1.234567890123456);
+  const run = {
+    id: "r-combined",
+    preparedId: "p",
+    inputRevision: "i",
+    state: "finished",
+    artifacts: [],
+    result: {
+      outcome: { status: "completed" },
+      log: "",
+      diagnostics: [],
+      durationMs: 1,
+      metadata: {
+        schemaVersion: 1,
+        input: {
+          inputRevision: "i",
+          netlistSha256: "0".repeat(64),
+          testbenchSha256: "1".repeat(64),
+          deckSha256: "2".repeat(64),
+        },
+        configuration: { modelLibrary: null },
+        environment: {
+          executor: "local-host",
+          reproducibility: "observed",
+          profileId: "p",
+          platform: "test",
+          simulator: {
+            name: "ngspice",
+            version: "test",
+            binarySha256: null,
+          },
+          models: null,
+          startupSha256: null,
+          fingerprint: "test",
+        },
+      },
+      data: {
+        schemaVersion: 1,
+        analyses: [
+          {
+            analysis: "tran",
+            plotName: "Transient",
+            timeSeconds: values,
+            probes: [
+              { name: "v(out)", quantity: "voltage", unit: "V", value: values },
+            ],
+          },
+        ],
+      },
+    },
+    outputData: {
+      schemaVersion: 1,
+      analyses: [
+        {
+          analysis: "tran",
+          plotName: "Transient",
+          outputs: [{ id: "o", label: "Output", unit: "V", values }],
+        },
+      ],
+      diagnostics: [],
+      measurements: [],
+    },
+  } satisfies Run;
+
+  const encoder = new TextEncoder();
+  expect(encoder.encode(JSON.stringify(run.result)).byteLength).toBeLessThan(
+    RUN_RECEIPT_MAX_BYTES,
+  );
+  expect(
+    encoder.encode(JSON.stringify(run.outputData)).byteLength,
+  ).toBeLessThan(RUN_RECEIPT_MAX_BYTES);
+  expect(encoder.encode(JSON.stringify(run)).byteLength).toBeGreaterThan(
+    RUN_RECEIPT_MAX_BYTES,
+  );
+  const receipt = runReceipt(run);
+  expect(receipt).toMatchObject({
+    resultPreview: true,
+    result: { outcome: { status: "completed" } },
+  });
+  expect(receipt.outputData).toBeUndefined();
+  expect(receipt.result?.data).toBeUndefined();
+});

--- a/scripts/lib/simulation-run-evidence.mjs
+++ b/scripts/lib/simulation-run-evidence.mjs
@@ -1,0 +1,28 @@
+/**
+ * Materialize a bounded simulation receipt from its immutable JSON artifacts.
+ * The receipt remains the control-plane response; artifacts remain the single
+ * source for arrays omitted from a preview.
+ */
+export async function materializeSimulationRunEvidence(run, readJsonArtifact) {
+  if (!run.resultPreview) return run;
+
+  const artifacts = new Map(
+    run.artifacts.map((artifact) => [artifact.name, artifact]),
+  );
+  const resultArtifact = artifacts.get("result.json");
+  if (!resultArtifact)
+    throw new Error("A bounded simulation receipt has no result.json artifact");
+
+  const result = await readJsonArtifact(resultArtifact);
+  const outputArtifact = artifacts.get("outputs.json");
+  const outputData = outputArtifact
+    ? await readJsonArtifact(outputArtifact)
+    : undefined;
+
+  return {
+    ...run,
+    result,
+    ...(outputData === undefined ? {} : { outputData }),
+    resultPreview: false,
+  };
+}

--- a/scripts/lib/simulation-run-evidence.test.mjs
+++ b/scripts/lib/simulation-run-evidence.test.mjs
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { materializeSimulationRunEvidence } from "./simulation-run-evidence.mjs";
+
+const artifact = (name) => ({ id: name, name });
+
+describe("bounded simulation run evidence", () => {
+  it("leaves an inline run untouched", async () => {
+    const run = { resultPreview: false, artifacts: [], result: { data: {} } };
+    const read = vi.fn();
+
+    expect(await materializeSimulationRunEvidence(run, read)).toBe(run);
+    expect(read).not.toHaveBeenCalled();
+  });
+
+  it("hydrates raw and named-output evidence from artifacts", async () => {
+    const run = {
+      resultPreview: true,
+      artifacts: [artifact("result.json"), artifact("outputs.json")],
+      result: { outcome: { status: "completed" } },
+    };
+    const read = vi.fn(async ({ name }) =>
+      name === "result.json"
+        ? { outcome: { status: "completed" }, data: { analyses: [] } }
+        : { schemaVersion: 1, analyses: [], diagnostics: [], measurements: [] },
+    );
+
+    const hydrated = await materializeSimulationRunEvidence(run, read);
+
+    expect(hydrated.resultPreview).toBe(false);
+    expect(hydrated.result.data).toEqual({ analyses: [] });
+    expect(hydrated.outputData.measurements).toEqual([]);
+    expect(read.mock.calls.map(([value]) => value.name)).toEqual([
+      "result.json",
+      "outputs.json",
+    ]);
+  });
+
+  it("fails clearly when a bounded receipt cannot locate full evidence", async () => {
+    await expect(
+      materializeSimulationRunEvidence(
+        { resultPreview: true, artifacts: [] },
+        vi.fn(),
+      ),
+    ).rejects.toThrow("no result.json artifact");
+  });
+});

--- a/scripts/preview-agent-simulation-journey.mjs
+++ b/scripts/preview-agent-simulation-journey.mjs
@@ -8,6 +8,9 @@ import { createInterface } from "node:readline";
 import { chromium } from "@playwright/test";
 import { compileStructuredSimulation } from "../packages/netlist/dist/index.js";
 import { parseProject } from "../packages/project-protocol/dist/index.js";
+import { SimulationOutputDataSchema } from "../packages/simulation-service/dist/contract.js";
+import { SimulationResultSchema } from "../packages/spice-run/dist/index.js";
+import { materializeSimulationRunEvidence } from "./lib/simulation-run-evidence.mjs";
 import { validateHostedSky130Result } from "./preview-simulation-smoke.mjs";
 
 const baseUrl = new URL(
@@ -298,15 +301,37 @@ try {
   }
   assert(finished, "The run returned no final state");
   assert.equal(finished.run.state, "finished");
-  assert.equal(finished.run.result?.outcome.status, "completed");
+  const exports = [];
+  const exportedArtifactNames = new Set();
+  const fullRun = await materializeSimulationRunEvidence(
+    finished.run,
+    async (artifact) => {
+      exports.push(await exportArtifact(artifact, artifact.name));
+      exportedArtifactNames.add(artifact.name);
+      const value = JSON.parse(
+        await readFile(join(outputDirectory, artifact.name), "utf8"),
+      );
+      return artifact.name === "result.json"
+        ? SimulationResultSchema.parse(value)
+        : SimulationOutputDataSchema.parse(value);
+    },
+  );
+  assert.equal(fullRun.result?.outcome.status, "completed");
   const accepted = validateHostedSky130Result(
-    finished.run.result,
+    fullRun.result,
     "operator-host",
     prepared.prepared.inputRevision,
     prepared.prepared.vectors,
   );
+  assert(
+    fullRun.outputData?.analyses.length,
+    "The completed OTA run returned no evaluated named outputs",
+  );
+  assert(
+    fullRun.outputData.measurements?.length,
+    "The completed OTA run returned no automatic measurements",
+  );
 
-  const exports = [];
   const resultArtifacts = finished.run.artifacts
     .filter(
       (artifact) =>
@@ -316,6 +341,7 @@ try {
     )
     .sort((left, right) => left.name.localeCompare(right.name));
   for (const artifact of resultArtifacts) {
+    if (exportedArtifactNames.has(artifact.name)) continue;
     exports.push(await exportArtifact(artifact, artifact.name));
   }
   exports.push(
@@ -378,14 +404,14 @@ try {
     artifacts: prepared.prepared.artifacts,
   };
   report.run = {
-    state: finished.run.state,
-    outcome: finished.run.result.outcome.status,
-    profileId: finished.run.result.metadata.environment.profileId,
+    state: fullRun.state,
+    outcome: fullRun.result.outcome.status,
+    profileId: fullRun.result.metadata.environment.profileId,
     environmentFingerprint: accepted.environmentFingerprint,
     inputRevision: prepared.prepared.inputRevision,
     preparedId: prepared.prepared.id,
     runId: finished.run.id,
-    analyses: finished.run.result.data?.analyses.map((analysis) => ({
+    analyses: fullRun.result.data?.analyses.map((analysis) => ({
       kind: analysis.analysis,
       plotName: analysis.plotName,
       points:
@@ -398,6 +424,11 @@ try {
               : analysis.timeSeconds.length,
       outputs: analysis.probes.map((probe) => probe.name),
     })),
+    namedOutputs: fullRun.outputData.analyses.map((analysis) => ({
+      kind: analysis.analysis,
+      outputs: analysis.outputs.map((output) => output.label),
+    })),
+    measurementCount: fullRun.outputData.measurements?.length ?? 0,
   };
   report.exports = exports;
   await tool("disconnect");


### PR DESCRIPTION
## Summary
- materialize bounded Agent/MCP simulation receipts from verified result artifacts
- validate full raw results, named outputs, and automatic measurements in the Preview journey
- cover the combined raw-plus-derived payload boundary that triggered the failure

## Root cause
The 96 KB receipt budget was applied to the complete Run. The OTA result (43,776 B) and evaluated outputs (52,987 B) fit separately but exceed the budget together. The service correctly returned a bounded receipt with artifact references, while the Preview Agent journey incorrectly expected inline result data.

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main (417 files passed, 2,784 tests passed)
- live Agent/MCP OTA journey against Preview: OP/DC/AC/TRAN passed; 48 automatic measurements hydrated

Test-Impact: tests-updated