### PR TITLE
Simulation: add managed Preview operations plane

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -50,6 +50,31 @@ jobs:
           VITE_ICM_AGENT_UI: enabled
       - run: pnpm --filter @icm/mcp-server... build
       - run: pnpm exec playwright install --with-deps chromium
+      - name: Reconcile managed simulation resources
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          wrangler="pnpm dlx wrangler@4.120.1"
+          ensure_queue() {
+            name="$1"
+            retention="$2"
+            if ! $wrangler queues info "$name" >/dev/null 2>&1; then
+              $wrangler queues create "$name" --message-retention-period-secs "$retention"
+            else
+              $wrangler queues update "$name" --message-retention-period-secs "$retention"
+            fi
+          }
+          ensure_queue analog-canvas-simulation-preview 900
+          ensure_queue analog-canvas-simulation-preview-dlq 604800
+          bucket=analog-canvas-simulation-artifacts-preview
+          if ! $wrangler r2 bucket info "$bucket" >/dev/null 2>&1; then
+            $wrangler r2 bucket create "$bucket"
+          fi
+          if ! $wrangler r2 bucket lifecycle list "$bucket" | grep -Fq simulation-artifact-retention; then
+            $wrangler r2 bucket lifecycle add "$bucket" simulation-artifact-retention --expire-days 1 --force
+          fi
       - name: Deploy to preview
         run: pnpm dlx wrangler@4.120.1 deploy --config wrangler.preview.jsonc
         env:

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -736,8 +736,14 @@ export function App({
         files: browserAgentFileHost.simulationFiles,
         getProjectSessionId: () => editorDocumentController.projectSessionId,
         getProject: () => editorDocumentController.project,
+        transport: releaseChannel === "preview" ? "managed" : "direct",
       }),
-    [editorDocumentController, projectSessionId],
+    [
+      browserAgentFileHost.simulationFiles,
+      editorDocumentController,
+      projectSessionId,
+      releaseChannel,
+    ],
   );
   const [analogSimulationState, setAnalogSimulationState] = useState<
     "closed" | "open" | "maximized" | "minimized"
