### PR TITLE
feat(simulation): define structured noise results

### DIFF
--- a/docs/specs/simulation.md
+++ b/docs/specs/simulation.md
@@ -804,6 +804,9 @@ result extends `SimulationResult` with:
 - `tran`: `timeSeconds` as computed by the solver and, per probe, a `value`
   array of the same length; different plots keep their own axes and are not
   resampled to share a table.
+- `noise`: the frequency axis, output and input-referred amplitude spectral
+  densities, and the two integrated totals. The input-referred unit follows
+  the selected independent voltage or current source.
 
 Array lengths, analysis and probe identities, non-finite values, an empty or
 truncated rawfile, and a requested vector that is missing are all checked; an
@@ -842,9 +845,14 @@ A rawfile may hold several plots back to back, and each is read on its own
 terms. A binary rawfile is refused by name: a testbench that wants numbers
 sets `filetype=ascii` before it writes.
 
-A plot this release does not read -- for example a noise analysis -- is
-reported by name as a `warning` beside the analyses that were read, and as an
-`error` when it was the only plot in the file. It is never dropped in silence.
+The two plots written by one ngspice 46 `noise` command are one result:
+`Noise Spectral Density Curves` carries `frequency`, `onoise_spectrum`, and
+`inoise_spectrum`; `Integrated Noise` carries the input- and output-referred
+totals. Exactly one of each is required. Density quantities are amplitudes per
+square-root hertz, not squared densities. Any other plot this release does not
+read is reported by name as a `warning` beside the analyses that were read,
+and as an `error` when it was the only plot in the file. It is never dropped
+in silence.
 
 ### No number is invented
 
@@ -909,6 +917,21 @@ type SimulationAnalysisResult =
       plotName: string;
       timeSeconds: readonly number[];
       probes: (SimulationProbe & { value: readonly number[] })[];
