### PR TITLE
refactor(editor): simplify simulation result hierarchy

### DIFF
--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -601,14 +601,9 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   const plotMeasurements = panel.locator(
     "details.simulation-measurement-results",
   );
-  await expect(plotMeasurements).toHaveCount(2);
-  expect(
-    await plotMeasurements.locator(":scope > summary").allTextContents(),
-  ).toEqual(
-    expect.arrayContaining([
-      expect.stringContaining("3 values"),
-      expect.stringContaining("5 values"),
-    ]),
+  await expect(plotMeasurements).toHaveCount(1);
+  await expect(plotMeasurements.locator(":scope > summary")).toContainText(
+    "8 values",
   );
   await expect(panel.locator(".spice-ac-plot svg")).toHaveCount(2);
   await expect(panel.locator('svg[aria-label="AC magnitude"]')).toBeVisible();
@@ -766,13 +761,17 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   ).toBeVisible();
   await page.getByRole("button", { name: "Close plot" }).click();
   const tracePoint = await magnitudePlot
-    .locator("polyline[data-trace-id]")
+    .locator("polyline.ac-trace-hit[data-trace-id]")
     .evaluate((element) => {
       const line = element as SVGPolylineElement;
-      const point = line.points.getItem(line.points.numberOfItems - 1);
-      const screen = new DOMPoint(point.x, point.y).matrixTransform(
-        line.getScreenCTM()!,
-      );
+      const left = line.points.getItem(0);
+      const right = line.points.getItem(1);
+      // Click between samples so a marker, tick, or grid line at a sampled
+      // coordinate cannot intercept the trace-selection regression check.
+      const screen = new DOMPoint(
+        (left.x + right.x) / 2,
+        (left.y + right.y) / 2,
+      ).matrixTransform(line.getScreenCTM()!);
       return { x: screen.x, y: screen.y };
     });
   await page.mouse.click(tracePoint.x, tracePoint.y);
@@ -796,7 +795,7 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
     .last();
   const fullTimeLabel = await rightTimeLabel.textContent();
   const toolbarBounds = await transientShell
-    .getByLabel("Plot tools")
+    .getByLabel("Plot tools", { exact: true })
     .boundingBox();
   const transientBounds = await transientPlot.boundingBox();
   expect(transientBounds).not.toBeNull();
@@ -820,6 +819,7 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   ).toHaveCount(0);
   await expect(rightTimeLabel).not.toHaveText(fullTimeLabel ?? "");
   const zoomTimeLabel = await rightTimeLabel.textContent();
+  await transientShell.getByRole("button", { name: "More plot tools" }).click();
   await transientShell.getByRole("button", { name: "Previous view" }).click();
   await expect(rightTimeLabel).toHaveText(fullTimeLabel ?? "");
   await transientShell.getByRole("button", { name: "Next view" }).click();
@@ -849,6 +849,7 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
       .locator('svg text[text-anchor="end"]')
       .allTextContents(),
   ).toEqual(yLabels);
+  await transientShell.getByRole("button", { name: "More plot tools" }).click();
   await transientShell
     .getByRole("button", { name: "Fit X", exact: true })
     .click();
@@ -901,6 +902,7 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   await page.mouse.up();
   await expect(fixedReadout).not.toHaveText(markerTextBeforeDrag ?? "");
   const markersBeforeRemount = await fixedReadout.textContent();
+  await transientShell.getByRole("button", { name: "More plot tools" }).click();
   await transientShell
     .getByRole("button", { name: "Ranges", exact: true })
     .click();
@@ -938,6 +940,7 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   await expect(rightTimeLabel).toHaveText(savedTicks ?? "");
   await expect(fixedReadout).toHaveText(markersBeforeRemount ?? "");
   await transientPlot.hover();
+  await transientShell.getByRole("button", { name: "More plot tools" }).click();
   await transientShell.getByRole("button", { name: "Previous view" }).click();
   await expect(rightTimeLabel).toHaveText(fullTimeLabel ?? "");
   await transientShell.getByRole("button", { name: "Next view" }).click();
@@ -1017,6 +1020,7 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   await panel.getByRole("tab", { name: "Plot" }).click();
   await expect(panel.locator(".ac-cursor-readout")).toHaveCount(0);
   await transientPlot.hover();
+  await transientShell.getByRole("button", { name: "More plot tools" }).click();
   await expect(
     transientShell.getByRole("button", { name: "Previous view" }),
   ).toBeDisabled();