@@ -752,8 +758,9 @@ export function App({
       new BrowserSimulationSession({
         getProjectSessionId: () => editorDocumentController.projectSessionId,
         getProject: () => editorDocumentController.project,
+        transport: releaseChannel === "preview" ? "managed" : "direct",
       }),
-    [editorDocumentController, projectSessionId],
+    [editorDocumentController, projectSessionId, releaseChannel],
   );
   useEffect(
     () => () => {

--- a/apps/editor/src/features/simulation/browser-simulation-session.ts
+++ b/apps/editor/src/features/simulation/browser-simulation-session.ts
@@ -11,6 +11,8 @@ export interface BrowserSimulationSessionOptions {
   getProject(): CircuitProject;
   files?: SimulationFiles;
   fetch?: typeof fetch;
+  /** Explicit deployment composition; never inferred after a start fails. */
+  transport?: "direct" | "managed";
 }
 
 /** Shared browser composition, not a second run registry. Each owner has an
@@ -52,12 +54,23 @@ export class BrowserSimulationSession {
     try {
       this.service ??= import("@icm/simulation-service")
         .then(
-          ({ SimulationService, createHostedExecutor }) =>
+          ({
+            SimulationService,
+            createHostedExecutor,
+            createManagedHostedExecutor,
+          }) =>
             new SimulationService(
               this.files,
-              createHostedExecutor(
-                this.options.fetch ?? ((...args) => globalThis.fetch(...args)),
-              ),
+              this.options.transport === "managed"
+                ? createManagedHostedExecutor({
+                    fetch:
+                      this.options.fetch ??
+                      ((...args) => globalThis.fetch(...args)),
+                  })
+                : createHostedExecutor(
+                    this.options.fetch ??
+                      ((...args) => globalThis.fetch(...args)),
+                  ),
               this.options.getProject,
             ),
         )

--- a/containers/ngspice/Dockerfile
+++ b/containers/ngspice/Dockerfile
@@ -69,7 +69,7 @@ WORKDIR ${RUN_ROOT}
 # The build context is the repository root (wrangler.preview.jsonc sets
 # image_build_context to "."), so every COPY is repo-root relative.
 ARG HARNESS_DIR=containers/ngspice
-COPY ${HARNESS_DIR}/entrypoint.mjs ${HARNESS_DIR}/run-supervisor.mjs /opt/harness/
+COPY ${HARNESS_DIR}/entrypoint.mjs ${HARNESS_DIR}/gateway.mjs ${HARNESS_DIR}/run-supervisor.mjs /opt/harness/
 COPY ${HARNESS_DIR}/hosted-sky130-profile.json /opt/harness/hosted-sky130-profile.json
 COPY ${HARNESS_DIR}/hosted.spiceinit /opt/harness/hosted.spiceinit
 

--- a/containers/ngspice/gateway.mjs
+++ b/containers/ngspice/gateway.mjs
@@ -1,0 +1,117 @@
+import { timingSafeEqual } from "node:crypto";
+import { createServer } from "node:http";
+
+const PORT = Number(process.env.PORT ?? 8080);
+const EXECUTOR_URL = new URL(
+  process.env.SIMULATION_EXECUTOR_URL ?? "http://executor:8080",
+);
+const ACCESS_TOKEN = (process.env.SIMULATION_ACCESS_TOKEN ?? "").trim();
+const MAX_REQUEST_BYTES = positiveEnv(
+  "SIMULATION_GATEWAY_MAX_REQUEST_BYTES",
+  4 * 1024 * 1024,
+);
+const MAX_RESPONSE_BYTES = positiveEnv(
+  "SIMULATION_GATEWAY_MAX_RESPONSE_BYTES",
+  4 * 1024 * 1024,
+);
+
+if (!ACCESS_TOKEN) throw new Error("SIMULATION_ACCESS_TOKEN is required");
+
+function positiveEnv(name, fallback) {
+  const value = Number(process.env[name]);
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+function authorized(request) {
+  const match = /^Bearer\s+(\S+)$/u.exec(request.headers.authorization ?? "");
+  if (!match) return false;
+  const presented = Buffer.from(match[1], "utf8");
+  const expected = Buffer.from(ACCESS_TOKEN, "utf8");
+  return (
+    presented.length === expected.length && timingSafeEqual(presented, expected)
+  );
+}
+
+function send(response, status, body, headers = {}) {
+  response.writeHead(status, {
+    "content-type": "application/json",
+    "content-length": body.byteLength,
+    "cache-control": "no-store",
+    ...headers,
+  });
+  response.end(body);
+}
+
+function readBounded(request) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    let bytes = 0;
+    request.on("data", (chunk) => {
+      bytes += chunk.length;
+      if (bytes > MAX_REQUEST_BYTES) {
+        reject(Object.assign(new Error("request-too-large"), { status: 413 }));
+        request.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    request.on("end", () => resolve(Buffer.concat(chunks)));
+    request.on("error", reject);
+  });
+}
+
+const server = createServer(async (request, response) => {
+  const path = request.url ?? "/";
+  const isHealth = request.method === "GET" && path === "/health";
+  const isOperation =
+    request.method === "POST" && (path === "/run" || path === "/cancel");
+  if (!isHealth && !isOperation) {
+    send(response, 404, Buffer.from('{"error":"not-found"}'));
+    return;
+  }
+  if (isOperation && !authorized(request)) {
+    send(response, 401, Buffer.from('{"error":"unauthorized"}'), {
+      "www-authenticate": "Bearer",
+    });
+    request.resume();
+    return;
+  }
+  try {
+    const body = isOperation ? await readBounded(request) : undefined;
+    const upstream = new URL(path, EXECUTOR_URL);
+    const result = await fetch(upstream, {
+      method: request.method,
+      ...(body
+        ? {
+            body,
+            headers: { "content-type": "application/json" },
+          }
+        : {}),
+      signal: AbortSignal.timeout(140_000),
+    });
+    const bytes = Buffer.from(await result.arrayBuffer());
+    if (bytes.byteLength > MAX_RESPONSE_BYTES) {
+      send(
+        response,
+        502,
+        Buffer.from('{"error":"executor-response-too-large"}'),
+      );
+      return;
+    }
+    send(response, result.status, bytes, {
+      ...(result.headers.get("retry-after")
+        ? { "retry-after": result.headers.get("retry-after") }
+        : {}),
+    });
+  } catch (error) {
+    const status = error?.status === 413 ? 413 : 502;
+    const code = status === 413 ? "request-too-large" : "executor-unreachable";
+    send(response, status, Buffer.from(JSON.stringify({ error: code })));
+  }
+});
+
+server.listen(PORT, () => {
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : PORT;
+  console.log(`simulation gateway listening on ${port}`);
+});

--- a/containers/ngspice/gateway.test.mjs
+++ b/containers/ngspice/gateway.test.mjs
@@ -1,0 +1,94 @@
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import { once } from "node:events";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const children = [];
+const servers = [];
+
+afterEach(async () => {
+  for (const child of children.splice(0)) {
+    child.kill("SIGTERM");
+    await once(child, "exit").catch(() => {});
+  }
+  for (const server of servers.splice(0)) {
+    server.close();
+    await once(server, "close").catch(() => {});
+  }
+});
+
+async function listen(server) {
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  servers.push(server);
+  return server.address().port;
+}
+
+async function startGateway(executorPort) {
+  const child = spawn(process.execPath, ["containers/ngspice/gateway.mjs"], {
+    env: {
+      PATH: process.env.PATH,
+      PORT: "0",
+      SIMULATION_ACCESS_TOKEN: "gateway-secret",
+      SIMULATION_EXECUTOR_URL: `http://127.0.0.1:${executorPort}`,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  children.push(child);
+  let output = "";
+  for await (const chunk of child.stdout) {
+    output += chunk.toString();
+    const match = /simulation gateway listening on (\d+)/u.exec(output);
+    if (match) return Number(match[1]);
+  }
+  throw new Error(`gateway exited before listening: ${output}`);
+}
+
+describe("operator-host simulation gateway", () => {
+  it("authenticates outside the executor and never forwards the credential", async () => {
+    const seen = [];
+    const executor = createServer((request, response) => {
+      seen.push({
+        url: request.url,
+        authorization: request.headers.authorization,
+      });
+      const body = JSON.stringify(
+        request.url === "/health" ? { status: "ready" } : { accepted: true },
+      );
+      response.writeHead(200, {
+        "content-type": "application/json",
+        "content-length": Buffer.byteLength(body),
+      });
+      response.end(body);
+    });
+    const gatewayPort = await startGateway(await listen(executor));
+    const base = `http://127.0.0.1:${gatewayPort}`;
+
+    expect((await fetch(`${base}/health`)).status).toBe(200);
+    expect(
+      (
+        await fetch(`${base}/run`, {
+          method: "POST",
+          body: JSON.stringify({ deck: "x" }),
+        })
+      ).status,
+    ).toBe(401);
+    expect(
+      (
+        await fetch(`${base}/run`, {
+          method: "POST",
+          headers: {
+            authorization: "Bearer gateway-secret",
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({ deck: "x" }),
+        })
+      ).status,
+    ).toBe(200);
+    expect(seen).toEqual([
+      { url: "/health", authorization: undefined },
+      { url: "/run", authorization: undefined },
+    ]);
+  });
+});

--- a/containers/ngspice/host/README.md
+++ b/containers/ngspice/host/README.md
@@ -6,12 +6,15 @@ result data is stored here. A replacement host needs Docker, `curl`,
 `sha256sum`, this repository, and the deployment secrets; the tracked
 bootstrap installs the pinned Compose plugin.
 
-`compose.yaml` is the sole desired-state definition. It gives the harness a
-private run-root volume and an internal network with no egress. `cloudflared`
-joins that network and a separate egress network, so it is the only path to the
-harness. Neither service publishes a host port. `deploy.sh` and `health.sh` are
-thin operators over that definition; `../verify-host-runtime.sh` independently
-checks the security and resource boundary after deployment.
+`compose.yaml` is the sole desired-state definition. It separates the trusted
+bearer-token gateway from the untrusted ngspice executor, gives the executor a
+private run-root volume, and places both on an internal network with no egress.
+`cloudflared` joins that network and a separate egress network, so it is the
+only public path to the gateway. The token never enters the executor container,
+where authored `.control` code runs. No service publishes a host port.
+`deploy.sh` and `health.sh` are thin operators over that definition;
+`../verify-host-runtime.sh` independently checks the security and resource
+boundary after deployment.
 
 ## Repository-owned deployment
 

--- a/containers/ngspice/host/compose.yaml
+++ b/containers/ngspice/host/compose.yaml
@@ -1,14 +1,12 @@
 name: analog-canvas-sim
 
 services:
-  simulator:
+  executor:
     image: analog-canvas-ngspice:${SIMULATION_IMAGE_TAG:-local}
     build:
       context: ../../..
       dockerfile: containers/ngspice/Dockerfile
-    container_name: analog-canvas-ngspice
-    environment:
-      SIMULATION_ACCESS_TOKEN: ${SIMULATION_ACCESS_TOKEN:?set SIMULATION_ACCESS_TOKEN in the host runtime env}
+    container_name: analog-canvas-ngspice-executor
     restart: unless-stopped
     read_only: true
     cap_drop:
@@ -31,6 +29,33 @@ services:
         target: /tmp
         tmpfs:
           size: 1073741824
+    networks:
+      - simulation
+
+  # The public tunnel reaches this small trusted process. The bearer token is
+  # deliberately absent from `executor`: an authored .control program runs
+  # there under the same uid as the harness and must not be able to recover
+  # the credential from /proc or inherited process state.
+  simulator:
+    image: analog-canvas-ngspice:${SIMULATION_IMAGE_TAG:-local}
+    container_name: analog-canvas-ngspice
+    command:
+      - node
+      - /opt/harness/gateway.mjs
+    environment:
+      SIMULATION_ACCESS_TOKEN: ${SIMULATION_ACCESS_TOKEN:?set SIMULATION_ACCESS_TOKEN in the host runtime env}
+      SIMULATION_EXECUTOR_URL: http://executor:8080
+    depends_on:
+      - executor
+    restart: unless-stopped
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 64
+    cpus: 0.5
+    mem_limit: 256m
     networks:
       - simulation
 

--- a/containers/ngspice/host/deploy.sh
+++ b/containers/ngspice/host/deploy.sh
@@ -70,8 +70,9 @@ replace_legacy_container() {
   fi
 }
 
-compose build --pull simulator
+compose build --pull executor
 replace_legacy_container analog-canvas-ngspice
+replace_legacy_container analog-canvas-ngspice-executor
 if [ "$tunnel_enabled" = true ]; then
   replace_legacy_container analog-canvas-tunnel
   compose up -d --remove-orphans

--- a/containers/ngspice/host/health.sh
+++ b/containers/ngspice/host/health.sh
@@ -30,4 +30,5 @@ done
 
 printf 'simulator host health failed after %s attempts\n' "$attempts" >&2
 docker logs --tail 100 "$container" >&2 || true
+docker logs --tail 100 "${SIMULATION_EXECUTOR_CONTAINER_NAME:-analog-canvas-ngspice-executor}" >&2 || true
 exit 1

--- a/containers/ngspice/verify-host-runtime.sh
+++ b/containers/ngspice/verify-host-runtime.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 set -eu
 
-container="${SIMULATION_CONTAINER_NAME:-analog-canvas-ngspice}"
+gateway="${SIMULATION_GATEWAY_CONTAINER_NAME:-analog-canvas-ngspice}"
+executor="${SIMULATION_EXECUTOR_CONTAINER_NAME:-analog-canvas-ngspice-executor}"
 
 fail() {
   printf 'simulator host runtime invalid: %s\n' "$1" >&2
@@ -9,50 +10,58 @@ fail() {
 }
 
 value() {
-  docker inspect --format "$1" "$container"
+  container="$1"
+  format="$2"
+  docker inspect --format "$format" "$container"
 }
 
-restart="$(value '{{.HostConfig.RestartPolicy.Name}}')"
-case "$restart" in
-  always|unless-stopped) ;;
-  *) fail "restart policy is '$restart', expected always or unless-stopped" ;;
-esac
+for container in "$gateway" "$executor"; do
+  restart="$(value "$container" '{{.HostConfig.RestartPolicy.Name}}')"
+  case "$restart" in
+    always|unless-stopped) ;;
+    *) fail "$container restart policy is '$restart'" ;;
+  esac
+  [ "$(value "$container" '{{.HostConfig.ReadonlyRootfs}}')" = "true" ] \
+    || fail "$container root filesystem is writable"
+  case "$(value "$container" '{{json .HostConfig.CapDrop}}')" in
+    *ALL*) ;;
+    *) fail "$container does not drop all Linux capabilities" ;;
+  esac
+  pids="$(value "$container" '{{.HostConfig.PidsLimit}}')"
+  [ "$pids" -gt 0 ] 2>/dev/null || fail "$container has no positive PID limit"
+  published="$(value "$container" '{{json .HostConfig.PortBindings}}')"
+  case "$published" in
+    null|'{}') ;;
+    *) fail "$container publishes host ports: $published" ;;
+  esac
+done
 
-[ "$(value '{{.HostConfig.ReadonlyRootfs}}')" = "true" ] \
-  || fail "root filesystem is writable"
-
-cap_drop="$(value '{{json .HostConfig.CapDrop}}')"
-case "$cap_drop" in
-  *ALL*) ;;
-  *) fail "the container does not drop all Linux capabilities" ;;
-esac
-
-pids="$(value '{{.HostConfig.PidsLimit}}')"
-[ "$pids" -gt 0 ] 2>/dev/null || fail "there is no positive PID limit"
-
-nanocpus="$(value '{{.HostConfig.NanoCpus}}')"
+nanocpus="$(value "$executor" '{{.HostConfig.NanoCpus}}')"
 [ "$nanocpus" -eq 8000000000 ] 2>/dev/null \
-  || fail "CPU limit is $nanocpus nanocpus, expected 8000000000"
+  || fail "executor CPU limit is $nanocpus nanocpus, expected 8000000000"
 
-memory="$(value '{{.HostConfig.Memory}}')"
+memory="$(value "$executor" '{{.HostConfig.Memory}}')"
 [ "$memory" -eq 17179869184 ] 2>/dev/null \
-  || fail "memory limit is $memory bytes, expected 17179869184"
+  || fail "executor memory limit is $memory bytes, expected 17179869184"
 
-published="$(value '{{json .HostConfig.PortBindings}}')"
-case "$published" in
-  null|'{}') ;;
-  *) fail "the simulator publishes host ports: $published" ;;
-esac
-
-run_root_rw="$(value '{{range .Mounts}}{{if eq .Destination "/var/lib/simulation"}}{{.RW}}{{end}}{{end}}')"
+run_root_rw="$(value "$executor" '{{range .Mounts}}{{if eq .Destination "/var/lib/simulation"}}{{.RW}}{{end}}{{end}}')"
 [ "$run_root_rw" = "true" ] \
   || fail "the private run-root volume is absent or read-only"
 
 # ngspice's tmpfile() always goes to /tmp; on a read-only root that must be a
 # private tmpfs or every run dies with "tmpfile(): Read-only file system".
-tmp_type="$(value '{{range .Mounts}}{{if eq .Destination "/tmp"}}{{.Type}}{{end}}{{end}}')"
+tmp_type="$(value "$executor" '{{range .Mounts}}{{if eq .Destination "/tmp"}}{{.Type}}{{end}}{{end}}')"
 [ "$tmp_type" = "tmpfs" ] \
   || fail "/tmp is not a private tmpfs, so the simulator cannot open its scratch files"
 
-printf 'simulator host runtime verified: restart=%s pids=%s cpus=8 memory=16GiB\n' \
-  "$restart" "$pids"
+executor_env="$(value "$executor" '{{json .Config.Env}}')"
+gateway_env="$(value "$gateway" '{{json .Config.Env}}')"
+case "$executor_env" in
+  *SIMULATION_ACCESS_TOKEN=*) fail "executor received the gateway token" ;;
+esac
+case "$gateway_env" in
+  *SIMULATION_ACCESS_TOKEN=*) ;;
+  *) fail "gateway has no access token" ;;
+esac
+
+printf 'simulator host runtime verified: isolated gateway; executor cpus=8 memory=16GiB\n'

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -119,12 +119,14 @@ configuration change, like any other.
 ### Where the simulator runs
 
 The Worker never runs ngspice itself; it hands the deck to a harness over
-HTTP (`worker/simulation.ts`). The harness is the image
+HTTP (`worker/simulation.ts`). On the operator host a small gateway authenticates
+the request and forwards it over an internal network to the harness image
 `containers/ngspice/Dockerfile`, pinned to the benchmark base image by
 digest, and it runs on **an operator-run host**, named by the var
 `SIMULATION_UPSTREAM_URL`: Docker behind a Cloudflare Tunnel, so the host
 opens no inbound port and its only public name is the tunnel's. It answers
-`/run` only to the bearer token in its `SIMULATION_ACCESS_TOKEN`; the Worker
+`/run` only to the bearer token in its `SIMULATION_ACCESS_TOKEN`; that token is
+held by the gateway and never enters the executor. The Worker
 presents the same value from its secret `SIMULATION_UPSTREAM_TOKEN`, which
 `deploy-preview.yml` sets from the repository secret of the same name on
 every deploy.
@@ -144,11 +146,13 @@ performed the run.
 The current operator host is the Frankfurt machine, under its `analogcanvas`
 account, in `~/analog-canvas-sim/`. Its desired state is not private machine
 configuration: [`containers/ngspice/host/compose.yaml`](../containers/ngspice/host/compose.yaml)
-is the sole definition of the harness container, tunnel container, internal
-network, egress boundary, private run-root volume, restart policy, and resource
-limits. The harness has a read-only root, no capabilities, bounded PIDs, 8 CPUs
-and 16 GiB, no published host port, and no egress. `cloudflared` alone joins
-both the internal network and an egress network.
+is the sole definition of the trusted authentication gateway, untrusted
+executor, tunnel container, internal network, egress boundary, private
+run-root volume, restart policy, and resource limits. Only the gateway receives
+the bearer token. The executor that runs authored `.control` code has a
+read-only root, no capabilities, bounded PIDs, 8 CPUs and 16 GiB, no published
+host port, no credential, and no egress. `cloudflared` alone joins both the
+internal network and an egress network.
 
 The `Simulator host` workflow (`.github/workflows/simulator-host.yml`) copies
 the exact tracked `containers/ngspice/` tree into a commit-addressed release on

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -179,13 +179,16 @@ concurrency count.
 container image, and the fingerprint identifies it, not the machine
 underneath. `execution.target` is the separate transport identity.
 
-The preview's `/api/simulate` is open on purpose — no login, no rate limit,
-no daily budget — by the owner's decision of 2026-09-04, after the cost
-question went away with the Cloudflare Container: the host is the owner's
-own machine, and the harness's isolation (an unprivileged account, a
-read-only root, no network route, one slot, a deadline that kills the
-process tree) is the whole boundary. Do not add an admission gate to the
-preview's simulation without the owner asking for one.
+The editor and browser Agent use `/api/simulation/runs` on Preview. A durable
+control object owns idempotency, per-owner/global admission, leases,
+cancellation, five-minute queue wait, and 24-hour run metadata; Cloudflare
+Queue dispatches one job at a time to the operator host and R2 retains bounded
+immutable inputs/results for one day. A signed-in account is the preferred
+owner. Preview can issue an opaque HttpOnly anonymous simulation capability so
+the feature does not depend on an OAuth provider; global admission remains the
+hard capacity boundary. `/api/simulate` remains the internal/direct execution
+contract and the explicit production/local transport until managed resources
+are promoted there. A failed managed start never falls back to it.
 
 ### The retired staging environment
 

--- a/docs/specs/simulation.md
+++ b/docs/specs/simulation.md
@@ -168,8 +168,11 @@ The implementation has these boundaries:
 - Model owns saved setups and canonical voltage/current expressions.
 - Netlist compiles structured intent. The service's preparation module resolves
   raw/structured inputs, capabilities and immutable deck identity.
-- SimulationService owns run lifecycle, idempotency and retention. Executor is
-  its execution port; GUI and MCP use the same service and File Resource.
+- SimulationService owns preparation and the session-facing run presentation.
+  Its Executor is the execution port; GUI and MCP use the same service and File
+  Resource. On Preview, the managed control plane owns authoritative hosted run
+  admission, idempotency, queueing, retry, cancellation and retention. Local
+  and production direct transports keep the same semantic service contract.
 - spice-run separates request/result types, deck assembly, metadata and terminal
   verdicts. Its public exports remain the same.
 - GUI setup editing, diagnostic display and result materialization are separate
@@ -998,11 +1001,16 @@ generated it, so an Agent can retry the identical start rather than duplicate it
 File Resource `list` recovers session draft IDs after a lost create response;
 it returns revision/entry/expiry metadata, not file bodies.
 
-The browser owns receipts, not a persistent queue: tab loss/reload may lose run
-state, and normal executor deadlines still apply. Revoking the session cancels
-known active work and clears its drafts/evidence. One active run, eight raw
-workspaces (24 files / 1 MiB each), and 15-minute artifact/input retention bound
-local resources; expired input can be prepared again. Export returns File
+The browser owns its presentation receipts, not execution authority. On the
+managed Preview transport, tab loss does not stop an admitted run: the owner can
+list its server records, and bounded immutable input/result evidence remains in
+the artifact store for one day. The queue admits at most 50 waiting runs, one
+queued and one active per owner, waits at most five minutes, and dispatches only
+the operator host's one declared slot. On direct/local transport, the earlier
+session deadline and 15-minute File Resource retention remain unchanged.
+Revoking a live browser session requests cancellation of active work and clears
+its local drafts/evidence. One active session run, eight raw workspaces (24 files
+/ 1 MiB each) bound local resources; expired input can be prepared again. Export returns File
 Resource references for prepared/executed deck, rawfile when produced, log,
 structured result, and CSV. Large read responses omit full arrays and bound the
 log/diagnostic preview, explicitly setting `resultPreview`. Full evidence remains

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@icm/netlist": "workspace:*",
     "@icm/project-protocol": "workspace:*",
     "@icm/render-svg": "workspace:*",
+    "@icm/simulation-service": "workspace:*",
     "@icm/spice-run": "workspace:*",
     "@icm/symbols": "workspace:*"
   },

--- a/packages/simulation-service/src/executor.ts
+++ b/packages/simulation-service/src/executor.ts
@@ -14,12 +14,17 @@ export interface ExecutionInput {
   entryPath?: string;
   preparedDeck?: string;
 }
+export interface ExecutionIdentity {
+  preparedId: string;
+  preparedDigest: string;
+}
 export interface Executor {
   capabilities(): Promise<Capabilities>;
   execute(
     input: ExecutionInput,
     runToken: string,
     timeoutMs?: number,
+    identity?: ExecutionIdentity,
   ): Promise<{
     result: SimulationResult;
     rawfile?: string;

--- a/packages/simulation-service/src/hosted-executor.ts
+++ b/packages/simulation-service/src/hosted-executor.ts
@@ -6,6 +6,44 @@ import {
   type ExecutionInput,
 } from "./executor.js";
 
+export type HostedExecutionPayload = Record<string, unknown> | null;
+
+export function decodeHostedExecutionPayload(
+  input: ExecutionInput,
+  body: HostedExecutionPayload,
+) {
+  const { rawfile, executedDeck, cancelled, ...value } = body ?? {};
+  const parsed = SimulationResultSchema.safeParse(value);
+  if (!parsed.success)
+    throw new ExecutionFailure(
+      {
+        code: "SIMULATION_RESULT_INVALID",
+        message:
+          "The executor returned an invalid result; this run was not retried.",
+        stage: "read",
+        recovery: "not-retryable",
+      },
+      true,
+    );
+  if (
+    parsed.data.metadata.input.inputRevision !== input.inputRevision ||
+    parsed.data.metadata.environment.profileId !== input.environment.profileId
+  )
+    throw new ExecutionFailure({
+      code: "SIMULATION_IDENTITY_MISMATCH",
+      message:
+        "Result input/environment identity differs from the prepared input",
+      stage: "read",
+      recovery: "not-retryable",
+    });
+  return {
+    result: parsed.data,
+    cancelled: cancelled === true,
+    ...(typeof rawfile === "string" ? { rawfile } : {}),
+    ...(typeof executedDeck === "string" ? { executedDeck } : {}),
+  };
+}
+
 export function createHostedExecutor(
   fetchImpl: typeof fetch = fetch,
 ): Executor {
@@ -117,37 +155,7 @@ export function createHostedExecutor(
         },
         "start",
       );
-      const { rawfile, executedDeck, cancelled, ...value } = body ?? {};
-      const parsed = SimulationResultSchema.safeParse(value);
-      if (!parsed.success)
-        throw new ExecutionFailure(
-          {
-            code: "SIMULATION_RESULT_INVALID",
-            message:
-              "The executor returned an invalid result; this run was not retried.",
-            stage: "read",
-            recovery: "not-retryable",
-          },
-          true,
-        );
-      if (
-        parsed.data.metadata.input.inputRevision !== input.inputRevision ||
-        parsed.data.metadata.environment.profileId !==
-          input.environment.profileId
-      )
-        throw new ExecutionFailure({
-          code: "SIMULATION_IDENTITY_MISMATCH",
-          message:
-            "Result input/environment identity differs from the prepared input",
-          stage: "read",
-          recovery: "not-retryable",
-        });
-      return {
-        result: parsed.data,
-        cancelled: cancelled === true,
-        ...(typeof rawfile === "string" ? { rawfile } : {}),
-        ...(typeof executedDeck === "string" ? { executedDeck } : {}),
-      };
+      return decodeHostedExecutionPayload(input, body);
     },
     async cancel(runToken: string) {
       await post({ operation: "cancel", runToken }, "cancel");

--- a/packages/simulation-service/src/index.ts
+++ b/packages/simulation-service/src/index.ts
@@ -5,5 +5,7 @@ export * from "./hosted-executor.js";
 export * from "./result-volume.js";
 export * from "./output-evaluation.js";
 export * from "./automatic-measurements.js";
+export * from "./managed-run.js";
+export * from "./managed-run-registry.js";
 
 export * from "./executor.js";

--- a/packages/simulation-service/src/index.ts
+++ b/packages/simulation-service/src/index.ts
@@ -2,6 +2,7 @@ export * from "./contract.js";
 export * from "./files.js";
 export * from "./service.js";
 export * from "./hosted-executor.js";
+export * from "./managed-hosted-executor.js";
 export * from "./result-volume.js";
 export * from "./output-evaluation.js";
 export * from "./automatic-measurements.js";

--- a/packages/simulation-service/src/managed-hosted-executor.test.ts
+++ b/packages/simulation-service/src/managed-hosted-executor.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ExecutionInput } from "./executor.js";
+import { createManagedHostedExecutor } from "./managed-hosted-executor.js";
+
+const input: ExecutionInput = {
+  mode: "raw",
+  netlist: "",
+  testbench: "* test\n.end",
+  files: [],
+  dependencies: [],
+  inputRevision: "revision-a",
+  environment: { profileId: "profile-a" },
+};
+
+const baseRun = {
+  schemaVersion: 1 as const,
+  id: "server-run-a",
+  ownerId: "owner-a",
+  requestId: "request-a",
+  requestFingerprint: "a".repeat(64),
+  preparedId: "prepared-a",
+  preparedDigest: "b".repeat(64),
+  inputRevision: "revision-a",
+  environment: { profileId: "profile-a" },
+  timeoutMs: 60_000,
+  attempt: 1,
+  maxAttempts: 3,
+  createdAt: 1,
+  updatedAt: 2,
+  queuedAt: 1,
+  startedAt: 2,
+  artifacts: [],
+};
+
+const result = {
+  outcome: { status: "completed" },
+  diagnostics: [],
+  log: "done",
+  durationMs: 5,
+  metadata: {
+    schemaVersion: 1,
+    input: {
+      inputRevision: "revision-a",
+      netlistSha256: "c".repeat(64),
+      testbenchSha256: "d".repeat(64),
+      deckSha256: "e".repeat(64),
+    },
+    configuration: { modelLibrary: null },
+    environment: {
+      executor: "hosted-container",
+      reproducibility: "pinned",
+      profileId: "profile-a",
+      platform: "linux/x64",
+      simulator: {
+        name: "ngspice",
+        version: "47",
+        binarySha256: "f".repeat(64),
+      },
+      models: null,
+      startupSha256: null,
+      fingerprint: "fixture",
+    },
+  },
+};
+
+describe("managed hosted executor", () => {
+  it("submits immutable identity, polls the server run, and reads its result", async () => {
+    let reads = 0;
+    const fetch = vi.fn<typeof globalThis.fetch>(async (request, init) => {
+      const path =
+        typeof request === "string"
+          ? request
+          : request instanceof URL
+            ? request.toString()
+            : request.url;
+      if (path === "/api/simulation/runs") {
+        expect(JSON.parse(String(init?.body))).toMatchObject({
+          requestId: "request-a",
+          preparedId: "prepared-a",
+          preparedDigest: "b".repeat(64),
+          input: { inputRevision: "revision-a", timeoutMs: 10_000 },
+        });
+        return Response.json({ run: { ...baseRun, state: "queued" } });
+      }
+      if (path === "/api/simulation/runs/server-run-a/result")
+        return Response.json(result);
+      if (path === "/api/simulation/runs/server-run-a") {
+        reads++;
+        return Response.json({
+          run: {
+            ...baseRun,
+            state: reads === 1 ? "running" : "succeeded",
+            ...(reads === 1 ? {} : { finishedAt: 3 }),
+          },
+        });
+      }
+      throw new Error(`unexpected ${path}`);
+    });
+    const executor = createManagedHostedExecutor({
+      fetch,
+      sleep: async () => undefined,
+    });
+    await expect(
+      executor.execute(input, "request-a", 10_000, {
+        preparedId: "prepared-a",
+        preparedDigest: "b".repeat(64),
+      }),
+    ).resolves.toMatchObject({ result: { outcome: { status: "completed" } } });
+    expect(reads).toBe(2);
+  });
+
+  it("cancels the server run identity rather than resubmitting work", async () => {
+    let releaseStart!: () => void;
+    const startGate = new Promise<void>((resolve) => {
+      releaseStart = resolve;
+    });
+    const fetch = vi.fn<typeof globalThis.fetch>(async (request) => {
+      const path =
+        typeof request === "string"
+          ? request
+          : request instanceof URL
+            ? request.toString()
+            : request.url;
+      if (path === "/api/simulation/runs") {
+        await startGate;
+        return Response.json({ run: { ...baseRun, state: "queued" } });
+      }
+      if (path === "/api/simulation/runs/server-run-a/cancel")
+        return Response.json({
+          run: { ...baseRun, state: "cancelled", finishedAt: 3 },
+        });
+      if (path === "/api/simulation/runs/server-run-a")
+        return Response.json({
+          run: { ...baseRun, state: "infrastructure-failed", finishedAt: 3 },
+        });
+      throw new Error(`unexpected ${path}`);
+    });
+    const executor = createManagedHostedExecutor({
+      fetch,
+      sleep: async () => undefined,
+    });
+    const running = executor.execute(input, "request-a", undefined, {
+      preparedId: "prepared-a",
+      preparedDigest: "b".repeat(64),
+    });
+    const cancelling = executor.cancel("request-a");
+    releaseStart();
+    await cancelling;
+    await expect(running).rejects.toMatchObject({
+      problem: { code: "MANAGED_RUN_UNAVAILABLE" },
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/simulation/runs/server-run-a/cancel",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+});

--- a/packages/simulation-service/src/managed-hosted-executor.ts
+++ b/packages/simulation-service/src/managed-hosted-executor.ts
@@ -1,0 +1,209 @@
+import {
+  ManagedRunRecordSchema,
+  type ManagedRunRecord,
+} from "./managed-run.js";
+import { CapabilitiesSchema } from "./contract.js";
+import {
+  ExecutionFailure,
+  type ExecutionIdentity,
+  type ExecutionInput,
+  type Executor,
+} from "./executor.js";
+import { decodeHostedExecutionPayload } from "./hosted-executor.js";
+
+export interface ManagedHostedExecutorOptions {
+  fetch?: typeof fetch;
+  pollIntervalMs?: number;
+  sleep?: (milliseconds: number) => Promise<void>;
+}
+
+const activeStates = new Set(["queued", "running", "cancelling"]);
+const resultStates = new Set(["succeeded", "failed", "timed-out", "cancelled"]);
+
+/**
+ * Browser/Agent adapter for the hosted operations plane.
+ *
+ * The service still owns prepare and presentation. Start, queueing, retries,
+ * cancellation and evidence retention belong to the server. There is no
+ * fallback to `/api/simulate`: the composition root selects one transport.
+ */
+export function createManagedHostedExecutor(
+  options: ManagedHostedExecutorOptions = {},
+): Executor {
+  const fetchImpl = options.fetch ?? fetch;
+  const pause =
+    options.sleep ??
+    ((milliseconds: number) =>
+      new Promise<void>((resolve) => setTimeout(resolve, milliseconds)));
+  const pollIntervalMs = options.pollIntervalMs ?? 750;
+  const serverRuns = new Map<string, Promise<string>>();
+
+  async function jsonRequest(path: string, init?: RequestInit) {
+    let response: Response;
+    try {
+      response = await fetchImpl(path, {
+        ...init,
+        headers: {
+          ...(init?.body ? { "content-type": "application/json" } : {}),
+          ...Object.fromEntries(new Headers(init?.headers)),
+        },
+      });
+    } catch {
+      throw new ExecutionFailure(
+        {
+          code: "RUN_RESPONSE_UNKNOWN",
+          message:
+            "The managed run remains server-owned, but its response could not be read.",
+          stage: "read",
+          recovery: "retry-same-request",
+        },
+        true,
+      );
+    }
+    const body = (await response.json().catch(() => null)) as Record<
+      string,
+      unknown
+    > | null;
+    if (!response.ok) {
+      const code =
+        typeof body?.error === "string" ? body.error : "SIMULATION_HTTP_ERROR";
+      throw new ExecutionFailure(
+        {
+          code,
+          message: typeof body?.message === "string" ? body.message : code,
+          stage: "read",
+          recovery:
+            response.status === 429 || response.status === 503
+              ? "retry-after"
+              : response.status === 401
+                ? "reauthorize"
+                : "not-retryable",
+          ...(response.headers.get("retry-after")
+            ? {
+                retryAfterMs:
+                  Number(response.headers.get("retry-after")) * 1_000,
+              }
+            : {}),
+        },
+        code === "RUN_RESPONSE_UNKNOWN",
+      );
+    }
+    return body;
+  }
+
+  async function readRun(runId: string): Promise<ManagedRunRecord> {
+    const body = await jsonRequest(
+      `/api/simulation/runs/${encodeURIComponent(runId)}`,
+    );
+    const parsed = ManagedRunRecordSchema.safeParse(body?.run);
+    if (!parsed.success)
+      throw new ExecutionFailure({
+        code: "MANAGED_RUN_INVALID",
+        message: "The simulation control plane returned an invalid run record.",
+        stage: "read",
+        recovery: "not-retryable",
+      });
+    return parsed.data;
+  }
+
+  async function waitForResult(
+    input: ExecutionInput,
+    runId: string,
+  ): ReturnType<Executor["execute"]> {
+    while (true) {
+      const run = await readRun(runId);
+      if (activeStates.has(run.state)) {
+        await pause(pollIntervalMs);
+        continue;
+      }
+      if (resultStates.has(run.state)) {
+        const payload = await jsonRequest(
+          `/api/simulation/runs/${encodeURIComponent(runId)}/result`,
+        );
+        return decodeHostedExecutionPayload(input, payload);
+      }
+      throw new ExecutionFailure(
+        run.error ?? {
+          code: "MANAGED_RUN_UNAVAILABLE",
+          message: `The managed run ended in state ${run.state}.`,
+          stage: "read",
+          recovery: run.state === "expired" ? "reprepare" : "retry-after",
+        },
+        run.state === "infrastructure-failed",
+      );
+    }
+  }
+
+  return {
+    async capabilities() {
+      const response = await fetchImpl("/api/simulate", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ operation: "capabilities" }),
+        signal: AbortSignal.timeout(10_000),
+      }).catch(() => null);
+      const parsed = CapabilitiesSchema.safeParse(
+        await response?.json().catch(() => null),
+      );
+      if (!response?.ok || !parsed.success)
+        throw new ExecutionFailure({
+          code: "SIMULATION_CAPABILITIES_UNAVAILABLE",
+          message: "This deployment does not advertise simulation capabilities",
+          stage: "read",
+          recovery: "retry-after",
+        });
+      return parsed.data;
+    },
+    async execute(
+      input: ExecutionInput,
+      runToken: string,
+      timeoutMs?: number,
+      identity?: ExecutionIdentity,
+    ) {
+      if (!identity)
+        throw new ExecutionFailure({
+          code: "MANAGED_RUN_IDENTITY_REQUIRED",
+          message: "Prepare this input before starting a managed run.",
+          stage: "start",
+          recovery: "reprepare",
+        });
+      const starting = jsonRequest("/api/simulation/runs", {
+        method: "POST",
+        body: JSON.stringify({
+          requestId: runToken,
+          preparedId: identity.preparedId,
+          preparedDigest: identity.preparedDigest,
+          input: {
+            ...input,
+            ...(timeoutMs === undefined ? {} : { timeoutMs }),
+          },
+        }),
+      }).then((body) => {
+        const parsed = ManagedRunRecordSchema.safeParse(body?.run);
+        if (!parsed.success)
+          throw new ExecutionFailure({
+            code: "MANAGED_RUN_INVALID",
+            message:
+              "The simulation control plane did not accept a run identity.",
+            stage: "start",
+            recovery: "retry-same-request",
+          });
+        return parsed.data.id;
+      });
+      serverRuns.set(runToken, starting);
+      try {
+        return await waitForResult(input, await starting);
+      } finally {
+        serverRuns.delete(runToken);
+      }
+    },
+    async cancel(runToken: string) {
+      const runId = await serverRuns.get(runToken);
+      if (!runId) return;
+      await jsonRequest(
+        `/api/simulation/runs/${encodeURIComponent(runId)}/cancel`,
+        { method: "POST", body: "{}" },
+      );
+    },
+  };
+}

