### PR TITLE
refactor(editor): stabilize simulation plot layout

### DIFF
--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -699,6 +699,12 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   await expect(
     panel.getByRole("button", { name: "Hide first-output" }),
   ).toHaveCount(2);
+  expect(
+    await panel
+      .locator(".waveform-trace-list")
+      .first()
+      .evaluate((list) => getComputedStyle(list).position),
+  ).toBe("static");
   const magnitudePlot = panel
     .locator(".ac-plot-row")
     .filter({ hasText: "Magnitude" })
@@ -798,9 +804,7 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
     "none",
   );
   await transientPlot.hover();
-  const rightTimeLabel = transientPlot
-    .locator('svg text[text-anchor="middle"]')
-    .last();
+  const rightTimeLabel = transientPlot.locator("svg .ac-x-axis-label").last();
   const fullTimeLabel = await rightTimeLabel.textContent();
   const toolbarBounds = await transientToolbar.boundingBox();
   const transientBounds = await transientPlot.boundingBox();
@@ -833,7 +837,7 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   await transientShell.getByRole("button", { name: "Fit plot" }).click();
   await expect(rightTimeLabel).toHaveText(fullTimeLabel ?? "");
   const yLabels = await transientPlot
-    .locator('svg text[text-anchor="end"]')
+    .locator('svg .ac-axis-label:not(.ac-x-axis-label)[text-anchor="end"]')
     .allTextContents();
   await transientToolbar.hover();
   await transientShell.getByRole("button", { name: "Control X axes" }).click();
@@ -853,7 +857,7 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   await expect(rightTimeLabel).not.toHaveText(fullTimeLabel ?? "");
   expect(
     await transientPlot
-      .locator('svg text[text-anchor="end"]')
+      .locator('svg .ac-axis-label:not(.ac-x-axis-label)[text-anchor="end"]')
       .allTextContents(),
   ).toEqual(yLabels);
   await transientToolbar.hover();
@@ -916,6 +920,16 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
     .getByRole("button", { name: "Ranges", exact: true })
     .click();
   const ranges = transientShell.getByRole("form", { name: "Axis ranges" });
+  const rangeBounds = await ranges.boundingBox();
+  const shellBounds = await transientShell.boundingBox();
+  const plotBoundsWithRanges = await transientPlot.boundingBox();
+  expect(rangeBounds!.x).toBeGreaterThanOrEqual(shellBounds!.x);
+  expect(rangeBounds!.x + rangeBounds!.width).toBeLessThanOrEqual(
+    shellBounds!.x + shellBounds!.width,
+  );
+  expect(rangeBounds!.y + rangeBounds!.height).toBeLessThanOrEqual(
+    plotBoundsWithRanges!.y,
+  );
   await ranges.getByLabel("Auto X", { exact: true }).uncheck();
   await ranges.getByLabel("X minimum").fill("8e-9");
   await ranges.getByLabel("X maximum").fill("2e-9");

--- a/apps/editor/src/features/simulation/ac-response-plot.ts
+++ b/apps/editor/src/features/simulation/ac-response-plot.ts
@@ -87,7 +87,7 @@ export interface AcResponseSvgOptions {
   valueUnit?: string;
 }
 