--- a/apps/editor/src/features/simulation/ac-results-explorer.test.tsx
+++ b/apps/editor/src/features/simulation/ac-results-explorer.test.tsx
@@ -65,6 +65,7 @@ describe("AC Results Explorer", () => {
     expect(markup).toContain('class="waveform-tools-hint"');
     expect(markup).toContain('class="waveform-tool-actions"');
     expect(markup).toContain('tabindex="0"');
+    expect(markup).toContain('aria-label="More plot tools"');
     expect(markup).toContain('aria-label="Open plot"');
     expect(markup).not.toContain("Wheel to zoom");
   });

--- a/apps/editor/src/features/simulation/simulation-output-results.test.tsx
+++ b/apps/editor/src/features/simulation/simulation-output-results.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 import { SimulationOutputResults } from "./simulation-output-results";
 
 describe("Simulation Output Results", () => {
-  it("groups an analysis and its measurements in one named result card", () => {
+  it("uses a compact analysis heading and one trailing measurement summary", () => {
     const markup = renderToStaticMarkup(
       <SimulationOutputResults
         resultKey="run-1"
@@ -48,9 +48,9 @@ describe("Simulation Output Results", () => {
     expect(markup).toContain('class="simulation-output-results"');
     expect(markup).toContain('class="simulation-analysis-card"');
     expect(markup).toContain("Operating Point Analysis");
-    expect(markup).toContain("Bias point");
+    expect(markup).not.toContain("<small>Bias point</small>");
     expect(markup).toContain("Measurements");
-    expect(markup.indexOf("Measurements")).toBeLessThan(
+    expect(markup.indexOf("Measurements")).toBeGreaterThan(
       markup.indexOf("</section>"),
     );
   });

--- a/apps/editor/src/features/simulation/simulation-output-results.tsx
+++ b/apps/editor/src/features/simulation/simulation-output-results.tsx
@@ -31,11 +31,9 @@ function simulationAnalysisTitle(kind: SimulationAnalysisKind): string {
 
 export function SimulationAnalysisCard({
   kind,
-  plotName,
   children,
 }: {
   kind: SimulationAnalysisKind;
-  plotName?: string;
   children: ReactNode;
 }) {
   const title = simulationAnalysisTitle(kind);
@@ -46,7 +44,6 @@ export function SimulationAnalysisCard({
     >
       <header className="simulation-analysis-card-header">
         <h3>{title}</h3>
-        {plotName && plotName !== title ? <small>{plotName}</small> : null}
       </header>
       <div className="simulation-analysis-card-body">{children}</div>
     </section>
@@ -77,16 +74,15 @@ export function SimulationOutputResults({
     const probe = focusProbe(output);
     return probe ? [probe] : [];
   });
+  const visibleAnalyses = new Set(
+    data.analyses.map((analysis) => analysis.analysis),
+  );
   return (
     <div className="simulation-output-results">
       {data.analyses.map((analysis, analysisIndex) => {
         if (analysis.analysis === "op")
           return (
-            <SimulationAnalysisCard
-              key={`op-${analysisIndex}`}
-              kind="op"
-              plotName={analysis.plotName}
-            >
+            <SimulationAnalysisCard key={`op-${analysisIndex}`} kind="op">
               <table>
                 <thead>
                   <tr>
@@ -106,13 +102,6 @@ export function SimulationOutputResults({
                   ))}
                 </tbody>
               </table>
-              <SimulationMeasurementResults
-                measurements={(data.measurements ?? []).filter(
-                  (measurement) =>
-                    measurement.analysis === analysis.analysis &&
-                    measurement.plotName === analysis.plotName,
-                )}
-              />
             </SimulationAnalysisCard>
           );
         if (!analysis.domain) return null;
@@ -128,7 +117,6 @@ export function SimulationOutputResults({
           <SimulationAnalysisCard
             key={`${analysis.analysis}-${analysisIndex}`}
             kind={analysis.analysis}
-            plotName={analysis.plotName}
           >
             {analysis.analysis === "ac" && complex.length > 0 ? (
               <ComplexResultsExplorer
@@ -215,13 +203,6 @@ export function SimulationOutputResults({
                 />
               );
             })}
-            <SimulationMeasurementResults
-              measurements={(data.measurements ?? []).filter(
-                (measurement) =>
-                  measurement.analysis === analysis.analysis &&
-                  measurement.plotName === analysis.plotName,
-              )}
-            />
           </SimulationAnalysisCard>
         );
       })}
@@ -238,6 +219,11 @@ export function SimulationOutputResults({
           ))}
         </div>
       ) : null}
+      <SimulationMeasurementResults
+        measurements={(data.measurements ?? []).filter((measurement) =>
+          visibleAnalyses.has(measurement.analysis),
+        )}
+      />
     </div>
   );
 }

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -947,11 +947,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
                   run?.result?.data?.analyses
                     .filter((analysis) => analysis.analysis === "dc")
                     .map((analysis, index) => (
-                      <SimulationAnalysisCard
-                        key={`dc-${index}`}
-                        kind="dc"
-                        plotName={analysis.plotName}
-                      >
+                      <SimulationAnalysisCard key={`dc-${index}`} kind="dc">
                         <DcResultsExplorer
                           analysis={analysis}
                           vectors={runPresentation?.prepared.vectors ?? []}
@@ -976,7 +972,6 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
                       <SimulationAnalysisCard
                         key={`${run.id}:ac:${index}`}
                         kind="ac"
-                        plotName={analysis.plotName}
                       >
                         <AcResultsExplorer
                           resultKey={`${run.id}:ac:${index}`}
@@ -1003,7 +998,6 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
                       <SimulationAnalysisCard
                         key={`${run.id}:tran:${index}`}
                         kind="tran"
-                        plotName={analysis.plotName}
                       >
                         <TransientResultsExplorer
                           resultKey={`${run.id}:tran:${index}`}
@@ -1100,11 +1094,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
                   run?.result?.data?.analyses
                     .filter((analysis) => analysis.analysis === "op")
                     .map((analysis, index) => (
-                      <SimulationAnalysisCard
-                        key={index}
-                        kind="op"
-                        plotName={analysis.plotName}
-                      >
+                      <SimulationAnalysisCard key={index} kind="op">
                         <table>
                           <thead>
                             <tr>

--- a/apps/editor/src/features/simulation/transient-results-explorer.test.tsx
+++ b/apps/editor/src/features/simulation/transient-results-explorer.test.tsx
@@ -98,6 +98,7 @@ describe("Transient Results Explorer", () => {
     expect(markup).toContain('aria-label="Plot tools"');
     expect(markup.match(/class="waveform-tools-hint"/gu)).toHaveLength(2);
     expect(markup.match(/class="waveform-tool-actions"/gu)).toHaveLength(2);
+    expect(markup.match(/aria-label="More plot tools"/gu)).toHaveLength(2);
     expect(markup.match(/drag to zoom, click to measure/gu)).toHaveLength(2);
     expect(markup).not.toContain('aria-label="Inspect plot"');
     expect(markup.match(/aria-label="Open plot"/gu)).toHaveLength(2);

--- a/apps/editor/src/features/simulation/waveform-tools.tsx
+++ b/apps/editor/src/features/simulation/waveform-tools.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useId, useState } from "react";
 import {
   parseWaveformRange,
   zoomWaveformRange,
@@ -26,6 +26,8 @@ export function WaveformTools({
   onOpen?: () => void;
 }) {
   const [editing, setEditing] = useState(false);
+  const [moreOpen, setMoreOpen] = useState(false);
+  const secondaryToolsId = useId();
   const fit = (axis: "xy" | "x" | "y") =>
     c.commit({
       x: axis === "y" ? x : undefined,
@@ -41,93 +43,121 @@ export function WaveformTools({
     });
   return (
     <div
-      className={`ac-plot-toolbar waveform-tools${editing ? " expanded" : ""}`}
+      className={`ac-plot-toolbar waveform-tools${editing ? " expanded" : ""}${moreOpen ? " more-open" : ""}`}
       aria-label="Plot tools"
       tabIndex={0}
+      onMouseLeave={() => {
+        if (!editing) setMoreOpen(false);
+      }}
+      onKeyDown={(event) => {
+        if (event.key === "Escape") setMoreOpen(false);
+      }}
     >
       <span className="waveform-tools-hint" aria-hidden="true">
-        Plot tools
+        Tools ···
       </span>
       <div className="waveform-tool-actions">
-        <button
-          type="button"
-          aria-label="Previous view"
-          disabled={c.state.index === 0}
-          onClick={() => c.travel(-1)}
-        >
-          ↶
-        </button>
-        <button
-          type="button"
-          aria-label="Next view"
-          disabled={c.state.index === c.state.history.length - 1}
-          onClick={() => c.travel(1)}
-        >
-          ↷
-        </button>
-        <div role="group" aria-label="Controlled axes">
-          {(["xy", "x", "y"] as const).map((axis) => (
-            <button
-              type="button"
-              key={axis}
-              aria-label={`Control ${axis.toUpperCase()} axes`}
-              aria-pressed={c.state.axes === axis}
-              onClick={() => c.set("axes", axis)}
-            >
-              {axis.toUpperCase()}
-            </button>
-          ))}
-        </div>
-        <button type="button" aria-label="Zoom in" onClick={() => zoom(0.6)}>
-          +
-        </button>
-        <button type="button" aria-label="Zoom out" onClick={() => zoom(1.7)}>
-          −
-        </button>
-        <button type="button" aria-label="Fit plot" onClick={() => fit("xy")}>
-          Fit
-        </button>
-        <button type="button" aria-label="Fit X" onClick={() => fit("x")}>
-          Fit X
-        </button>
-        <button type="button" aria-label="Fit Y" onClick={() => fit("y")}>
-          Fit Y
-        </button>
-        <button
-          type="button"
-          aria-expanded={editing}
-          onClick={() => setEditing(!editing)}
-        >
-          Ranges
-        </button>
-        <div role="group" aria-label="Active marker">
-          {(["A", "B"] as const).map((marker) => (
-            <button
-              key={marker}
-              type="button"
-              aria-label={`Place marker ${marker}`}
-              aria-pressed={c.state.activeMarker === marker}
-              onClick={() => c.set("activeMarker", marker)}
-            >
-              {marker}
-            </button>
-          ))}
-        </div>
-        <button
-          type="button"
-          aria-label="Clear markers"
-          disabled={
-            c.state.markers.A === undefined && c.state.markers.B === undefined
-          }
-          onClick={() => c.set("markers", {})}
-        >
-          ×│
-        </button>
-        {onOpen && (
-          <button type="button" aria-label="Open plot" onClick={onOpen}>
-            ⛶
+        <div className="waveform-primary-actions">
+          <button type="button" aria-label="Zoom out" onClick={() => zoom(1.7)}>
+            −
           </button>
-        )}
+          <button type="button" aria-label="Zoom in" onClick={() => zoom(0.6)}>
+            +
+          </button>
+          <button type="button" aria-label="Fit plot" onClick={() => fit("xy")}>
+            Fit
+          </button>
+          <div role="group" aria-label="Active marker">
+            {(["A", "B"] as const).map((marker) => (
+              <button
+                key={marker}
+                type="button"
+                aria-label={`Place marker ${marker}`}
+                aria-pressed={c.state.activeMarker === marker}
+                onClick={() => c.set("activeMarker", marker)}
+              >
+                {marker}
+              </button>
+            ))}
+          </div>
+        </div>
+        <button
+          type="button"
+          className="waveform-more-toggle"
+          aria-label="More plot tools"
+          aria-controls={secondaryToolsId}
+          aria-expanded={moreOpen}
+          onClick={() => setMoreOpen((open) => !open)}
+        >
+          ···
+        </button>
+        <div
+          id={secondaryToolsId}
+          className="waveform-secondary-actions"
+          role="group"
+          aria-label="More plot controls"
+        >
+          <button
+            type="button"
+            aria-label="Previous view"
+            disabled={c.state.index === 0}
+            onClick={() => c.travel(-1)}
+          >
+            ↶
+          </button>
+          <button
+            type="button"
+            aria-label="Next view"
+            disabled={c.state.index === c.state.history.length - 1}
+            onClick={() => c.travel(1)}
+          >
+            ↷
+          </button>
+          <div role="group" aria-label="Controlled axes">
+            {(["xy", "x", "y"] as const).map((axis) => (
+              <button
+                type="button"
+                key={axis}
+                aria-label={`Control ${axis.toUpperCase()} axes`}
+                aria-pressed={c.state.axes === axis}
+                onClick={() => c.set("axes", axis)}
+              >
+                {axis.toUpperCase()}
+              </button>
+            ))}
+          </div>
+          <button type="button" aria-label="Fit X" onClick={() => fit("x")}>
+            Fit X
+          </button>
+          <button type="button" aria-label="Fit Y" onClick={() => fit("y")}>
+            Fit Y
+          </button>
+          <button
+            type="button"
+            aria-expanded={editing}
+            onClick={() => {
+              setMoreOpen(false);
+              setEditing(!editing);
+            }}
+          >
+            Ranges
+          </button>
+          <button
+            type="button"
+            aria-label="Clear markers"
+            disabled={
+              c.state.markers.A === undefined && c.state.markers.B === undefined
+            }
+            onClick={() => c.set("markers", {})}
+          >
+            ×│
+          </button>
+          {onOpen && (
+            <button type="button" aria-label="Open plot" onClick={onOpen}>
+              ⛶
+            </button>
+          )}
+        </div>
       </div>
       {editing && (
         <WaveformRangeEditor

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -744,43 +744,34 @@
 }
 .simulation-analysis-card {
   min-width: 0;
-  overflow: hidden;
-  border: 1px solid var(--icm-border-strong);
-  border-radius: var(--icm-radius-md);
-  background: var(--icm-surface);
-  box-shadow: var(--icm-shadow-sm);
+}
+.simulation-analysis-card + .simulation-analysis-card {
+  padding-top: 16px;
+  border-top: 1px solid var(--icm-border);
 }
 .simulation-analysis-card-header {
   display: grid;
   justify-items: center;
-  gap: 2px;
-  padding: 11px 16px;
-  border-bottom: 1px solid var(--icm-border);
-  background: var(--icm-surface-muted);
+  padding: 0 0 6px;
   text-align: center;
 }
 .simulation-analysis-view .simulation-analysis-card-header h3 {
   margin: 0;
   color: var(--icm-text);
-  font-size: var(--icm-font-md);
+  font-size: var(--icm-font-lg);
   font-weight: 700;
   letter-spacing: 0.01em;
 }
-.simulation-analysis-card-header small {
-  color: var(--icm-text-muted);
-  font-size: var(--icm-font-xs);
-}
 .simulation-analysis-card-body {
   display: grid;
-  gap: 14px;
+  gap: 10px;
   min-width: 0;
-  padding: 14px;
 }
 .simulation-analysis-card-body > .ac-results-explorer > header,
 .simulation-analysis-card-body > .transient-results-explorer > header {
   display: none;
 }
-.simulation-analysis-card-body > .simulation-measurement-results {
+.simulation-output-results > .simulation-measurement-results {
   margin-top: 0;
 }
 
@@ -1220,7 +1211,7 @@
 
 .transient-results-explorer {
   display: grid;
-  gap: 10px;
+  gap: 8px;
 }
 .transient-results-explorer > header > div {
   display: grid;
@@ -1292,7 +1283,7 @@
 .ac-results-explorer {
   position: relative;
   display: grid;
-  gap: 12px;
+  gap: 8px;
   min-width: 0;
 }
 .ac-results-explorer > header {
@@ -1313,29 +1304,19 @@
 }
 .ac-view-toolbar {
   display: flex;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   align-items: center;
   gap: 8px;
   min-width: 0;
-  min-height: 40px;
-  padding: 5px 7px;
-  overflow-x: auto;
-  border: 1px solid var(--icm-border);
-  border-radius: var(--icm-radius-sm);
-  background: var(--icm-surface-muted);
+  min-height: 32px;
 }
 .ac-view-toolbar > strong {
-  min-width: 88px;
-  padding-left: 3px;
+  min-width: 72px;
 }
 .ac-view-toolbar > [role="group"] {
   display: flex;
   flex-wrap: nowrap;
   gap: 2px;
-  padding: 2px;
-  border: 1px solid var(--icm-border);
-  border-radius: 7px;
-  background: var(--icm-surface-muted);
 }
 .ac-view-toolbar button {
   min-height: 26px;
@@ -1344,9 +1325,9 @@
   background: transparent;
 }
 .ac-view-toolbar button[aria-pressed="true"] {
-  background: var(--icm-surface);
+  background: color-mix(in srgb, var(--icm-accent) 8%, transparent);
   color: var(--icm-accent);
-  box-shadow: 0 1px 2px rgb(16 24 40 / 12%);
+  box-shadow: inset 0 -2px 0 var(--icm-accent);
 }
 .ac-view-toolbar > label {
   display: inline-flex;
@@ -1368,13 +1349,13 @@
 .simulation-plot-layout {
   display: grid;
   grid-template-columns: minmax(88px, 108px) minmax(0, 1fr);
-  gap: 12px;
+  gap: 8px;
   align-items: start;
   min-width: 0;
 }
 .simulation-plot-stack {
   display: grid;
-  gap: 12px;
+  gap: 8px;
   min-width: 0;
 }
 .waveform-trace-list {
@@ -1432,7 +1413,7 @@
 }
 .ac-quantity-group {
   display: grid;
-  gap: 10px;
+  gap: 6px;
   min-width: 0;
 }
 .ac-plot-row {
@@ -1463,19 +1444,21 @@
   border: 1px solid var(--icm-border);
   border-radius: var(--icm-radius-sm);
   background: #fff;
+  container-type: inline-size;
 }
 .ac-plot-toolbar {
   position: relative;
+  z-index: 2;
   order: -1;
   align-self: stretch;
   display: block;
-  height: 34px;
-  min-height: 34px;
+  height: 30px;
+  min-height: 30px;
   padding: 0;
   border: 0;
-  border-bottom: 1px solid var(--icm-border);
+  border-bottom: 1px solid color-mix(in srgb, var(--icm-border) 60%, white);
   border-radius: 0;
-  background: var(--icm-surface-muted);
+  background: #fff;
   box-shadow: none;
   outline-offset: -2px;
 }
@@ -1490,7 +1473,8 @@
   position: absolute;
   inset: 0;
   display: grid;
-  place-items: center;
+  place-items: center end;
+  padding-right: 8px;
   color: var(--icm-text-muted);
   font-size: var(--icm-font-xs);
   pointer-events: none;
@@ -1501,10 +1485,9 @@
   inset: 0;
   display: flex;
   align-items: center;
-  justify-content: flex-start;
-  gap: 2px;
+  justify-content: flex-end;
+  gap: 4px;
   padding: 3px 4px;
-  overflow-x: auto;
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
@@ -1514,7 +1497,8 @@
 }
 .ac-plot-shell:hover .waveform-tool-actions,
 .ac-plot-toolbar:focus-within .waveform-tool-actions,
-.ac-plot-toolbar.expanded .waveform-tool-actions {
+.ac-plot-toolbar.expanded .waveform-tool-actions,
+.ac-plot-toolbar.more-open .waveform-tool-actions {
   opacity: 1;
   visibility: visible;
   pointer-events: auto;
@@ -1522,14 +1506,16 @@
 }
 .ac-plot-shell:hover .waveform-tools-hint,
 .ac-plot-toolbar:focus-within .waveform-tools-hint,
-.ac-plot-toolbar.expanded .waveform-tools-hint {
+.ac-plot-toolbar.expanded .waveform-tools-hint,
+.ac-plot-toolbar.more-open .waveform-tools-hint {
   opacity: 0;
 }
 .ac-plot-toolbar button {
   min-width: 27px;
-  min-height: 25px;
+  min-height: 24px;
   padding: 2px 6px;
-  background: var(--icm-surface);
+  border-color: transparent;
+  background: transparent;
   font-size: var(--icm-font-xs);
 }
 .ac-plot-toolbar button[aria-pressed="true"] {
@@ -2186,10 +2172,56 @@
 .waveform-tools {
   align-self: stretch;
 }
-.waveform-tool-actions > [role="group"] {
+.waveform-primary-actions,
+.waveform-secondary-actions,
+.waveform-primary-actions > [role="group"],
+.waveform-secondary-actions > [role="group"] {
   display: flex;
+  align-items: center;
+  gap: 2px;
+}
+.waveform-primary-actions > [role="group"],
+.waveform-secondary-actions > [role="group"] {
   border-left: 1px solid var(--icm-border);
   padding-left: 4px;
+}
+.waveform-more-toggle {
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+.waveform-secondary-actions {
+  position: absolute;
+  z-index: 6;
+  top: calc(100% + 4px);
+  right: 4px;
+  display: none;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  width: min(310px, calc(100% - 8px));
+  padding: 6px;
+  border: 1px solid var(--icm-border-strong);
+  border-radius: var(--icm-radius-sm);
+  background: #fff;
+  box-shadow: var(--icm-shadow-sm);
+}
+.waveform-tools.more-open .waveform-secondary-actions {
+  display: flex;
+}
+@container (min-width: 560px) {
+  .waveform-more-toggle {
+    display: none;
+  }
+  .waveform-secondary-actions {
+    position: static;
+    display: flex;
+    flex-wrap: nowrap;
+    width: auto;
+    padding: 0;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
+  }
 }
 .waveform-range-editor {
   position: absolute;


### PR DESCRIPTION
## Summary
- remove redundant analysis subtitles and boxed result chrome
- use larger compact centered analysis titles and one trailing measurement section
- make waveform controls hover-revealed and responsive without horizontal scrollbars

## Validation
- pnpm gate:preflight -- --base main
- pnpm gate:affected -- --base main
- 2828 unit tests passed (22 skipped)
- 6 affected browser tests passed