### PR TITLE
Simulation results: explicit AC views and organized measurements

### DIFF
--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -1,11 +1,25 @@
 import { test, expect, type WebSocketRoute } from "@playwright/test";
 import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import { strFromU8, unzipSync } from "fflate";
 import {
   createSimulationEnvironmentMetadata,
   createSimulationInputMetadata,
   readSimulationData,
 } from "@icm/spice-run";
+
+const loadModule = createRequire(import.meta.url);
+const { PNG } = loadModule("pngjs") as {
+  PNG: {
+    sync: {
+      read(input: Buffer): {
+        readonly width: number;
+        readonly height: number;
+        readonly data: Uint8Array;
+      };
+    };
+  };
+};
 const profile = JSON.parse(
   readFileSync(
     new URL(
@@ -567,7 +581,9 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   const opMeasurements = panel.locator(
     "details.simulation-measurement-results",
   );
-  await expect(opMeasurements.locator("summary")).toContainText("1 value");
+  await expect(opMeasurements.locator(":scope > summary")).toContainText(
+    "1 value",
+  );
   await expect(opMeasurements).not.toHaveAttribute("open", "");
   await panel.getByRole("button", { name: "Show on canvas" }).click();
   await expect(page.getByTestId("operating-point-badges")).toContainText(
@@ -579,7 +595,9 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   const plotMeasurements = panel.locator(
     "details.simulation-measurement-results",
   );
-  await expect(plotMeasurements.locator("summary")).toContainText("8 values");
+  await expect(plotMeasurements.locator(":scope > summary")).toContainText(
+    "8 values",
+  );
   await expect(panel.locator(".spice-ac-plot svg")).toHaveCount(2);
   await expect(panel.locator('svg[aria-label="AC magnitude"]')).toBeVisible();
   await expect(panel.locator('svg[aria-label="AC phase"]')).toHaveCount(0);
@@ -589,13 +607,10 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   await expect(panel.locator('svg[aria-label="AC phase"]')).toBeVisible();
   await expect(panel.getByLabel("Voltage reference")).toHaveValue("");
   await expect(panel.getByText("ref 1 V", { exact: false })).toHaveCount(2);
-  await acDisplay.getByRole("button", { name: "Magnitude" }).click();
-  await expect(panel.locator('svg[aria-label="AC magnitude"]')).toBeVisible();
-  await expect(panel.locator('svg[aria-label="AC phase"]')).toHaveCount(0);
   await expect
     .poll(
       async () =>
-        (await panel.locator('svg[aria-label="AC magnitude"]').boundingBox())
+        (await panel.locator('svg[aria-label="AC db20"]').boundingBox())
           ?.height ?? 0,
     )
     .toBeGreaterThan(300);
@@ -608,7 +623,7 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   const svgBundle = await svgBundlePromise;
   expect(svgBundle.suggestedFilename()).toBe("simulation-plots-svg.zip");
   const svgEntries = unzipSync(readFileSync((await svgBundle.path())!));
-  expect(Object.keys(svgEntries)).toHaveLength(2);
+  expect(Object.keys(svgEntries)).toHaveLength(3);
   const exportedSvg = strFromU8(Object.values(svgEntries)[0]!);
   expect(exportedSvg).toContain('<?xml version="1.0"');
   expect(exportedSvg).toContain('fill="white"');
@@ -620,10 +635,25 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   const pngBundle = await pngBundlePromise;
   expect(pngBundle.suggestedFilename()).toBe("simulation-plots-png.zip");
   const pngEntries = unzipSync(readFileSync((await pngBundle.path())!));
-  expect(Object.keys(pngEntries)).toHaveLength(2);
+  expect(Object.keys(pngEntries)).toHaveLength(3);
   expect([...Object.values(pngEntries)[0]!.slice(0, 8)]).toEqual([
     137, 80, 78, 71, 13, 10, 26, 10,
   ]);
+  const phasePngEntry = Object.entries(pngEntries).find(([name]) =>
+    name.includes("ac-phase"),
+  );
+  expect(phasePngEntry).toBeDefined();
+  const phasePng = PNG.sync.read(Buffer.from(phasePngEntry![1]));
+  let darkPixels = 0;
+  for (let index = 0; index < phasePng.data.length; index += 4) {
+    if (
+      phasePng.data[index]! < 32 &&
+      phasePng.data[index + 1]! < 32 &&
+      phasePng.data[index + 2]! < 32
+    )
+      darkPixels += 1;
+  }
+  expect(darkPixels / (phasePng.width * phasePng.height)).toBeLessThan(0.25);
   const csvDownloadPromise = page.waitForEvent("download");
   await resultExport.getByRole("button", { name: "outputs-op-0.csv" }).click();
   expect((await csvDownloadPromise).suggestedFilename()).toBe(
@@ -637,6 +667,9 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
     '"TRAN","Transient response","first-output","Time-weighted RMS"',
   );
   resultExport.evaluate((element) => element.removeAttribute("open"));
+  await acDisplay.getByRole("button", { name: "Magnitude" }).click();
+  await expect(panel.locator('svg[aria-label="AC magnitude"]')).toBeVisible();
+  await expect(panel.locator('svg[aria-label="AC phase"]')).toHaveCount(0);
   await panel.getByRole("tab", { name: "Compare" }).click();
   await expect(panel.getByText("Session only", { exact: false })).toBeVisible();
   await panel.getByRole("button", { name: "Keep current" }).click();

--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -580,9 +580,18 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
     "details.simulation-measurement-results",
   );
   await expect(plotMeasurements.locator("summary")).toContainText("8 values");
-  await expect(panel.locator(".spice-ac-plot svg")).toHaveCount(3);
+  await expect(panel.locator(".spice-ac-plot svg")).toHaveCount(2);
   await expect(panel.locator('svg[aria-label="AC magnitude"]')).toBeVisible();
+  await expect(panel.locator('svg[aria-label="AC phase"]')).toHaveCount(0);
+  const acDisplay = panel.getByRole("group", { name: "Voltage display" });
+  await acDisplay.getByRole("button", { name: "Bode" }).click();
+  await expect(panel.locator('svg[aria-label="AC db20"]')).toBeVisible();
   await expect(panel.locator('svg[aria-label="AC phase"]')).toBeVisible();
+  await expect(panel.getByLabel("Voltage reference")).toHaveValue("");
+  await expect(panel.getByText("ref 1 V", { exact: false })).toHaveCount(2);
+  await acDisplay.getByRole("button", { name: "Magnitude" }).click();
+  await expect(panel.locator('svg[aria-label="AC magnitude"]')).toBeVisible();
+  await expect(panel.locator('svg[aria-label="AC phase"]')).toHaveCount(0);
   await expect
     .poll(
       async () =>
@@ -599,7 +608,7 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   const svgBundle = await svgBundlePromise;
   expect(svgBundle.suggestedFilename()).toBe("simulation-plots-svg.zip");
   const svgEntries = unzipSync(readFileSync((await svgBundle.path())!));
-  expect(Object.keys(svgEntries)).toHaveLength(3);
+  expect(Object.keys(svgEntries)).toHaveLength(2);
   const exportedSvg = strFromU8(Object.values(svgEntries)[0]!);
   expect(exportedSvg).toContain('<?xml version="1.0"');
   expect(exportedSvg).toContain('fill="white"');
@@ -611,7 +620,7 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   const pngBundle = await pngBundlePromise;
   expect(pngBundle.suggestedFilename()).toBe("simulation-plots-png.zip");
   const pngEntries = unzipSync(readFileSync((await pngBundle.path())!));
-  expect(Object.keys(pngEntries)).toHaveLength(3);
+  expect(Object.keys(pngEntries)).toHaveLength(2);
   expect([...Object.values(pngEntries)[0]!.slice(0, 8)]).toEqual([
     137, 80, 78, 71, 13, 10, 26, 10,
   ]);

--- a/apps/editor/src/features/simulation/ac-response-plot.test.ts
+++ b/apps/editor/src/features/simulation/ac-response-plot.test.ts
@@ -16,38 +16,56 @@ function singlePole(): AcTrace {
   for (let decade = 0; decade <= 6; decade += 1) {
     const frequency = 10 ** decade;
     const ratio = frequency / 1000;
+    const magnitudeDb = 40 - 10 * Math.log10(1 + ratio * ratio);
+    const phaseDeg = -(Math.atan(ratio) * 180) / Math.PI;
+    const magnitude = 10 ** (magnitudeDb / 20);
     points.push({
       frequency,
-      magnitudeDb: 40 - 10 * Math.log10(1 + ratio * ratio),
-      phaseDeg: -(Math.atan(ratio) * 180) / Math.PI,
+      real: magnitude * Math.cos((phaseDeg * Math.PI) / 180),
+      imaginary: magnitude * Math.sin((phaseDeg * Math.PI) / 180),
+      magnitude,
+      magnitudeDb,
+      phaseDeg,
     });
   }
-  return { label: "vdb(vout)", points };
+  return { label: "vout/vin", unit: "1", points };
 }
 
 describe("AC response plot", () => {
   it("puts whole decades on the frequency axis", () => {
-    const layout = layoutAcPlot([singlePole()], { width: 600, height: 300 });
+    const layout = layoutAcPlot(
+      [singlePole()],
+      { width: 600, height: 300 },
+      "db20",
+    );
     expect(layout).not.toBeNull();
     // A sweep from 1 Hz to 1 MHz reads as decades, not as raw sample points.
     expect(layout!.frequency.ticks).toEqual([1, 100, 1e4, 1e6]);
   });
 
   it("contains the data with readable adaptive grid steps", () => {
-    const layout = layoutAcPlot([singlePole()], { width: 600, height: 300 })!;
+    const layout = layoutAcPlot(
+      [singlePole()],
+      { width: 600, height: 300 },
+      "db20",
+    )!;
     // The trace spans about -20 dB to 40 dB; the axis must contain it and
     // land on round gridlines rather than on the data's own extremes.
-    expect(layout.magnitude.min).toBeLessThan(-20);
-    expect(layout.magnitude.max).toBeGreaterThan(
+    expect(layout.value.min).toBeLessThan(-20);
+    expect(layout.value.max).toBeGreaterThan(
       singlePole().points[0]!.magnitudeDb,
     );
     expect(layout.frequency.min).toBeLessThan(1);
     expect(layout.frequency.max).toBeGreaterThan(1e6);
-    expect(layout.magnitude.ticks).toContain(0);
+    expect(layout.value.ticks).toContain(0);
   });
 
   it("reads a frequency back from a position, for a crosshair", () => {
-    const layout = layoutAcPlot([singlePole()], { width: 600, height: 300 })!;
+    const layout = layoutAcPlot(
+      [singlePole()],
+      { width: 600, height: 300 },
+      "db20",
+    )!;
     const left = layout.frequencyAt(layout.frame.x);
     const right = layout.frequencyAt(layout.frame.x + layout.frame.width);
 
@@ -64,12 +82,13 @@ describe("AC response plot", () => {
     const layout = layoutAcPlot(
       [singlePole()],
       { width: 600, height: 300 },
+      "db20",
       range,
     )!;
     const svg = acResponseSvg(
       [singlePole()],
       { width: 600, height: 300 },
-      { kind: "magnitude", frequencyRange: range },
+      { kind: "db20", frequencyRange: range, valueUnit: "dB" },
     )!;
 
     expect(layout.frequency.min).toBe(range[0]);
@@ -81,7 +100,7 @@ describe("AC response plot", () => {
     const magnitude = acResponseSvg(
       [singlePole()],
       { width: 600, height: 300 },
-      { kind: "magnitude" },
+      { kind: "db20", valueUnit: "dB" },
     )!;
     const phase = acResponseSvg(
       [singlePole()],
@@ -95,7 +114,7 @@ describe("AC response plot", () => {
     expect(phase.match(/<polyline class="ac-trace ac-trace-/gu)).toHaveLength(
       1,
     );
-    expect(magnitude).toContain('aria-label="AC magnitude"');
+    expect(magnitude).toContain('aria-label="AC db20"');
     expect(phase).toContain('aria-label="AC phase"');
     expect(magnitude).toContain("dB");
     expect(phase).toContain("°");
@@ -107,7 +126,8 @@ describe("AC response plot", () => {
       [trace],
       { width: 600, height: 300 },
       {
-        kind: "magnitude",
+        kind: "db20",
+        valueUnit: "dB",
         selectedTraceId: trace.id,
       },
     )!;
@@ -122,7 +142,8 @@ describe("AC response plot", () => {
       [trace],
       { width: 600, height: 300 },
       {
-        kind: "magnitude",
+        kind: "db20",
+        valueUnit: "dB",
         selectedTraceId: trace.id,
         cursorFrequency: 1e3,
         cursorFrequencyB: 1e4,
@@ -141,7 +162,7 @@ describe("AC response plot", () => {
     // looks like a measurement.
     expect(layoutAcPlot([], { width: 600, height: 300 })).toBeNull();
     expect(
-      layoutAcPlot([{ label: "vdb(vout)", points: [] }], {
+      layoutAcPlot([{ label: "vout", unit: "V", points: [] }], {
         width: 600,
         height: 300,
       }),
@@ -152,8 +173,18 @@ describe("AC response plot", () => {
       layoutAcPlot(
         [
           {
-            label: "vdb(vout)",
-            points: [{ frequency: 0, magnitudeDb: 1, phaseDeg: 0 }],
+            label: "vout",
+            unit: "V",
+            points: [
+              {
+                frequency: 0,
+                real: 1,
+                imaginary: 0,
+                magnitude: 1,
+                magnitudeDb: 0,
+                phaseDeg: 0,
+              },
+            ],
           },
         ],
         { width: 600, height: 300 },
@@ -169,15 +200,15 @@ describe("AC response plot", () => {
     // would leave anyone who cannot separate the hues with nothing.
     const svg = acResponseSvg(
       [
-        { label: "vdb(vout)", points: singlePole().points },
-        { label: "vdb(vout_loaded)", points: singlePole().points },
+        { label: "vout", unit: "V", points: singlePole().points },
+        { label: "vout_loaded", unit: "V", points: singlePole().points },
       ],
       { width: 600, height: 300 },
-      { kind: "magnitude" },
+      { kind: "magnitude", valueUnit: "V" },
     )!;
 
-    expect(svg).toContain("vdb(vout)");
-    expect(svg).toContain("vdb(vout_loaded)");
+    expect(svg).toContain("vout");
+    expect(svg).toContain("vout_loaded");
     expect(svg).toContain("ac-trace-0");
     expect(svg).toContain("ac-trace-1");
   });

--- a/apps/editor/src/features/simulation/ac-response-plot.ts
+++ b/apps/editor/src/features/simulation/ac-response-plot.ts
@@ -1,6 +1,6 @@
 import { waveformTicks } from "./waveform-interaction";
 /**
- * A Bode plot for AC analysis results.
+ * A projected waveform plot for complex AC analysis results.
  *
  * Why this draws its own SVG rather than reusing either of the two obvious
  * options:
@@ -23,7 +23,12 @@ import { waveformTicks } from "./waveform-interaction";
 export interface AcPoint {
   /** Hertz. Must be positive: the frequency axis is logarithmic. */
   frequency: number;
-  /** Magnitude in decibels. */
+  /** Original complex result, retained for every presentation projection. */
+  real: number;
+  imaginary: number;
+  /** Linear magnitude in the trace's physical unit. */
+  magnitude: number;
+  /** Magnitude relative to one trace unit, in decibels. */
   magnitudeDb: number;
   /** Phase in degrees. */
   phaseDeg: number;
@@ -34,6 +39,8 @@ export interface AcTrace {
   id?: string;
   /** The expression the author asked for, printed verbatim as the legend. */
   label: string;
+  /** Physical result unit before a presentation-only projection. */
+  unit: string;
   /** Stable Results Browser colour slot, independent of hide/show filtering. */
   colorIndex?: number;
   points: readonly AcPoint[];
@@ -56,13 +63,12 @@ export interface AcPlotLayout {
   /** Drawing area inside the axes, in SVG units. */
   frame: { x: number; y: number; width: number; height: number };
   frequency: AcPlotAxis;
-  magnitude: AcPlotAxis;
-  phase: AcPlotAxis;
+  value: AcPlotAxis;
   /** Frequency in Hz for an x in SVG units, for crosshair readout. */
   frequencyAt: (x: number) => number;
 }
 
-export type AcPlotKind = "magnitude" | "phase";
+export type AcPlotKind = "magnitude" | "db20" | "phase" | "real" | "imaginary";
 
 export interface AcResponseSvgOptions {
   /** One physical quantity per plot. Bode magnitude and phase never share an axis. */
@@ -77,6 +83,8 @@ export interface AcResponseSvgOptions {
   /** Explicit axes-toolbar range; traces are clipped to this interval. */
   frequencyRange?: readonly [number, number];
   valueRange?: readonly [number, number];
+  /** Presentation unit printed on the value axis. */
+  valueUnit?: string;
 }
 
 const MARGIN = { left: 56, right: 56, top: 16, bottom: 32 };
@@ -111,11 +119,15 @@ function adaptiveAxis(
 export function layoutAcPlot(
   traces: readonly AcTrace[],
   size: AcPlotSize,
+  kind: AcPlotKind = "magnitude",
   frequencyRange?: readonly [number, number],
-  valueOverride?: { kind: AcPlotKind; range: readonly [number, number] },
+  valueRange?: readonly [number, number],
 ): AcPlotLayout | null {
   const points = traces.flatMap((trace) => trace.points);
-  const usable = points.filter((point) => point.frequency > 0);
+  const usable = points.filter(
+    (point) =>
+      point.frequency > 0 && Number.isFinite(acPointValue(point, kind)),
+  );
   if (usable.length === 0) return null;
 
   const frequencies = usable.map((point) => point.frequency);
@@ -126,8 +138,7 @@ export function layoutAcPlot(
         point.frequency <= frequencyRange[1]),
   );
   const visible = inView.length ? inView : usable;
-  const magnitudes = visible.map((point) => point.magnitudeDb);
-  const phases = visible.map((point) => point.phaseDeg);
+  const values = visible.map((point) => acPointValue(point, kind));
   const frame = {
     x: MARGIN.left,
     y: MARGIN.top,
@@ -168,19 +179,10 @@ export function layoutAcPlot(
     size,
     frame,
     frequency,
-    magnitude: adaptiveAxis(
-      valueOverride?.kind === "magnitude"
-        ? valueOverride.range
-        : [Math.min(...magnitudes), Math.max(...magnitudes)],
+    value: adaptiveAxis(
+      valueRange ?? [Math.min(...values), Math.max(...values)],
       size.height,
-      valueOverride?.kind !== "magnitude",
-    ),
-    phase: adaptiveAxis(
-      valueOverride?.kind === "phase"
-        ? valueOverride.range
-        : [Math.min(...phases), Math.max(...phases)],
-      size.height,
-      valueOverride?.kind !== "phase",
+      valueRange === undefined,
     ),
     frequencyAt: (x: number) =>
       10 ** (logMin + ((x - frame.x) / frame.width) * logSpan),
@@ -205,40 +207,45 @@ export function formatFrequency(hertz: number): string {
 
 interface Projection {
   x: (frequency: number) => number;
-  magnitudeY: (db: number) => number;
-  phaseY: (deg: number) => number;
+  valueY: (value: number) => number;
 }
 
 function projection(layout: AcPlotLayout): Projection {
-  const { frame, frequency, magnitude, phase } = layout;
+  const { frame, frequency, value } = layout;
   const logMin = Math.log10(frequency.min);
   const logSpan = Math.log10(frequency.max) - logMin || 1;
   const span = (axis: AcPlotAxis) => axis.max - axis.min || 1;
   return {
     x: (hz) => frame.x + ((Math.log10(hz) - logMin) / logSpan) * frame.width,
-    magnitudeY: (db) =>
+    valueY: (pointValue) =>
       frame.y +
       frame.height -
-      ((db - magnitude.min) / span(magnitude)) * frame.height,
-    phaseY: (deg) =>
-      frame.y + frame.height - ((deg - phase.min) / span(phase)) * frame.height,
+      ((pointValue - value.min) / span(value)) * frame.height,
   };
+}
+
+export function acPointValue(point: AcPoint, kind: AcPlotKind): number {
+  if (kind === "magnitude") return point.magnitude;
+  if (kind === "db20") return point.magnitudeDb;
+  if (kind === "phase") return point.phaseDeg;
+  if (kind === "real") return point.real;
+  return point.imaginary;
 }
 
 function polyline(
   trace: AcTrace,
   project: Projection,
-  axis: "magnitude" | "phase",
+  kind: AcPlotKind,
 ): string {
   return trace.points
-    .filter((point) => point.frequency > 0)
-    .map((point) => {
-      const y =
-        axis === "magnitude"
-          ? project.magnitudeY(point.magnitudeDb)
-          : project.phaseY(point.phaseDeg);
-      return `${project.x(point.frequency).toFixed(2)},${y.toFixed(2)}`;
-    })
+    .filter(
+      (point) =>
+        point.frequency > 0 && Number.isFinite(acPointValue(point, kind)),
+    )
+    .map(
+      (point) =>
+        `${project.x(point.frequency).toFixed(2)},${project.valueY(acPointValue(point, kind)).toFixed(2)}`,
+    )
     .join(" ");
 }
 
@@ -264,18 +271,16 @@ export function acResponseSvg(
   const layout = layoutAcPlot(
     traces,
     size,
+    options.kind,
     options.frequencyRange,
-    options.valueRange
-      ? { kind: options.kind, range: options.valueRange }
-      : undefined,
+    options.valueRange,
   );
   if (!layout) return null;
   const project = projection(layout);
   const { frame } = layout;
-  const axis = options.kind === "magnitude" ? layout.magnitude : layout.phase;
-  const axisY =
-    options.kind === "magnitude" ? project.magnitudeY : project.phaseY;
-  const unit = options.kind === "magnitude" ? "dB" : "°";
+  const axis = layout.value;
+  const axisY = project.valueY;
+  const unit = options.valueUnit ?? (options.kind === "phase" ? "°" : "");
 
   const gridLines = [
     ...layout.frequency.ticks.map((hz) => {
@@ -339,9 +344,7 @@ export function acResponseSvg(
       const point = cursorTrace
         ? closestPoint(cursorTrace.points, frequency)
         : undefined;
-      const value =
-        point &&
-        (options.kind === "magnitude" ? point.magnitudeDb : point.phaseDeg);
+      const value = point && acPointValue(point, options.kind);
       const y = value === undefined ? undefined : axisY(value).toFixed(2);
       const horizontal =
         y === undefined

--- a/apps/editor/src/features/simulation/ac-results-explorer.test.tsx
+++ b/apps/editor/src/features/simulation/ac-results-explorer.test.tsx
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 
-import { AcResultsExplorer, unwrapPhaseDegrees } from "./ac-results-explorer";
+import {
+  AcResultsExplorer,
+  complexAcPoint,
+  referenceAcTrace,
+  unwrapPhaseDegrees,
+} from "./ac-results-explorer";
 
 describe("AC Results Explorer", () => {
   it("unwraps phase without inventing 360-degree discontinuities", () => {
@@ -13,7 +18,7 @@ describe("AC Results Explorer", () => {
     ]);
   });
 
-  it("presents one Output with separate magnitude and phase plots", () => {
+  it("defaults a voltage Output to linear magnitude and offers AC views", () => {
     const markup = renderToStaticMarkup(
       <AcResultsExplorer
         analysis={{
@@ -47,14 +52,41 @@ describe("AC Results Explorer", () => {
     );
 
     expect(markup).toContain("VOUT");
-    expect(markup).toContain("Voltage magnitude");
-    expect(markup).toContain("Voltage phase");
+    expect(markup).toContain("Voltage Magnitude");
+    expect(markup).not.toContain("Voltage Phase");
     expect(markup).not.toContain("<h4>Voltage</h4>");
     expect(markup).toContain('aria-label="AC magnitude"');
-    expect(markup).toContain('aria-label="AC phase"');
-    expect(markup.match(/data-trace-index="0"/gu)).toHaveLength(2);
+    expect(markup).not.toContain('aria-label="AC phase"');
+    expect(markup.match(/data-trace-index="0"/gu)).toHaveLength(1);
+    expect(markup).toContain('aria-label="Voltage display"');
+    expect(markup).toContain('aria-pressed="true">Magnitude');
+    expect(markup).toContain("0.7V");
     expect(markup).toContain('aria-label="Plot tools"');
     expect(markup).toContain('aria-label="Open plot"');
     expect(markup).not.toContain("Wheel to zoom");
+  });
+
+  it("uses another complex trace as a presentation-only reference", () => {
+    const trace = {
+      id: "out",
+      label: "Vout",
+      unit: "V",
+      quantity: "voltage",
+      points: [complexAcPoint(1e3, 2, 2)],
+    };
+    const reference = {
+      id: "in",
+      label: "Vin",
+      unit: "V",
+      quantity: "voltage",
+      points: [complexAcPoint(1e3, 1, 1)],
+    };
+
+    const relative = referenceAcTrace(trace, reference);
+
+    expect(relative.unit).toBe("1");
+    expect(relative.points[0]?.real).toBeCloseTo(2);
+    expect(relative.points[0]?.imaginary).toBeCloseTo(0);
+    expect(relative.points[0]?.magnitudeDb).toBeCloseTo(20 * Math.log10(2));
   });
 });

--- a/apps/editor/src/features/simulation/ac-results-explorer.tsx
+++ b/apps/editor/src/features/simulation/ac-results-explorer.tsx
@@ -12,6 +12,7 @@ import type { AcResult } from "@icm/spice-run";
 import type { Prepared } from "@icm/simulation-service/contract";
 
 import {
+  acPointValue,
   acResponseSvg,
   layoutAcPlot,
   type AcPlotKind,
@@ -28,7 +29,19 @@ export interface OutputTrace extends AcTrace {
 interface ExpandedPlot {
   quantity: OutputTrace["quantity"];
   kind: AcPlotKind;
+  referenced: boolean;
 }
+
+type AcViewMode = AcPlotKind | "bode";
+
+const VIEW_MODES: readonly { mode: AcViewMode; label: string }[] = [
+  { mode: "magnitude", label: "Magnitude" },
+  { mode: "db20", label: "dB" },
+  { mode: "phase", label: "Phase" },
+  { mode: "real", label: "Real" },
+  { mode: "imaginary", label: "Imag" },
+  { mode: "bode", label: "Bode" },
+];
 
 export interface AcResultsExplorerProps {
   resultKey?: string;
@@ -69,6 +82,55 @@ function closestPoint(points: readonly AcPoint[], frequency: number): AcPoint {
   );
 }
 
+export function complexAcPoint(
+  frequency: number,
+  real: number,
+  imaginary: number,
+): AcPoint {
+  const magnitude = Math.hypot(real, imaginary);
+  return {
+    frequency,
+    real,
+    imaginary,
+    magnitude,
+    magnitudeDb: 20 * Math.log10(Math.max(magnitude, 1e-30)),
+    phaseDeg: (Math.atan2(imaginary, real) * 180) / Math.PI,
+  };
+}
+
+/** Divide one complex trace by another without changing authored result data. */
+export function referenceAcTrace(
+  trace: OutputTrace,
+  reference: OutputTrace,
+): OutputTrace {
+  const points = trace.points.map((point, index) => {
+    const divisor = reference.points[index];
+    if (!divisor || divisor.frequency !== point.frequency)
+      return complexAcPoint(point.frequency, Number.NaN, Number.NaN);
+    const denominator =
+      divisor.real * divisor.real + divisor.imaginary * divisor.imaginary;
+    if (!Number.isFinite(denominator) || denominator === 0)
+      return complexAcPoint(point.frequency, Number.NaN, Number.NaN);
+    return complexAcPoint(
+      point.frequency,
+      (point.real * divisor.real + point.imaginary * divisor.imaginary) /
+        denominator,
+      (point.imaginary * divisor.real - point.real * divisor.imaginary) /
+        denominator,
+    );
+  });
+  const phases = unwrapPhaseDegrees(points.map((point) => point.phaseDeg));
+  return {
+    ...trace,
+    unit:
+      trace.unit === reference.unit ? "1" : `${trace.unit}/${reference.unit}`,
+    points: points.map((point, index) => ({
+      ...point,
+      phaseDeg: phases[index] ?? point.phaseDeg,
+    })),
+  };
+}
+
 function outputTraces(
   analysis: AcResult,
   vectors: Prepared["vectors"],
@@ -93,24 +155,19 @@ function outputTraces(
       id: binding?.probeId ?? resultProbe.name,
       label: (binding && labels[binding.probeId]) || resultProbe.name,
       colorIndex: index,
+      unit:
+        resultProbe.unit ?? (resultProbe.quantity === "current" ? "A" : "V"),
       quantity:
         (binding && groups[binding.probeId]) ??
         binding?.quantity ??
         (resultProbe.quantity === "current" ? "current" : "voltage"),
       ...(authored ? { probe: authored } : {}),
       points: analysis.frequencyHz.map((frequency, pointIndex) => ({
-        frequency,
-        magnitudeDb:
-          20 *
-          Math.log10(
-            Math.max(
-              Math.hypot(
-                resultProbe.real[pointIndex] ?? 0,
-                resultProbe.imag[pointIndex] ?? 0,
-              ),
-              1e-30,
-            ),
-          ),
+        ...complexAcPoint(
+          frequency,
+          resultProbe.real[pointIndex] ?? 0,
+          resultProbe.imag[pointIndex] ?? 0,
+        ),
         phaseDeg: phases[pointIndex] ?? 0,
       })),
     };
@@ -122,6 +179,35 @@ function groupLabel(quantity: string): string {
   if (quantity === "current") return "Current";
   if (quantity === "ratio") return "Ratio";
   return quantity;
+}
+
+function displayKinds(mode: AcViewMode): readonly AcPlotKind[] {
+  return mode === "bode" ? ["db20", "phase"] : [mode];
+}
+
+function plotKindLabel(kind: AcPlotKind): string {
+  if (kind === "db20") return "dB";
+  if (kind === "imaginary") return "Imaginary";
+  return kind[0]!.toUpperCase() + kind.slice(1);
+}
+
+function unityReferenceLabel(unit: string): string {
+  return unit === "1" ? "1" : `1 ${unit}`;
+}
+
+function plotUnit(
+  kind: AcPlotKind,
+  sourceUnit: string,
+  referencedToTrace: boolean,
+): string {
+  if (kind === "phase") return "°";
+  if (kind === "db20") {
+    if (referencedToTrace || sourceUnit === "1") return "dB";
+    if (sourceUnit === "V") return "dBV";
+    if (sourceUnit === "A") return "dBA";
+    return `dB ref 1 ${sourceUnit}`;
+  }
+  return sourceUnit === "1" ? "" : sourceUnit;
 }
 
 export function AcResultsExplorer({
@@ -161,6 +247,12 @@ export function ComplexResultsExplorer({
   const frequencyRange = controller.view.x;
   const valueRanges = controller.view.y;
   const [expandedPlot, setExpandedPlot] = useState<ExpandedPlot | null>(null);
+  const [viewModes, setViewModes] = useState<
+    Readonly<Record<string, AcViewMode>>
+  >({});
+  const [references, setReferences] = useState<
+    Readonly<Record<string, string>>
+  >({});
   const visible = traces.filter((trace) => !hidden.has(trace.id));
   useEffect(() => {
     if (!expandedPlot) return;
@@ -189,6 +281,21 @@ export function ComplexResultsExplorer({
     if (showing) focusTrace(traceId);
   };
 
+  const presentedTraces = (
+    quantity: string,
+    source: readonly OutputTrace[],
+  ): readonly OutputTrace[] => {
+    const referenceId = references[quantity];
+    if (!referenceId) return source;
+    const reference = traces.find(
+      (candidate) =>
+        candidate.quantity === quantity && candidate.id === referenceId,
+    );
+    return reference
+      ? source.map((trace) => referenceAcTrace(trace, reference))
+      : source;
+  };
+
   const renderPlot = (
     plot: ExpandedPlot,
     plotTraces: readonly OutputTrace[],
@@ -205,11 +312,19 @@ export function ComplexResultsExplorer({
     const layout = layoutAcPlot(
       plotTraces,
       size,
+      plot.kind,
       frequencyRange,
-      valueRange ? { kind: plot.kind, range: valueRange } : undefined,
+      valueRange,
     );
     if (!layout) return null;
-    const axis = layout[plot.kind];
+    const axis = layout.value;
+    const sourceUnit =
+      traces.find((trace) => trace.quantity === plot.quantity)?.unit ?? "1";
+    const valueUnit = plotUnit(
+      plot.kind,
+      sourceUnit,
+      plot.referenced && references[plot.quantity] !== undefined,
+    );
     const frequencyAt = (x: number) =>
       layout.frequencyAt(layout.frame.x + x * layout.frame.width);
     const svg = acResponseSvg(plotTraces, size, {
@@ -220,6 +335,7 @@ export function ComplexResultsExplorer({
       ...(markers.A === undefined ? {} : { cursorFrequency: markers.A }),
       ...(markers.B === undefined ? {} : { cursorFrequencyB: markers.B }),
       ...(selected === null ? {} : { selectedTraceId: selected }),
+      valueUnit,
     });
     return (
       <div
@@ -306,21 +422,24 @@ export function ComplexResultsExplorer({
           x={[layout.frequency.min, layout.frequency.max]}
           y={[axis.min, axis.max]}
           xUnit="Hz"
-          yUnit={plot.kind === "phase" ? "°" : "dB"}
+          yUnit={valueUnit}
           logarithmicX
           {...(!expanded ? { onOpen: () => setExpandedPlot(plot) } : {})}
         />
-        {!expanded && measurement(plot)}
+        {!expanded && measurement(plot, plotTraces)}
       </div>
     );
   };
 
-  const measurement = (plot?: ExpandedPlot) => (
+  const measurement = (
+    plot: ExpandedPlot | undefined,
+    measurementTraces: readonly OutputTrace[] = visible,
+  ) => (
     <WaveformMeasurements
       a={markers.A}
       b={markers.B}
       unit="Hz"
-      rows={visible
+      rows={measurementTraces
         .filter((trace) => !plot || trace.quantity === plot.quantity)
         .flatMap((trace) => {
           const a =
@@ -333,13 +452,18 @@ export function ComplexResultsExplorer({
               : closestPoint(trace.points, markers.B);
           return (plot ? [plot.kind] : (["magnitude", "phase"] as const)).map(
             (kind) => {
-              const property =
-                kind === "magnitude" ? "magnitudeDb" : "phaseDeg";
+              const sourceUnit = trace.unit;
+              const unit = plotUnit(
+                kind,
+                sourceUnit,
+                plot?.referenced === true &&
+                  references[plot.quantity] !== undefined,
+              );
               return {
                 label: trace.label + " " + kind,
-                unit: kind === "magnitude" ? "dB" : "°",
-                ...(a ? { a: a[property] } : {}),
-                ...(b ? { b: b[property] } : {}),
+                unit,
+                ...(a ? { a: acPointValue(a, kind) } : {}),
+                ...(b ? { b: acPointValue(b, kind) } : {}),
               };
             },
           );
@@ -356,11 +480,66 @@ export function ComplexResultsExplorer({
         const quantityTraces = traces.filter(
           (trace) => trace.quantity === quantity,
         );
-        const visibleQuantityTraces = quantityTraces.filter(
+        const mode = viewModes[quantity] ?? "magnitude";
+        const kinds = displayKinds(mode);
+        const referenceActive = mode === "db20" || mode === "bode";
+        const rawVisibleQuantityTraces = quantityTraces.filter(
           (trace) => !hidden.has(trace.id),
         );
+        const visibleQuantityTraces = referenceActive
+          ? presentedTraces(quantity, rawVisibleQuantityTraces)
+          : rawVisibleQuantityTraces;
+        const sourceUnit = quantityTraces[0]?.unit ?? "1";
+        const referenceId = references[quantity] ?? "";
         return (
           <section key={quantity} className="ac-quantity-group">
+            <div className="ac-view-toolbar">
+              <strong>{groupLabel(quantity)}</strong>
+              <div role="group" aria-label={`${groupLabel(quantity)} display`}>
+                {VIEW_MODES.map(({ mode: candidate, label }) => (
+                  <button
+                    key={candidate}
+                    type="button"
+                    aria-pressed={mode === candidate}
+                    onClick={() =>
+                      setViewModes((current) => ({
+                        ...current,
+                        [quantity]: candidate,
+                      }))
+                    }
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+              {(mode === "db20" || mode === "bode") && (
+                <label>
+                  Reference
+                  <select
+                    aria-label={`${groupLabel(quantity)} reference`}
+                    value={referenceId}
+                    onChange={(event) =>
+                      setReferences((current) => {
+                        const next = { ...current };
+                        if (event.target.value)
+                          next[quantity] = event.target.value;
+                        else delete next[quantity];
+                        return next;
+                      })
+                    }
+                  >
+                    <option value="">{unityReferenceLabel(sourceUnit)}</option>
+                    {quantityTraces
+                      .filter((trace) => trace.unit === sourceUnit)
+                      .map((trace) => (
+                        <option key={trace.id} value={trace.id}>
+                          {trace.label}
+                        </option>
+                      ))}
+                  </select>
+                </label>
+              )}
+            </div>
             <div className="simulation-plot-layout">
               <WaveformTraceList
                 label={`${groupLabel(quantity)} outputs`}
@@ -374,12 +553,26 @@ export function ComplexResultsExplorer({
               />
               <div className="simulation-plot-stack">
                 {visibleQuantityTraces.length ? (
-                  (["magnitude", "phase"] as const).map((kind) => (
+                  kinds.map((kind) => (
                     <div key={kind} className="ac-plot-row">
                       <strong>
-                        {groupLabel(quantity)} {kind}
+                        {groupLabel(quantity)} {plotKindLabel(kind)}
+                        {(kind === "db20" || mode === "bode") && (
+                          <small>
+                            {" "}
+                            · ref{" "}
+                            {referenceId
+                              ? quantityTraces.find(
+                                  (trace) => trace.id === referenceId,
+                                )?.label
+                              : unityReferenceLabel(sourceUnit)}
+                          </small>
+                        )}
                       </strong>
-                      {renderPlot({ quantity, kind }, visibleQuantityTraces)}
+                      {renderPlot(
+                        { quantity, kind, referenced: referenceActive },
+                        visibleQuantityTraces,
+                      )}
                     </div>
                   ))
                 ) : (
@@ -408,7 +601,7 @@ export function ComplexResultsExplorer({
                 <strong>{plotName}</strong>
                 <span>
                   {groupLabel(expandedPlot.quantity)} ·{" "}
-                  {expandedPlot.kind === "magnitude" ? "Magnitude" : "Phase"}
+                  {plotKindLabel(expandedPlot.kind)}
                 </span>
               </div>
               <button
@@ -438,9 +631,16 @@ export function ComplexResultsExplorer({
                 ) ? (
                   renderPlot(
                     expandedPlot,
-                    visible.filter(
-                      (trace) => trace.quantity === expandedPlot.quantity,
-                    ),
+                    expandedPlot.referenced
+                      ? presentedTraces(
+                          expandedPlot.quantity,
+                          visible.filter(
+                            (trace) => trace.quantity === expandedPlot.quantity,
+                          ),
+                        )
+                      : visible.filter(
+                          (trace) => trace.quantity === expandedPlot.quantity,
+                        ),
                     true,
                   )
                 ) : (
@@ -448,7 +648,19 @@ export function ComplexResultsExplorer({
                 )}
               </div>
             </div>
-            {measurement(expandedPlot)}
+            {measurement(
+              expandedPlot,
+              expandedPlot.referenced
+                ? presentedTraces(
+                    expandedPlot.quantity,
+                    visible.filter(
+                      (trace) => trace.quantity === expandedPlot.quantity,
+                    ),
+                  )
+                : visible.filter(
+                    (trace) => trace.quantity === expandedPlot.quantity,
+                  ),
+            )}
           </section>
         </div>
       ) : null}

--- a/apps/editor/src/features/simulation/simulation-measurement-results.test.tsx
+++ b/apps/editor/src/features/simulation/simulation-measurement-results.test.tsx
@@ -13,7 +13,7 @@ describe("SimulationMeasurementResults", () => {
     unit: "V",
   };
 
-  it("keeps successful detail compact behind a visible summary", () => {
+  it("groups one Output's measurements behind its own summary", () => {
     const markup = renderToStaticMarkup(
       <SimulationMeasurementResults
         measurements={[
@@ -25,11 +25,23 @@ describe("SimulationMeasurementResults", () => {
             status: "available",
             value: 1.25,
           },
+          {
+            ...base,
+            id: "0:out:minimum",
+            metric: "minimum",
+            label: "Minimum",
+            status: "available",
+            value: 0.25,
+          },
         ]}
       />,
     );
     expect(markup).toContain("Measurements");
-    expect(markup).toContain("1 value");
+    expect(markup).toContain("2 values");
+    expect(markup.match(/simulation-measurement-output"/gu)).toHaveLength(1);
+    expect(markup.match(/<strong>Vout<\/strong>/gu)).toHaveLength(1);
+    expect(markup).toContain("Maximum");
+    expect(markup).toContain("Minimum");
     expect(markup).not.toContain("<details open");
   });
 
@@ -49,6 +61,7 @@ describe("SimulationMeasurementResults", () => {
       />,
     );
     expect(markup).toContain('open=""');
+    expect(markup).toContain('class="simulation-measurement-output" open=""');
     expect(markup).toContain("1 unavailable");
     expect(markup).toContain("At least two samples are required");
   });

--- a/apps/editor/src/features/simulation/simulation-measurement-results.tsx
+++ b/apps/editor/src/features/simulation/simulation-measurement-results.tsx
@@ -54,40 +54,81 @@ export function SimulationMeasurementResults({
         </span>
       </summary>
       <div>
-        {[...groups.entries()].map(([key, group]) => (
-          <section key={key}>
-            <header>
-              <strong>{group[0]!.analysis.toUpperCase()}</strong>
-              <span>{group[0]!.plotName}</span>
-            </header>
-            <table>
-              <thead>
-                <tr>
-                  <th>Output</th>
-                  <th>Measurement</th>
-                  <th>Value</th>
-                </tr>
-              </thead>
-              <tbody>
-                {group.map((measurement) => (
-                  <tr key={measurement.id} data-status={measurement.status}>
-                    <td>{measurement.outputLabel}</td>
-                    <td>{measurement.label}</td>
-                    <td>
-                      {measurement.status === "available" ? (
-                        formatMeasurement(measurement.value, measurement.unit)
-                      ) : (
-                        <span title={measurement.reason}>
-                          Unavailable · {measurement.reason}
+        {[...groups.entries()].map(([key, group]) => {
+          const outputs = new Map<string, Measurement[]>();
+          for (const measurement of group)
+            outputs.set(measurement.outputId, [
+              ...(outputs.get(measurement.outputId) ?? []),
+              measurement,
+            ]);
+          return (
+            <section key={key}>
+              <header>
+                <strong>{group[0]!.analysis.toUpperCase()}</strong>
+                <span>{group[0]!.plotName}</span>
+              </header>
+              <div className="simulation-measurement-output-groups">
+                {[...outputs.entries()].map(([outputId, output]) => {
+                  const outputUnavailable = output.filter(
+                    (measurement) => measurement.status === "unavailable",
+                  ).length;
+                  return (
+                    <details
+                      key={outputId}
+                      className="simulation-measurement-output"
+                      open={outputUnavailable > 0}
+                    >
+                      <summary>
+                        <strong>{output[0]!.outputLabel}</strong>
+                        <span
+                          data-status={
+                            outputUnavailable ? "attention" : "ready"
+                          }
+                        >
+                          {output.length}{" "}
+                          {output.length === 1 ? "value" : "values"}
+                          {outputUnavailable
+                            ? ` · ${outputUnavailable} unavailable`
+                            : ""}
                         </span>
-                      )}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </section>
-        ))}
+                      </summary>
+                      <table>
+                        <thead>
+                          <tr>
+                            <th>Measurement</th>
+                            <th>Value</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {output.map((measurement) => (
+                            <tr
+                              key={measurement.id}
+                              data-status={measurement.status}
+                            >
+                              <td>{measurement.label}</td>
+                              <td>
+                                {measurement.status === "available" ? (
+                                  formatMeasurement(
+                                    measurement.value,
+                                    measurement.unit,
+                                  )
+                                ) : (
+                                  <span title={measurement.reason}>
+                                    Unavailable · {measurement.reason}
+                                  </span>
+                                )}
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </details>
+                  );
+                })}
+              </div>
+            </section>
+          );
+        })}
       </div>
     </details>
   );

--- a/apps/editor/src/features/simulation/simulation-output-results.tsx
+++ b/apps/editor/src/features/simulation/simulation-output-results.tsx
@@ -7,6 +7,7 @@ import type { SimulationOutputData } from "@icm/simulation-service/contract";
 
 import {
   ComplexResultsExplorer,
+  complexAcPoint,
   unwrapPhaseDegrees,
 } from "./ac-results-explorer";
 import { ScalarResultsExplorer } from "./transient-results-explorer";
@@ -103,6 +104,7 @@ export function SimulationOutputResults({
                     id: output.id,
                     label: output.label,
                     colorIndex,
+                    unit: output.unit,
                     quantity:
                       output.unit === "V"
                         ? "voltage"
@@ -113,18 +115,11 @@ export function SimulationOutputResults({
                             : output.unit,
                     ...(probe ? { probe } : {}),
                     points: analysis.domain!.values.map((frequency, i) => ({
-                      frequency,
-                      magnitudeDb:
-                        20 *
-                        Math.log10(
-                          Math.max(
-                            Math.hypot(
-                              output.values[i] ?? Number.NaN,
-                              output.imaginary![i] ?? Number.NaN,
-                            ),
-                            1e-30,
-                          ),
-                        ),
+                      ...complexAcPoint(
+                        frequency,
+                        output.values[i] ?? Number.NaN,
+                        output.imaginary![i] ?? Number.NaN,
+                      ),
                       phaseDeg: phases[i] ?? Number.NaN,
                     })),
                   };

--- a/apps/editor/src/features/simulation/simulation-plot-export.ts
+++ b/apps/editor/src/features/simulation/simulation-plot-export.ts
@@ -57,6 +57,9 @@ export function standaloneSimulationPlotSvg(svg: SVGSVGElement): string {
     const source = sourceElements[index];
     const target = clonedElements[index];
     if (!source || !target) continue;
+    // Definitions and structural containers do not paint content themselves.
+    // Copying their inherited fill would turn the standalone image black.
+    if (source.closest("defs") || source.matches("svg, g")) continue;
     const computed = getComputedStyle(source);
     for (const property of PRESENTATION_PROPERTIES) {
       const value = computed.getPropertyValue(property);
@@ -66,6 +69,13 @@ export function standaloneSimulationPlotSvg(svg: SVGSVGElement): string {
   clone
     .querySelectorAll(".ac-trace-hit, .ac-cursor-hit")
     .forEach((element) => element.remove());
+  clone.querySelectorAll<SVGElement>(".ac-frame").forEach((element) => {
+    // The live frame is transparent. Give the standalone artifact an explicit
+    // background because SVG-to-Canvas otherwise resolves `fill: none` to the
+    // inherited default in Chromium and produces a black plot panel.
+    element.setAttribute("fill", "white");
+    element.style.setProperty("fill", "white");
+  });
   const size = dimensions(svg);
   clone.setAttribute("xmlns", "http://www.w3.org/2000/svg");
   clone.setAttribute("width", String(size.width));

--- a/apps/editor/src/features/simulation/waveform-interaction.test.ts
+++ b/apps/editor/src/features/simulation/waveform-interaction.test.ts
@@ -30,21 +30,37 @@ describe("waveform axes", () => {
       [
         {
           label: "out",
+          unit: "V",
           points: [
-            { frequency: 100, magnitudeDb: 1, phaseDeg: 0 },
-            { frequency: 1000, magnitudeDb: 5, phaseDeg: 10 },
+            {
+              frequency: 100,
+              real: 1,
+              imaginary: 0,
+              magnitude: 1,
+              magnitudeDb: 0,
+              phaseDeg: 0,
+            },
+            {
+              frequency: 1000,
+              real: 5,
+              imaginary: 0,
+              magnitude: 5,
+              magnitudeDb: 20 * Math.log10(5),
+              phaseDeg: 0,
+            },
           ],
         },
       ],
       { width: 500, height: 280 },
+      "magnitude",
       [240, 280],
-      { kind: "magnitude", range: [2, 3] },
+      [2, 3],
     )!;
     expect(result.frequency.ticks.length).toBeGreaterThan(2);
     expect(
       result.frequency.ticks.every((tick) => tick >= 240 && tick <= 280),
     ).toBe(true);
-    expect(result.magnitude.min).toBe(2);
-    expect(result.magnitude.max).toBe(3);
+    expect(result.value.min).toBe(2);
+    expect(result.value.max).toBe(3);
   });
 });

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -807,6 +807,49 @@
   color: var(--icm-text-muted);
   font-size: var(--icm-font-xs);
 }
+.simulation-measurement-output-groups {
+  display: grid;
+  gap: 5px;
+}
+.simulation-measurement-output {
+  overflow: hidden;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+}
+.simulation-measurement-output > summary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 34px;
+  padding: 5px 8px;
+  background: var(--icm-surface-muted);
+  cursor: pointer;
+  list-style: none;
+}
+.simulation-measurement-output > summary::-webkit-details-marker {
+  display: none;
+}
+.simulation-measurement-output > summary::before {
+  width: 12px;
+  color: var(--icm-text-muted);
+  content: "›";
+  font-size: 16px;
+  line-height: 1;
+  transform-origin: center;
+  transition: transform 120ms ease;
+}
+.simulation-measurement-output[open] > summary::before {
+  transform: rotate(90deg);
+}
+.simulation-measurement-output > summary > span {
+  margin-left: auto;
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+}
+.simulation-measurement-output > summary > span[data-status="attention"] {
+  color: var(--icm-danger);
+  font-weight: 650;
+}
 .simulation-measurement-results table {
   width: 100%;
   border-collapse: collapse;

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -1220,6 +1220,53 @@
 .ac-results-explorer > header button {
   margin-left: auto;
 }
+.ac-view-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  margin-bottom: 5px;
+}
+.ac-view-toolbar > strong {
+  min-width: 72px;
+}
+.ac-view-toolbar > [role="group"] {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid var(--icm-border);
+  border-radius: 7px;
+  background: var(--icm-surface-muted);
+}
+.ac-view-toolbar button {
+  min-height: 26px;
+  padding: 3px 8px;
+  border: 0;
+  background: transparent;
+}
+.ac-view-toolbar button[aria-pressed="true"] {
+  background: var(--icm-surface);
+  color: var(--icm-accent);
+  box-shadow: 0 1px 2px rgb(16 24 40 / 12%);
+}
+.ac-view-toolbar > label {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  margin-left: auto;
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+}
+.ac-view-toolbar select {
+  min-height: 28px;
+  max-width: 180px;
+}
+.ac-plot-row > strong small {
+  color: var(--icm-text-muted);
+  font-weight: 500;
+}
 .simulation-plot-layout {
   display: grid;
   grid-template-columns: minmax(74px, 108px) minmax(0, 1fr);


### PR DESCRIPTION
## Summary
- make AC Magnitude, dB, Phase, Real, Imag, and Bode projections explicit, with unity-reference defaults
- preserve reference-trace complex division for normalized dB/Bode views
- fix black Phase PNG exports by giving standalone waveform frames an explicit white fill
- group Max, Min, Span, and other measurements under collapsible output/probe headings

## Validation
- pnpm install --frozen-lockfile
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
- 2785 unit tests passed, 22 skipped
- 6 affected browser tests passed

Test-Impact: tests-updated