--- a/packages/simulation-service/src/managed-run-registry.ts
+++ b/packages/simulation-service/src/managed-run-registry.ts
@@ -1,0 +1,115 @@
+import {
+  DEFAULT_MANAGED_RUN_POLICY,
+  createManagedRun,
+  isManagedRunTerminal,
+  transitionManagedRun,
+  type ManagedRunAdmission,
+  type ManagedRunEvent,
+  type ManagedRunPolicy,
+  type ManagedRunRecord,
+  type ManagedRunTransition,
+} from "./managed-run.js";
+
+export type ManagedRunAdmissionResult =
+  | { ok: true; run: ManagedRunRecord; accepted: boolean }
+  | {
+      ok: false;
+      code:
+        | "REQUEST_ID_REUSED"
+        | "OWNER_QUEUE_LIMIT"
+        | "OWNER_ACTIVE_LIMIT"
+        | "GLOBAL_QUEUE_LIMIT";
+      retryAfterMs?: number;
+    };
+
+/** Local registry and behavioral oracle for durable storage adapters. */
+export class InMemoryManagedRunRegistry {
+  private readonly runs = new Map<string, ManagedRunRecord>();
+  private readonly requests = new Map<
+    string,
+    { fingerprint: string; runId: string }
+  >();
+
+  constructor(
+    private readonly policy: ManagedRunPolicy = DEFAULT_MANAGED_RUN_POLICY,
+    private readonly now: () => number = Date.now,
+    private readonly id: () => string = () => crypto.randomUUID(),
+  ) {}
+
+  accept(admission: ManagedRunAdmission): ManagedRunAdmissionResult {
+    this.prune();
+    const requestKey = `${admission.ownerId}\u0000${admission.requestId}`;
+    const previous = this.requests.get(requestKey);
+    if (previous) {
+      if (previous.fingerprint !== admission.requestFingerprint)
+        return { ok: false, code: "REQUEST_ID_REUSED" };
+      const run = this.runs.get(previous.runId);
+      if (run) return { ok: true, run: structuredClone(run), accepted: false };
+      return { ok: false, code: "REQUEST_ID_REUSED" };
+    }
+
+    const records = [...this.runs.values()];
+    const queued = records.filter((run) => run.state === "queued");
+    if (queued.length >= this.policy.maxQueuedGlobal)
+      return { ok: false, code: "GLOBAL_QUEUE_LIMIT", retryAfterMs: 2_000 };
+    if (
+      queued.filter((run) => run.ownerId === admission.ownerId).length >=
+      this.policy.maxQueuedPerOwner
+    )
+      return { ok: false, code: "OWNER_QUEUE_LIMIT", retryAfterMs: 2_000 };
+    if (
+      records.filter(
+        (run) =>
+          run.ownerId === admission.ownerId &&
+          (run.state === "running" || run.state === "cancelling"),
+      ).length >= this.policy.maxActivePerOwner
+    )
+      return { ok: false, code: "OWNER_ACTIVE_LIMIT", retryAfterMs: 2_000 };
+
+    const run = createManagedRun(this.id(), admission, this.now());
+    this.runs.set(run.id, run);
+    this.requests.set(requestKey, {
+      fingerprint: admission.requestFingerprint,
+      runId: run.id,
+    });
+    return { ok: true, run: structuredClone(run), accepted: true };
+  }
+
+  read(runId: string): ManagedRunRecord | null {
+    this.prune();
+    const run = this.runs.get(runId);
+    return run ? structuredClone(run) : null;
+  }
+
+  transition(runId: string, event: ManagedRunEvent): ManagedRunTransition {
+    const run = this.runs.get(runId);
+    if (!run)
+      return { ok: false, code: "INVALID_RUN_TRANSITION", state: "expired" };
+    const result = transitionManagedRun(run, event);
+    if (result.ok) this.runs.set(runId, result.run);
+    return result.ok ? { ...result, run: structuredClone(result.run) } : result;
+  }
+
+  list(ownerId?: string): ManagedRunRecord[] {
+    this.prune();
+    return [...this.runs.values()]
+      .filter((run) => ownerId === undefined || run.ownerId === ownerId)
+      .sort((a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id))
+      .map((run) => structuredClone(run));
+  }
+
+  private prune(): void {
+    const now = this.now();
+    for (const [runId, run] of this.runs) {
+      if (
+        isManagedRunTerminal(run.state) &&
+        run.state !== "expired" &&
+        run.finishedAt !== undefined &&
+        run.finishedAt + this.policy.retentionMs <= now
+      ) {
+        const expired = transitionManagedRun(run, { kind: "expired", at: now });
+        if (expired.ok) this.runs.set(runId, expired.run);
+      }
+    }
+  }
+}

--- a/packages/simulation-service/src/managed-run-registry.ts
+++ b/packages/simulation-service/src/managed-run-registry.ts
@@ -102,6 +102,23 @@ export class InMemoryManagedRunRegistry {
     const now = this.now();
     for (const [runId, run] of this.runs) {
       if (
+        run.state === "queued" &&
+        run.queuedAt + this.policy.maxQueueWaitMs <= now
+      ) {
+        const expired = transitionManagedRun(run, {
+          kind: "queue-expired",
+          at: now,
+          error: {
+            code: "QUEUE_WAIT_EXPIRED",
+            message: "The run exceeded the queue wait limit.",
+            stage: "start",
+            recovery: "retry-after",
+          },
+        });
+        if (expired.ok) this.runs.set(runId, expired.run);
+        continue;
+      }
+      if (
         isManagedRunTerminal(run.state) &&
         run.state !== "expired" &&
         run.finishedAt !== undefined &&

--- a/packages/simulation-service/src/managed-run.test.ts
+++ b/packages/simulation-service/src/managed-run.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+
+import { InMemoryManagedRunRegistry } from "./managed-run-registry.js";
+import {
+  DEFAULT_MANAGED_RUN_POLICY,
+  type ManagedRunAdmission,
+} from "./managed-run.js";
+
+const digest = (character: string) => character.repeat(64);
+
+function admission(
+  ownerId = "owner-a",
+  requestId = "request-a",
+): ManagedRunAdmission {
+  return {
+    ownerId,
+    requestId,
+    requestFingerprint: digest("a"),
+    preparedId: "prepared-a",
+    preparedDigest: digest("b"),
+    inputRevision: "revision-a",
+    environment: { profileId: "profile-a" },
+    timeoutMs: 60_000,
+    maxAttempts: 3,
+    artifacts: [],
+  };
+}
+
+describe("managed simulation run lifecycle", () => {
+  it("accepts one idempotent start and rejects request-id reuse", () => {
+    const registry = new InMemoryManagedRunRegistry(
+      DEFAULT_MANAGED_RUN_POLICY,
+      () => 100,
+      () => "run-a",
+    );
+    const first = registry.accept(admission());
+    const retry = registry.accept(admission());
+    const changed = registry.accept({
+      ...admission(),
+      requestFingerprint: digest("c"),
+    });
+
+    expect(first).toMatchObject({
+      ok: true,
+      accepted: true,
+      run: { id: "run-a", state: "queued", attempt: 0 },
+    });
+    expect(retry).toMatchObject({
+      ok: true,
+      accepted: false,
+      run: { id: "run-a" },
+    });
+    expect(changed).toEqual({ ok: false, code: "REQUEST_ID_REUSED" });
+  });
+
+  it("leases, retries infrastructure failure, and completes", () => {
+    let now = 100;
+    const registry = new InMemoryManagedRunRegistry(
+      DEFAULT_MANAGED_RUN_POLICY,
+      () => now,
+      () => "run-a",
+    );
+    const accepted = registry.accept(admission());
+    if (!accepted.ok) throw new Error("run was not accepted");
+
+    expect(
+      registry.transition(accepted.run.id, {
+        kind: "lease-acquired",
+        lease: { id: "lease-1", acquiredAt: 110, expiresAt: 1_110 },
+      }),
+    ).toMatchObject({ ok: true, run: { state: "running", attempt: 1 } });
+    expect(
+      registry.transition(accepted.run.id, {
+        kind: "infrastructure-failed",
+        at: 120,
+        error: {
+          code: "HOST_UNREACHABLE",
+          message: "host unavailable",
+          stage: "start",
+          recovery: "retry-after",
+        },
+      }),
+    ).toMatchObject({ ok: true, enqueue: true, run: { state: "queued" } });
+    expect(
+      registry.transition(accepted.run.id, {
+        kind: "lease-acquired",
+        lease: { id: "lease-2", acquiredAt: 130, expiresAt: 1_130 },
+      }),
+    ).toMatchObject({ ok: true, run: { state: "running", attempt: 2 } });
+    expect(
+      registry.transition(accepted.run.id, {
+        kind: "completed",
+        at: 150,
+        artifacts: [],
+      }),
+    ).toMatchObject({ ok: true, run: { state: "succeeded", finishedAt: 150 } });
+
+    now = 150 + DEFAULT_MANAGED_RUN_POLICY.retentionMs;
+    expect(registry.read(accepted.run.id)).toMatchObject({
+      state: "expired",
+      artifacts: [],
+    });
+  });
+
+  it("cancels queued work and waits for running cleanup", () => {
+    const registry = new InMemoryManagedRunRegistry(
+      DEFAULT_MANAGED_RUN_POLICY,
+      () => 100,
+      (() => {
+        let i = 0;
+        return () => `run-${++i}`;
+      })(),
+    );
+    const queued = registry.accept(admission());
+    if (!queued.ok) throw new Error("queued run missing");
+    expect(
+      registry.transition(queued.run.id, {
+        kind: "cancel-requested",
+        at: 105,
+      }),
+    ).toMatchObject({ ok: true, run: { state: "cancelled" } });
+
+    const running = registry.accept(admission("owner-b", "request-b"));
+    if (!running.ok) throw new Error("running run missing");
+    registry.transition(running.run.id, {
+      kind: "lease-acquired",
+      lease: { id: "lease-b", acquiredAt: 110, expiresAt: 1_110 },
+    });
+    expect(
+      registry.transition(running.run.id, {
+        kind: "cancel-requested",
+        at: 115,
+      }),
+    ).toMatchObject({ ok: true, run: { state: "cancelling" } });
+    expect(
+      registry.transition(running.run.id, { kind: "cancelled", at: 120 }),
+    ).toMatchObject({ ok: true, run: { state: "cancelled" } });
+  });
+
+  it("enforces owner and global queue admission", () => {
+    const policy = {
+      ...DEFAULT_MANAGED_RUN_POLICY,
+      maxQueuedGlobal: 2,
+      maxQueuedPerOwner: 1,
+    };
+    const registry = new InMemoryManagedRunRegistry(
+      policy,
+      () => 100,
+      (() => {
+        let i = 0;
+        return () => `run-${++i}`;
+      })(),
+    );
+    expect(registry.accept(admission("owner-a", "request-a"))).toMatchObject({
+      ok: true,
+    });
+    expect(registry.accept(admission("owner-a", "request-b"))).toEqual({
+      ok: false,
+      code: "OWNER_QUEUE_LIMIT",
+      retryAfterMs: 2_000,
+    });
+    expect(registry.accept(admission("owner-b", "request-c"))).toMatchObject({
+      ok: true,
+    });
+    expect(registry.accept(admission("owner-c", "request-d"))).toEqual({
+      ok: false,
+      code: "GLOBAL_QUEUE_LIMIT",
+      retryAfterMs: 2_000,
+    });
+  });
+});

--- a/packages/simulation-service/src/managed-run.test.ts
+++ b/packages/simulation-service/src/managed-run.test.ts
@@ -168,4 +168,32 @@ describe("managed simulation run lifecycle", () => {
       retryAfterMs: 2_000,
     });
   });
+
+  it("expires an abandoned queue entry without retaining input artifacts", () => {
+    let now = 100;
+    const registry = new InMemoryManagedRunRegistry(
+      DEFAULT_MANAGED_RUN_POLICY,
+      () => now,
+      () => "run-a",
+    );
+    const accepted = registry.accept({
+      ...admission(),
+      artifacts: [
+        {
+          id: "input-a",
+          name: "managed-input.json",
+          mediaType: "application/json",
+          byteLength: 2,
+          sha256: digest("d"),
+        },
+      ],
+    });
+    if (!accepted.ok) throw new Error("run was not accepted");
+    now += DEFAULT_MANAGED_RUN_POLICY.maxQueueWaitMs;
+    expect(registry.read(accepted.run.id)).toMatchObject({
+      state: "expired",
+      artifacts: [],
+      error: { code: "QUEUE_WAIT_EXPIRED" },
+    });
+  });
 });