+    }
+  | {
+      analysis: "noise";
+      plotName: "Noise Analysis";
+      frequencyHz: readonly number[];
+      outputNoiseDensity: readonly number[];
+      inputNoiseDensity: readonly number[];
+      integratedOutputNoise: number;
+      integratedInputNoise: number;
+      units: {
+        outputDensity: "V/sqrt(Hz)";
+        inputDensity: "V/sqrt(Hz)" | "A/sqrt(Hz)";
+        integratedOutput: "V";
+        integratedInput: "V" | "A";
+      };
     };
 ```
 
@@ -1077,7 +1100,8 @@ release. A deployment without the binding answers
 ## Deterministic validation (first release)
 
 - Closed-form fixtures under `fixtures/ngspice-rawfile/`: a resistor divider
-  operating point, an RC low-pass AC sweep, and an RC step transient, each
+  operating point, an RC low-pass AC sweep, an RC step transient, and
+  ngspice 46 voltage- and current-referred resistor noise results, each
   with the deck that produced it. The parser is asserted against the
   arithmetic, not against itself: AC to a relative tolerance of `1e-12`,
   transient to `1e-3`, on a time axis whose step spans six orders of

--- a/fixtures/ngspice-rawfile/README.md
+++ b/fixtures/ngspice-rawfile/README.md
@@ -1,8 +1,6 @@
 # ngspice ASCII rawfile fixtures
 
-Four rawfiles written by ngspice 46, each beside the deck that produced it,
-plus one deterministic DC protocol fixture pending regeneration in the pinned
-Linux image.
+Six rawfiles written by ngspice 46, each beside the deck that produced it.
 They exist so a parser is tested against output a simulator actually wrote,
 not against output someone believed it writes.
 
@@ -15,6 +13,8 @@ Regenerate any of them with `ngspice -b <name>.deck.spi` from this directory.
 | `divider-dc.raw`        | DC transfer        | real        | 4              | 4      |
 | `rc-ac.raw`             | AC Analysis        | **complex** | 4              | 17     |
 | `rc-tran.raw`           | Transient Analysis | real        | 4              | 79     |
+| `resistor-noise-ngspice46.raw` | Noise spectrum + integrated | real | 3 + 2 | 7 + 1 |
+| `resistor-current-noise-ngspice46.raw` | Noise spectrum + integrated | real | 3 + 2 | 7 + 1 |
 
 ## What each one is for
 
@@ -59,6 +59,19 @@ and the integrator has the least to work with; 1e-3 is a tolerance that holds
 with margin. The timesteps are chosen by ngspice and range from 1e-11 to
 8e-05 — a factor of eight million — so a parser that assumes a uniform grid
 will read this file and be wrong about when everything happened.
+
+**`resistor-noise-ngspice46`** — two 1 kΩ resistors leave 500 Ω of
+small-signal resistance at the output. At 27 °C its thermal-noise density is
+`sqrt(4 k T R)`, and the 0.5 V/V signal gain makes input-referred voltage noise
+twice the output density. Integrating the constant density from 10 Hz to
+1 kHz multiplies it by `sqrt(990 Hz)`.
+
+**`resistor-current-noise-ngspice46`** — the same passive network driven by
+an independent current source. It proves ngspice declares input-referred
+density as `current-density` and the integrated input total as current, while
+the output remains voltage-referred. Both noise fixtures were generated with
+the official ngspice 46 Windows console build. The command and two-plot write
+sequence follow the official manual: https://ngspice.sourceforge.io/docs/ngspice-46-manual.pdf
 
 ## One thing the format does that the header does not announce
 

--- a/fixtures/ngspice-rawfile/resistor-current-noise-ngspice46.deck.spi
+++ b/fixtures/ngspice-rawfile/resistor-current-noise-ngspice46.deck.spi
@@ -1,0 +1,10 @@
+* ngspice current-referred noise rawfile probe
+I1 0 in DC 0 AC 1
+R1 in out 1k
+R2 out 0 1k
+.control
+set filetype=ascii
+noise v(out) I1 dec 3 10 1k
+write resistor-current-noise-ngspice46.raw noise1.all noise2.all
+.endc
+.end

--- a/fixtures/ngspice-rawfile/resistor-current-noise-ngspice46.raw
+++ b/fixtures/ngspice-rawfile/resistor-current-noise-ngspice46.raw
@@ -1,0 +1,54 @@
+Title: * ngspice current-referred noise rawfile probe
+Date: Mon Sep  7 20:28:40  2026
+Command: ngspice-46, Build Mar 29 2026   15:02:07
+Plotname: Noise Spectral Density Curves
+Flags: real
+No. Variables: 3
+No. Points: 7
+Variables:
+	0	frequency	frequency grid=3
+	1	inoise_spectrum	current-density
+	2	onoise_spectrum	voltage-density
+Values:
+ 0	1.000000000000000e+01
+	4.071371529487330e-12
+	4.071371529487329e-09
+
+ 1	2.154434690031884e+01
+	4.071371529487330e-12
+	4.071371529487329e-09
+
+ 2	4.641588833612779e+01
+	4.071371529487330e-12
+	4.071371529487329e-09
+
+ 3	1.000000000000000e+02
+	4.071371529487330e-12
+	4.071371529487329e-09
+
+ 4	2.154434690031884e+02
+	4.071371529487330e-12
+	4.071371529487329e-09
+
+ 5	4.641588833612780e+02
+	4.071371529487330e-12
+	4.071371529487329e-09
+
+ 6	1.000000000000000e+03
+	4.071371529487330e-12
+	4.071371529487329e-09
+
+Title: * ngspice current-referred noise rawfile probe
+Date: Mon Sep  7 20:28:40  2026
+Command: ngspice-46, Build Mar 29 2026   15:02:07
+Plotname: Integrated Noise
+Flags: real
+No. Variables: 2
+No. Points: 1
+Variables:
+	0	v(onoise_total)	voltage
+	1	i(inoise_total)	current
+Values:
+ 0	1.281027145294307e-07
+	1.281027145294306e-10
+

--- a/fixtures/ngspice-rawfile/resistor-noise-ngspice46.deck.spi
+++ b/fixtures/ngspice-rawfile/resistor-noise-ngspice46.deck.spi
@@ -1,0 +1,10 @@
+* ngspice noise rawfile probe
+V1 in 0 DC 0 AC 1
+R1 in out 1k
+R2 out 0 1k
+.control
+set filetype=ascii
+noise v(out) V1 dec 3 10 1k
+write resistor-noise-ngspice46.raw noise1.all noise2.all
+.endc
+.end

--- a/fixtures/ngspice-rawfile/resistor-noise-ngspice46.raw
+++ b/fixtures/ngspice-rawfile/resistor-noise-ngspice46.raw
@@ -1,0 +1,54 @@
+Title: * ngspice noise rawfile probe
+Date: Mon Sep  7 20:28:01  2026
+Command: ngspice-46, Build Mar 29 2026   15:02:07
+Plotname: Noise Spectral Density Curves
+Flags: real
+No. Variables: 3
+No. Points: 7
+Variables:
+	0	frequency	frequency grid=3
+	1	inoise_spectrum	voltage-density
+	2	onoise_spectrum	voltage-density
+Values:
+ 0	1.000000000000000e+01
+	5.757788834460673e-09
+	2.878894417230337e-09
+
+ 1	2.154434690031884e+01
+	5.757788834460673e-09
+	2.878894417230337e-09
+
+ 2	4.641588833612779e+01
+	5.757788834460673e-09
+	2.878894417230337e-09
+
+ 3	1.000000000000000e+02
+	5.757788834460673e-09
+	2.878894417230337e-09
+
+ 4	2.154434690031884e+02
+	5.757788834460673e-09
+	2.878894417230337e-09
+
+ 5	4.641588833612780e+02
+	5.757788834460673e-09
+	2.878894417230337e-09
+
+ 6	1.000000000000000e+03
+	5.757788834460673e-09
+	2.878894417230337e-09
+
+Title: * ngspice noise rawfile probe
+Date: Mon Sep  7 20:28:01  2026
+Command: ngspice-46, Build Mar 29 2026   15:02:07
+Plotname: Integrated Noise
+Flags: real
+No. Variables: 2
+No. Points: 1
+Variables:
+	0	v(onoise_total)	voltage
+	1	v(inoise_total)	voltage
+Values:
+ 0	9.058229813216489e-08
+	1.811645962643298e-07
+

--- a/packages/netlist/src/simulation-compile.test.ts
+++ b/packages/netlist/src/simulation-compile.test.ts
@@ -1424,6 +1424,8 @@ describe.skipIf(!ngspiceOnPath())("running a compiled deck", () => {
         "ac",
       ]);
       for (const analysis of reading.data.analyses) {
+        if (!("probes" in analysis))
+          throw new Error(`Unexpected ${analysis.analysis} result`);
         const names = new Set(analysis.probes.map((probe) => probe.name));
         for (const vector of compiled.vectors) {
           expect(names).toContain(vector.vector);

--- a/packages/simulation-service/src/output-evaluation.ts
+++ b/packages/simulation-service/src/output-evaluation.ts
@@ -188,7 +188,10 @@ function evaluate(
 }
 
 function sourceSeries(
-  analysis: SimulationResultData["analyses"][number],
+  analysis: Exclude<
+    SimulationResultData["analyses"][number],
+    { analysis: "noise" }
+  >,
   vectors: readonly CompiledSimulationVector[],
 ): Map<string, ComplexSeries> {
   const byName = new Map(
@@ -228,8 +231,12 @@ export function evaluateSimulationOutputs(
   measurementSpecs: readonly SimulationMeasurementSpec[] = [],
 ): SimulationOutputData {
   const diagnostics: SimulationOutputData["diagnostics"] = [];
-  const analyses: SimulationOutputData["analyses"] = data.analyses.map(
-    (analysis) => {
+  const analyses: SimulationOutputData["analyses"] = data.analyses
+    .filter(
+      (analysis): analysis is Exclude<typeof analysis, { analysis: "noise" }> =>
+        analysis.analysis !== "noise",
+    )
+    .map((analysis) => {
       const acquisitions = sourceSeries(analysis, vectors);
       const pointCount =
         analysis.analysis === "op"
@@ -283,8 +290,7 @@ export function evaluateSimulationOutputs(
         ...(domain ? { domain } : {}),
         outputs: evaluated,
       };
-    },
-  );
+    });
   return {
     schemaVersion: 1,
     diagnostics,

--- a/packages/spice-run/src/contract.ts
+++ b/packages/spice-run/src/contract.ts
@@ -1,5 +1,5 @@
 import type { SimulationResultData } from "./result-data.js";
-export type SimulationAnalysis = "op" | "dc" | "ac" | "tran";
+export type SimulationAnalysis = "op" | "dc" | "ac" | "tran" | "noise";
 
 export interface SimulationRequest {
   /** Circuit netlist from @icm/netlist. Subcircuits and device cards only. */

--- a/packages/spice-run/src/result-data.test.ts
+++ b/packages/spice-run/src/result-data.test.ts
@@ -8,6 +8,7 @@ import {
   simulationAnalysisToCsv,
   type AcResult,
   type DcSweepResult,
+  type NoiseResult,
   type OperatingPointResult,
   type SimulationAnalysisResult,
   type SimulationDataReading,
@@ -420,6 +421,86 @@ describe("a transient run", () => {
     expect(
       relative(vout.value[last]!, ideal(analysis.timeSeconds[last]!)),
     ).toBeLessThan(1e-4);
+  });
+});
+
+describe("a noise analysis written by ngspice 46", () => {
+  const BOLTZMANN = 1.380649e-23;
+  const TEMPERATURE_K = 273.15 + 27;
+  const OUTPUT_RESISTANCE = R1 / 2;
+
+  it("assembles the spectral and integrated plots without exposing plot ordinals", () => {
+    const noise = only(
+      "resistor-noise-ngspice46.raw",
+      "noise",
+    ) satisfies NoiseResult;
+    expect(noise.plotName).toBe("Noise Analysis");
+    expect(noise.frequencyHz).toEqual([
+      10, 21.54434690031884, 46.41588833612779, 100, 215.4434690031884,
+      464.158883361278, 1000,
+    ]);
+    expect(noise.units).toEqual({
+      outputDensity: "V/sqrt(Hz)",
+      inputDensity: "V/sqrt(Hz)",
+      integratedOutput: "V",
+      integratedInput: "V",
+    });
+
+    const expectedOutputDensity = Math.sqrt(
+      4 * BOLTZMANN * TEMPERATURE_K * OUTPUT_RESISTANCE,
+    );
+    for (const density of noise.outputNoiseDensity)
+      expect(relative(density, expectedOutputDensity)).toBeLessThan(2e-5);
+    for (const density of noise.inputNoiseDensity)
+      expect(relative(density, expectedOutputDensity * 2)).toBeLessThan(2e-5);
+
+    const bandwidthHz = 1000 - 10;
+    expect(
+      relative(
+        noise.integratedOutputNoise,
+        expectedOutputDensity * Math.sqrt(bandwidthHz),
+      ),
+    ).toBeLessThan(2e-5);
+    expect(
+      relative(
+        noise.integratedInputNoise,
+        expectedOutputDensity * 2 * Math.sqrt(bandwidthHz),
+      ),
+    ).toBeLessThan(2e-5);
+  });
+
+  it("keeps current-referred input noise in current units", () => {
+    const noise = only("resistor-current-noise-ngspice46.raw", "noise");
+    expect(noise.units).toEqual({
+      outputDensity: "V/sqrt(Hz)",
+      inputDensity: "A/sqrt(Hz)",
+      integratedOutput: "V",
+      integratedInput: "A",
+    });
+    expect(noise.outputNoiseDensity[0]).toBe(4.071371529487329e-9);
+    expect(noise.inputNoiseDensity[0]).toBe(4.07137152948733e-12);
+  });
+
+  it("refuses one half of ngspice's two-plot result", () => {
+    const full = fixture("resistor-noise-ngspice46.raw");
+    const integrated = full.indexOf("Title: * ngspice noise rawfile probe", 1);
+    const reading = readSimulationData(full.slice(0, integrated));
+    expect(reading.status).toBe("unusable");
+    expect(reading.diagnostics[0]?.text).toContain(
+      "one spectral-density plot and one integrated-noise plot",
+    );
+  });
+
+  it("exports density rows and integrated scalars from the same parse", () => {
+    const noise = only("resistor-noise-ngspice46.raw", "noise");
+    const lines = simulationAnalysisToCsv(noise).trimEnd().split("\n");
+    expect(lines[0]).toBe(
+      "frequency [Hz],output noise density [V/sqrt(Hz)],input noise density [V/sqrt(Hz)]",
+    );
+    expect(lines[8]).toBe("");
+    expect(lines[9]).toBe("integrated quantity,value,unit");
+    expect(lines[10]).toBe("output noise,9.058229813216489e-8,V");
+    expect(lines[11]).toBe("input-referred noise,1.811645962643298e-7,V");
   });
 });
 

--- a/packages/spice-run/src/result-data.ts
+++ b/packages/spice-run/src/result-data.ts
@@ -103,8 +103,34 @@ export interface TransientResult {
   readonly probes: readonly TransientProbe[];
 }
 
+/**
+ * A small-signal noise result, assembled from the two plots one ngspice
+ * `noise` command produces. Density values are amplitudes per square-root
+ * hertz, not squared power densities; the input-referred unit follows the
+ * selected independent source (voltage or current).
+ */
+export interface NoiseResult {
+  readonly analysis: "noise";
+  readonly plotName: "Noise Analysis";
+  readonly frequencyHz: readonly number[];
+  readonly outputNoiseDensity: readonly number[];
+  readonly inputNoiseDensity: readonly number[];
+  readonly integratedOutputNoise: number;
+  readonly integratedInputNoise: number;
+  readonly units: {
+    readonly outputDensity: "V/sqrt(Hz)";
+    readonly inputDensity: "V/sqrt(Hz)" | "A/sqrt(Hz)";
+    readonly integratedOutput: "V";
+    readonly integratedInput: "V" | "A";
+  };
+}
+
 export type SimulationAnalysisResult =
-  OperatingPointResult | DcSweepResult | AcResult | TransientResult;
+  | OperatingPointResult
+  | DcSweepResult
+  | AcResult
+  | TransientResult
+  | NoiseResult;
 
 export interface SimulationResultData {
   readonly schemaVersion: 1;
@@ -186,7 +212,33 @@ export function readSimulationData(rawfile: string): SimulationDataReading {
 
   const analyses: SimulationAnalysisResult[] = [];
   const diagnostics: SimulationDiagnostic[] = [];
+  const noiseSpectra = parse.plots.filter(
+    (plot) =>
+      plot.plotName.trim().toLowerCase() === "noise spectral density curves",
+  );
+  const integratedNoise = parse.plots.filter(
+    (plot) => plot.plotName.trim().toLowerCase() === "integrated noise",
+  );
+  if (noiseSpectra.length > 0 || integratedNoise.length > 0) {
+    if (noiseSpectra.length !== 1 || integratedNoise.length !== 1) {
+      diagnostics.push(
+        error(
+          `A noise result requires one spectral-density plot and one integrated-noise plot; this rawfile holds ${noiseSpectra.length} and ${integratedNoise.length}.`,
+        ),
+      );
+    } else {
+      const reading = readNoise(noiseSpectra[0]!, integratedNoise[0]!);
+      if ("analysis" in reading) analyses.push(reading.analysis);
+      else diagnostics.push(reading.diagnostic);
+    }
+  }
   for (const plot of parse.plots) {
+    const plotName = plot.plotName.trim().toLowerCase();
+    if (
+      plotName === "noise spectral density curves" ||
+      plotName === "integrated noise"
+    )
+      continue;
     const reading = readPlot(plot);
     if ("analysis" in reading) analyses.push(reading.analysis);
     else diagnostics.push(reading.diagnostic);
@@ -228,8 +280,140 @@ function readPlot(plot: RawfilePlot): PlotReading {
   if (name === "transient analysis") return readTransient(plot);
   return {
     diagnostic: warning(
-      `The rawfile holds a "${plot.plotName}" plot, which this release does not read. Operating point, DC, AC, and transient analyses are read.`,
+      `The rawfile holds a "${plot.plotName}" plot, which this release does not read. Operating point, DC, AC, transient, and noise analyses are read.`,
     ),
+  };
+}
+
+function requiredNoiseVector(
+  plot: RawfilePlot,
+  name: string,
+  quantity: string,
+): RawfileVector | SimulationDiagnostic {
+  const candidates = plot.vectors.filter(
+    (vector) => vector.variable.name.toLowerCase() === name,
+  );
+  if (candidates.length !== 1) {
+    return error(
+      `The "${plot.plotName}" plot contains ${candidates.length} ${name} vectors; exactly one is required.`,
+    );
+  }
+  const vector = candidates[0]!;
+  if (vector.variable.quantity.toLowerCase() !== quantity) {
+    return error(
+      `The "${plot.plotName}" plot declares ${name} as ${vector.variable.quantity}, not ${quantity}.`,
+    );
+  }
+  return vector;
+}
+
+function scalarNoiseValue(
+  vector: RawfileVector,
+  plotName: string,
+): number | SimulationDiagnostic {
+  if (vector.real.length !== 1 || vector.real[0] === undefined) {
+    return error(
+      `The "${plotName}" plot must contain one value for ${vector.variable.name}; it contains ${vector.real.length}.`,
+    );
+  }
+  return vector.real[0];
+}
+
+function readNoise(
+  spectrum: RawfilePlot,
+  integrated: RawfilePlot,
+): PlotReading {
+  if (spectrum.complex || integrated.complex) {
+    return {
+      diagnostic: error(
+        "Noise spectral-density and integrated-noise plots must be real-valued.",
+      ),
+    };
+  }
+  const frequency = sweepColumn(spectrum, "frequency");
+  if (!("variable" in frequency)) return { diagnostic: frequency };
+  const outputDensity = requiredNoiseVector(
+    spectrum,
+    "onoise_spectrum",
+    "voltage-density",
+  );
+  if (!("variable" in outputDensity)) return { diagnostic: outputDensity };
+  const inputDensityCandidates = spectrum.vectors.filter(
+    (vector) => vector.variable.name.toLowerCase() === "inoise_spectrum",
+  );
+  if (inputDensityCandidates.length !== 1) {
+    return {
+      diagnostic: error(
+        `The "${spectrum.plotName}" plot contains ${inputDensityCandidates.length} inoise_spectrum vectors; exactly one is required.`,
+      ),
+    };
+  }
+  const inputDensity = inputDensityCandidates[0]!;
+  const inputDensityQuantity = inputDensity.variable.quantity.toLowerCase();
+  if (
+    inputDensityQuantity !== "voltage-density" &&
+    inputDensityQuantity !== "current-density"
+  ) {
+    return {
+      diagnostic: error(
+        `The "${spectrum.plotName}" plot declares inoise_spectrum as ${inputDensity.variable.quantity}, not voltage-density or current-density.`,
+      ),
+    };
+  }
+
+  const integratedOutput = requiredNoiseVector(
+    integrated,
+    "v(onoise_total)",
+    "voltage",
+  );
+  if (!("variable" in integratedOutput))
+    return { diagnostic: integratedOutput };
+  const inputTotalName =
+    inputDensityQuantity === "voltage-density"
+      ? "v(inoise_total)"
+      : "i(inoise_total)";
+  const inputTotalQuantity =
+    inputDensityQuantity === "voltage-density" ? "voltage" : "current";
+  const integratedInput = requiredNoiseVector(
+    integrated,
+    inputTotalName,
+    inputTotalQuantity,
+  );
+  if (!("variable" in integratedInput)) return { diagnostic: integratedInput };
+  const outputTotal = scalarNoiseValue(integratedOutput, integrated.plotName);
+  if (typeof outputTotal !== "number") return { diagnostic: outputTotal };
+  const inputTotal = scalarNoiseValue(integratedInput, integrated.plotName);
+  if (typeof inputTotal !== "number") return { diagnostic: inputTotal };
+  if (
+    outputDensity.real.length !== frequency.real.length ||
+    inputDensity.real.length !== frequency.real.length
+  ) {
+    return {
+      diagnostic: error(
+        "Noise density vectors do not have the same point count as the frequency axis.",
+      ),
+    };
+  }
+
+  return {
+    analysis: {
+      analysis: "noise",
+      plotName: "Noise Analysis",
+      frequencyHz: frequency.real,
+      outputNoiseDensity: outputDensity.real,
+      inputNoiseDensity: inputDensity.real,
+      integratedOutputNoise: outputTotal,
+      integratedInputNoise: inputTotal,
+      units: {
+        outputDensity: "V/sqrt(Hz)",
+        inputDensity:
+          inputDensityQuantity === "voltage-density"
+            ? "V/sqrt(Hz)"
+            : "A/sqrt(Hz)",
+        integratedOutput: "V",
+        integratedInput: inputDensityQuantity === "voltage-density" ? "V" : "A",
+      },
+    },
   };
 }
 
@@ -425,8 +609,37 @@ export function simulationAnalysisToCsv(
         ? dcSweepRows(analysis)
         : analysis.analysis === "ac"
           ? acRows(analysis)
-          : transientRows(analysis);
+          : analysis.analysis === "tran"
+            ? transientRows(analysis)
+            : noiseRows(analysis);
   return rows.map((row) => row.map(csvField).join(",")).join("\n") + "\n";
+}
+
+function noiseRows(analysis: NoiseResult): string[][] {
+  return [
+    [
+      "frequency [Hz]",
+      `output noise density [${analysis.units.outputDensity}]`,
+      `input noise density [${analysis.units.inputDensity}]`,
+    ],
+    ...analysis.frequencyHz.map((frequency, point) => [
+      csvNumber(frequency),
+      cell(analysis.outputNoiseDensity, point),
+      cell(analysis.inputNoiseDensity, point),
+    ]),
+    [],
+    ["integrated quantity", "value", "unit"],
+    [
+      "output noise",
+      csvNumber(analysis.integratedOutputNoise),
+      analysis.units.integratedOutput,
+    ],
+    [
+      "input-referred noise",
+      csvNumber(analysis.integratedInputNoise),
+      analysis.units.integratedInput,
+    ],
+  ];
 }
 
 function dcSweepRows(analysis: DcSweepResult): string[][] {

--- a/packages/spice-run/src/result-schema.ts
+++ b/packages/spice-run/src/result-schema.ts
@@ -66,6 +66,21 @@ const SimulationAnalysisResultSchema = z.discriminatedUnion("analysis", [
       z.strictObject({ ...SimulationProbeShape, value: z.array(z.number()) }),
     ),
   }),
+  z.strictObject({
+    analysis: z.literal("noise"),
+    plotName: z.literal("Noise Analysis"),
+    frequencyHz: z.array(z.number()),
+    outputNoiseDensity: z.array(z.number()),
+    inputNoiseDensity: z.array(z.number()),
+    integratedOutputNoise: z.number(),
+    integratedInputNoise: z.number(),
+    units: z.strictObject({
+      outputDensity: z.literal("V/sqrt(Hz)"),
+      inputDensity: z.enum(["V/sqrt(Hz)", "A/sqrt(Hz)"]),
+      integratedOutput: z.literal("V"),
+      integratedInput: z.enum(["V", "A"]),
+    }),
+  }),
 ]);
 
 const SimulationResultDataSchema = z.strictObject({


### PR DESCRIPTION
## Summary
- record ngspice 46 voltage- and current-referred resistor noise fixtures
- combine ngspice's spectral and integrated plots into one typed Noise result
- preserve voltage/current-referred units and export canonical Noise CSV
- keep Hosted Profile qualification unchanged until compiler/service and Preview evidence land

## Validation
- pnpm gate:preflight -- --base origin/main`n- pnpm gate:full (2822 unit tests and 358 browser tests passed)
- fixture arithmetic checks sqrt(4 k T R) and bandwidth integration

Test-Impact: tests-updated