### PR TITLE
refactor(editor): align simulation result controls

### DIFF
--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -716,10 +716,17 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
       .getBoundingClientRect();
     return { height: plot.height, toolbarGap: plot.top - toolbar.bottom };
   });
-  await magnitudePlot.hover();
+  await magnitudeToolbar.hover();
   await expect(
     magnitudeToolbar.getByRole("button", { name: "Zoom in" }),
   ).toBeVisible();
+  const toolbarBox = await magnitudeToolbar.boundingBox();
+  const lastToolBox = await magnitudeToolbar
+    .getByRole("button", { name: "Open plot" })
+    .boundingBox();
+  expect(lastToolBox!.x + lastToolBox!.width).toBeLessThanOrEqual(
+    toolbarBox!.x + toolbarBox!.width,
+  );
   const plotLayoutAfterToolbar = await magnitudePlot.evaluate((element) => {
     const plot = element.getBoundingClientRect();
     const toolbar = element
@@ -746,12 +753,10 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
     "innerHTML",
     plotBeforeWheel,
   );
-  await magnitudePlot
-    .locator("..")
-    .getByRole("button", { name: "Fit plot" })
-    .click();
+  await magnitudeToolbar.hover();
+  await magnitudeToolbar.getByRole("button", { name: "Fit plot" }).click();
   await expect(magnitudePlot).toHaveJSProperty("innerHTML", plotBeforeWheel);
-  await magnitudePlot.hover();
+  await magnitudeToolbar.hover();
   await expect(
     panel.getByRole("button", { name: "Zoom in" }).first(),
   ).toBeVisible();
@@ -785,6 +790,9 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
     .locator(".spice-ac-plot")
     .first();
   const transientShell = transientPlot.locator("..");
+  const transientToolbar = transientShell.getByLabel("Plot tools", {
+    exact: true,
+  });
   await expect(transientPlot.locator(".ac-trace-hit")).toHaveAttribute(
     "fill",
     "none",
@@ -794,9 +802,7 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
     .locator('svg text[text-anchor="middle"]')
     .last();
   const fullTimeLabel = await rightTimeLabel.textContent();
-  const toolbarBounds = await transientShell
-    .getByLabel("Plot tools", { exact: true })
-    .boundingBox();
+  const toolbarBounds = await transientToolbar.boundingBox();
   const transientBounds = await transientPlot.boundingBox();
   expect(transientBounds).not.toBeNull();
   await page.mouse.move(
@@ -819,7 +825,7 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   ).toHaveCount(0);
   await expect(rightTimeLabel).not.toHaveText(fullTimeLabel ?? "");
   const zoomTimeLabel = await rightTimeLabel.textContent();
-  await transientShell.getByRole("button", { name: "More plot tools" }).click();
+  await transientToolbar.hover();
   await transientShell.getByRole("button", { name: "Previous view" }).click();
   await expect(rightTimeLabel).toHaveText(fullTimeLabel ?? "");
   await transientShell.getByRole("button", { name: "Next view" }).click();
@@ -829,6 +835,7 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   const yLabels = await transientPlot
     .locator('svg text[text-anchor="end"]')
     .allTextContents();
+  await transientToolbar.hover();
   await transientShell.getByRole("button", { name: "Control X axes" }).click();
   const xDrag = (await transientPlot.boundingBox())!;
   await page.mouse.move(
@@ -849,11 +856,12 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
       .locator('svg text[text-anchor="end"]')
       .allTextContents(),
   ).toEqual(yLabels);
-  await transientShell.getByRole("button", { name: "More plot tools" }).click();
+  await transientToolbar.hover();
   await transientShell
     .getByRole("button", { name: "Fit X", exact: true })
     .click();
   await expect(rightTimeLabel).toHaveText(fullTimeLabel ?? "");
+  await transientToolbar.hover();
   await transientShell.getByRole("button", { name: "Control XY axes" }).click();
   await transientPlot.click({
     position: {
@@ -873,6 +881,7 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
     },
   });
   await expect(fixedReadout).toHaveText(measurement ?? "");
+  await transientToolbar.hover();
   await transientShell.getByRole("button", { name: "Place marker B" }).click();
   await transientPlot.click({
     position: {
@@ -902,7 +911,7 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   await page.mouse.up();
   await expect(fixedReadout).not.toHaveText(markerTextBeforeDrag ?? "");
   const markersBeforeRemount = await fixedReadout.textContent();
-  await transientShell.getByRole("button", { name: "More plot tools" }).click();
+  await transientToolbar.hover();
   await transientShell
     .getByRole("button", { name: "Ranges", exact: true })
     .click();
@@ -939,8 +948,7 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
     .click();
   await expect(rightTimeLabel).toHaveText(savedTicks ?? "");
   await expect(fixedReadout).toHaveText(markersBeforeRemount ?? "");
-  await transientPlot.hover();
-  await transientShell.getByRole("button", { name: "More plot tools" }).click();
+  await transientToolbar.hover();
   await transientShell.getByRole("button", { name: "Previous view" }).click();
   await expect(rightTimeLabel).toHaveText(fullTimeLabel ?? "");
   await transientShell.getByRole("button", { name: "Next view" }).click();
@@ -1019,8 +1027,7 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   await expect(panel.getByRole("status")).toHaveText("finished · completed");
   await panel.getByRole("tab", { name: "Plot" }).click();
   await expect(panel.locator(".ac-cursor-readout")).toHaveCount(0);
-  await transientPlot.hover();
-  await transientShell.getByRole("button", { name: "More plot tools" }).click();
+  await transientToolbar.hover();
   await expect(
     transientShell.getByRole("button", { name: "Previous view" }),
   ).toBeDisabled();
@@ -1031,7 +1038,8 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   const comparisonTable = panel.locator(".simulation-run-comparison-table");
   await expect(comparisonTable.locator("thead th")).toHaveCount(3);
   await expect(comparisonTable).toContainText("Current");
-  await expect(comparisonTable).toContainText("TRAN · Time-weighted RMS");
+  await expect(comparisonTable).toContainText("Transient Analysis");
+  await expect(comparisonTable).toContainText("Time-weighted RMS");
   await expect(
     comparisonTable.getByRole("button", {
       name: "Remove E2E setup from comparison",

--- a/apps/editor/src/features/simulation/ac-results-explorer.test.tsx
+++ b/apps/editor/src/features/simulation/ac-results-explorer.test.tsx
@@ -65,7 +65,8 @@ describe("AC Results Explorer", () => {
     expect(markup).toContain('class="waveform-tools-hint"');
     expect(markup).toContain('class="waveform-tool-actions"');
     expect(markup).toContain('tabindex="0"');
-    expect(markup).toContain('aria-label="More plot tools"');
+    expect(markup).not.toContain('aria-label="More plot tools"');
+    expect(markup).not.toContain("<strong>Voltage</strong>");
     expect(markup).toContain('aria-label="Open plot"');
     expect(markup).not.toContain("Wheel to zoom");
   });

--- a/apps/editor/src/features/simulation/ac-results-explorer.tsx
+++ b/apps/editor/src/features/simulation/ac-results-explorer.tsx
@@ -493,52 +493,58 @@ export function ComplexResultsExplorer({
         const referenceId = references[quantity] ?? "";
         return (
           <section key={quantity} className="ac-quantity-group">
-            <div className="ac-view-toolbar">
-              <strong>{groupLabel(quantity)}</strong>
-              <div role="group" aria-label={`${groupLabel(quantity)} display`}>
-                {VIEW_MODES.map(({ mode: candidate, label }) => (
-                  <button
-                    key={candidate}
-                    type="button"
-                    aria-pressed={mode === candidate}
-                    onClick={() =>
-                      setViewModes((current) => ({
-                        ...current,
-                        [quantity]: candidate,
-                      }))
-                    }
-                  >
-                    {label}
-                  </button>
-                ))}
+            <div className="ac-view-alignment">
+              <div className="ac-view-toolbar">
+                <div
+                  role="group"
+                  aria-label={`${groupLabel(quantity)} display`}
+                >
+                  {VIEW_MODES.map(({ mode: candidate, label }) => (
+                    <button
+                      key={candidate}
+                      type="button"
+                      aria-pressed={mode === candidate}
+                      onClick={() =>
+                        setViewModes((current) => ({
+                          ...current,
+                          [quantity]: candidate,
+                        }))
+                      }
+                    >
+                      {label}
+                    </button>
+                  ))}
+                </div>
+                {(mode === "db20" || mode === "bode") && (
+                  <label>
+                    Reference
+                    <select
+                      aria-label={`${groupLabel(quantity)} reference`}
+                      value={referenceId}
+                      onChange={(event) =>
+                        setReferences((current) => {
+                          const next = { ...current };
+                          if (event.target.value)
+                            next[quantity] = event.target.value;
+                          else delete next[quantity];
+                          return next;
+                        })
+                      }
+                    >
+                      <option value="">
+                        {unityReferenceLabel(sourceUnit)}
+                      </option>
+                      {quantityTraces
+                        .filter((trace) => trace.unit === sourceUnit)
+                        .map((trace) => (
+                          <option key={trace.id} value={trace.id}>
+                            {trace.label}
+                          </option>
+                        ))}
+                    </select>
+                  </label>
+                )}
               </div>
-              {(mode === "db20" || mode === "bode") && (
-                <label>
-                  Reference
-                  <select
-                    aria-label={`${groupLabel(quantity)} reference`}
-                    value={referenceId}
-                    onChange={(event) =>
-                      setReferences((current) => {
-                        const next = { ...current };
-                        if (event.target.value)
-                          next[quantity] = event.target.value;
-                        else delete next[quantity];
-                        return next;
-                      })
-                    }
-                  >
-                    <option value="">{unityReferenceLabel(sourceUnit)}</option>
-                    {quantityTraces
-                      .filter((trace) => trace.unit === sourceUnit)
-                      .map((trace) => (
-                        <option key={trace.id} value={trace.id}>
-                          {trace.label}
-                        </option>
-                      ))}
-                  </select>
-                </label>
-              )}
             </div>
             <div className="simulation-plot-layout">
               <WaveformTraceList

--- a/apps/editor/src/features/simulation/simulation-run-comparison.test.tsx
+++ b/apps/editor/src/features/simulation/simulation-run-comparison.test.tsx
@@ -32,6 +32,19 @@ function run(
         status: "available",
         value,
       },
+      {
+        id: `1:out:maximum:${id}`,
+        analysisIndex: 1,
+        analysis: "ac",
+        plotName: "AC",
+        outputId: "out",
+        outputLabel: "Vout",
+        metric: "maximum",
+        label: "Maximum",
+        unit: "V",
+        status: "available",
+        value: value * 2,
+      },
     ],
   };
 }
@@ -49,7 +62,11 @@ describe("SimulationRunComparison", () => {
     );
     expect(markup).toContain("Before");
     expect(markup).toContain("After");
-    expect(markup).toContain("TRAN · Maximum");
+    expect(markup).toContain("Transient Analysis");
+    expect(markup).toContain("AC Analysis");
+    expect(markup).toContain('aria-label="Transient analysis"');
+    expect(markup).toContain('aria-label="AC analysis"');
+    expect(markup).toContain("<small>Maximum</small>");
     expect(markup).toContain("1 V");
     expect(markup).toContain("1.2 V");
     expect(markup).toContain("Remove Before from comparison");

--- a/apps/editor/src/features/simulation/simulation-run-comparison.tsx
+++ b/apps/editor/src/features/simulation/simulation-run-comparison.tsx
@@ -35,6 +35,12 @@ function measurementKey(measurement: Measurement): string {
     : `automatic\u0000${measurement.analysis}\u0000${measurement.outputId}\u0000${measurement.metric}\u0000${measurement.unit}`;
 }
 
+function analysisTitle(analysis: Measurement["analysis"]): string {
+  if (analysis === "op") return "Operating Point";
+  if (analysis === "tran") return "Transient";
+  return analysis.toUpperCase();
+}
+
 export function SimulationRunComparison({
   runs,
   onRemove,
@@ -48,10 +54,16 @@ export function SimulationRunComparison({
         Complete a structured run to compare its measurements.
       </p>
     );
-  const rows = new Map<string, Measurement>();
+  const rowGroups = new Map<
+    Measurement["analysis"],
+    Map<string, Measurement>
+  >();
   for (const run of runs)
-    for (const measurement of run.measurements)
+    for (const measurement of run.measurements) {
+      const rows = rowGroups.get(measurement.analysis) ?? new Map();
       rows.set(measurementKey(measurement), measurement);
+      rowGroups.set(measurement.analysis, rows);
+    }
   return (
     <div className="simulation-run-comparison-table-wrap">
       <table className="simulation-run-comparison-table">
@@ -80,39 +92,47 @@ export function SimulationRunComparison({
             ))}
           </tr>
         </thead>
-        <tbody>
-          {[...rows.entries()].map(([key, row]) => (
-            <tr key={key}>
-              <th>
-                <strong>{row.outputLabel}</strong>
-                <small>
-                  {row.analysis.toUpperCase()} · {row.label}
-                </small>
+        {[...rowGroups.entries()].map(([analysis, rows]) => (
+          <tbody
+            key={analysis}
+            aria-label={`${analysisTitle(analysis)} analysis`}
+          >
+            <tr className="simulation-comparison-analysis-row">
+              <th colSpan={runs.length + 1}>
+                {analysisTitle(analysis)} Analysis
               </th>
-              {runs.map((run) => {
-                const item = run.measurements.find(
-                  (candidate) => measurementKey(candidate) === key,
-                );
-                return (
-                  <td key={run.id}>
-                    {!item ? (
-                      <span className="simulation-comparison-missing">—</span>
-                    ) : item.status === "available" ? (
-                      format(item.value, item.unit)
-                    ) : (
-                      <span
-                        className="simulation-comparison-unavailable"
-                        title={item.reason}
-                      >
-                        Unavailable
-                      </span>
-                    )}
-                  </td>
-                );
-              })}
             </tr>
-          ))}
-        </tbody>
+            {[...rows.entries()].map(([key, row]) => (
+              <tr key={key}>
+                <th>
+                  <strong>{row.outputLabel}</strong>
+                  <small>{row.label}</small>
+                </th>
+                {runs.map((run) => {
+                  const item = run.measurements.find(
+                    (candidate) => measurementKey(candidate) === key,
+                  );
+                  return (
+                    <td key={run.id}>
+                      {!item ? (
+                        <span className="simulation-comparison-missing">—</span>
+                      ) : item.status === "available" ? (
+                        format(item.value, item.unit)
+                      ) : (
+                        <span
+                          className="simulation-comparison-unavailable"
+                          title={item.reason}
+                        >
+                          Unavailable
+                        </span>
+                      )}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        ))}
       </table>
     </div>
   );

--- a/apps/editor/src/features/simulation/transient-results-explorer.test.tsx
+++ b/apps/editor/src/features/simulation/transient-results-explorer.test.tsx
@@ -98,7 +98,7 @@ describe("Transient Results Explorer", () => {
     expect(markup).toContain('aria-label="Plot tools"');
     expect(markup.match(/class="waveform-tools-hint"/gu)).toHaveLength(2);
     expect(markup.match(/class="waveform-tool-actions"/gu)).toHaveLength(2);
-    expect(markup.match(/aria-label="More plot tools"/gu)).toHaveLength(2);
+    expect(markup).not.toContain('aria-label="More plot tools"');
     expect(markup.match(/drag to zoom, click to measure/gu)).toHaveLength(2);
     expect(markup).not.toContain('aria-label="Inspect plot"');
     expect(markup.match(/aria-label="Open plot"/gu)).toHaveLength(2);

--- a/apps/editor/src/features/simulation/waveform-tools.tsx
+++ b/apps/editor/src/features/simulation/waveform-tools.tsx
@@ -1,4 +1,4 @@
-import { useId, useState } from "react";
+import { useState } from "react";
 import {
   parseWaveformRange,
   zoomWaveformRange,
@@ -26,8 +26,6 @@ export function WaveformTools({
   onOpen?: () => void;
 }) {
   const [editing, setEditing] = useState(false);
-  const [moreOpen, setMoreOpen] = useState(false);
-  const secondaryToolsId = useId();
   const fit = (axis: "xy" | "x" | "y") =>
     c.commit({
       x: axis === "y" ? x : undefined,
@@ -43,21 +41,44 @@ export function WaveformTools({
     });
   return (
     <div
-      className={`ac-plot-toolbar waveform-tools${editing ? " expanded" : ""}${moreOpen ? " more-open" : ""}`}
+      className={`ac-plot-toolbar waveform-tools${editing ? " expanded" : ""}`}
       aria-label="Plot tools"
       tabIndex={0}
-      onMouseLeave={() => {
-        if (!editing) setMoreOpen(false);
-      }}
-      onKeyDown={(event) => {
-        if (event.key === "Escape") setMoreOpen(false);
-      }}
     >
       <span className="waveform-tools-hint" aria-hidden="true">
-        Tools ···
+        Tools
       </span>
       <div className="waveform-tool-actions">
-        <div className="waveform-primary-actions">
+        <button
+          type="button"
+          aria-label="Previous view"
+          disabled={c.state.index === 0}
+          onClick={() => c.travel(-1)}
+        >
+          ↶
+        </button>
+        <button
+          type="button"
+          aria-label="Next view"
+          disabled={c.state.index === c.state.history.length - 1}
+          onClick={() => c.travel(1)}
+        >
+          ↷
+        </button>
+        <div role="group" aria-label="Controlled axes">
+          {(["xy", "x", "y"] as const).map((axis) => (
+            <button
+              type="button"
+              key={axis}
+              aria-label={`Control ${axis.toUpperCase()} axes`}
+              aria-pressed={c.state.axes === axis}
+              onClick={() => c.set("axes", axis)}
+            >
+              {axis.toUpperCase()}
+            </button>
+          ))}
+        </div>
+        <div role="group" aria-label="Zoom and fit">
           <button type="button" aria-label="Zoom out" onClick={() => zoom(1.7)}>
             −
           </button>
@@ -67,65 +88,6 @@ export function WaveformTools({
           <button type="button" aria-label="Fit plot" onClick={() => fit("xy")}>
             Fit
           </button>
-          <div role="group" aria-label="Active marker">
-            {(["A", "B"] as const).map((marker) => (
-              <button
-                key={marker}
-                type="button"
-                aria-label={`Place marker ${marker}`}
-                aria-pressed={c.state.activeMarker === marker}
-                onClick={() => c.set("activeMarker", marker)}
-              >
-                {marker}
-              </button>
-            ))}
-          </div>
-        </div>
-        <button
-          type="button"
-          className="waveform-more-toggle"
-          aria-label="More plot tools"
-          aria-controls={secondaryToolsId}
-          aria-expanded={moreOpen}
-          onClick={() => setMoreOpen((open) => !open)}
-        >
-          ···
-        </button>
-        <div
-          id={secondaryToolsId}
-          className="waveform-secondary-actions"
-          role="group"
-          aria-label="More plot controls"
-        >
-          <button
-            type="button"
-            aria-label="Previous view"
-            disabled={c.state.index === 0}
-            onClick={() => c.travel(-1)}
-          >
-            ↶
-          </button>
-          <button
-            type="button"
-            aria-label="Next view"
-            disabled={c.state.index === c.state.history.length - 1}
-            onClick={() => c.travel(1)}
-          >
-            ↷
-          </button>
-          <div role="group" aria-label="Controlled axes">
-            {(["xy", "x", "y"] as const).map((axis) => (
-              <button
-                type="button"
-                key={axis}
-                aria-label={`Control ${axis.toUpperCase()} axes`}
-                aria-pressed={c.state.axes === axis}
-                onClick={() => c.set("axes", axis)}
-              >
-                {axis.toUpperCase()}
-              </button>
-            ))}
-          </div>
           <button type="button" aria-label="Fit X" onClick={() => fit("x")}>
             Fit X
           </button>
@@ -135,13 +97,23 @@ export function WaveformTools({
           <button
             type="button"
             aria-expanded={editing}
-            onClick={() => {
-              setMoreOpen(false);
-              setEditing(!editing);
-            }}
+            onClick={() => setEditing(!editing)}
           >
             Ranges
           </button>
+        </div>
+        <div role="group" aria-label="Active marker">
+          {(["A", "B"] as const).map((marker) => (
+            <button
+              key={marker}
+              type="button"
+              aria-label={`Place marker ${marker}`}
+              aria-pressed={c.state.activeMarker === marker}
+              onClick={() => c.set("activeMarker", marker)}
+            >
+              {marker}
+            </button>
+          ))}
           <button
             type="button"
             aria-label="Clear markers"
@@ -152,12 +124,12 @@ export function WaveformTools({
           >
             ×│
           </button>
-          {onOpen && (
-            <button type="button" aria-label="Open plot" onClick={onOpen}>
-              ⛶
-            </button>
-          )}
         </div>
+        {onOpen && (
+          <button type="button" aria-label="Open plot" onClick={onOpen}>
+            ⛶
+          </button>
+        )}
       </div>
       {editing && (
         <WaveformRangeEditor

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -773,8 +773,9 @@
 .simulation-analysis-view .simulation-analysis-card-header h3 {
   margin: 0;
   color: var(--icm-text);
-  font-size: var(--icm-font-lg);
+  font-size: 28px;
   font-weight: 700;
+  line-height: 1.1;
   letter-spacing: 0.01em;
 }
 .simulation-analysis-card-body {
@@ -967,6 +968,15 @@
 }
 .simulation-run-comparison-table thead th:not(:first-child) {
   padding-right: 30px;
+}
+.simulation-run-comparison-table .simulation-comparison-analysis-row th {
+  display: table-cell;
+  padding: 7px 9px;
+  border-right: 0;
+  color: var(--icm-text);
+  background: color-mix(in srgb, var(--icm-surface-muted) 58%, white);
+  font-size: var(--icm-font-sm);
+  font-weight: 700;
 }
 .simulation-run-comparison-table thead th > span,
 .simulation-run-comparison-table tbody th {
@@ -1317,16 +1327,20 @@
 .ac-results-explorer > header button {
   margin-left: auto;
 }
+.ac-view-alignment {
+  display: grid;
+  grid-template-columns: minmax(88px, 108px) minmax(0, 1fr);
+  gap: 8px;
+  min-width: 0;
+}
 .ac-view-toolbar {
+  grid-column: 2;
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: 8px;
   min-width: 0;
   min-height: 32px;
-}
-.ac-view-toolbar > strong {
-  min-width: 72px;
 }
 .ac-view-toolbar > [role="group"] {
   display: flex;
@@ -1488,8 +1502,8 @@
   position: absolute;
   inset: 0;
   display: grid;
-  place-items: center end;
-  padding-right: 8px;
+  place-items: center start;
+  padding-left: 8px;
   color: var(--icm-text-muted);
   font-size: var(--icm-font-xs);
   pointer-events: none;
@@ -1500,8 +1514,8 @@
   inset: 0;
   display: flex;
   align-items: center;
-  justify-content: flex-end;
-  gap: 4px;
+  justify-content: flex-start;
+  gap: 1px;
   padding: 3px 4px;
   opacity: 0;
   visibility: hidden;
@@ -1510,25 +1524,23 @@
     opacity 120ms ease,
     visibility 0s linear 120ms;
 }
-.ac-plot-shell:hover .waveform-tool-actions,
+.ac-plot-toolbar:hover .waveform-tool-actions,
 .ac-plot-toolbar:focus-within .waveform-tool-actions,
-.ac-plot-toolbar.expanded .waveform-tool-actions,
-.ac-plot-toolbar.more-open .waveform-tool-actions {
+.ac-plot-toolbar.expanded .waveform-tool-actions {
   opacity: 1;
   visibility: visible;
   pointer-events: auto;
   transition-delay: 0s;
 }
-.ac-plot-shell:hover .waveform-tools-hint,
+.ac-plot-toolbar:hover .waveform-tools-hint,
 .ac-plot-toolbar:focus-within .waveform-tools-hint,
-.ac-plot-toolbar.expanded .waveform-tools-hint,
-.ac-plot-toolbar.more-open .waveform-tools-hint {
+.ac-plot-toolbar.expanded .waveform-tools-hint {
   opacity: 0;
 }
 .ac-plot-toolbar button {
-  min-width: 27px;
+  min-width: 20px;
   min-height: 24px;
-  padding: 2px 6px;
+  padding: 2px 4px;
   border-color: transparent;
   background: transparent;
   font-size: var(--icm-font-xs);
@@ -1642,6 +1654,12 @@
   }
   .simulation-plot-layout {
     grid-template-columns: 1fr;
+  }
+  .ac-view-alignment {
+    grid-template-columns: 1fr;
+  }
+  .ac-view-toolbar {
+    grid-column: 1;
   }
   .waveform-trace-list {
     position: static;
@@ -2187,55 +2205,26 @@
 .waveform-tools {
   align-self: stretch;
 }
-.waveform-primary-actions,
-.waveform-secondary-actions,
-.waveform-primary-actions > [role="group"],
-.waveform-secondary-actions > [role="group"] {
+.waveform-tool-actions > [role="group"] {
   display: flex;
   align-items: center;
-  gap: 2px;
-}
-.waveform-primary-actions > [role="group"],
-.waveform-secondary-actions > [role="group"] {
+  gap: 1px;
   border-left: 1px solid var(--icm-border);
-  padding-left: 4px;
+  padding-left: 3px;
 }
-.waveform-more-toggle {
-  font-weight: 700;
-  letter-spacing: 0.08em;
-}
-.waveform-secondary-actions {
-  position: absolute;
-  z-index: 6;
-  top: calc(100% + 4px);
-  right: 4px;
-  display: none;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-  width: min(310px, calc(100% - 8px));
-  padding: 6px;
-  border: 1px solid var(--icm-border-strong);
-  border-radius: var(--icm-radius-sm);
-  background: #fff;
-  box-shadow: var(--icm-shadow-sm);
-}
-.waveform-tools.more-open .waveform-secondary-actions {
-  display: flex;
-}
-@container (min-width: 560px) {
-  .waveform-more-toggle {
-    display: none;
+@container (max-width: 460px) {
+  .waveform-tool-actions {
+    gap: 0;
+    padding-inline: 2px;
   }
-  .waveform-secondary-actions {
-    position: static;
-    display: flex;
-    flex-wrap: nowrap;
-    width: auto;
-    padding: 0;
-    border: 0;
-    border-radius: 0;
-    background: transparent;
-    box-shadow: none;
+  .ac-plot-toolbar button {
+    min-width: 18px;
+    padding-inline: 2px;
+    font-size: 10px;
+  }
+  .waveform-tool-actions > [role="group"] {
+    gap: 0;
+    padding-left: 2px;
   }
 }
 .waveform-range-editor {


### PR DESCRIPTION
## Summary
- keep the complete waveform toolbar in a stable, hover-revealed row without an overflow menu
- align AC view controls with the plot column and enlarge analysis headings
- group comparison measurements by analysis type

## Validation
- pnpm gate:preflight -- --base main
- pnpm gate:affected -- --base main
- 2828 unit tests (2806 passed, 22 skipped)
- 6 focused browser tests passed