--- a/packages/simulation-service/src/managed-run.ts
+++ b/packages/simulation-service/src/managed-run.ts
@@ -74,6 +74,7 @@ export const ManagedRunPolicySchema = z.strictObject({
   maxQueuedPerOwner: z.number().int().positive(),
   maxActivePerOwner: z.number().int().positive(),
   leaseMs: z.number().int().positive(),
+  maxQueueWaitMs: z.number().int().positive(),
   retentionMs: z.number().int().positive(),
 });
 export type ManagedRunPolicy = z.infer<typeof ManagedRunPolicySchema>;
@@ -83,6 +84,7 @@ export const DEFAULT_MANAGED_RUN_POLICY: ManagedRunPolicy = {
   maxQueuedPerOwner: 1,
   maxActivePerOwner: 1,
   leaseMs: 150_000,
+  maxQueueWaitMs: 5 * 60_000,
   retentionMs: 24 * 60 * 60_000,
 };
 
@@ -110,9 +112,15 @@ export const ManagedRunEventSchema = z.discriminatedUnion("kind", [
       kind: z.literal(kind),
       at: eventAt,
       error: ProblemSchema,
+      artifacts: z.array(ArtifactRefSchema).optional(),
     }),
   ),
   z.strictObject({ kind: z.literal("expired"), at: eventAt }),
+  z.strictObject({
+    kind: z.literal("queue-expired"),
+    at: eventAt,
+    error: ProblemSchema,
+  }),
 ]);
 export type ManagedRunEvent = z.infer<typeof ManagedRunEventSchema>;
 
@@ -200,7 +208,7 @@ export function transitionManagedRun(
         return update({ updatedAt: source.updatedAt });
       return invalid();
     case "completed":
-      if (source.state !== "running") return invalid();
+      if (!active) return invalid();
       return update({
         state: "succeeded",
         updatedAt: event.at,
@@ -225,6 +233,7 @@ export function transitionManagedRun(
         finishedAt: event.at,
         lease: undefined,
         error: event.error,
+        ...(event.artifacts ? { artifacts: [...event.artifacts] } : {}),
       });
     case "failed":
       if (!active) return invalid();
@@ -234,6 +243,7 @@ export function transitionManagedRun(
         finishedAt: event.at,
         lease: undefined,
         error: event.error,
+        ...(event.artifacts ? { artifacts: [...event.artifacts] } : {}),
       });
     case "infrastructure-failed":
     case "lease-expired":
@@ -260,5 +270,14 @@ export function transitionManagedRun(
     case "expired":
       if (!isManagedRunTerminal(source.state)) return invalid();
       return update({ state: "expired", updatedAt: event.at, artifacts: [] });
+    case "queue-expired":
+      if (source.state !== "queued") return invalid();
+      return update({
+        state: "expired",
+        updatedAt: event.at,
+        finishedAt: event.at,
+        error: event.error,
+        artifacts: [],
+      });
   }
 }

--- a/packages/simulation-service/src/managed-run.ts
+++ b/packages/simulation-service/src/managed-run.ts
@@ -1,0 +1,264 @@
+import { z } from "zod";
+
+import {
+  ArtifactRefSchema,
+  Digest,
+  EnvironmentSchema,
+  Id,
+  ProblemSchema,
+} from "./contract.js";
+
+/** Durable lifecycle shared by hosted and local control planes. */
+export const ManagedRunStateSchema = z.enum([
+  "queued",
+  "running",
+  "cancelling",
+  "succeeded",
+  "failed",
+  "timed-out",
+  "cancelled",
+  "infrastructure-failed",
+  "expired",
+]);
+export type ManagedRunState = z.infer<typeof ManagedRunStateSchema>;
+
+export const ManagedRunLeaseSchema = z.strictObject({
+  id: Id,
+  acquiredAt: z.number().int().nonnegative(),
+  expiresAt: z.number().int().nonnegative(),
+});
+export type ManagedRunLease = z.infer<typeof ManagedRunLeaseSchema>;
+
+export const ManagedRunRecordSchema = z.strictObject({
+  schemaVersion: z.literal(1),
+  id: Id,
+  ownerId: Id,
+  requestId: Id,
+  requestFingerprint: Digest,
+  preparedId: Id,
+  preparedDigest: Digest,
+  inputRevision: z.string(),
+  environment: EnvironmentSchema,
+  timeoutMs: z.number().int().positive().max(120_000),
+  state: ManagedRunStateSchema,
+  attempt: z.number().int().nonnegative(),
+  maxAttempts: z.number().int().positive(),
+  createdAt: z.number().int().nonnegative(),
+  updatedAt: z.number().int().nonnegative(),
+  queuedAt: z.number().int().nonnegative(),
+  startedAt: z.number().int().nonnegative().optional(),
+  finishedAt: z.number().int().nonnegative().optional(),
+  cancelRequestedAt: z.number().int().nonnegative().optional(),
+  lease: ManagedRunLeaseSchema.optional(),
+  error: ProblemSchema.optional(),
+  artifacts: z.array(ArtifactRefSchema),
+});
+export type ManagedRunRecord = z.infer<typeof ManagedRunRecordSchema>;
+
+export const ManagedRunAdmissionSchema = z.strictObject({
+  ownerId: Id,
+  requestId: Id,
+  requestFingerprint: Digest,
+  preparedId: Id,
+  preparedDigest: Digest,
+  inputRevision: z.string(),
+  environment: EnvironmentSchema,
+  timeoutMs: z.number().int().positive().max(120_000),
+  maxAttempts: z.number().int().positive().max(10).default(3),
+  artifacts: z.array(ArtifactRefSchema).default([]),
+});
+export type ManagedRunAdmission = z.infer<typeof ManagedRunAdmissionSchema>;
+
+export const ManagedRunPolicySchema = z.strictObject({
+  maxQueuedGlobal: z.number().int().positive(),
+  maxQueuedPerOwner: z.number().int().positive(),
+  maxActivePerOwner: z.number().int().positive(),
+  leaseMs: z.number().int().positive(),
+  retentionMs: z.number().int().positive(),
+});
+export type ManagedRunPolicy = z.infer<typeof ManagedRunPolicySchema>;
+
+export const DEFAULT_MANAGED_RUN_POLICY: ManagedRunPolicy = {
+  maxQueuedGlobal: 50,
+  maxQueuedPerOwner: 1,
+  maxActivePerOwner: 1,
+  leaseMs: 150_000,
+  retentionMs: 24 * 60 * 60_000,
+};
+
+const eventAt = z.number().int().nonnegative();
+export const ManagedRunEventSchema = z.discriminatedUnion("kind", [
+  z.strictObject({
+    kind: z.literal("lease-acquired"),
+    lease: ManagedRunLeaseSchema,
+  }),
+  z.strictObject({ kind: z.literal("cancel-requested"), at: eventAt }),
+  z.strictObject({
+    kind: z.literal("completed"),
+    at: eventAt,
+    artifacts: z.array(ArtifactRefSchema),
+  }),
+  z.strictObject({
+    kind: z.literal("cancelled"),
+    at: eventAt,
+    artifacts: z.array(ArtifactRefSchema).optional(),
+  }),
+  ...(
+    ["timed-out", "failed", "infrastructure-failed", "lease-expired"] as const
+  ).map((kind) =>
+    z.strictObject({
+      kind: z.literal(kind),
+      at: eventAt,
+      error: ProblemSchema,
+    }),
+  ),
+  z.strictObject({ kind: z.literal("expired"), at: eventAt }),
+]);
+export type ManagedRunEvent = z.infer<typeof ManagedRunEventSchema>;
+
+export type ManagedRunTransition =
+  | { ok: true; run: ManagedRunRecord; enqueue: boolean }
+  | { ok: false; code: "INVALID_RUN_TRANSITION"; state: ManagedRunState };
+
+const terminalStates = new Set<ManagedRunState>([
+  "succeeded",
+  "failed",
+  "timed-out",
+  "cancelled",
+  "infrastructure-failed",
+  "expired",
+]);
+
+export function isManagedRunTerminal(state: ManagedRunState): boolean {
+  return terminalStates.has(state);
+}
+
+export function createManagedRun(
+  id: string,
+  admission: ManagedRunAdmission,
+  now: number,
+): ManagedRunRecord {
+  return ManagedRunRecordSchema.parse({
+    schemaVersion: 1,
+    id,
+    ...admission,
+    state: "queued",
+    attempt: 0,
+    createdAt: now,
+    updatedAt: now,
+    queuedAt: now,
+  });
+}
+
+/** The sole transition table. Adapters persist its result atomically. */
+export function transitionManagedRun(
+  source: ManagedRunRecord,
+  event: ManagedRunEvent,
+): ManagedRunTransition {
+  const invalid = (): ManagedRunTransition => ({
+    ok: false,
+    code: "INVALID_RUN_TRANSITION",
+    state: source.state,
+  });
+  const update = (
+    fields: Partial<ManagedRunRecord>,
+    enqueue = false,
+  ): ManagedRunTransition => ({
+    ok: true,
+    run: ManagedRunRecordSchema.parse({ ...source, ...fields }),
+    enqueue,
+  });
+  const active = source.state === "running" || source.state === "cancelling";
+
+  switch (event.kind) {
+    case "lease-acquired":
+      if (source.state !== "queued") return invalid();
+      if (event.lease.expiresAt <= event.lease.acquiredAt) return invalid();
+      return update({
+        state: "running",
+        attempt: source.attempt + 1,
+        startedAt: event.lease.acquiredAt,
+        updatedAt: event.lease.acquiredAt,
+        lease: event.lease,
+        error: undefined,
+      });
+    case "cancel-requested":
+      if (source.state === "queued")
+        return update({
+          state: "cancelled",
+          cancelRequestedAt: event.at,
+          finishedAt: event.at,
+          updatedAt: event.at,
+        });
+      if (source.state === "running")
+        return update({
+          state: "cancelling",
+          cancelRequestedAt: event.at,
+          updatedAt: event.at,
+        });
+      if (source.state === "cancelling" || isManagedRunTerminal(source.state))
+        return update({ updatedAt: source.updatedAt });
+      return invalid();
+    case "completed":
+      if (source.state !== "running") return invalid();
+      return update({
+        state: "succeeded",
+        updatedAt: event.at,
+        finishedAt: event.at,
+        lease: undefined,
+        artifacts: [...event.artifacts],
+      });
+    case "cancelled":
+      if (!active) return invalid();
+      return update({
+        state: "cancelled",
+        updatedAt: event.at,
+        finishedAt: event.at,
+        lease: undefined,
+        ...(event.artifacts ? { artifacts: [...event.artifacts] } : {}),
+      });
+    case "timed-out":
+      if (!active) return invalid();
+      return update({
+        state: "timed-out",
+        updatedAt: event.at,
+        finishedAt: event.at,
+        lease: undefined,
+        error: event.error,
+      });
+    case "failed":
+      if (!active) return invalid();
+      return update({
+        state: "failed",
+        updatedAt: event.at,
+        finishedAt: event.at,
+        lease: undefined,
+        error: event.error,
+      });
+    case "infrastructure-failed":
+    case "lease-expired":
+      if (!active) return invalid();
+      if (source.state !== "cancelling" && source.attempt < source.maxAttempts)
+        return update(
+          {
+            state: "queued",
+            updatedAt: event.at,
+            queuedAt: event.at,
+            lease: undefined,
+            error: event.error,
+          },
+          true,
+        );
+      return update({
+        state:
+          source.state === "cancelling" ? "cancelled" : "infrastructure-failed",
+        updatedAt: event.at,
+        finishedAt: event.at,
+        lease: undefined,
+        error: event.error,
+      });
+    case "expired":
+      if (!isManagedRunTerminal(source.state)) return invalid();
+      return update({ state: "expired", updatedAt: event.at, artifacts: [] });
+  }
+}

--- a/packages/simulation-service/src/service.test.ts
+++ b/packages/simulation-service/src/service.test.ts
@@ -215,6 +215,7 @@ describe("shared simulation lifecycle", () => {
       expect.objectContaining({ testbench: "B deck\n.end\n" }),
       expect.any(String),
       undefined,
+      { preparedId: prepared.id, preparedDigest: prepared.digest },
     );
     f.release();
   });
@@ -392,6 +393,7 @@ describe("shared simulation lifecycle", () => {
       }),
       expect.any(String),
       undefined,
