### PR TITLE
feat(simulation): organize analysis result layouts

### DIFF
--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -592,11 +592,23 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   await panel.getByRole("button", { name: "Hide canvas values" }).click();
   await expect(page.getByTestId("operating-point-badges")).toHaveCount(0);
   await panel.getByRole("tab", { name: "Plot" }).click();
+  await expect(
+    panel.getByRole("heading", { name: "AC Analysis" }),
+  ).toBeVisible();
+  await expect(
+    panel.getByRole("heading", { name: "Transient Analysis" }),
+  ).toBeVisible();
   const plotMeasurements = panel.locator(
     "details.simulation-measurement-results",
   );
-  await expect(plotMeasurements.locator(":scope > summary")).toContainText(
-    "8 values",
+  await expect(plotMeasurements).toHaveCount(2);
+  expect(
+    await plotMeasurements.locator(":scope > summary").allTextContents(),
+  ).toEqual(
+    expect.arrayContaining([
+      expect.stringContaining("3 values"),
+      expect.stringContaining("5 values"),
+    ]),
   );
   await expect(panel.locator(".spice-ac-plot svg")).toHaveCount(2);
   await expect(panel.locator('svg[aria-label="AC magnitude"]')).toBeVisible();
@@ -697,6 +709,30 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
     .filter({ hasText: "Magnitude" })
     .locator(".spice-ac-plot")
     .first();
+  const magnitudeToolbar = magnitudePlot.locator("..").getByLabel("Plot tools");
+  await page.mouse.move(1, 1);
+  await expect(
+    magnitudeToolbar.getByRole("button", { name: "Zoom in" }),
+  ).toBeHidden();
+  const plotLayoutBeforeToolbar = await magnitudePlot.evaluate((element) => {
+    const plot = element.getBoundingClientRect();
+    const toolbar = element
+      .parentElement!.querySelector('[aria-label="Plot tools"]')!
+      .getBoundingClientRect();
+    return { height: plot.height, toolbarGap: plot.top - toolbar.bottom };
+  });
+  await magnitudePlot.hover();
+  await expect(
+    magnitudeToolbar.getByRole("button", { name: "Zoom in" }),
+  ).toBeVisible();
+  const plotLayoutAfterToolbar = await magnitudePlot.evaluate((element) => {
+    const plot = element.getBoundingClientRect();
+    const toolbar = element
+      .parentElement!.querySelector('[aria-label="Plot tools"]')!
+      .getBoundingClientRect();
+    return { height: plot.height, toolbarGap: plot.top - toolbar.bottom };
+  });
+  expect(plotLayoutAfterToolbar).toEqual(plotLayoutBeforeToolbar);
   const plotBeforeWheel = await magnitudePlot.innerHTML();
   await magnitudePlot.dispatchEvent("wheel", { deltaY: -120 });
   await expect(magnitudePlot).toHaveJSProperty("innerHTML", plotBeforeWheel);
@@ -901,6 +937,7 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
     .click();
   await expect(rightTimeLabel).toHaveText(savedTicks ?? "");
   await expect(fixedReadout).toHaveText(markersBeforeRemount ?? "");
+  await transientPlot.hover();
   await transientShell.getByRole("button", { name: "Previous view" }).click();
   await expect(rightTimeLabel).toHaveText(fullTimeLabel ?? "");
   await transientShell.getByRole("button", { name: "Next view" }).click();
@@ -979,6 +1016,7 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   await expect(panel.getByRole("status")).toHaveText("finished · completed");
   await panel.getByRole("tab", { name: "Plot" }).click();
   await expect(panel.locator(".ac-cursor-readout")).toHaveCount(0);
+  await transientPlot.hover();
   await expect(
     transientShell.getByRole("button", { name: "Previous view" }),
   ).toBeDisabled();

--- a/apps/editor/src/features/simulation/ac-results-explorer.test.tsx
+++ b/apps/editor/src/features/simulation/ac-results-explorer.test.tsx
@@ -62,6 +62,9 @@ describe("AC Results Explorer", () => {
     expect(markup).toContain('aria-pressed="true">Magnitude');
     expect(markup).toContain("0.7V");
     expect(markup).toContain('aria-label="Plot tools"');
+    expect(markup).toContain('class="waveform-tools-hint"');
+    expect(markup).toContain('class="waveform-tool-actions"');
+    expect(markup).toContain('tabindex="0"');
     expect(markup).toContain('aria-label="Open plot"');
     expect(markup).not.toContain("Wheel to zoom");
   });

--- a/apps/editor/src/features/simulation/simulation-output-results.test.tsx
+++ b/apps/editor/src/features/simulation/simulation-output-results.test.tsx
@@ -1,0 +1,57 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { SimulationOutputResults } from "./simulation-output-results";
+
+describe("Simulation Output Results", () => {
+  it("groups an analysis and its measurements in one named result card", () => {
+    const markup = renderToStaticMarkup(
+      <SimulationOutputResults
+        resultKey="run-1"
+        outputs={[]}
+        data={{
+          schemaVersion: 1,
+          diagnostics: [],
+          analyses: [
+            {
+              analysis: "op",
+              plotName: "Bias point",
+              outputs: [
+                {
+                  id: "out-v",
+                  label: "VOUT",
+                  unit: "V",
+                  values: [1.5],
+                },
+              ],
+            },
+          ],
+          measurements: [
+            {
+              id: "measurement-out-v",
+              analysisIndex: 0,
+              analysis: "op",
+              plotName: "Bias point",
+              outputId: "out-v",
+              outputLabel: "VOUT",
+              metric: "operating-point",
+              label: "Operating point",
+              unit: "V",
+              status: "available",
+              value: 1.5,
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(markup).toContain('class="simulation-output-results"');
+    expect(markup).toContain('class="simulation-analysis-card"');
+    expect(markup).toContain("Operating Point Analysis");
+    expect(markup).toContain("Bias point");
+    expect(markup).toContain("Measurements");
+    expect(markup.indexOf("Measurements")).toBeLessThan(
+      markup.indexOf("</section>"),
+    );
+  });
+});

--- a/apps/editor/src/features/simulation/simulation-output-results.tsx
+++ b/apps/editor/src/features/simulation/simulation-output-results.tsx
@@ -1,4 +1,5 @@
 import type { SimulationFocusTarget } from "./simulation-focus-target";
+import type { ReactNode } from "react";
 import {
   simulationExpressionDependencies,
   type SimulationOutputSpec,
@@ -12,6 +13,45 @@ import {
 } from "./ac-results-explorer";
 import { ScalarResultsExplorer } from "./transient-results-explorer";
 import { SimulationMeasurementResults } from "./simulation-measurement-results";
+
+export type SimulationAnalysisKind = "op" | "dc" | "ac" | "tran";
+
+function simulationAnalysisTitle(kind: SimulationAnalysisKind): string {
+  switch (kind) {
+    case "op":
+      return "Operating Point Analysis";
+    case "dc":
+      return "DC Analysis";
+    case "ac":
+      return "AC Analysis";
+    case "tran":
+      return "Transient Analysis";
+  }
+}
+
+export function SimulationAnalysisCard({
+  kind,
+  plotName,
+  children,
+}: {
+  kind: SimulationAnalysisKind;
+  plotName?: string;
+  children: ReactNode;
+}) {
+  const title = simulationAnalysisTitle(kind);
+  return (
+    <section
+      className="simulation-analysis-card"
+      aria-label={kind === "op" ? "OP results" : `${title} results`}
+    >
+      <header className="simulation-analysis-card-header">
+        <h3>{title}</h3>
+        {plotName && plotName !== title ? <small>{plotName}</small> : null}
+      </header>
+      <div className="simulation-analysis-card-body">{children}</div>
+    </section>
+  );
+}
 
 function focusProbe(
   output: SimulationOutputSpec,
@@ -37,20 +77,16 @@ export function SimulationOutputResults({
     const probe = focusProbe(output);
     return probe ? [probe] : [];
   });
-  const visibleAnalyses = new Set(
-    data.analyses.map((analysis) => analysis.analysis),
-  );
-
   return (
-    <>
+    <div className="simulation-output-results">
       {data.analyses.map((analysis, analysisIndex) => {
         if (analysis.analysis === "op")
           return (
-            <section
+            <SimulationAnalysisCard
               key={`op-${analysisIndex}`}
-              aria-label="Derived OP results"
+              kind="op"
+              plotName={analysis.plotName}
             >
-              <h3>{analysis.plotName}</h3>
               <table>
                 <thead>
                   <tr>
@@ -70,7 +106,14 @@ export function SimulationOutputResults({
                   ))}
                 </tbody>
               </table>
-            </section>
+              <SimulationMeasurementResults
+                measurements={(data.measurements ?? []).filter(
+                  (measurement) =>
+                    measurement.analysis === analysis.analysis &&
+                    measurement.plotName === analysis.plotName,
+                )}
+              />
+            </SimulationAnalysisCard>
           );
         if (!analysis.domain) return null;
         const complex = analysis.outputs.filter((output) => output.imaginary);
@@ -82,7 +125,11 @@ export function SimulationOutputResults({
             output,
           ]);
         return (
-          <section key={`${analysis.analysis}-${analysisIndex}`}>
+          <SimulationAnalysisCard
+            key={`${analysis.analysis}-${analysisIndex}`}
+            kind={analysis.analysis}
+            plotName={analysis.plotName}
+          >
             {analysis.analysis === "ac" && complex.length > 0 ? (
               <ComplexResultsExplorer
                 resultKey={`${resultKey}:complex:${analysisIndex}`}
@@ -168,7 +215,14 @@ export function SimulationOutputResults({
                 />
               );
             })}
-          </section>
+            <SimulationMeasurementResults
+              measurements={(data.measurements ?? []).filter(
+                (measurement) =>
+                  measurement.analysis === analysis.analysis &&
+                  measurement.plotName === analysis.plotName,
+              )}
+            />
+          </SimulationAnalysisCard>
         );
       })}
       {data.diagnostics.length > 0 ? (
@@ -184,11 +238,6 @@ export function SimulationOutputResults({
           ))}
         </div>
       ) : null}
-      <SimulationMeasurementResults
-        measurements={(data.measurements ?? []).filter((measurement) =>
-          visibleAnalyses.has(measurement.analysis),
-        )}
-      />
-    </>
+    </div>
   );
 }

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -25,7 +25,10 @@ import { SimulationRunDetails } from "./simulation-run-details";
 import { AcResultsExplorer } from "./ac-results-explorer";
 import { DcResultsExplorer } from "./dc-results-explorer";
 import { TransientResultsExplorer } from "./transient-results-explorer";
-import { SimulationOutputResults } from "./simulation-output-results";
+import {
+  SimulationAnalysisCard,
+  SimulationOutputResults,
+} from "./simulation-output-results";
 import { deriveOperatingPointCanvasProjection } from "./operating-point-projection";
 import type { OperatingPointDisplay } from "./operating-point-labels";
 
@@ -944,66 +947,81 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
                   run?.result?.data?.analyses
                     .filter((analysis) => analysis.analysis === "dc")
                     .map((analysis, index) => (
-                      <DcResultsExplorer
+                      <SimulationAnalysisCard
                         key={`dc-${index}`}
-                        analysis={analysis}
-                        vectors={runPresentation?.prepared.vectors ?? []}
-                        probes={presentationProbes}
-                        labels={presentationLabels}
-                        {...(props.onFocusProbe
-                          ? {
-                              onFocusProbe: (probe: SimulationFocusTarget) =>
-                                props.onFocusProbe?.(
-                                  probe,
-                                  runPresentation?.rootDocumentId,
-                                ),
-                            }
-                          : {})}
-                      />
+                        kind="dc"
+                        plotName={analysis.plotName}
+                      >
+                        <DcResultsExplorer
+                          analysis={analysis}
+                          vectors={runPresentation?.prepared.vectors ?? []}
+                          probes={presentationProbes}
+                          labels={presentationLabels}
+                          {...(props.onFocusProbe
+                            ? {
+                                onFocusProbe: (probe: SimulationFocusTarget) =>
+                                  props.onFocusProbe?.(
+                                    probe,
+                                    runPresentation?.rootDocumentId,
+                                  ),
+                              }
+                            : {})}
+                        />
+                      </SimulationAnalysisCard>
                     ))}
                 {!run?.outputData &&
                   run?.result?.data?.analyses
                     .filter((analysis) => analysis.analysis === "ac")
                     .map((analysis, index) => (
-                      <AcResultsExplorer
+                      <SimulationAnalysisCard
                         key={`${run.id}:ac:${index}`}
-                        resultKey={`${run.id}:ac:${index}`}
-                        analysis={analysis}
-                        vectors={runPresentation?.prepared.vectors ?? []}
-                        probes={presentationProbes}
-                        labels={presentationLabels}
-                        {...(props.onFocusProbe
-                          ? {
-                              onFocusProbe: (probe: SimulationFocusTarget) =>
-                                props.onFocusProbe?.(
-                                  probe,
-                                  runPresentation?.rootDocumentId,
-                                ),
-                            }
-                          : {})}
-                      />
+                        kind="ac"
+                        plotName={analysis.plotName}
+                      >
+                        <AcResultsExplorer
+                          resultKey={`${run.id}:ac:${index}`}
+                          analysis={analysis}
+                          vectors={runPresentation?.prepared.vectors ?? []}
+                          probes={presentationProbes}
+                          labels={presentationLabels}
+                          {...(props.onFocusProbe
+                            ? {
+                                onFocusProbe: (probe: SimulationFocusTarget) =>
+                                  props.onFocusProbe?.(
+                                    probe,
+                                    runPresentation?.rootDocumentId,
+                                  ),
+                              }
+                            : {})}
+                        />
+                      </SimulationAnalysisCard>
                     ))}
                 {!run?.outputData &&
                   run?.result?.data?.analyses
                     .filter((analysis) => analysis.analysis === "tran")
                     .map((analysis, index) => (
-                      <TransientResultsExplorer
+                      <SimulationAnalysisCard
                         key={`${run.id}:tran:${index}`}
-                        resultKey={`${run.id}:tran:${index}`}
-                        analysis={analysis}
-                        vectors={runPresentation?.prepared.vectors ?? []}
-                        probes={presentationProbes}
-                        labels={presentationLabels}
-                        {...(props.onFocusProbe
-                          ? {
-                              onFocusProbe: (probe: SimulationFocusTarget) =>
-                                props.onFocusProbe?.(
-                                  probe,
-                                  runPresentation?.rootDocumentId,
-                                ),
-                            }
-                          : {})}
-                      />
+                        kind="tran"
+                        plotName={analysis.plotName}
+                      >
+                        <TransientResultsExplorer
+                          resultKey={`${run.id}:tran:${index}`}
+                          analysis={analysis}
+                          vectors={runPresentation?.prepared.vectors ?? []}
+                          probes={presentationProbes}
+                          labels={presentationLabels}
+                          {...(props.onFocusProbe
+                            ? {
+                                onFocusProbe: (probe: SimulationFocusTarget) =>
+                                  props.onFocusProbe?.(
+                                    probe,
+                                    runPresentation?.rootDocumentId,
+                                  ),
+                              }
+                            : {})}
+                        />
+                      </SimulationAnalysisCard>
                     ))}
                 {!run?.result?.data?.analyses.some(
                   (analysis) =>
@@ -1082,8 +1100,11 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
                   run?.result?.data?.analyses
                     .filter((analysis) => analysis.analysis === "op")
                     .map((analysis, index) => (
-                      <section key={index} aria-label="OP results">
-                        <h3>{analysis.plotName}</h3>
+                      <SimulationAnalysisCard
+                        key={index}
+                        kind="op"
+                        plotName={analysis.plotName}
+                      >
                         <table>
                           <thead>
                             <tr>
@@ -1102,7 +1123,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
                             ))}
                           </tbody>
                         </table>
-                      </section>
+                      </SimulationAnalysisCard>
                     ))}
                 {!run?.result?.data?.analyses.some(
                   (analysis) => analysis.analysis === "op",

--- a/apps/editor/src/features/simulation/transient-results-explorer.test.tsx
+++ b/apps/editor/src/features/simulation/transient-results-explorer.test.tsx
@@ -96,6 +96,8 @@ describe("Transient Results Explorer", () => {
     expect(markup).toContain('aria-label="Transient current"');
     expect(markup.match(/data-trace-index=/gu)).toHaveLength(2);
     expect(markup).toContain('aria-label="Plot tools"');
+    expect(markup.match(/class="waveform-tools-hint"/gu)).toHaveLength(2);
+    expect(markup.match(/class="waveform-tool-actions"/gu)).toHaveLength(2);
     expect(markup.match(/drag to zoom, click to measure/gu)).toHaveLength(2);
     expect(markup).not.toContain('aria-label="Inspect plot"');
     expect(markup.match(/aria-label="Open plot"/gu)).toHaveLength(2);

--- a/apps/editor/src/features/simulation/waveform-tools.tsx
+++ b/apps/editor/src/features/simulation/waveform-tools.tsx
@@ -40,72 +40,79 @@ export function WaveformTools({
           : { ...c.view.y, [plotKey]: zoomWaveformRange(y, factor) },
     });
   return (
-    <div className="ac-plot-toolbar waveform-tools" aria-label="Plot tools">
-      <button
-        type="button"
-        aria-label="Previous view"
-        disabled={c.state.index === 0}
-        onClick={() => c.travel(-1)}
-      >
-        ↶
-      </button>
-      <button
-        type="button"
-        aria-label="Next view"
-        disabled={c.state.index === c.state.history.length - 1}
-        onClick={() => c.travel(1)}
-      >
-        ↷
-      </button>
-      <div role="group" aria-label="Controlled axes">
-        {(["xy", "x", "y"] as const).map((axis) => (
-          <button
-            type="button"
-            key={axis}
-            aria-label={`Control ${axis.toUpperCase()} axes`}
-            aria-pressed={c.state.axes === axis}
-            onClick={() => c.set("axes", axis)}
-          >
-            {axis.toUpperCase()}
-          </button>
-        ))}
-      </div>
-      <button type="button" aria-label="Zoom in" onClick={() => zoom(0.6)}>
-        +
-      </button>
-      <button type="button" aria-label="Zoom out" onClick={() => zoom(1.7)}>
-        −
-      </button>
-      <button type="button" aria-label="Fit plot" onClick={() => fit("xy")}>
-        Fit
-      </button>
-      <button type="button" aria-label="Fit X" onClick={() => fit("x")}>
-        Fit X
-      </button>
-      <button type="button" aria-label="Fit Y" onClick={() => fit("y")}>
-        Fit Y
-      </button>
-      <button
-        type="button"
-        aria-expanded={editing}
-        onClick={() => setEditing(!editing)}
-      >
-        Ranges
-      </button>
-      <div role="group" aria-label="Active marker">
-        {(["A", "B"] as const).map((marker) => (
-          <button
-            key={marker}
-            type="button"
-            aria-label={`Place marker ${marker}`}
-            aria-pressed={c.state.activeMarker === marker}
-            onClick={() => c.set("activeMarker", marker)}
-          >
-            {marker}
-          </button>
-        ))}
-      </div>
-      {
+    <div
+      className={`ac-plot-toolbar waveform-tools${editing ? " expanded" : ""}`}
+      aria-label="Plot tools"
+      tabIndex={0}
+    >
+      <span className="waveform-tools-hint" aria-hidden="true">
+        Plot tools
+      </span>
+      <div className="waveform-tool-actions">
+        <button
+          type="button"
+          aria-label="Previous view"
+          disabled={c.state.index === 0}
+          onClick={() => c.travel(-1)}
+        >
+          ↶
+        </button>
+        <button
+          type="button"
+          aria-label="Next view"
+          disabled={c.state.index === c.state.history.length - 1}
+          onClick={() => c.travel(1)}
+        >
+          ↷
+        </button>
+        <div role="group" aria-label="Controlled axes">
+          {(["xy", "x", "y"] as const).map((axis) => (
+            <button
+              type="button"
+              key={axis}
+              aria-label={`Control ${axis.toUpperCase()} axes`}
+              aria-pressed={c.state.axes === axis}
+              onClick={() => c.set("axes", axis)}
+            >
+              {axis.toUpperCase()}
+            </button>
+          ))}
+        </div>
+        <button type="button" aria-label="Zoom in" onClick={() => zoom(0.6)}>
+          +
+        </button>
+        <button type="button" aria-label="Zoom out" onClick={() => zoom(1.7)}>
+          −
+        </button>
+        <button type="button" aria-label="Fit plot" onClick={() => fit("xy")}>
+          Fit
+        </button>
+        <button type="button" aria-label="Fit X" onClick={() => fit("x")}>
+          Fit X
+        </button>
+        <button type="button" aria-label="Fit Y" onClick={() => fit("y")}>
+          Fit Y
+        </button>
+        <button
+          type="button"
+          aria-expanded={editing}
+          onClick={() => setEditing(!editing)}
+        >
+          Ranges
+        </button>
+        <div role="group" aria-label="Active marker">
+          {(["A", "B"] as const).map((marker) => (
+            <button
+              key={marker}
+              type="button"
+              aria-label={`Place marker ${marker}`}
+              aria-pressed={c.state.activeMarker === marker}
+              onClick={() => c.set("activeMarker", marker)}
+            >
+              {marker}
+            </button>
+          ))}
+        </div>
         <button
           type="button"
           aria-label="Clear markers"
@@ -116,12 +123,12 @@ export function WaveformTools({
         >
           ×│
         </button>
-      }
-      {onOpen && (
-        <button type="button" aria-label="Open plot" onClick={onOpen}>
-          ⛶
-        </button>
-      )}
+        {onOpen && (
+          <button type="button" aria-label="Open plot" onClick={onOpen}>
+            ⛶
+          </button>
+        )}
+      </div>
       {editing && (
         <WaveformRangeEditor
           x={x}

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -721,7 +721,7 @@
 }
 .simulation-results-body {
   min-height: 0;
-  padding: 12px;
+  padding: 16px;
   overflow: auto;
 }
 .simulation-files-view small {
@@ -734,6 +734,54 @@
 .simulation-analysis-view h3 {
   margin: 0 0 8px;
   font-size: var(--icm-font-sm);
+}
+.simulation-analysis-view,
+.simulation-output-results {
+  display: grid;
+  align-content: start;
+  gap: 16px;
+  min-width: 0;
+}
+.simulation-analysis-card {
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid var(--icm-border-strong);
+  border-radius: var(--icm-radius-md);
+  background: var(--icm-surface);
+  box-shadow: var(--icm-shadow-sm);
+}
+.simulation-analysis-card-header {
+  display: grid;
+  justify-items: center;
+  gap: 2px;
+  padding: 11px 16px;
+  border-bottom: 1px solid var(--icm-border);
+  background: var(--icm-surface-muted);
+  text-align: center;
+}
+.simulation-analysis-view .simulation-analysis-card-header h3 {
+  margin: 0;
+  color: var(--icm-text);
+  font-size: var(--icm-font-md);
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+.simulation-analysis-card-header small {
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+}
+.simulation-analysis-card-body {
+  display: grid;
+  gap: 14px;
+  min-width: 0;
+  padding: 14px;
+}
+.simulation-analysis-card-body > .ac-results-explorer > header,
+.simulation-analysis-card-body > .transient-results-explorer > header {
+  display: none;
+}
+.simulation-analysis-card-body > .simulation-measurement-results {
+  margin-top: 0;
 }
 
 .simulation-op-canvas-controls {
@@ -1244,7 +1292,7 @@
 .ac-results-explorer {
   position: relative;
   display: grid;
-  gap: 6px;
+  gap: 12px;
   min-width: 0;
 }
 .ac-results-explorer > header {
@@ -1265,18 +1313,24 @@
 }
 .ac-view-toolbar {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
   min-width: 0;
-  margin-bottom: 5px;
+  min-height: 40px;
+  padding: 5px 7px;
+  overflow-x: auto;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  background: var(--icm-surface-muted);
 }
 .ac-view-toolbar > strong {
-  min-width: 72px;
+  min-width: 88px;
+  padding-left: 3px;
 }
 .ac-view-toolbar > [role="group"] {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: 2px;
   padding: 2px;
   border: 1px solid var(--icm-border);
@@ -1301,6 +1355,7 @@
   margin-left: auto;
   color: var(--icm-text-muted);
   font-size: var(--icm-font-xs);
+  white-space: nowrap;
 }
 .ac-view-toolbar select {
   min-height: 28px;
@@ -1312,14 +1367,14 @@
 }
 .simulation-plot-layout {
   display: grid;
-  grid-template-columns: minmax(74px, 108px) minmax(0, 1fr);
-  gap: 6px;
+  grid-template-columns: minmax(88px, 108px) minmax(0, 1fr);
+  gap: 12px;
   align-items: start;
   min-width: 0;
 }
 .simulation-plot-stack {
   display: grid;
-  gap: 8px;
+  gap: 12px;
   min-width: 0;
 }
 .waveform-trace-list {
@@ -1328,7 +1383,7 @@
   display: grid;
   gap: 4px;
   min-width: 0;
-  padding-top: 20px;
+  padding-top: 23px;
 }
 .waveform-trace-toggle {
   width: 100%;
@@ -1377,12 +1432,12 @@
 }
 .ac-quantity-group {
   display: grid;
-  gap: 4px;
+  gap: 10px;
   min-width: 0;
 }
 .ac-plot-row {
   display: grid;
-  gap: 3px;
+  gap: 6px;
   min-width: 0;
 }
 .ac-plot-row > strong {
@@ -1413,18 +1468,16 @@
   position: relative;
   order: -1;
   align-self: stretch;
-  justify-content: flex-end;
-  flex-wrap: wrap;
-  display: flex;
-  gap: 2px;
-  padding: 3px 4px;
+  display: block;
+  height: 34px;
+  min-height: 34px;
+  padding: 0;
   border: 0;
   border-bottom: 1px solid var(--icm-border);
   border-radius: 0;
   background: var(--icm-surface-muted);
   box-shadow: none;
-  opacity: 1;
-  pointer-events: auto;
+  outline-offset: -2px;
 }
 .ac-plot-shell > .ac-cursor-readout {
   margin: 0;
@@ -1433,11 +1486,44 @@
   border-radius: 0;
   box-shadow: none;
 }
-.ac-plot-shell:hover .ac-plot-toolbar,
-.ac-plot-shell:focus-within .ac-plot-toolbar,
-.ac-plot-toolbar.expanded {
+.waveform-tools-hint {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+  pointer-events: none;
+  transition: opacity 120ms ease;
+}
+.waveform-tool-actions {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 2px;
+  padding: 3px 4px;
+  overflow-x: auto;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    opacity 120ms ease,
+    visibility 0s linear 120ms;
+}
+.ac-plot-shell:hover .waveform-tool-actions,
+.ac-plot-toolbar:focus-within .waveform-tool-actions,
+.ac-plot-toolbar.expanded .waveform-tool-actions {
   opacity: 1;
+  visibility: visible;
   pointer-events: auto;
+  transition-delay: 0s;
+}
+.ac-plot-shell:hover .waveform-tools-hint,
+.ac-plot-toolbar:focus-within .waveform-tools-hint,
+.ac-plot-toolbar.expanded .waveform-tools-hint {
+  opacity: 0;
 }
 .ac-plot-toolbar button {
   min-width: 27px;
@@ -1571,6 +1657,17 @@
   }
   .simulation-artifact-list small {
     display: none;
+  }
+}
+
+@media (hover: none) {
+  .waveform-tools-hint {
+    display: none;
+  }
+  .waveform-tool-actions {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
   }
 }
 
@@ -2088,19 +2185,29 @@
 }
 .waveform-tools {
   align-self: stretch;
-  justify-content: flex-end;
 }
-.waveform-tools > [role="group"] {
+.waveform-tool-actions > [role="group"] {
   display: flex;
   border-left: 1px solid var(--icm-border);
   padding-left: 4px;
 }
 .waveform-range-editor {
-  flex-basis: 100%;
+  position: absolute;
+  z-index: 5;
+  top: 100%;
+  right: 0;
   display: flex;
   flex-wrap: wrap;
+  width: min(100%, 520px);
   gap: 6px;
   padding: 6px;
+  border: 1px solid var(--icm-border-strong);
+  border-radius: 0 0 var(--icm-radius-sm) var(--icm-radius-sm);
+  background: var(--icm-surface);
+  box-shadow: var(--icm-shadow-sm);
+}
+.ac-plot-shell:has(.waveform-range-editor) {
+  overflow: visible;
 }
 .waveform-range-editor fieldset {
   display: flex;


### PR DESCRIPTION
## Summary
- frame OP, DC, AC, and transient outputs as consistent analysis cards
- align analysis controls, plots, trace lists, and measurements
- collapse plot tools into a fixed-height hover/focus rail without waveform layout shifts

## Validation
- pnpm ci:static
- pnpm test:local (418 files, 2786 tests)
- pnpm test:e2e:local apps/editor/e2e/web-agent-session.spec.ts apps/editor/e2e/agent-simulation.spec.ts (6 tests)
- pnpm gate:preflight -- --base origin/main

Test-Impact: tests-updated