### PR TITLE
fix(editor): clarify component property order

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -1148,7 +1148,7 @@ test("carries a manual Value through placement and Q property editing", async ({
   await expect(instanceReference).toHaveValue("R7");
   await page
     .locator("summary")
-    .filter({ hasText: "Advanced parameters" })
+    .filter({ hasText: "Netlist overrides" })
     .click();
   await page.getByRole("button", { name: "Add parameter" }).click();
   await page.getByLabel("Additional parameter name 1").fill("tc");

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -3348,6 +3348,11 @@ test("Properties toggles reference label visibility for one or many components",
   await expect(
     componentProperties.locator(":scope > .property-disclosure"),
   ).toHaveCount(4);
+  expect(
+    await componentProperties
+      .locator(":scope > .property-disclosure > summary > span")
+      .allTextContents(),
+  ).toEqual(["Identity", "Parameters", "Placement", "Appearance"]);
   await expect(
     componentProperties.locator(
       ':scope > details[aria-label="Component appearance"]',

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -3335,7 +3335,7 @@ test("Properties toggles reference label visibility for one or many components",
     "Identity",
     "Parameters",
     "Display",
-    "Advanced parameters",
+    "Netlist overrides",
     "Placement",
   ]) {
     await expect(

--- a/apps/editor/src/app/editor-properties-dock.tsx
+++ b/apps/editor/src/app/editor-properties-dock.tsx
@@ -152,11 +152,11 @@ export function EditorPropertiesDock({
                 <ComponentSignalFlowProperties {...component.signalFlow} />
               ) : null}
               <ComponentElectricalProperties {...component.electrical} />
+              <ComponentPlacementProperties {...component.placement} />
               <ComponentStyleProperties
                 key={component.style.instance.id}
                 {...component.style}
               />
-              <ComponentPlacementProperties {...component.placement} />
             </section>
           ) : null}
           {annotationText ? (

--- a/apps/editor/src/features/properties/component-electrical-properties.test.tsx
+++ b/apps/editor/src/features/properties/component-electrical-properties.test.tsx
@@ -60,6 +60,8 @@ describe("component electrical properties", () => {
     expect(markup).toMatch(
       /<details[^>]*aria-label="Component parameters and display"[^>]*open=""/u,
     );
+    expect(markup).toContain("Netlist overrides");
+    expect(markup).not.toContain("Advanced parameters");
     expect(markup).toContain('aria-label="Additional parameter name 1"');
     expect(markup).toContain("Apply parameters");
     expect(markup).not.toContain("Component compatibility field");

--- a/apps/editor/src/features/properties/component-electrical-properties.tsx
+++ b/apps/editor/src/features/properties/component-electrical-properties.tsx
@@ -257,7 +257,7 @@ export function ComponentElectricalProperties({
       {instance.netlist ? (
         <details className="property-details property-details-inline">
           <summary>
-            <span>Advanced parameters</span>
+            <span>Netlist overrides</span>
             <small>{additionalParameters.length}</small>
           </summary>
           <div


### PR DESCRIPTION
## Summary
- place routine Placement controls before the less-common Appearance section
- rename the existing collapsed Advanced parameters section to Netlist overrides
- keep Project persistence, export/simulation behavior, and Agent APIs unchanged

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
  - 2780 unit tests passed (22 skipped)
  - 33 component-insert browser tests passed
  - 135 editor browser tests passed

Test-Impact: tests-updated