+      { preparedId: prepared.id, preparedDigest: prepared.digest },
     );
     f.release();
     await vi.waitFor(async () =>

--- a/packages/simulation-service/src/service.ts
+++ b/packages/simulation-service/src/service.ts
@@ -358,7 +358,10 @@ export class SimulationService {
     epoch: number,
   ) {
     try {
-      const output = await this.executor.execute(input, run.token, timeoutMs);
+      const output = await this.executor.execute(input, run.token, timeoutMs, {
+        preparedId: run.prepared.id,
+        preparedDigest: run.prepared.digest,
+      });
       if (epoch !== this.epoch) return;
       run.view.result = output.result;
       if (output.result.data && run.prepared.outputs.length > 0) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ importers:
       "@icm/render-svg":
         specifier: workspace:*
         version: link:packages/render-svg
+      "@icm/simulation-service":
+        specifier: workspace:*
+        version: link:packages/simulation-service
       "@icm/spice-run":
         specifier: workspace:*
         version: link:packages/spice-run

--- a/scripts/preview-workflow.test.mjs
+++ b/scripts/preview-workflow.test.mjs
@@ -33,6 +33,17 @@ describe("the preview deploy", () => {
     expect(preview).not.toContain("volare");
   });
 
+  it("reconciles the preview's bounded queue and artifact store before deploy", () => {
+    const resources = preview.indexOf("Reconcile managed simulation resources");
+    const deploy = preview.indexOf("Deploy to preview");
+    expect(resources).toBeGreaterThanOrEqual(0);
+    expect(deploy).toBeGreaterThan(resources);
+    expect(preview).toContain("analog-canvas-simulation-preview-dlq");
+    expect(preview).toContain("--message-retention-period-secs");
+    expect(preview).toContain("simulation-artifact-retention");
+    expect(preview).toContain("--expire-days 1");
+  });
+
   it("verifies what a preview is for", () => {
     expect(preview).toContain("/api/channel");
     expect(preview).toContain('"preview"');

--- a/scripts/simulator-host-workflow.test.mjs
+++ b/scripts/simulator-host-workflow.test.mjs
@@ -30,8 +30,9 @@ describe("the operator simulator host", () => {
     expect(bootstrap).not.toContain("sudo");
   });
 
-  it("keeps the harness private and resource bounded in one desired-state file", () => {
+  it("keeps the gateway and executor private and resource bounded in one desired-state file", () => {
     expect(compose).toContain("container_name: analog-canvas-ngspice");
+    expect(compose).toContain("container_name: analog-canvas-ngspice-executor");
     expect(compose).toContain("read_only: true");
     expect(compose).toMatch(/cap_drop:\s*\n\s*- ALL/u);
     expect(compose).toContain("pids_limit: 256");
@@ -42,6 +43,20 @@ describe("the operator simulator host", () => {
     expect(compose).toContain(
       "cloudflare/cloudflared:2025.8.1@sha256:b77d84e8704db38db22c22661cf7e56468c526e3a6a5fe9c8b7c151452fa1472",
     );
+  });
+
+  it("keeps the host token out of the untrusted executor", () => {
+    const executor = compose.slice(
+      compose.indexOf("  executor:"),
+      compose.indexOf("  simulator:"),
+    );
+    const gateway = compose.slice(
+      compose.indexOf("  simulator:"),
+      compose.indexOf("  tunnel:"),
+    );
+    expect(executor).not.toContain("SIMULATION_ACCESS_TOKEN");
+    expect(gateway).toContain("SIMULATION_ACCESS_TOKEN");
+    expect(gateway).toContain("SIMULATION_EXECUTOR_URL: http://executor:8080");
   });
 
   it("uses the tracked topology instead of repeating docker run flags", () => {
@@ -55,6 +70,9 @@ describe("the operator simulator host", () => {
 
   it("bounds the one-time legacy takeover to the two known containers", () => {
     expect(deploy).toContain("replace_legacy_container analog-canvas-ngspice");
+    expect(deploy).toContain(
+      "replace_legacy_container analog-canvas-ngspice-executor",
+    );
     expect(deploy).toContain("replace_legacy_container analog-canvas-tunnel");
     expect(deploy).not.toMatch(/docker (?:system|volume|network) prune/u);
   });

--- a/worker/channel.test.ts
+++ b/worker/channel.test.ts
@@ -54,6 +54,9 @@ describe("release channel", () => {
     // Simulation runs are the preview's whole purpose; agent sessions and
     // analytics are its own namespaces. None of these reach shared data.
     expect(previewWriteRefusal(req("/api/simulate", "POST"), env)).toBeNull();
+    expect(
+      previewWriteRefusal(req("/api/simulation/runs", "POST"), env),
+    ).toBeNull();
     expect(previewWriteRefusal(req("/api/track", "POST"), env)).toBeNull();
     expect(
       previewWriteRefusal(req("/api/agent/sessions", "POST"), env),

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -15,6 +15,13 @@ import {
 import { routeGalleryRequest, type GalleryNamespaceLike } from "./gallery";
 import { routeSimulationRequest, type SimulationEnv } from "./simulation";
 import {
+  consumeSimulationJobs,
+  routeManagedSimulationRequest,
+  type SimulationJobMessage,
+  type SimulationOperationsEnv,
+  type SimulationQueueBatch,
+} from "./simulation-operations";
+import {
   channelResponse,
   markPreviewResponse,
   previewGalleryReadThrough,
@@ -32,6 +39,7 @@ export { AuthDO } from "./auth";
 export { SimulationControlDO } from "./simulation-control-do";
 
 type Env = SimulationEnv &
+  SimulationOperationsEnv &
   ChannelEnv & {
     ANALYTICS: DurableObjectNamespaceLike;
     ASSETS: { fetch(request: Request): Promise<Response> };
@@ -108,6 +116,12 @@ export default {
     // Every preview response is stamped noindex on the way out (ADR 0057).
     return markPreviewResponse(await route(request, env), env);
   },
+  async queue(
+    batch: SimulationQueueBatch<SimulationJobMessage>,
+    env: Env,
+  ): Promise<void> {
+    await consumeSimulationJobs(batch, env);
+  },
 };
 
 async function route(request: Request, env: Env): Promise<Response> {
@@ -135,6 +149,12 @@ async function route(request: Request, env: Env): Promise<Response> {
 
   const galleryResponse = await routeGalleryRequest(request, env);
   if (galleryResponse) return galleryResponse;
+
+  const managedSimulationResponse = await routeManagedSimulationRequest(
+    request,
+    env,
+  );
+  if (managedSimulationResponse) return managedSimulationResponse;
 
   const simulationResponse = await routeSimulationRequest(request, env);
   if (simulationResponse) return simulationResponse;

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -29,6 +29,7 @@ export { AnalyticsDO } from "./analytics";
 export { AgentSessionDO } from "./agent-session";
 export { GalleryDO } from "./gallery";
 export { AuthDO } from "./auth";
+export { SimulationControlDO } from "./simulation-control-do";
 
 type Env = SimulationEnv &
   ChannelEnv & {

--- a/worker/preview-config.test.ts
+++ b/worker/preview-config.test.ts
@@ -14,6 +14,17 @@ function readConfig(file: string): {
   durable_objects?: {
     bindings: { name: string; class_name: string; script_name?: string }[];
   };
+  r2_buckets?: { binding: string; bucket_name: string }[];
+  queues?: {
+    producers: { binding: string; queue: string }[];
+    consumers: {
+      queue: string;
+      max_batch_size?: number;
+      max_concurrency?: number;
+      max_retries?: number;
+      dead_letter_queue?: string;
+    }[];
+  };
   migrations: {
     tag: string;
     new_sqlite_classes?: string[];
@@ -107,6 +118,39 @@ describe("the preview channel configuration (ADR 0057)", () => {
     expect(
       production.durable_objects?.bindings.some((b) => b.name === "NGSPICE"),
     ).toBe(false);
+  });
+
+  it("bounds managed runs to the operator host's single execution slot", () => {
+    expect(preview.r2_buckets).toEqual([
+      {
+        binding: "SIMULATION_ARTIFACTS",
+        bucket_name: "analog-canvas-simulation-artifacts-preview",
+      },
+    ]);
+    expect(preview.queues?.producers).toEqual([
+      {
+        binding: "SIMULATION_JOBS",
+        queue: "analog-canvas-simulation-preview",
+      },
+    ]);
+    expect(preview.queues?.consumers).toEqual([
+      expect.objectContaining({
+        queue: "analog-canvas-simulation-preview",
+        max_batch_size: 1,
+        max_concurrency: 1,
+        max_retries: 3,
+        dead_letter_queue: "analog-canvas-simulation-preview-dlq",
+      }),
+    ]);
+    expect(
+      preview.durable_objects?.bindings.some(
+        (binding) =>
+          binding.name === "SIMULATION_CONTROL" &&
+          binding.class_name === "SimulationControlDO",
+      ),
+    ).toBe(true);
+    expect(production.r2_buckets).toBeUndefined();
+    expect(production.queues).toBeUndefined();
   });
 
   it("writes the Dockerfile for a repository-root build context", () => {

--- a/worker/simulation-control-do.test.ts
+++ b/worker/simulation-control-do.test.ts
@@ -173,4 +173,52 @@ describe("simulation control durable object", () => {
       retryAfterMs: 2_000,
     });
   });
+
+  it("drains new work without invalidating idempotent reads of accepted work", async () => {
+    const control = new SimulationControlDO(sqliteState());
+    const accepted = await body<{ run: { id: string } }>(
+      await control.fetch(
+        new Request("https://control/accept", {
+          method: "POST",
+          body: JSON.stringify(admission()),
+        }),
+      ),
+    );
+    const drained = await control.fetch(
+      new Request("https://control/operations", {
+        method: "POST",
+        body: JSON.stringify({ accepting: false }),
+      }),
+    );
+    expect(await body(drained)).toMatchObject({
+      accepting: false,
+      counts: { queued: 1 },
+    });
+    expect(
+      (
+        await body<{ run: { id: string } }>(
+          await control.fetch(
+            new Request("https://control/accept", {
+              method: "POST",
+              body: JSON.stringify(admission()),
+            }),
+          ),
+        )
+      ).run.id,
+    ).toBe(accepted.run.id);
+    const refused = await control.fetch(
+      new Request("https://control/accept", {
+        method: "POST",
+        body: JSON.stringify({
+          ...admission("request-new"),
+          requestFingerprint: digest("c"),
+        }),
+      }),
+    );
+    expect(refused.status).toBe(409);
+    expect(await body(refused)).toMatchObject({
+      error: "SIMULATION_DRAINED",
+      retryAfterMs: 30_000,
+    });
+  });
 });

--- a/worker/simulation-control-do.test.ts
+++ b/worker/simulation-control-do.test.ts
@@ -1,7 +1,10 @@
 import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
 
-import { SimulationControlDO } from "./simulation-control-do";
+import {
+  SIMULATION_SESSION_COOKIE,
+  SimulationControlDO,
+} from "./simulation-control-do";
 
 function sqliteState() {
   const db = new DatabaseSync(":memory:");
@@ -57,6 +60,32 @@ async function body<T>(response: Response): Promise<T> {
 }
 
 describe("simulation control durable object", () => {
+  it("issues an opaque anonymous owner capability and resolves it later", async () => {
+    const control = new SimulationControlDO(
+      sqliteState(),
+      undefined,
+      () => 100,
+    );
+    const issued = await control.fetch(
+      new Request("https://control/anonymous-session", { method: "POST" }),
+    );
+    expect(issued.status).toBe(201);
+    const cookie = issued.headers.get("set-cookie");
+    expect(cookie).toContain(`${SIMULATION_SESSION_COOKIE}=`);
+    expect(cookie).toContain("HttpOnly");
+    expect(cookie).toContain("Secure");
+    const principal = await body<{ principal: { id: string } }>(issued);
+    expect(principal.principal.id).toMatch(/^anonymous-/u);
+
+    const resolved = await control.fetch(
+      new Request("https://control/anonymous-session", {
+        headers: { cookie: cookie!.split(";")[0]! },
+      }),
+    );
+    expect(resolved.status).toBe(200);
+    expect(await body(resolved)).toEqual(principal);
+  });
+
   it("persists idempotent admission and lifecycle transitions", async () => {
     const state = sqliteState();
     const firstInstance = new SimulationControlDO(state);

--- a/worker/simulation-control-do.test.ts
+++ b/worker/simulation-control-do.test.ts
@@ -138,6 +138,12 @@ describe("simulation control durable object", () => {
       state: "running",
       lease: { id: "lease-a" },
     });
+    const listed = await body<{ runs: { id: string }[] }>(
+      await restoredInstance.fetch(
+        new Request("https://control/runs?ownerId=owner-a"),
+      ),
+    );
+    expect(listed.runs.map((run) => run.id)).toEqual([accepted.run.id]);
   });
 
   it("enforces the per-owner queue limit atomically", async () => {

--- a/worker/simulation-control-do.test.ts
+++ b/worker/simulation-control-do.test.ts
@@ -1,0 +1,141 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+
+import { SimulationControlDO } from "./simulation-control-do";
+
+function sqliteState() {
+  const db = new DatabaseSync(":memory:");
+  return {
+    storage: {
+      sql: {
+        exec<T>(query: string, ...bindings: unknown[]) {
+          const statement = db.prepare(query);
+          if (/^\s*(select|with|pragma)/iu.test(query)) {
+            const rows = statement.all(
+              ...(bindings as (string | number | null)[]),
+            ) as T[];
+            return {
+              toArray: () => rows,
+              one: () => {
+                if (rows.length !== 1) throw new Error("expected one row");
+                return rows[0]!;
+              },
+            };
+          }
+          statement.run(...(bindings as (string | number | null)[]));
+          return {
+            toArray: () => [] as T[],
+            one: () => {
+              throw new Error("no rows");
+            },
+          };
+        },
+      },
+      transactionSync<T>(callback: () => T): T {
+        return callback();
+      },
+    },
+  };
+}
+
+const digest = (character: string) => character.repeat(64);
+const admission = (requestId = "request-a") => ({
+  ownerId: "owner-a",
+  requestId,
+  requestFingerprint: digest("a"),
+  preparedId: "prepared-a",
+  preparedDigest: digest("b"),
+  inputRevision: "revision-a",
+  environment: { profileId: "profile-a" },
+  timeoutMs: 60_000,
+  maxAttempts: 3,
+  artifacts: [],
+});
+
+async function body<T>(response: Response): Promise<T> {
+  return (await response.json()) as T;
+}
+
+describe("simulation control durable object", () => {
+  it("persists idempotent admission and lifecycle transitions", async () => {
+    const state = sqliteState();
+    const firstInstance = new SimulationControlDO(state);
+    const acceptedResponse = await firstInstance.fetch(
+      new Request("https://control/accept", {
+        method: "POST",
+        body: JSON.stringify(admission()),
+      }),
+    );
+    expect(acceptedResponse.status).toBe(201);
+    const accepted = await body<{
+      accepted: boolean;
+      run: { id: string; state: string };
+    }>(acceptedResponse);
+    expect(accepted).toMatchObject({
+      accepted: true,
+      run: { state: "queued" },
+    });
+
+    const restoredInstance = new SimulationControlDO(state);
+    const retry = await body<{ accepted: boolean; run: { id: string } }>(
+      await restoredInstance.fetch(
+        new Request("https://control/accept", {
+          method: "POST",
+          body: JSON.stringify(admission()),
+        }),
+      ),
+    );
+    expect(retry).toEqual({ accepted: false, run: accepted.run });
+
+    const leased = await body<{ run: { state: string; attempt: number } }>(
+      await restoredInstance.fetch(
+        new Request(`https://control/runs/${accepted.run.id}`, {
+          method: "POST",
+          body: JSON.stringify({
+            kind: "lease-acquired",
+            lease: { id: "lease-a", acquiredAt: 100, expiresAt: 1_000 },
+          }),
+        }),
+      ),
+    );
+    expect(leased.run).toMatchObject({ state: "running", attempt: 1 });
+
+    const read = await body<{ run: { state: string; lease: { id: string } } }>(
+      await restoredInstance.fetch(
+        new Request(`https://control/runs/${accepted.run.id}`),
+      ),
+    );
+    expect(read.run).toMatchObject({
+      state: "running",
+      lease: { id: "lease-a" },
+    });
+  });
+
+  it("enforces the per-owner queue limit atomically", async () => {
+    const control = new SimulationControlDO(sqliteState());
+    expect(
+      (
+        await control.fetch(
+          new Request("https://control/accept", {
+            method: "POST",
+            body: JSON.stringify(admission()),
+          }),
+        )
+      ).status,
+    ).toBe(201);
+    const refused = await control.fetch(
+      new Request("https://control/accept", {
+        method: "POST",
+        body: JSON.stringify({
+          ...admission("request-b"),
+          requestFingerprint: digest("c"),
+        }),
+      }),
+    );
+    expect(refused.status).toBe(409);
+    expect(await body(refused)).toEqual({
+      error: "OWNER_QUEUE_LIMIT",
+      retryAfterMs: 2_000,
+    });
+  });
+});

--- a/worker/simulation-control-do.ts
+++ b/worker/simulation-control-do.ts
@@ -46,12 +46,14 @@ export class SimulationControlDO {
   constructor(
     private readonly state: DurableObjectStateLike,
     private readonly policy: ManagedRunPolicy = DEFAULT_MANAGED_RUN_POLICY,
+    private readonly now: () => number = Date.now,
   ) {
     this.sql = state.storage.sql;
     this.initializeSchema();
   }
 
   async fetch(request: Request): Promise<Response> {
+    this.pruneExpired(this.now());
     const url = new URL(request.url);
     if (request.method === "POST" && url.pathname === "/accept")
       return this.accept(request);
@@ -138,7 +140,7 @@ export class SimulationControlDO {
       if (activeOwner >= this.policy.maxActivePerOwner)
         return { error: "OWNER_ACTIVE_LIMIT", retryAfterMs: 2_000 } as const;
 
-      const run = createManagedRun(crypto.randomUUID(), admission, Date.now());
+      const run = createManagedRun(crypto.randomUUID(), admission, this.now());
       this.writeRecord(run);
       this.sql.exec(
         `INSERT INTO simulation_start_requests
@@ -223,6 +225,51 @@ export class SimulationControlDO {
       run.finishedAt ?? null,
       JSON.stringify(run),
     );
+  }
+
+  private pruneExpired(now: number): void {
+    const queued = this.sql
+      .exec<RunRow>(
+        `SELECT record_json FROM simulation_runs
+         WHERE state = 'queued' AND updated_at <= ?`,
+        now - this.policy.maxQueueWaitMs,
+      )
+      .toArray();
+    for (const row of queued) {
+      const parsed = ManagedRunRecordSchema.safeParse(
+        JSON.parse(row.record_json),
+      );
+      if (!parsed.success) continue;
+      const transition = transitionManagedRun(parsed.data, {
+        kind: "queue-expired",
+        at: now,
+        error: {
+          code: "QUEUE_WAIT_EXPIRED",
+          message: "The run exceeded the queue wait limit.",
+          stage: "start",
+          recovery: "retry-after",
+        },
+      });
+      if (transition.ok) this.writeRecord(transition.run);
+    }
+    const retained = this.sql
+      .exec<RunRow>(
+        `SELECT record_json FROM simulation_runs
+         WHERE finished_at IS NOT NULL AND finished_at <= ? AND state != 'expired'`,
+        now - this.policy.retentionMs,
+      )
+      .toArray();
+    for (const row of retained) {
+      const parsed = ManagedRunRecordSchema.safeParse(
+        JSON.parse(row.record_json),
+      );
+      if (!parsed.success || !managedRunNeedsRetention(parsed.data)) continue;
+      const transition = transitionManagedRun(parsed.data, {
+        kind: "expired",
+        at: now,
+      });
+      if (transition.ok) this.writeRecord(transition.run);
+    }
   }
 }
 

--- a/worker/simulation-control-do.ts
+++ b/worker/simulation-control-do.ts
@@ -61,6 +61,7 @@ export class SimulationControlDO {
     const url = new URL(request.url);
     if (url.pathname === "/anonymous-session")
       return this.anonymousSession(request);
+    if (url.pathname === "/operations") return this.operations(request);
     if (request.method === "POST" && url.pathname === "/accept")
       return this.accept(request);
     if (request.method === "GET" && url.pathname === "/runs")
@@ -105,6 +106,16 @@ export class SimulationControlDO {
         expires_at INTEGER NOT NULL
       ) WITHOUT ROWID
     `);
+    this.sql.exec(`
+      CREATE TABLE IF NOT EXISTS simulation_operations (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+      ) WITHOUT ROWID
+    `);
+    this.sql.exec(
+      `INSERT OR IGNORE INTO simulation_operations (key, value)
+       VALUES ('accepting', 'true')`,
+    );
   }
 
   private async accept(request: Request): Promise<Response> {
@@ -138,6 +149,9 @@ export class SimulationControlDO {
           ? ({ run, accepted: false } as const)
           : ({ error: "REQUEST_ID_REUSED" } as const);
       }
+
+      if (!this.isAccepting())
+        return { error: "SIMULATION_DRAINED", retryAfterMs: 30_000 } as const;
 
       const queuedGlobal = this.count("state = 'queued'");
       if (queuedGlobal >= this.policy.maxQueuedGlobal)
@@ -303,6 +317,41 @@ export class SimulationControlDO {
           "cache-control": "no-store",
         },
       },
+    );
+  }
+
+  private async operations(request: Request): Promise<Response> {
+    if (request.method === "POST") {
+      const body = (await request.json().catch(() => null)) as {
+        accepting?: unknown;
+      } | null;
+      if (!body || typeof body.accepting !== "boolean")
+        return json({ error: "invalid-operations-command" }, 400);
+      this.sql.exec(
+        `UPDATE simulation_operations SET value = ? WHERE key = 'accepting'`,
+        body.accepting ? "true" : "false",
+      );
+    } else if (request.method !== "GET") {
+      return json({ error: "method-not-allowed" }, 405);
+    }
+    const counts = Object.fromEntries(
+      this.sql
+        .exec<{ state: string; count: number }>(
+          `SELECT state, COUNT(*) AS count FROM simulation_runs GROUP BY state`,
+        )
+        .toArray()
+        .map((row) => [row.state, row.count]),
+    );
+    return json({ accepting: this.isAccepting(), counts });
+  }
+
+  private isAccepting(): boolean {
+    return (
+      this.sql
+        .exec<{ value: string }>(
+          `SELECT value FROM simulation_operations WHERE key = 'accepting'`,
+        )
+        .one().value === "true"
     );
   }
 

--- a/worker/simulation-control-do.ts
+++ b/worker/simulation-control-do.ts
@@ -1,0 +1,231 @@
+import {
+  DEFAULT_MANAGED_RUN_POLICY,
+  ManagedRunAdmissionSchema,
+  ManagedRunEventSchema,
+  ManagedRunRecordSchema,
+  createManagedRun,
+  isManagedRunTerminal,
+  transitionManagedRun,
+  type ManagedRunPolicy,
+  type ManagedRunRecord,
+} from "@icm/simulation-service";
+
+type SqlResult<T> = { one(): T; toArray(): T[] };
+type SqlStorage = {
+  exec<T>(query: string, ...bindings: unknown[]): SqlResult<T>;
+};
+type DurableObjectStateLike = {
+  storage: {
+    sql: SqlStorage;
+    transactionSync<T>(callback: () => T): T;
+  };
+};
+
+export type SimulationControlNamespaceLike = {
+  getByName(name: string): {
+    fetch(input: string, init?: RequestInit): Promise<Response>;
+  };
+};
+
+type RunRow = { record_json: string };
+type CountRow = { count: number };
+type RequestRow = { request_fingerprint: string; run_id: string };
+
+const json = (value: unknown, status = 200) => Response.json(value, { status });
+
+/**
+ * Small durable control plane for one release channel.
+ *
+ * It owns run admission, idempotency and lifecycle metadata only. Decks,
+ * rawfiles and result bytes belong to the artifact store, and execution never
+ * waits inside this Durable Object.
+ */
+export class SimulationControlDO {
+  private readonly sql: SqlStorage;
+
+  constructor(
+    private readonly state: DurableObjectStateLike,
+    private readonly policy: ManagedRunPolicy = DEFAULT_MANAGED_RUN_POLICY,
+  ) {
+    this.sql = state.storage.sql;
+    this.initializeSchema();
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    if (request.method === "POST" && url.pathname === "/accept")
+      return this.accept(request);
+    const runMatch = url.pathname.match(/^\/runs\/([^/]+)$/u);
+    if (!runMatch) return json({ error: "not-found" }, 404);
+    const runId = decodeURIComponent(runMatch[1]!);
+    if (request.method === "GET") return this.read(runId);
+    if (request.method === "POST") return this.transition(runId, request);
+    return json({ error: "method-not-allowed" }, 405);
+  }
+
+  private initializeSchema(): void {
+    this.sql.exec(`
+      CREATE TABLE IF NOT EXISTS simulation_runs (
+        id TEXT PRIMARY KEY,
+        owner_id TEXT NOT NULL,
+        state TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        finished_at INTEGER,
+        record_json TEXT NOT NULL
+      ) WITHOUT ROWID
+    `);
+    this.sql.exec(`
+      CREATE INDEX IF NOT EXISTS simulation_runs_owner_state
+      ON simulation_runs(owner_id, state)
+    `);
+    this.sql.exec(`
+      CREATE TABLE IF NOT EXISTS simulation_start_requests (
+        owner_id TEXT NOT NULL,
+        request_id TEXT NOT NULL,
+        request_fingerprint TEXT NOT NULL,
+        run_id TEXT NOT NULL,
+        PRIMARY KEY (owner_id, request_id)
+      ) WITHOUT ROWID
+    `);
+  }
+
+  private async accept(request: Request): Promise<Response> {
+    const parsed = ManagedRunAdmissionSchema.safeParse(
+      await request.json().catch(() => null),
+    );
+    if (!parsed.success)
+      return json(
+        {
+          error: "invalid-admission",
+          message: parsed.error.issues[0]?.message ?? "Invalid run admission",
+        },
+        400,
+      );
+    const admission = parsed.data;
+    const result = this.state.storage.transactionSync(() => {
+      const previous = this.sql
+        .exec<RequestRow>(
+          `SELECT request_fingerprint, run_id
+           FROM simulation_start_requests
+           WHERE owner_id = ? AND request_id = ?`,
+          admission.ownerId,
+          admission.requestId,
+        )
+        .toArray()[0];
+      if (previous) {
+        if (previous.request_fingerprint !== admission.requestFingerprint)
+          return { error: "REQUEST_ID_REUSED" } as const;
+        const run = this.readRecord(previous.run_id);
+        return run
+          ? ({ run, accepted: false } as const)
+          : ({ error: "REQUEST_ID_REUSED" } as const);
+      }
+
+      const queuedGlobal = this.count("state = 'queued'");
+      if (queuedGlobal >= this.policy.maxQueuedGlobal)
+        return { error: "GLOBAL_QUEUE_LIMIT", retryAfterMs: 2_000 } as const;
+      const queuedOwner = this.count(
+        "owner_id = ? AND state = 'queued'",
+        admission.ownerId,
+      );
+      if (queuedOwner >= this.policy.maxQueuedPerOwner)
+        return { error: "OWNER_QUEUE_LIMIT", retryAfterMs: 2_000 } as const;
+      const activeOwner = this.count(
+        "owner_id = ? AND state IN ('running', 'cancelling')",
+        admission.ownerId,
+      );
+      if (activeOwner >= this.policy.maxActivePerOwner)
+        return { error: "OWNER_ACTIVE_LIMIT", retryAfterMs: 2_000 } as const;
+
+      const run = createManagedRun(crypto.randomUUID(), admission, Date.now());
+      this.writeRecord(run);
+      this.sql.exec(
+        `INSERT INTO simulation_start_requests
+          (owner_id, request_id, request_fingerprint, run_id)
+         VALUES (?, ?, ?, ?)`,
+        admission.ownerId,
+        admission.requestId,
+        admission.requestFingerprint,
+        run.id,
+      );
+      return { run, accepted: true } as const;
+    });
+    return "error" in result ? json(result, 409) : json(result, 201);
+  }
+
+  private read(runId: string): Response {
+    const run = this.readRecord(runId);
+    return run ? json({ run }) : json({ error: "RUN_NOT_FOUND" }, 404);
+  }
+
+  private async transition(runId: string, request: Request): Promise<Response> {
+    const parsed = ManagedRunEventSchema.safeParse(
+      await request.json().catch(() => null),
+    );
+    if (!parsed.success)
+      return json(
+        {
+          error: "invalid-transition",
+          message: parsed.error.issues[0]?.message ?? "Invalid run transition",
+        },
+        400,
+      );
+    const result = this.state.storage.transactionSync(() => {
+      const run = this.readRecord(runId);
+      if (!run) return null;
+      const transition = transitionManagedRun(run, parsed.data);
+      if (transition.ok) this.writeRecord(transition.run);
+      return transition;
+    });
+    if (!result) return json({ error: "RUN_NOT_FOUND" }, 404);
+    return result.ok ? json(result) : json(result, 409);
+  }
+
+  private count(where: string, ...bindings: unknown[]): number {
+    return this.sql
+      .exec<CountRow>(
+        `SELECT COUNT(*) AS count FROM simulation_runs WHERE ${where}`,
+        ...bindings,
+      )
+      .one().count;
+  }
+
+  private readRecord(runId: string): ManagedRunRecord | null {
+    const row = this.sql
+      .exec<RunRow>(
+        "SELECT record_json FROM simulation_runs WHERE id = ?",
+        runId,
+      )
+      .toArray()[0];
+    if (!row) return null;
+    const parsed = ManagedRunRecordSchema.safeParse(
+      JSON.parse(row.record_json),
+    );
+    return parsed.success ? parsed.data : null;
+  }
+
+  private writeRecord(run: ManagedRunRecord): void {
+    this.sql.exec(
+      `INSERT INTO simulation_runs
+        (id, owner_id, state, created_at, updated_at, finished_at, record_json)
+       VALUES (?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(id) DO UPDATE SET
+         state = excluded.state,
+         updated_at = excluded.updated_at,
+         finished_at = excluded.finished_at,
+         record_json = excluded.record_json`,
+      run.id,
+      run.ownerId,
+      run.state,
+      run.createdAt,
+      run.updatedAt,
+      run.finishedAt ?? null,
+      JSON.stringify(run),
+    );
+  }
+}
+
+export function managedRunNeedsRetention(run: ManagedRunRecord): boolean {
+  return isManagedRunTerminal(run.state) && run.state !== "expired";
+}

--- a/worker/simulation-control-do.ts
+++ b/worker/simulation-control-do.ts
@@ -63,6 +63,8 @@ export class SimulationControlDO {
       return this.anonymousSession(request);
     if (request.method === "POST" && url.pathname === "/accept")
       return this.accept(request);
+    if (request.method === "GET" && url.pathname === "/runs")
+      return this.list(url.searchParams.get("ownerId"));
     const runMatch = url.pathname.match(/^\/runs\/([^/]+)$/u);
     if (!runMatch) return json({ error: "not-found" }, 404);
     const runId = decodeURIComponent(runMatch[1]!);
@@ -172,6 +174,24 @@ export class SimulationControlDO {
   private read(runId: string): Response {
     const run = this.readRecord(runId);
     return run ? json({ run }) : json({ error: "RUN_NOT_FOUND" }, 404);
+  }
+
+  private list(ownerId: string | null): Response {
+    if (!ownerId) return json({ error: "owner-required" }, 400);
+    const runs = this.sql
+      .exec<RunRow>(
+        `SELECT record_json FROM simulation_runs
+         WHERE owner_id = ? ORDER BY created_at DESC LIMIT 50`,
+        ownerId,
+      )
+      .toArray()
+      .flatMap((row) => {
+        const parsed = ManagedRunRecordSchema.safeParse(
+          JSON.parse(row.record_json),
+        );
+        return parsed.success ? [parsed.data] : [];
+      });
+    return json({ runs });
   }
 
   private async transition(runId: string, request: Request): Promise<Response> {

--- a/worker/simulation-control-do.ts
+++ b/worker/simulation-control-do.ts
@@ -30,6 +30,10 @@ export type SimulationControlNamespaceLike = {
 type RunRow = { record_json: string };
 type CountRow = { count: number };
 type RequestRow = { request_fingerprint: string; run_id: string };
+type AnonymousSessionRow = { owner_id: string };
+
+export const SIMULATION_SESSION_COOKIE = "icm_simulation_session";
+const SIMULATION_SESSION_TTL_MS = 24 * 60 * 60_000;
 
 const json = (value: unknown, status = 200) => Response.json(value, { status });
 
@@ -55,6 +59,8 @@ export class SimulationControlDO {
   async fetch(request: Request): Promise<Response> {
     this.pruneExpired(this.now());
     const url = new URL(request.url);
+    if (url.pathname === "/anonymous-session")
+      return this.anonymousSession(request);
     if (request.method === "POST" && url.pathname === "/accept")
       return this.accept(request);
     const runMatch = url.pathname.match(/^\/runs\/([^/]+)$/u);
@@ -88,6 +94,13 @@ export class SimulationControlDO {
         request_fingerprint TEXT NOT NULL,
         run_id TEXT NOT NULL,
         PRIMARY KEY (owner_id, request_id)
+      ) WITHOUT ROWID
+    `);
+    this.sql.exec(`
+      CREATE TABLE IF NOT EXISTS simulation_anonymous_sessions (
+        token_hash TEXT PRIMARY KEY,
+        owner_id TEXT NOT NULL,
+        expires_at INTEGER NOT NULL
       ) WITHOUT ROWID
     `);
   }
@@ -227,7 +240,57 @@ export class SimulationControlDO {
     );
   }
 
+  private async anonymousSession(request: Request): Promise<Response> {
+    if (request.method !== "GET" && request.method !== "POST")
+      return json({ error: "method-not-allowed" }, 405);
+    const token = cookieValue(
+      request.headers.get("cookie"),
+      SIMULATION_SESSION_COOKIE,
+    );
+    if (token) {
+      const tokenHash = await sha256(token);
+      const row = this.sql
+        .exec<AnonymousSessionRow>(
+          `SELECT owner_id FROM simulation_anonymous_sessions
+           WHERE token_hash = ? AND expires_at > ?`,
+          tokenHash,
+          this.now(),
+        )
+        .toArray()[0];
+      if (row)
+        return json({
+          principal: anonymousPrincipal(row.owner_id),
+        });
+    }
+    if (request.method !== "POST")
+      return json({ error: "simulation-authentication-required" }, 401);
+    const issuedToken = randomToken();
+    const ownerId = `anonymous-${crypto.randomUUID()}`;
+    const expiresAt = this.now() + SIMULATION_SESSION_TTL_MS;
+    this.sql.exec(
+      `INSERT INTO simulation_anonymous_sessions
+        (token_hash, owner_id, expires_at) VALUES (?, ?, ?)`,
+      await sha256(issuedToken),
+      ownerId,
+      expiresAt,
+    );
+    return Response.json(
+      { principal: anonymousPrincipal(ownerId) },
+      {
+        status: 201,
+        headers: {
+          "set-cookie": `${SIMULATION_SESSION_COOKIE}=${issuedToken}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=${Math.floor(SIMULATION_SESSION_TTL_MS / 1_000)}`,
+          "cache-control": "no-store",
+        },
+      },
+    );
+  }
+
   private pruneExpired(now: number): void {
+    this.sql.exec(
+      "DELETE FROM simulation_anonymous_sessions WHERE expires_at <= ?",
+      now,
+    );
     const queued = this.sql
       .exec<RunRow>(
         `SELECT record_json FROM simulation_runs
@@ -271,6 +334,42 @@ export class SimulationControlDO {
       if (transition.ok) this.writeRecord(transition.run);
     }
   }
+}
+
+function cookieValue(header: string | null, name: string): string | null {
+  for (const item of (header ?? "").split(";")) {
+    const [key, ...rest] = item.trim().split("=");
+    if (key === name && rest.length > 0) return rest.join("=");
+  }
+  return null;
+}
+
+function randomToken(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(32));
+  return [...bytes]
+    .map((value) => value.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function sha256(text: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(text),
+  );
+  return [...new Uint8Array(digest)]
+    .map((value) => value.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function anonymousPrincipal(ownerId: string) {
+  return {
+    id: ownerId,
+    displayName: "Anonymous simulator",
+    email: null,
+    provider: "simulation-session",
+    role: "user",
+    isAdmin: false,
+  };
 }
 
 export function managedRunNeedsRetention(run: ManagedRunRecord): boolean {

--- a/worker/simulation-operations.test.ts
+++ b/worker/simulation-operations.test.ts
@@ -185,6 +185,38 @@ describe("managed simulation operations", () => {
     expect(response?.status).toBe(401);
   });
 
+  it("exposes drain and state counts only to administrators", async () => {
+    const { env, runtime } = harness();
+    const denied = await routeManagedSimulationRequest(
+      new Request("https://canvas.test/api/simulation/operations"),
+      env,
+      runtime,
+    );
+    expect(denied?.status).toBe(403);
+    const adminRuntime = {
+      ...runtime,
+      principalOf: async () => ({
+        id: "admin-a",
+        displayName: "Admin",
+        email: "admin@example.test",
+        provider: "test",
+        role: "user",
+        isAdmin: true,
+      }),
+    };
+    const drained = await routeManagedSimulationRequest(
+      new Request("https://canvas.test/api/simulation/operations", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ accepting: false }),
+      }),
+      env,
+      adminRuntime,
+    );
+    expect(drained?.status).toBe(200);
+    expect(await drained!.json()).toMatchObject({ accepting: false });
+  });
+
   it("persists input, queues once, and finishes independently of a browser", async () => {
     const { bucket, env, jobs, runtime } = harness();
     const started = await routeManagedSimulationRequest(

--- a/worker/simulation-operations.test.ts
+++ b/worker/simulation-operations.test.ts
@@ -159,6 +159,22 @@ function startRequest() {
 }
 
 describe("managed simulation operations", () => {
+  it("keeps anonymous preview runs usable with an opaque session cookie", async () => {
+    const { env } = harness();
+    const started = await routeManagedSimulationRequest(startRequest(), env);
+    expect(started?.status).toBe(202);
+    const cookie = started?.headers.get("set-cookie");
+    expect(cookie).toContain("icm_simulation_session=");
+    const runId = ((await started!.json()) as { run: { id: string } }).run.id;
+    const read = await routeManagedSimulationRequest(
+      new Request(`https://canvas.test/api/simulation/runs/${runId}`, {
+        headers: { cookie: cookie!.split(";")[0]! },
+      }),
+      env,
+    );
+    expect(read?.status).toBe(200);
+  });
+
   it("requires a principal before accepting computation", async () => {
     const { env } = harness();
     const response = await routeManagedSimulationRequest(startRequest(), env, {

--- a/worker/simulation-operations.test.ts
+++ b/worker/simulation-operations.test.ts
@@ -1,0 +1,274 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+
+import {
+  buildSimulationDeck,
+  createSimulationEnvironmentMetadata,
+} from "@icm/spice-run";
+import hostedSky130Profile from "../containers/ngspice/hosted-sky130-profile.json";
+
+import { SimulationControlDO } from "./simulation-control-do";
+import {
+  consumeSimulationJobs,
+  routeManagedSimulationRequest,
+  type SimulationArtifactBucket,
+  type SimulationJobMessage,
+  type SimulationOperationsEnv,
+  type SimulationQueueMessage,
+} from "./simulation-operations";
+
+function sqliteState() {
+  const db = new DatabaseSync(":memory:");
+  return {
+    storage: {
+      sql: {
+        exec<T>(query: string, ...bindings: unknown[]) {
+          const statement = db.prepare(query);
+          if (/^\s*(select|with|pragma)/iu.test(query)) {
+            const rows = statement.all(
+              ...(bindings as (string | number | null)[]),
+            ) as T[];
+            return {
+              toArray: () => rows,
+              one: () => {
+                if (rows.length !== 1) throw new Error("expected one row");
+                return rows[0]!;
+              },
+            };
+          }
+          statement.run(...(bindings as (string | number | null)[]));
+          return {
+            toArray: () => [] as T[],
+            one: () => {
+              throw new Error("no rows");
+            },
+          };
+        },
+      },
+      transactionSync<T>(callback: () => T): T {
+        return callback();
+      },
+    },
+  };
+}
+
+class MemoryBucket implements SimulationArtifactBucket {
+  readonly objects = new Map<string, string>();
+  async get(key: string) {
+    const value = this.objects.get(key);
+    return value === undefined ? null : { text: async () => value };
+  }
+  async put(key: string, value: string) {
+    this.objects.set(key, value);
+    return {};
+  }
+  async delete(key: string) {
+    this.objects.delete(key);
+  }
+}
+
+const environment = await createSimulationEnvironmentMetadata({
+  executor: "hosted-container",
+  reproducibility: "observed",
+  profileId: null,
+  platform: "linux/x64",
+  simulator: {
+    name: "ngspice",
+    version: "ngspice-47",
+    binarySha256:
+      "22d5cae2bd32b2e39157a8d27bf457122f68285b72a9ebefdf41551b628233ab",
+  },
+  models: {
+    id: "sky130A",
+    contentSha256:
+      "17c208a699228f5acb87bf59c09c22a4c4d3937b6766b4957737d34e8e075f64",
+  },
+  startupSha256: null,
+});
+
+function harness() {
+  const control = new SimulationControlDO(sqliteState(), undefined, () => 100);
+  const bucket = new MemoryBucket();
+  const jobs: SimulationJobMessage[] = [];
+  const env: SimulationOperationsEnv = {
+    SIMULATION_CONTROL: {
+      getByName: () => ({
+        fetch: (input, init) => control.fetch(new Request(input, init)),
+      }),
+    },
+    SIMULATION_ARTIFACTS: bucket,
+    SIMULATION_JOBS: {
+      async send(message) {
+        jobs.push(message);
+      },
+    },
+    NGSPICE: {
+      getByName: () => ({
+        fetch: async () =>
+          Response.json({
+            environment,
+            log: "Circuit: * divider\nv(in) = 1\n",
+            exitCode: 0,
+            timedOut: false,
+            durationMs: 5,
+          }),
+      }),
+    },
+  };
+  const principal = {
+    id: "user-a",
+    displayName: "User A",
+    email: "a@example.test",
+    provider: "test",
+    role: "user",
+    isAdmin: false,
+  };
+  const runtime = {
+    principalOf: async () => principal,
+    now: () => 100,
+    uuid: () => "lease-a",
+  };
+  return { bucket, control, env, jobs, runtime };
+}
+
+function startRequest() {
+  const netlist = "R1 in 0 1k";
+  const testbench = "V1 in 0 1\n.op";
+  return new Request("https://canvas.test/api/simulation/runs", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      requestId: "request-a",
+      preparedId: "prepared-a",
+      preparedDigest: "a".repeat(64),
+      input: {
+        mode: "structured",
+        environment: {
+          profileId: hostedSky130Profile.id,
+          corner: "tt",
+        },
+        files: [],
+        dependencies: [],
+        netlist,
+        testbench,
+        preparedDeck: buildSimulationDeck({ netlist, testbench }, null),
+        inputRevision: "revision-a",
+      },
+    }),
+  });
+}
+
+describe("managed simulation operations", () => {
+  it("requires a principal before accepting computation", async () => {
+    const { env } = harness();
+    const response = await routeManagedSimulationRequest(startRequest(), env, {
+      principalOf: async () => null,
+      now: () => 100,
+      uuid: () => "unused",
+    });
+    expect(response?.status).toBe(401);
+  });
+
+  it("persists input, queues once, and finishes independently of a browser", async () => {
+    const { bucket, env, jobs, runtime } = harness();
+    const started = await routeManagedSimulationRequest(
+      startRequest(),
+      env,
+      runtime,
+    );
+    expect(started?.status).toBe(202);
+    const startBody = (await started!.json()) as {
+      run: { id: string; state: string };
+    };
+    expect(startBody.run.state).toBe("queued");
+    expect(jobs).toHaveLength(1);
+    expect([...bucket.objects.keys()]).toEqual([
+      expect.stringMatching(/^simulation-inputs\/user-a\/[a-f0-9]{64}\.json$/u),
+    ]);
+    expect(jobs[0]).toEqual({ schemaVersion: 1, runId: startBody.run.id });
+
+    const delivery: SimulationQueueMessage<SimulationJobMessage> = {
+      body: jobs[0]!,
+      ack: () => undefined,
+      retry: () => {
+        throw new Error("successful run must not retry");
+      },
+    };
+    await consumeSimulationJobs({ messages: [delivery] }, env, runtime);
+
+    const read = await routeManagedSimulationRequest(
+      new Request(
+        `https://canvas.test/api/simulation/runs/${startBody.run.id}`,
+      ),
+      env,
+      runtime,
+    );
+    expect(read?.status).toBe(200);
+    expect(await read!.json()).toMatchObject({
+      run: {
+        id: startBody.run.id,
+        state: "succeeded",
+        attempt: 1,
+        artifacts: [{ name: "managed-input.json" }, { name: "response.json" }],
+      },
+    });
+    const result = await routeManagedSimulationRequest(
+      new Request(
+        `https://canvas.test/api/simulation/runs/${startBody.run.id}/result`,
+      ),
+      env,
+      runtime,
+    );
+    expect(result?.status).toBe(200);
+    expect(await result!.json()).toMatchObject({
+      outcome: { status: "completed" },
+      metadata: { input: { inputRevision: "revision-a" } },
+    });
+  });
+
+  it("requeues infrastructure refusal under the same run", async () => {
+    const { env, jobs, runtime } = harness();
+    env.NGSPICE = {
+      getByName: () => ({
+        fetch: async () =>
+          Response.json(
+            { error: "simulator-busy", message: "one circuit at a time" },
+            { status: 503 },
+          ),
+      }),
+    };
+    const started = await routeManagedSimulationRequest(
+      startRequest(),
+      env,
+      runtime,
+    );
+    const runId = ((await started!.json()) as { run: { id: string } }).run.id;
+    let retried = false;
+    await consumeSimulationJobs(
+      {
+        messages: [
+          {
+            body: jobs[0]!,
+            ack: () => {
+              throw new Error("busy run must not be acknowledged");
+            },
+            retry: () => {
+              retried = true;
+            },
+          },
+        ],
+      },
+      env,
+      runtime,
+    );
+    expect(retried).toBe(true);
+    const response = await routeManagedSimulationRequest(
+      new Request(`https://canvas.test/api/simulation/runs/${runId}`),
+      env,
+      runtime,
+    );
+    expect(await response!.json()).toMatchObject({
+      run: { state: "queued", attempt: 1 },
+    });
+  });
+});

--- a/worker/simulation-operations.ts
+++ b/worker/simulation-operations.ts
@@ -1,0 +1,564 @@
+import {
+  DEFAULT_MANAGED_RUN_POLICY,
+  Digest,
+  ManagedRunRecordSchema,
+  type ArtifactRef,
+  type ManagedRunRecord,
+  type Problem,
+} from "@icm/simulation-service";
+
+import { sessionUserOf } from "./auth";
+import type { AuthEnv, SessionUser } from "./auth-do";
+import type { SimulationControlNamespaceLike } from "./simulation-control-do";
+import {
+  routeSimulationRequest,
+  type SimulationEnv,
+  type SimulationRequestBody,
+} from "./simulation";
+
+const MAX_MANAGED_INPUT_BYTES = 2 * 1024 * 1024;
+const CONTROL_NAME = "simulation";
+
+export interface SimulationArtifactObject {
+  text(): Promise<string>;
+}
+
+export interface SimulationArtifactBucket {
+  get(key: string): Promise<SimulationArtifactObject | null>;
+  put(
+    key: string,
+    value: string,
+    options?: {
+      httpMetadata?: { contentType?: string };
+      customMetadata?: Record<string, string>;
+    },
+  ): Promise<unknown>;
+  delete(key: string): Promise<void>;
+}
+
+export interface SimulationJobQueue {
+  send(body: SimulationJobMessage): Promise<void>;
+}
+
+export interface SimulationOperationsEnv
+  extends SimulationEnv, Partial<AuthEnv> {
+  SIMULATION_CONTROL?: SimulationControlNamespaceLike;
+  SIMULATION_JOBS?: SimulationJobQueue;
+  SIMULATION_ARTIFACTS?: SimulationArtifactBucket;
+}
+
+export interface SimulationJobMessage {
+  schemaVersion: 1;
+  runId: string;
+}
+
+export interface SimulationQueueMessage<T> {
+  body: T;
+  ack(): void;
+  retry(options?: { delaySeconds?: number }): void;
+}
+
+export interface SimulationQueueBatch<T> {
+  messages: readonly SimulationQueueMessage<T>[];
+}
+
+export interface SimulationOperationsRuntime {
+  principalOf(
+    request: Request,
+    env: SimulationOperationsEnv,
+  ): Promise<SessionUser | null>;
+  now(): number;
+  uuid(): string;
+}
+
+const defaultRuntime: SimulationOperationsRuntime = {
+  principalOf: (request, env) => sessionUserOf(request, env),
+  now: Date.now,
+  uuid: () => crypto.randomUUID(),
+};
+
+type StartBody = {
+  requestId?: unknown;
+  preparedId?: unknown;
+  preparedDigest?: unknown;
+  input?: unknown;
+};
+
+function control(env: SimulationOperationsEnv) {
+  return env.SIMULATION_CONTROL?.getByName(CONTROL_NAME) ?? null;
+}
+
+function configured(env: SimulationOperationsEnv): boolean {
+  return !!(
+    env.SIMULATION_CONTROL &&
+    env.SIMULATION_JOBS &&
+    env.SIMULATION_ARTIFACTS
+  );
+}
+
+function runPath(runId: string): string {
+  return `https://simulation-control/runs/${encodeURIComponent(runId)}`;
+}
+
+async function sha256(text: string): Promise<string> {
+  const bytes = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(text),
+  );
+  return [...new Uint8Array(bytes)]
+    .map((value) => value.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function safeSegment(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]/gu, "_").slice(0, 160);
+}
+
+function asInput(value: unknown): SimulationRequestBody | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const input = value as SimulationRequestBody;
+  if (
+    input.operation !== undefined ||
+    typeof input.inputRevision !== "string" ||
+    !input.environment ||
+    typeof input.environment.profileId !== "string"
+  )
+    return null;
+  return input;
+}
+
+async function readRun(
+  env: SimulationOperationsEnv,
+  runId: string,
+): Promise<ManagedRunRecord | null> {
+  const stub = control(env);
+  if (!stub) return null;
+  const response = await stub.fetch(runPath(runId));
+  if (!response.ok) return null;
+  const value = (await response.json()) as { run?: unknown };
+  const parsed = ManagedRunRecordSchema.safeParse(value.run);
+  return parsed.success ? parsed.data : null;
+}
+
+async function transitionRun(
+  env: SimulationOperationsEnv,
+  runId: string,
+  event: unknown,
+): Promise<ManagedRunRecord | null> {
+  const stub = control(env);
+  if (!stub) return null;
+  const response = await stub.fetch(runPath(runId), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(event),
+  });
+  if (!response.ok) return null;
+  const value = (await response.json()) as { run?: unknown };
+  const parsed = ManagedRunRecordSchema.safeParse(value.run);
+  return parsed.success ? parsed.data : null;
+}
+
+function ownerMayRead(run: ManagedRunRecord, principal: SessionUser): boolean {
+  return run.ownerId === principal.id || principal.isAdmin;
+}
+
+export async function routeManagedSimulationRequest(
+  request: Request,
+  env: SimulationOperationsEnv,
+  runtime: SimulationOperationsRuntime = defaultRuntime,
+): Promise<Response | null> {
+  const url = new URL(request.url);
+  if (!url.pathname.startsWith("/api/simulation/runs")) return null;
+  if (!configured(env))
+    return Response.json(
+      {
+        error: "simulation-operations-not-configured",
+        message:
+          "Managed simulation runs are not configured in this deployment.",
+      },
+      { status: 503 },
+    );
+  const principal = await runtime.principalOf(request, env);
+  if (!principal)
+    return Response.json(
+      { error: "simulation-authentication-required" },
+      { status: 401 },
+    );
+
+  if (url.pathname === "/api/simulation/runs") {
+    if (request.method !== "POST")
+      return Response.json({ error: "method-not-allowed" }, { status: 405 });
+    const body = (await request.json().catch(() => null)) as StartBody | null;
+    const input = asInput(body?.input);
+    if (
+      !body ||
+      typeof body.requestId !== "string" ||
+      body.requestId.length === 0 ||
+      body.requestId.length > 256 ||
+      typeof body.preparedId !== "string" ||
+      typeof body.preparedDigest !== "string" ||
+      !Digest.safeParse(body.preparedDigest).success ||
+      !input
+    )
+      return Response.json({ error: "invalid-managed-run" }, { status: 400 });
+    const canonicalInput = JSON.stringify(input);
+    if (
+      new TextEncoder().encode(canonicalInput).length > MAX_MANAGED_INPUT_BYTES
+    )
+      return Response.json({ error: "deck-too-large" }, { status: 413 });
+    const requestFingerprint = await sha256(
+      JSON.stringify({
+        preparedId: body.preparedId,
+        preparedDigest: body.preparedDigest,
+        timeoutMs: input.timeoutMs ?? null,
+        input,
+      }),
+    );
+    const inputKey = `simulation-inputs/${safeSegment(principal.id)}/${requestFingerprint}.json`;
+    await env.SIMULATION_ARTIFACTS!.put(inputKey, canonicalInput, {
+      httpMetadata: { contentType: "application/json" },
+      customMetadata: {
+        ownerId: principal.id,
+        requestFingerprint,
+      },
+    });
+    const inputArtifact: ArtifactRef = {
+      id: inputKey,
+      name: "managed-input.json",
+      mediaType: "application/json",
+      byteLength: new TextEncoder().encode(canonicalInput).length,
+      sha256: await sha256(canonicalInput),
+    };
+    const response = await control(env)!.fetch(
+      "https://simulation-control/accept",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          ownerId: principal.id,
+          requestId: body.requestId,
+          requestFingerprint,
+          preparedId: body.preparedId,
+          preparedDigest: body.preparedDigest,
+          inputRevision: input.inputRevision,
+          environment: input.environment,
+          timeoutMs:
+            typeof input.timeoutMs === "number" ? input.timeoutMs : 60_000,
+          maxAttempts: 3,
+          artifacts: [inputArtifact],
+        }),
+      },
+    );
+    const result = (await response.json()) as {
+      run?: ManagedRunRecord;
+      accepted?: boolean;
+      error?: string;
+      retryAfterMs?: number;
+    };
+    if (!response.ok || !result.run)
+      return Response.json(result, {
+        status: response.status,
+        ...(result.retryAfterMs === undefined
+          ? {}
+          : {
+              headers: {
+                "retry-after": String(Math.ceil(result.retryAfterMs / 1_000)),
+              },
+            }),
+      });
+    try {
+      await env.SIMULATION_JOBS!.send({
+        schemaVersion: 1,
+        runId: result.run.id,
+      });
+    } catch {
+      return Response.json(
+        {
+          error: "simulation-queue-unavailable",
+          run: result.run,
+          recovery: "retry-same-request",
+        },
+        { status: 503 },
+      );
+    }
+    return Response.json(
+      { run: result.run, accepted: result.accepted === true },
+      { status: result.accepted === true ? 202 : 200 },
+    );
+  }
+
+  const match = url.pathname.match(
+    /^\/api\/simulation\/runs\/([^/]+)(\/(?:cancel|result))?$/u,
+  );
+  if (!match) return Response.json({ error: "not-found" }, { status: 404 });
+  const runId = decodeURIComponent(match[1]!);
+  const run = await readRun(env, runId);
+  if (!run || !ownerMayRead(run, principal))
+    return Response.json({ error: "RUN_NOT_FOUND" }, { status: 404 });
+  if (!match[2]) {
+    if (request.method !== "GET")
+      return Response.json({ error: "method-not-allowed" }, { status: 405 });
+    return Response.json({ run });
+  }
+  if (match[2] === "/result") {
+    if (request.method !== "GET")
+      return Response.json({ error: "method-not-allowed" }, { status: 405 });
+    const result = run.artifacts.find(
+      (artifact) => artifact.name === "response.json",
+    );
+    if (!result)
+      return Response.json(
+        {
+          error: "RESULT_NOT_READY",
+          state: run.state,
+          retryAfterMs: 1_000,
+        },
+        { status: 409, headers: { "retry-after": "1" } },
+      );
+    const object = await env.SIMULATION_ARTIFACTS!.get(result.id);
+    if (!object)
+      return Response.json({ error: "RESULT_EXPIRED" }, { status: 410 });
+    return new Response(await object.text(), {
+      headers: {
+        "content-type": result.mediaType,
+        "cache-control": "private, no-store",
+        "x-content-type-options": "nosniff",
+      },
+    });
+  }
+  if (request.method !== "POST")
+    return Response.json({ error: "method-not-allowed" }, { status: 405 });
+  const transitioned = await transitionRun(env, runId, {
+    kind: "cancel-requested",
+    at: runtime.now(),
+  });
+  if (!transitioned)
+    return Response.json(
+      { error: "cancel-transition-failed" },
+      { status: 409 },
+    );
+  if (transitioned.state === "cancelling") {
+    await routeSimulationRequest(
+      new Request("https://simulation/api/simulate", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ operation: "cancel", runToken: runId }),
+      }),
+      env,
+    );
+  }
+  return Response.json({ run: transitioned });
+}
+
+function infrastructureProblem(code: string): Problem {
+  return {
+    code,
+    message: "The execution infrastructure did not complete this attempt.",
+    stage: "start",
+    recovery: "retry-after",
+    retryAfterMs: 2_000,
+  };
+}
+
+function responseCode(value: unknown): string | null {
+  if (!value || typeof value !== "object") return null;
+  const body = value as { error?: unknown; reason?: unknown };
+  return typeof body.reason === "string"
+    ? body.reason
+    : typeof body.error === "string"
+      ? body.error
+      : null;
+}
+
+const retryableInfrastructureCodes = new Set([
+  "simulator-busy",
+  "simulator-unreachable",
+  "simulation-executor-unavailable",
+  "simulator-not-ready",
+]);
+
+export async function consumeSimulationJobs(
+  batch: SimulationQueueBatch<SimulationJobMessage>,
+  env: SimulationOperationsEnv,
+  runtime: Pick<SimulationOperationsRuntime, "now" | "uuid"> = defaultRuntime,
+): Promise<void> {
+  for (const message of batch.messages) {
+    try {
+      const current = await readRun(env, message.body.runId);
+      if (
+        !current ||
+        [
+          "succeeded",
+          "failed",
+          "timed-out",
+          "cancelled",
+          "infrastructure-failed",
+          "expired",
+        ].includes(current.state)
+      ) {
+        message.ack();
+        continue;
+      }
+      let queued = current;
+      if (
+        (current.state === "running" || current.state === "cancelling") &&
+        current.lease &&
+        current.lease.expiresAt <= runtime.now()
+      ) {
+        const recovered = await transitionRun(env, current.id, {
+          kind: "lease-expired",
+          at: runtime.now(),
+          error: infrastructureProblem("RUN_LEASE_EXPIRED"),
+        });
+        if (!recovered || recovered.state !== "queued") {
+          message.ack();
+          continue;
+        }
+        queued = recovered;
+      }
+      if (queued.state !== "queued") {
+        message.retry({ delaySeconds: 2 });
+        continue;
+      }
+      const leased = await transitionRun(env, queued.id, {
+        kind: "lease-acquired",
+        lease: {
+          id: runtime.uuid(),
+          acquiredAt: runtime.now(),
+          expiresAt: runtime.now() + DEFAULT_MANAGED_RUN_POLICY.leaseMs,
+        },
+      });
+      if (!leased) {
+        message.retry({ delaySeconds: 2 });
+        continue;
+      }
+      // Queue messages carry identity, not storage authority. The immutable
+      // input key comes from the admitted run, so a stale or malformed queue
+      // delivery cannot make the consumer execute another owner's object.
+      const inputArtifact = queued.artifacts.find(
+        (artifact) => artifact.name === "managed-input.json",
+      );
+      const inputObject = inputArtifact
+        ? await env.SIMULATION_ARTIFACTS?.get(inputArtifact.id)
+        : null;
+      if (!inputObject) {
+        await transitionRun(env, queued.id, {
+          kind: "failed",
+          at: runtime.now(),
+          error: {
+            code: "PREPARED_INPUT_UNAVAILABLE",
+            message: "The immutable input artifact is unavailable.",
+            stage: "start",
+            recovery: "reprepare",
+          },
+        });
+        message.ack();
+        continue;
+      }
+      const input = JSON.parse(
+        await inputObject.text(),
+      ) as SimulationRequestBody;
+      input.runToken = queued.id;
+      const response = await routeSimulationRequest(
+        new Request("https://simulation/api/simulate", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(input),
+        }),
+        env,
+      );
+      if (!response) throw new Error("simulation route unavailable");
+      const responseText = await response.text();
+      const responseValue = JSON.parse(responseText) as {
+        cancelled?: unknown;
+        outcome?: { status?: unknown };
+      };
+      const code = responseCode(responseValue);
+      if (!response.ok && code && retryableInfrastructureCodes.has(code)) {
+        const retried = await transitionRun(env, queued.id, {
+          kind: "infrastructure-failed",
+          at: runtime.now(),
+          error: infrastructureProblem(code),
+        });
+        if (retried?.state === "queued") message.retry({ delaySeconds: 2 });
+        else message.ack();
+        continue;
+      }
+      const resultKey = `simulation-runs/${safeSegment(queued.ownerId)}/${queued.id}/response.json`;
+      await env.SIMULATION_ARTIFACTS!.put(resultKey, responseText, {
+        httpMetadata: { contentType: "application/json" },
+        customMetadata: { ownerId: queued.ownerId, runId: queued.id },
+      });
+      const resultArtifact: ArtifactRef = {
+        id: resultKey,
+        name: "response.json",
+        mediaType: "application/json",
+        byteLength: new TextEncoder().encode(responseText).length,
+        sha256: await sha256(responseText),
+      };
+      const artifacts = [...queued.artifacts, resultArtifact];
+      if (responseValue.cancelled === true)
+        await transitionRun(env, queued.id, {
+          kind: "cancelled",
+          at: runtime.now(),
+          artifacts,
+        });
+      else if (responseValue.outcome?.status === "timed-out")
+        await transitionRun(env, queued.id, {
+          kind: "timed-out",
+          at: runtime.now(),
+          error: {
+            code: "RUN_TIMED_OUT",
+            message: "The simulator reached the run deadline.",
+            stage: "start",
+            recovery: "fix-input",
+          },
+          artifacts,
+        });
+      else if (responseValue.outcome?.status === "failed")
+        await transitionRun(env, queued.id, {
+          kind: "failed",
+          at: runtime.now(),
+          error: {
+            code: "SIMULATION_FAILED",
+            message: "ngspice did not produce the requested result.",
+            stage: "start",
+            recovery: "fix-input",
+          },
+          artifacts,
+        });
+      else if (
+        response.ok &&
+        (responseValue.outcome?.status === "completed" ||
+          responseValue.outcome?.status === "completed-with-dropped-input")
+      )
+        await transitionRun(env, queued.id, {
+          kind: "completed",
+          at: runtime.now(),
+          artifacts,
+        });
+      else
+        await transitionRun(env, queued.id, {
+          kind: "failed",
+          at: runtime.now(),
+          error: {
+            code: code ?? "SIMULATION_FAILED",
+            message: "The simulator refused or failed this input.",
+            stage: "start",
+            recovery: "fix-input",
+          },
+          artifacts,
+        });
+      message.ack();
+    } catch {
+      const run = await readRun(env, message.body.runId).catch(() => null);
+      if (run?.state === "running")
+        await transitionRun(env, run.id, {
+          kind: "infrastructure-failed",
+          at: runtime.now(),
+          error: infrastructureProblem("SIMULATION_CONSUMER_FAILED"),
+        }).catch(() => null);
+      message.retry({ delaySeconds: 2 });
+    }
+  }
+}

--- a/worker/simulation-operations.ts
+++ b/worker/simulation-operations.ts
@@ -225,6 +225,17 @@ export async function routeManagedSimulationRequest(
   };
 
   if (url.pathname === "/api/simulation/runs") {
+    if (request.method === "GET") {
+      const response = await control(env)!.fetch(
+        `https://simulation-control/runs?ownerId=${encodeURIComponent(principal.id)}`,
+      );
+      return ownedResponse(
+        new Response(response.body, {
+          status: response.status,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    }
     if (request.method !== "POST")
       return ownedResponse(
         Response.json({ error: "method-not-allowed" }, { status: 405 }),

--- a/worker/simulation-operations.ts
+++ b/worker/simulation-operations.ts
@@ -67,12 +67,36 @@ export interface SimulationOperationsRuntime {
     request: Request,
     env: SimulationOperationsEnv,
   ): Promise<SessionUser | null>;
+  anonymousPrincipalOf?(
+    request: Request,
+    env: SimulationOperationsEnv,
+    create: boolean,
+  ): Promise<{ principal: SessionUser | null; cookie?: string }>;
   now(): number;
   uuid(): string;
 }
 
 const defaultRuntime: SimulationOperationsRuntime = {
   principalOf: (request, env) => sessionUserOf(request, env),
+  anonymousPrincipalOf: async (request, env, create) => {
+    const stub = control(env);
+    if (!stub) return { principal: null };
+    const response = await stub.fetch(
+      "https://simulation-control/anonymous-session",
+      {
+        method: create ? "POST" : "GET",
+        headers: { cookie: request.headers.get("cookie") ?? "" },
+      },
+    );
+    if (!response.ok) return { principal: null };
+    const body = (await response.json()) as { principal?: SessionUser };
+    return {
+      principal: body.principal ?? null,
+      ...(response.headers.get("set-cookie")
+        ? { cookie: response.headers.get("set-cookie")! }
+        : {}),
+    };
+  },
   now: Date.now,
   uuid: () => crypto.randomUUID(),
 };
@@ -178,16 +202,33 @@ export async function routeManagedSimulationRequest(
       },
       { status: 503 },
     );
-  const principal = await runtime.principalOf(request, env);
+  let principal = await runtime.principalOf(request, env);
+  let ownerCookie: string | undefined;
+  if (!principal && runtime.anonymousPrincipalOf) {
+    const anonymous = await runtime.anonymousPrincipalOf(
+      request,
+      env,
+      url.pathname === "/api/simulation/runs" && request.method === "POST",
+    );
+    principal = anonymous.principal;
+    ownerCookie = anonymous.cookie;
+  }
   if (!principal)
     return Response.json(
       { error: "simulation-authentication-required" },
       { status: 401 },
     );
+  const ownedResponse = (response: Response): Response => {
+    response.headers.set("cache-control", "private, no-store");
+    if (ownerCookie) response.headers.append("set-cookie", ownerCookie);
+    return response;
+  };
 
   if (url.pathname === "/api/simulation/runs") {
     if (request.method !== "POST")
-      return Response.json({ error: "method-not-allowed" }, { status: 405 });
+      return ownedResponse(
+        Response.json({ error: "method-not-allowed" }, { status: 405 }),
+      );
     const body = (await request.json().catch(() => null)) as StartBody | null;
     const input = asInput(body?.input);
     if (
@@ -200,12 +241,16 @@ export async function routeManagedSimulationRequest(
       !Digest.safeParse(body.preparedDigest).success ||
       !input
     )
-      return Response.json({ error: "invalid-managed-run" }, { status: 400 });
+      return ownedResponse(
+        Response.json({ error: "invalid-managed-run" }, { status: 400 }),
+      );
     const canonicalInput = JSON.stringify(input);
     if (
       new TextEncoder().encode(canonicalInput).length > MAX_MANAGED_INPUT_BYTES
     )
-      return Response.json({ error: "deck-too-large" }, { status: 413 });
+      return ownedResponse(
+        Response.json({ error: "deck-too-large" }, { status: 413 }),
+      );
     const requestFingerprint = await sha256(
       JSON.stringify({
         preparedId: body.preparedId,
@@ -256,35 +301,40 @@ export async function routeManagedSimulationRequest(
       retryAfterMs?: number;
     };
     if (!response.ok || !result.run)
-      return Response.json(result, {
-        status: response.status,
-        ...(result.retryAfterMs === undefined
-          ? {}
-          : {
-              headers: {
-                "retry-after": String(Math.ceil(result.retryAfterMs / 1_000)),
-              },
-            }),
-      });
+      return ownedResponse(
+        Response.json(result, {
+          status: response.status,
+          ...(result.retryAfterMs === undefined
+            ? {}
+            : {
+                headers: {
+                  "retry-after": String(Math.ceil(result.retryAfterMs / 1_000)),
+                },
+              }),
+        }),
+      );
     try {
       await env.SIMULATION_JOBS!.send({
         schemaVersion: 1,
         runId: result.run.id,
       });
     } catch {
-      return Response.json(
-        {
-          error: "simulation-queue-unavailable",
-          run: result.run,
-          recovery: "retry-same-request",
-        },
-        { status: 503 },
+      return ownedResponse(
+        Response.json(
+          {
+            error: "simulation-queue-unavailable",
+            run: result.run,
+            recovery: "retry-same-request",
+          },
+          { status: 503 },
+        ),
       );
     }
-    return Response.json(
+    const startResponse = Response.json(
       { run: result.run, accepted: result.accepted === true },
       { status: result.accepted === true ? 202 : 200 },
     );
+    return ownedResponse(startResponse);
   }
 
   const match = url.pathname.match(
@@ -298,7 +348,7 @@ export async function routeManagedSimulationRequest(
   if (!match[2]) {
     if (request.method !== "GET")
       return Response.json({ error: "method-not-allowed" }, { status: 405 });
-    return Response.json({ run });
+    return ownedResponse(Response.json({ run }));
   }
   if (match[2] === "/result") {
     if (request.method !== "GET")

--- a/worker/simulation-operations.ts
+++ b/worker/simulation-operations.ts
@@ -192,7 +192,7 @@ export async function routeManagedSimulationRequest(
   runtime: SimulationOperationsRuntime = defaultRuntime,
 ): Promise<Response | null> {
   const url = new URL(request.url);
-  if (!url.pathname.startsWith("/api/simulation/runs")) return null;
+  if (!url.pathname.startsWith("/api/simulation/")) return null;
   if (!configured(env))
     return Response.json(
       {
@@ -223,6 +223,38 @@ export async function routeManagedSimulationRequest(
     if (ownerCookie) response.headers.append("set-cookie", ownerCookie);
     return response;
   };
+
+  if (url.pathname === "/api/simulation/operations") {
+    if (!principal.isAdmin)
+      return ownedResponse(
+        Response.json({ error: "simulation-admin-required" }, { status: 403 }),
+      );
+    if (request.method !== "GET" && request.method !== "POST")
+      return ownedResponse(
+        Response.json({ error: "method-not-allowed" }, { status: 405 }),
+      );
+    const response = await control(env)!.fetch(
+      "https://simulation-control/operations",
+      request.method === "POST"
+        ? {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: await request.text(),
+          }
+        : undefined,
+    );
+    return ownedResponse(
+      new Response(response.body, {
+        status: response.status,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+  }
+
+  if (!url.pathname.startsWith("/api/simulation/runs"))
+    return ownedResponse(
+      Response.json({ error: "not-found" }, { status: 404 }),
+    );
 
   if (url.pathname === "/api/simulation/runs") {
     if (request.method === "GET") {
@@ -351,34 +383,47 @@ export async function routeManagedSimulationRequest(
   const match = url.pathname.match(
     /^\/api\/simulation\/runs\/([^/]+)(\/(?:cancel|result))?$/u,
   );
-  if (!match) return Response.json({ error: "not-found" }, { status: 404 });
+  if (!match)
+    return ownedResponse(
+      Response.json({ error: "not-found" }, { status: 404 }),
+    );
   const runId = decodeURIComponent(match[1]!);
   const run = await readRun(env, runId);
   if (!run || !ownerMayRead(run, principal))
-    return Response.json({ error: "RUN_NOT_FOUND" }, { status: 404 });
+    return ownedResponse(
+      Response.json({ error: "RUN_NOT_FOUND" }, { status: 404 }),
+    );
   if (!match[2]) {
     if (request.method !== "GET")
-      return Response.json({ error: "method-not-allowed" }, { status: 405 });
+      return ownedResponse(
+        Response.json({ error: "method-not-allowed" }, { status: 405 }),
+      );
     return ownedResponse(Response.json({ run }));
   }
   if (match[2] === "/result") {
     if (request.method !== "GET")
-      return Response.json({ error: "method-not-allowed" }, { status: 405 });
+      return ownedResponse(
+        Response.json({ error: "method-not-allowed" }, { status: 405 }),
+      );
     const result = run.artifacts.find(
       (artifact) => artifact.name === "response.json",
     );
     if (!result)
-      return Response.json(
-        {
-          error: "RESULT_NOT_READY",
-          state: run.state,
-          retryAfterMs: 1_000,
-        },
-        { status: 409, headers: { "retry-after": "1" } },
+      return ownedResponse(
+        Response.json(
+          {
+            error: "RESULT_NOT_READY",
+            state: run.state,
+            retryAfterMs: 1_000,
+          },
+          { status: 409, headers: { "retry-after": "1" } },
+        ),
       );
     const object = await env.SIMULATION_ARTIFACTS!.get(result.id);
     if (!object)
-      return Response.json({ error: "RESULT_EXPIRED" }, { status: 410 });
+      return ownedResponse(
+        Response.json({ error: "RESULT_EXPIRED" }, { status: 410 }),
+      );
     return new Response(await object.text(), {
       headers: {
         "content-type": result.mediaType,
@@ -388,15 +433,16 @@ export async function routeManagedSimulationRequest(
     });
   }
   if (request.method !== "POST")
-    return Response.json({ error: "method-not-allowed" }, { status: 405 });
+    return ownedResponse(
+      Response.json({ error: "method-not-allowed" }, { status: 405 }),
+    );
   const transitioned = await transitionRun(env, runId, {
     kind: "cancel-requested",
     at: runtime.now(),
   });
   if (!transitioned)
-    return Response.json(
-      { error: "cancel-transition-failed" },
-      { status: 409 },
+    return ownedResponse(
+      Response.json({ error: "cancel-transition-failed" }, { status: 409 }),
     );
   if (transitioned.state === "cancelling") {
     await routeSimulationRequest(
@@ -408,7 +454,7 @@ export async function routeManagedSimulationRequest(
       env,
     );
   }
-  return Response.json({ run: transitioned });
+  return ownedResponse(Response.json({ run: transitioned }));
 }
 
 function infrastructureProblem(code: string): Problem {

--- a/worker/simulation.ts
+++ b/worker/simulation.ts
@@ -84,7 +84,7 @@ function advertisedMaxOutputBytes(env: SimulationEnv): number {
  */
 const CLOUDFLARE_CONTAINER_INSTANCE_KEY = `profile:${hostedSky130Profile.id}`;
 
-interface SimulationRequestBody {
+export interface SimulationRequestBody {
   operation?: unknown;
   mode?: unknown;
   environment?: {

--- a/wrangler.preview.jsonc
+++ b/wrangler.preview.jsonc
@@ -61,6 +61,36 @@
       // The preview's own accounts: nobody signs in here, and no login
       // provider is configured, so this namespace stays empty by design.
       { "name": "AUTH", "class_name": "AuthDO" },
+      // Server-side authority for queued runs. Large immutable bytes live in
+      // R2; this object stores only lifecycle, ownership and artifact refs.
+      { "name": "SIMULATION_CONTROL", "class_name": "SimulationControlDO" },
+    ],
+  },
+  "r2_buckets": [
+    {
+      "binding": "SIMULATION_ARTIFACTS",
+      "bucket_name": "analog-canvas-simulation-artifacts-preview",
+    },
+  ],
+  "queues": {
+    "producers": [
+      {
+        "binding": "SIMULATION_JOBS",
+        "queue": "analog-canvas-simulation-preview",
+      },
+    ],
+    "consumers": [
+      {
+        "queue": "analog-canvas-simulation-preview",
+        "max_batch_size": 1,
+        "max_batch_timeout": 1,
+        // The Frankfurt harness currently owns one ngspice slot. Consumer
+        // concurrency must never promise more capacity than the executor.
+        "max_concurrency": 1,
+        "max_retries": 3,
+        "retry_delay": 2,
+        "dead_letter_queue": "analog-canvas-simulation-preview-dlq",
+      },
     ],
   },
   "migrations": [
@@ -72,6 +102,7 @@
     // The simulator moved to the operator host; the container class, its
     // namespace, and its billed instance go with this migration.
     { "tag": "v6", "deleted_classes": ["NgspiceContainer"] },
+    { "tag": "v7", "new_sqlite_classes": ["SimulationControlDO"] },
   ],
   "observability": {
     "enabled": true,


### PR DESCRIPTION
## Outcome

Moves Preview simulation admission and run authority out of the browser without changing the preparation/result semantics shared by GUI and Agent.

- durable idempotent run lifecycle, owner/global admission, leases, retry, cancel, expiry, history, and admin drain
- one-slot Cloudflare Queue aligned with the Frankfurt executor
- immutable bounded input/result evidence in Preview R2 with one-day lifecycle
- signed-in owner or opaque HttpOnly anonymous simulation session
- explicit managed transport for Preview; production and localhost remain direct, with no automatic fallback
- trusted operator-host auth gateway separated from the no-egress ngspice executor so authored control code cannot read the bearer token
- current specs and deployment recovery record updated

## Safety boundary

Production bindings are unchanged. Preview resource reconciliation creates/updates only nalog-canvas-simulation-preview, its DLQ, and nalog-canvas-simulation-artifacts-preview. The Preview deploy token therefore needs Queue and R2 edit permission; deploy fails closed if it does not have them.

## Validation

- pnpm gate:preflight -- --base origin/main
- pnpm gate:full -- --base origin/main
  - 2805 unit tests passed (22 skipped)
  - 358 browser tests passed
  - static/docs/reference/MCP distribution checks passed
  - workspace build, release/performance/golden/production smoke passed
- Docker Compose config parsed with contract environment
- gateway integration and host topology tests passed

Test-Impact: tests-updated