-const MARGIN = { left: 56, right: 56, top: 16, bottom: 32 };
+const MARGIN = { left: 56, right: 56, top: 16, bottom: 48 };
 
 function niceDecades(min: number, max: number): number[] {
   const low = Math.floor(Math.log10(min));
@@ -205,6 +205,15 @@ export function formatFrequency(hertz: number): string {
   return `${hertz * 1e3} mHz`;
 }
 
+function horizontalTickAnchor(
+  x: number,
+  frame: AcPlotLayout["frame"],
+): "start" | "middle" | "end" {
+  if (x - frame.x < 36) return "start";
+  if (frame.x + frame.width - x < 36) return "end";
+  return "middle";
+}
+
 interface Projection {
   x: (frequency: number) => number;
   valueY: (value: number) => number;
@@ -284,8 +293,9 @@ export function acResponseSvg(
 
   const gridLines = [
     ...layout.frequency.ticks.map((hz) => {
-      const x = project.x(hz).toFixed(2);
-      return `<line class="ac-grid" x1="${x}" y1="${frame.y}" x2="${x}" y2="${frame.y + frame.height}"/><text class="ac-axis-label" x="${x}" y="${frame.y + frame.height + 18}" text-anchor="middle">${escapeXml(formatFrequency(hz))}</text>`;
+      const projectedX = project.x(hz);
+      const x = projectedX.toFixed(2);
+      return `<line class="ac-grid" x1="${x}" y1="${frame.y}" x2="${x}" y2="${frame.y + frame.height}"/><text class="ac-axis-label ac-x-axis-label" x="${x}" y="${frame.y + frame.height + 18}" text-anchor="${horizontalTickAnchor(projectedX, frame)}">${escapeXml(formatFrequency(hz))}</text>`;
     }),
     ...axis.ticks.map((value) => {
       const y = axisY(value).toFixed(2);
@@ -359,6 +369,7 @@ export function acResponseSvg(
     `<defs><clipPath id="${clipId}"><rect x="${frame.x}" y="${frame.y}" width="${frame.width}" height="${frame.height}"/></clipPath></defs>` +
     `<rect class="ac-frame" x="${frame.x}" y="${frame.y}" width="${frame.width}" height="${frame.height}"/>` +
     gridLines +
+    `<text class="ac-axis-title" x="${frame.x + frame.width}" y="${size.height - 7}" text-anchor="end">Frequency</text>` +
     `<g clip-path="url(#${clipId})">${curves}</g>` +
     cursor +
     legend +

--- a/apps/editor/src/features/simulation/ac-results-explorer.test.tsx
+++ b/apps/editor/src/features/simulation/ac-results-explorer.test.tsx
@@ -68,6 +68,8 @@ describe("AC Results Explorer", () => {
     expect(markup).not.toContain('aria-label="More plot tools"');
     expect(markup).not.toContain("<strong>Voltage</strong>");
     expect(markup).toContain('aria-label="Open plot"');
+    expect(markup).toContain('class="ac-axis-title"');
+    expect(markup).toContain(">Frequency</text>");
     expect(markup).not.toContain("Wheel to zoom");
   });
 

--- a/apps/editor/src/features/simulation/dc-results-explorer.test.tsx
+++ b/apps/editor/src/features/simulation/dc-results-explorer.test.tsx
@@ -44,6 +44,8 @@ describe("DcResultsExplorer", () => {
     expect(markup).toContain('aria-label="DC voltage"');
     expect(markup).toContain("3 points");
     expect(markup).toContain("Output");
+    expect(markup).toContain('class="ac-axis-title"');
+    expect(markup).toContain(">v-sweep</text>");
     expect(markup).toContain("<polyline");
     expect(markup).toContain("-50mV");
     expect(markup).toContain("1.050V");

--- a/apps/editor/src/features/simulation/dc-results-explorer.tsx
+++ b/apps/editor/src/features/simulation/dc-results-explorer.tsx
@@ -14,9 +14,9 @@ const PLOT = {
   width: 760,
   height: 280,
   left: 64,
-  right: 18,
+  right: 48,
   top: 16,
-  bottom: 34,
+  bottom: 48,
 };
 
 function extent(values: readonly number[]): readonly [number, number] {
@@ -135,17 +135,30 @@ export function DcResultsExplorer({
                     x2={PLOT.width - PLOT.right}
                     y2={PLOT.height - PLOT.bottom}
                   />
-                  <text x={PLOT.left} y={PLOT.height - 8}>
+                  <text
+                    className="ac-axis-label ac-x-axis-label"
+                    x={PLOT.left}
+                    y={PLOT.height - PLOT.bottom + 18}
+                  >
                     {compact(xExtent[0])}
                     {analysis.sweep.unit ?? ""}
                   </text>
                   <text
+                    className="ac-axis-label ac-x-axis-label"
                     textAnchor="end"
                     x={PLOT.width - PLOT.right}
-                    y={PLOT.height - 8}
+                    y={PLOT.height - PLOT.bottom + 18}
                   >
                     {compact(xExtent[1])}
                     {analysis.sweep.unit ?? ""}
+                  </text>
+                  <text
+                    className="ac-axis-title"
+                    textAnchor="end"
+                    x={PLOT.width - PLOT.right}
+                    y={PLOT.height - 7}
+                  >
+                    {analysis.sweep.name}
                   </text>
                   <text x={4} y={PLOT.top + 5}>
                     {compact(yExtent[1])}

--- a/apps/editor/src/features/simulation/transient-results-explorer.test.tsx
+++ b/apps/editor/src/features/simulation/transient-results-explorer.test.tsx
@@ -102,6 +102,8 @@ describe("Transient Results Explorer", () => {
     expect(markup.match(/drag to zoom, click to measure/gu)).toHaveLength(2);
     expect(markup).not.toContain('aria-label="Inspect plot"');
     expect(markup.match(/aria-label="Open plot"/gu)).toHaveLength(2);
+    expect(markup.match(/class="ac-axis-title"/gu)).toHaveLength(2);
+    expect(markup.match(/>Time<\/text>/gu)).toHaveLength(2);
     expect(markup).toContain(
       'class="ac-trace-hit" fill="none" stroke="transparent" stroke-width="12" pointer-events="stroke"',
     );

--- a/apps/editor/src/features/simulation/transient-results-explorer.tsx
+++ b/apps/editor/src/features/simulation/transient-results-explorer.tsx
@@ -42,9 +42,9 @@ const PLOT = {
   width: 760,
   height: 395,
   left: 64,
-  right: 18,
+  right: 48,
   top: 16,
-  bottom: 34,
+  bottom: 48,
 } as const;
 const EXPANDED_PLOT = { ...PLOT, width: 1400, height: 700 } as const;
 
@@ -420,6 +420,12 @@ export function ScalarResultsExplorer({
                 geometry.left +
                 xFraction(value, range) *
                   (geometry.width - geometry.left - geometry.right);
+              const textAnchor =
+                x - geometry.left < 36
+                  ? "start"
+                  : geometry.width - geometry.right - x < 36
+                    ? "end"
+                    : "middle";
               return (
                 <g key={value}>
                   <line
@@ -430,10 +436,10 @@ export function ScalarResultsExplorer({
                     y2={geometry.height - geometry.bottom}
                   />
                   <text
-                    className="ac-axis-label"
-                    textAnchor="middle"
+                    className="ac-axis-label ac-x-axis-label"
+                    textAnchor={textAnchor}
                     x={x}
-                    y={geometry.height - 8}
+                    y={geometry.height - geometry.bottom + 18}
                   >
                     {waveformTickLabel(
                       value,
@@ -445,6 +451,14 @@ export function ScalarResultsExplorer({
                 </g>
               );
             })}
+            <text
+              className="ac-axis-title"
+              textAnchor="end"
+              x={geometry.width - geometry.right}
+              y={geometry.height - 7}
+            >
+              {domainLabel}
+            </text>
             {waveformTicks(
               extent[0],
               extent[1],

--- a/apps/editor/src/features/simulation/waveform-tools.tsx
+++ b/apps/editor/src/features/simulation/waveform-tools.tsx
@@ -200,45 +200,49 @@ function WaveformRangeEditor({
         onApply(nextX, nextY);
       }}
     >
-      {(["x", "y"] as const).map((axis) => (
-        <fieldset key={axis}>
-          <legend>
-            {axis.toUpperCase()} ({axis === "x" ? xUnit : yUnit})
-          </legend>
-          <label>
-            <input
-              type="checkbox"
-              aria-label={`Auto ${axis.toUpperCase()}`}
-              checked={axis === "x" ? autoX : autoY}
-              onChange={(event) =>
-                (axis === "x" ? setAutoX : setAutoY)(event.target.checked)
-              }
-            />
-            Auto
-          </label>
-          {([0, 1] as const).map((index) => (
-            <label key={index}>
-              {index === 0 ? "Min" : "Max"}
+      <div className="waveform-range-grid">
+        {(["x", "y"] as const).map((axis) => (
+          <fieldset key={axis}>
+            <legend>
+              {axis.toUpperCase()} ({axis === "x" ? xUnit : yUnit})
+            </legend>
+            <label className="waveform-range-auto">
               <input
-                aria-label={`${axis.toUpperCase()} ${index === 0 ? "minimum" : "maximum"}`}
-                value={bounds[`${axis}${index}`]}
-                disabled={axis === "x" ? autoX : autoY}
+                type="checkbox"
+                aria-label={`Auto ${axis.toUpperCase()}`}
+                checked={axis === "x" ? autoX : autoY}
                 onChange={(event) =>
-                  setBounds({
-                    ...bounds,
-                    [`${axis}${index}`]: event.target.value,
-                  })
+                  (axis === "x" ? setAutoX : setAutoY)(event.target.checked)
                 }
               />
+              Auto
             </label>
-          ))}
-        </fieldset>
-      ))}
+            {([0, 1] as const).map((index) => (
+              <label key={index}>
+                <span>{index === 0 ? "Min" : "Max"}</span>
+                <input
+                  aria-label={`${axis.toUpperCase()} ${index === 0 ? "minimum" : "maximum"}`}
+                  value={bounds[`${axis}${index}`]}
+                  disabled={axis === "x" ? autoX : autoY}
+                  onChange={(event) =>
+                    setBounds({
+                      ...bounds,
+                      [`${axis}${index}`]: event.target.value,
+                    })
+                  }
+                />
+              </label>
+            ))}
+          </fieldset>
+        ))}
+      </div>
       {error && <p role="alert">{error}</p>}
-      <button type="submit">Apply ranges</button>
-      <button type="button" onClick={onCancel}>
-        Cancel
-      </button>
+      <div className="waveform-range-actions">
+        <button type="button" onClick={onCancel}>
+          Cancel
+        </button>
+        <button type="submit">Apply ranges</button>
+      </div>
     </form>
   );
 }

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -773,7 +773,7 @@
 .simulation-analysis-view .simulation-analysis-card-header h3 {
   margin: 0;
   color: var(--icm-text);
-  font-size: 28px;
+  font-size: 19px;
   font-weight: 700;
   line-height: 1.1;
   letter-spacing: 0.01em;
@@ -1388,8 +1388,6 @@
   min-width: 0;
 }
 .waveform-trace-list {
-  position: sticky;
-  top: 0;
   display: grid;
   gap: 4px;
   min-width: 0;
@@ -1491,6 +1489,9 @@
   box-shadow: none;
   outline-offset: -2px;
 }
+.ac-plot-toolbar.expanded {
+  height: auto;
+}
 .ac-plot-shell > .ac-cursor-readout {
   margin: 0;
   border: 0;
@@ -1500,8 +1501,9 @@
 }
 .waveform-tools-hint {
   position: absolute;
-  inset: 0;
+  inset: 0 0 auto;
   display: grid;
+  height: 30px;
   place-items: center start;
   padding-left: 8px;
   color: var(--icm-text-muted);
@@ -1511,8 +1513,9 @@
 }
 .waveform-tool-actions {
   position: absolute;
-  inset: 0;
+  inset: 0 0 auto;
   display: flex;
+  height: 30px;
   align-items: center;
   justify-content: flex-start;
   gap: 1px;
@@ -2143,6 +2146,13 @@
   font-variant-numeric: tabular-nums;
 }
 
+.ac-response .ac-axis-title,
+.transient-results-explorer .ac-axis-title {
+  font-size: 12px;
+  font-weight: 650;
+  fill: #344054;
+}
+
 .ac-plot-shell.expanded .ac-axis-label {
   font-size: 16px;
 }
@@ -2228,44 +2238,63 @@
   }
 }
 .waveform-range-editor {
-  position: absolute;
-  z-index: 5;
-  top: 100%;
-  right: 0;
-  display: flex;
-  flex-wrap: wrap;
-  width: min(100%, 520px);
-  gap: 6px;
-  padding: 6px;
-  border: 1px solid var(--icm-border-strong);
-  border-radius: 0 0 var(--icm-radius-sm) var(--icm-radius-sm);
-  background: var(--icm-surface);
-  box-shadow: var(--icm-shadow-sm);
+  position: static;
+  display: grid;
+  gap: 8px;
+  width: auto;
+  margin-top: 30px;
+  padding: 8px;
+  border: 0;
+  border-top: 1px solid var(--icm-border);
+  background: #fff;
+  box-shadow: none;
 }
-.ac-plot-shell:has(.waveform-range-editor) {
-  overflow: visible;
+.waveform-range-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
 }
 .waveform-range-editor fieldset {
-  display: flex;
-  flex: 1 1 220px;
+  display: grid;
+  grid-template-columns: auto repeat(2, minmax(0, 1fr));
+  align-items: end;
   min-width: 0;
-  gap: 6px;
+  gap: 8px;
+  margin: 0;
+  padding: 5px 7px 7px;
   border: 1px solid var(--icm-border);
   border-radius: var(--icm-radius-sm);
 }
 .waveform-range-editor label {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+}
+.waveform-range-editor .waveform-range-auto {
   display: flex;
   align-items: center;
+  align-self: center;
   gap: 4px;
-  min-width: 0;
 }
 .waveform-range-editor input:not([type="checkbox"]) {
   width: 100%;
   min-width: 0;
 }
 .waveform-range-editor [role="alert"] {
-  flex-basis: 100%;
+  margin: 0;
   color: var(--icm-danger, #b42318);
+}
+.waveform-range-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+}
+@container (max-width: 560px) {
+  .waveform-range-grid {
+    grid-template-columns: 1fr;
+  }
 }
 .spice-ac-plot.interactive {
   overflow: hidden;


### PR DESCRIPTION
## Summary
- keep trace selectors in document flow and reduce analysis heading scale
- replace the overlapping range popover with a responsive in-flow axis editor
- keep edge ticks inside plots and label each horizontal domain at the right edge

## Validation
- pnpm gate:preflight -- --base main
- pnpm gate:affected -- --base main
- 2844 unit tests (2822 passed, 22 skipped)
- 6 affected browser tests passed