### PR TITLE
Add a schematic selection filter

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -305,6 +305,7 @@ test("keeps quick-start shortcuts in the upper-right corner until the first comp
   await expect(quickStart).toContainText("Quick start");
   await expect(quickStart).toContainText("Cadence keys");
   await expect(quickStart.locator("li")).toHaveText([
+    "CtrlFSelection filter",
     "FFit view",
     "IInsert component",
     "RRotate",

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -5431,12 +5431,12 @@ test("selecting an object does not change canvas width", async ({ page }) => {
   expect(widthAfter).toBe(widthBefore);
 });
 
-test("opens project search with Ctrl+F and selects a matching component", async ({
+test("opens project search with Ctrl+Shift+F and selects a matching component", async ({
   page,
 }) => {
   await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 420, y: 260 });
-  await page.keyboard.press("Control+f");
+  await page.keyboard.press("Control+Shift+f");
   const input = page.getByTestId("project-search-input");
   await expect(input).toBeFocused();
   await input.fill("R1");
@@ -5445,6 +5445,47 @@ test("opens project search with Ctrl+F and selects a matching component", async 
     "Selected instance R1",
   );
   await expect(page.getByTestId("project-search-input")).toHaveCount(0);
+});
+
+test("opens Selection Filter with Ctrl+F and filters Select All", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await placeComponent(page, "resistor", { x: 380, y: 260 });
+  await placeComponent(page, "resistor", { x: 600, y: 260 });
+  await clickDrawTool(page, "wire");
+  await page.getByTestId("terminal-R1-2").click();
+  await page.getByTestId("terminal-R2-1").click();
+  await page.keyboard.press("Escape");
+
+  await page.keyboard.press("Control+f");
+  const filter = page.getByTestId("selection-filter-popover");
+  await expect(filter).toBeVisible();
+  await filter.getByRole("button", { name: "None" }).click();
+  await filter.getByLabel("Wires").check();
+  await filter.getByRole("button", { name: "Close" }).click();
+  await expect(page.getByTestId("selection-filter-status")).toContainText(
+    "Filter: Wires",
+  );
+
+  await page.keyboard.press("Control+a");
+  await expect(page.getByTestId("route-hit-route-ui-1")).toHaveClass(
+    /selected/,
+  );
+  await expect(page.getByTestId("hit-R1")).not.toHaveClass(/selected/);
+  await expect(page.getByTestId("hit-R2")).not.toHaveClass(/selected/);
+  await page.getByTestId("hit-R1").click();
+  await expect(page.getByTestId("hit-R1")).not.toHaveClass(/selected/);
+
+  await page.getByTestId("selection-filter-status").click();
+  await filter.getByRole("button", { name: "None" }).click();
+  await filter.getByLabel("Instances").check();
+  await filter.getByRole("button", { name: "Close" }).click();
+  await page.keyboard.press("Control+d");
+  await page.getByTestId("route-hit-route-ui-1").click({ force: true });
+  await expect(page.getByTestId("route-hit-route-ui-1")).not.toHaveClass(
+    /selected/,
+  );
 });
 
 test("highlights the complete current-document Net from a selected route", async ({

--- a/apps/editor/src/app/App.test.tsx
+++ b/apps/editor/src/app/App.test.tsx
@@ -268,6 +268,7 @@ describe("editor shell", () => {
     expect(markup).toContain(">Library</span>");
     expect(markup).toContain('class="app-statusbar"');
     expect(markup).toContain("Insert component (I)");
+    expect(markup).toContain("Selection filter");
     expect(markup).not.toContain("Symbols &amp; Tools");
     expect(markup).not.toContain("Search components");
     expect(markup).not.toContain("Browse all");

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -259,6 +259,13 @@ import {
 } from "../presentation/razavi-presentation";
 import { useRecoveryCoordinator } from "../document/recovery-coordinator";
 import { useSelectionController } from "../features/selection/selection-controller";
+import { SelectionFilterPopover } from "../features/selection/selection-filter-popover";
+import {
+  DEFAULT_SELECTION_FILTER,
+  selectionFilterSummary,
+  selectionForDocument,
+  type SelectionFilter,
+} from "../features/selection/selection-filter";
 import { deriveSelectionInspectionModel } from "../features/selection/selection-inspection-model";
 import { usePropertiesEditor } from "../features/properties/use-properties-editor";
 import { createPropertyEditPlanner } from "../features/properties/property-edit-planner";
@@ -507,6 +514,10 @@ export function App({
     clearKinds: clearSelectionKinds,
     reset: resetSelection,
   } = useSelectionController();
+  const [selectionFilter, setSelectionFilter] = useState<SelectionFilter>(
+    DEFAULT_SELECTION_FILTER,
+  );
+  const [selectionFilterOpen, setSelectionFilterOpen] = useState(false);
   const uniqueSuffixCounter = useRef(0);
   const [viewBox, setRawViewBox] = useState<GridRect>(DEFAULT_VIEWBOX);
   const cameraRuntimeRef = useRef<CameraRuntime | null>(null);
@@ -2824,6 +2835,7 @@ export function App({
       selectedInternalRouteIds,
       selectedInternalJunctionIds,
       selectedInternalObjectIds,
+      selectionFilter,
     },
     session: {
       getInteractionKind: () => getCurrentInteractionState().kind,
@@ -2905,7 +2917,13 @@ export function App({
     continueCanvasGesture,
     finishCanvasGesture,
   } = createCanvasGestureController({
-    model: { document, resolver, routeGeometryRecords, styleProfile },
+    model: {
+      document,
+      resolver,
+      routeGeometryRecords,
+      styleProfile,
+      selectionFilter,
+    },
     viewport: {
       defaultViewBox: DEFAULT_VIEWBOX,
       contentBounds: contentSceneBounds,
@@ -3120,17 +3138,7 @@ export function App({
   }
 
   function selectAllObjects(): void {
-    replaceSelection({
-      instanceIds: document.instances
-        .filter((instance) => instance.placement)
-        .map((instance) => instance.id),
-      routeIds: document.routes.map((route) => route.id),
-      junctionIds: document.junctions.map((junction) => junction.id),
-      annotationIds: document.annotations.map((annotation) => annotation.id),
-      draftingIds: (document.drafting?.objects ?? []).map(
-        (object) => object.id,
-      ),
-    });
+    replaceSelection(selectionForDocument(document, selectionFilter));
     setSelectedEndpoint(null);
   }
 
@@ -3713,6 +3721,14 @@ export function App({
         armVerb("copy");
       },
       copyVisualSelection: visualClipboard.copy,
+      openSelectionFilter: () => {
+        closeSearch();
+        setSelectionFilterOpen(true);
+      },
+      openSearch: () => {
+        setSelectionFilterOpen(false);
+        setSearchOpen(true);
+      },
       beginMove: (detach) => {
         if (canBeginKeyboardSelectionMove()) {
           beginKeyboardSelectionMoveFromSelection(undefined, { detach });
@@ -3838,15 +3854,6 @@ export function App({
         ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"].includes(event.key)
       )
         return;
-      if (
-        (event.ctrlKey || event.metaKey) &&
-        event.key.toLowerCase() === "f" &&
-        !isTypingTarget(event.target)
-      ) {
-        event.preventDefault();
-        setSearchOpen(true);
-        return;
-      }
       if (event.key === "Escape" && simulationPickActive) {
         event.preventDefault();
         setSimulationPickMode(null);
@@ -3862,6 +3869,11 @@ export function App({
       if (event.key === "Escape" && searchOpen) {
         event.preventDefault();
         closeSearch();
+        return;
+      }
+      if (event.key === "Escape" && selectionFilterOpen) {
+        event.preventDefault();
+        setSelectionFilterOpen(false);
         return;
       }
       if (event.key === "Escape" && insertDialogOpen) {
@@ -4329,13 +4341,17 @@ export function App({
           onOpenRecovery: openRecoveryDialog,
         }}
         searchOpen={searchOpen}
+        selectionFilterOpen={selectionFilterOpen}
         onManageCells={() => setCellManagerOpen(true)}
         onNewTestbench={() => openNewTestbenchDialog()}
         placeProjectCell={{
           enabled: cellInsertCandidates.length > 0,
           execute: placeCellInstance,
         }}
-        onOpenSearch={() => setSearchOpen(true)}
+        onOpenSelectionFilter={() =>
+          editorCommands.execute({ id: "selection.filter.open" })
+        }
+        onOpenSearch={() => editorCommands.execute({ id: "search.open" })}
         undo={{
           enabled: editorCommands.state({ id: "history.undo" }).enabled,
           execute: () => editorCommands.execute({ id: "history.undo" }),
@@ -5952,6 +5968,9 @@ export function App({
               selectedRouteSegmentIndex,
               selectedEndpoint,
               supplementalJunctionIds: supplementalSelection.junctionIds,
+              selectionFilter: simulationPickActive
+                ? DEFAULT_SELECTION_FILTER
+                : selectionFilter,
               endpointLabel: endpointTestId,
               ...(simulationPickTerminalsActive
                 ? {
@@ -6255,6 +6274,12 @@ export function App({
           onPlaceOnCanvas={beginWaveformPlacement}
         />
       ) : null}
+      <SelectionFilterPopover
+        open={selectionFilterOpen}
+        filter={selectionFilter}
+        onChange={setSelectionFilter}
+        onClose={() => setSelectionFilterOpen(false)}
+      />
       <EditorStatusbar
         visitStats={visitStats}
         status={status}
@@ -6273,6 +6298,10 @@ export function App({
         wheelBehavior={wheelBehavior}
         onWheelBehaviorChange={setWheelBehavior}
         zoomPercent={zoomPercent}
+        selectionFilterSummary={selectionFilterSummary(selectionFilter)}
+        onOpenSelectionFilter={() =>
+          editorCommands.execute({ id: "selection.filter.open" })
+        }
         issues={{
           checkStatus: projectCheck.status,
           errorCount: issueCounts.errorCount,

--- a/apps/editor/src/app/editor-app-chrome.tsx
+++ b/apps/editor/src/app/editor-app-chrome.tsx
@@ -41,6 +41,8 @@ export interface EditorAppChromeProps {
   onManageCells: () => void;
   onNewTestbench: () => void;
   placeProjectCell: CommandAction;
+  selectionFilterOpen: boolean;
+  onOpenSelectionFilter: () => void;
   onOpenSearch: () => void;
   undo: CommandAction;
   redo: CommandAction;
@@ -86,6 +88,8 @@ export function EditorAppChrome({
   onManageCells,
   onNewTestbench,
   placeProjectCell,
+  selectionFilterOpen,
+  onOpenSelectionFilter,
   onOpenSearch,
   undo,
   redo,
@@ -218,12 +222,21 @@ export function EditorAppChrome({
                 </button>
                 <button
                   type="button"
+                  data-testid="selection-filter-button"
+                  aria-haspopup="dialog"
+                  aria-expanded={selectionFilterOpen}
+                  onClick={onOpenSelectionFilter}
+                >
+                  Selection Filter… (Ctrl+F)
+                </button>
+                <button
+                  type="button"
                   data-testid="project-search-button"
                   aria-haspopup="dialog"
                   aria-expanded={searchOpen}
                   onClick={onOpenSearch}
                 >
-                  Search…
+                  Search schematic… (Ctrl+Shift+F)
                 </button>
                 <button
                   type="button"

--- a/apps/editor/src/canvas/canvas-gesture-controller.ts
+++ b/apps/editor/src/canvas/canvas-gesture-controller.ts
@@ -15,6 +15,10 @@ import {
   marqueeSelection,
 } from "../features/selection/marquee-selection";
 import {
+  DEFAULT_SELECTION_FILTER,
+  type SelectionFilter,
+} from "../features/selection/selection-filter";
+import {
   EMPTY_VISUAL_SELECTION,
   type VisualSelection,
 } from "../features/selection/visual-selection";
@@ -60,6 +64,7 @@ export interface CanvasGestureControllerDependencies {
     resolver: SymbolResolver;
     routeGeometryRecords: readonly RouteGeometryRecord[];
     styleProfile: SchematicStyleProfile;
+    selectionFilter?: SelectionFilter;
   };
   viewport: {
     defaultViewBox: GridRect;
@@ -215,7 +220,13 @@ let lastTrackpadWheelAt = Number.NEGATIVE_INFINITY;
 
 /** Own viewport gestures and canvas-background pointer progression. */
 export function createCanvasGestureController({
-  model: { document, resolver, routeGeometryRecords, styleProfile },
+  model: {
+    document,
+    resolver,
+    routeGeometryRecords,
+    styleProfile,
+    selectionFilter = DEFAULT_SELECTION_FILTER,
+  },
   viewport: {
     defaultViewBox,
     contentBounds,
@@ -632,6 +643,7 @@ export function createCanvasGestureController({
           styleProfile,
           rect,
           marqueeMode(boxPreview.start, boxPreview.end),
+          selectionFilter,
         );
     replaceSelection(selection);
     clearSelectedEndpoint();

--- a/apps/editor/src/canvas/canvas-hit-controller.ts
+++ b/apps/editor/src/canvas/canvas-hit-controller.ts
@@ -5,6 +5,11 @@ import type { Annotation, DraftingObject, SchematicDocument } from "@icm/model";
 
 import type { EditorTool } from "../interaction/interaction-state";
 import { planSelectionMove } from "../features/selection/selection-move-plan";
+import {
+  DEFAULT_SELECTION_FILTER,
+  selectionFilterAllowsCanvasHit,
+  type SelectionFilter,
+} from "../features/selection/selection-filter";
 import type { VisualSelection } from "../features/selection/visual-selection";
 import {
   resolveCanvasHitAtPoint,
@@ -20,6 +25,7 @@ export interface CanvasHitControllerDependencies {
     selectedInternalRouteIds: ReadonlySet<string>;
     selectedInternalJunctionIds: ReadonlySet<string>;
     selectedInternalObjectIds: ReadonlySet<string>;
+    selectionFilter?: SelectionFilter;
   };
   session: {
     getInteractionKind: () => string;
@@ -84,6 +90,7 @@ export function createCanvasHitController({
     selectedInternalRouteIds,
     selectedInternalJunctionIds,
     selectedInternalObjectIds,
+    selectionFilter = DEFAULT_SELECTION_FILTER,
   },
   session: {
     getInteractionKind,
@@ -175,6 +182,15 @@ export function createCanvasHitController({
           event.currentTarget.ownerDocument,
           { x: event.clientX, y: event.clientY },
           event.altKey ? 1 : 0,
+          simulationPickMode === null
+            ? (candidate) =>
+                candidate.selected ||
+                selectionFilterAllowsCanvasHit(
+                  selectionFilter,
+                  document,
+                  candidate,
+                )
+            : undefined,
         )
       : null;
     // The offer runs the verb, so it is withheld while a simulation probe is

--- a/apps/editor/src/canvas/canvas-hit-resolver.test.ts
+++ b/apps/editor/src/canvas/canvas-hit-resolver.test.ts
@@ -105,6 +105,20 @@ describe("resolveCanvasHit", () => {
       id: "M1",
     });
   });
+
+  it("removes disabled candidates before priority and Alt cycling", () => {
+    const route = element("route", "route-1");
+    const instance = element("instance", "M1");
+    const accepts = (hit: { kind: string }) => hit.kind !== "route";
+    expect(resolveCanvasHit([route, instance], 0, accepts)).toMatchObject({
+      kind: "instance",
+      id: "M1",
+    });
+    expect(resolveCanvasHit([route, instance], 1, accepts)).toMatchObject({
+      kind: "instance",
+      id: "M1",
+    });
+  });
 });
 
 describe("a hit radius that does not shrink when the view does", () => {

--- a/apps/editor/src/canvas/canvas-hit-resolver.ts
+++ b/apps/editor/src/canvas/canvas-hit-resolver.ts
@@ -49,10 +49,14 @@ function readHit(element: Element): CanvasHit | null {
  * Resolve once at pointer-down. `elements` must be in paint order (topmost
  * first), as returned by `document.elementsFromPoint()`.
  */
-export function rankCanvasHits(elements: readonly Element[]): CanvasHit[] {
+export function rankCanvasHits(
+  elements: readonly Element[],
+  accepts: (hit: CanvasHit) => boolean = () => true,
+): CanvasHit[] {
   const hits = elements
     .map(readHit)
-    .filter((hit): hit is CanvasHit => hit !== null);
+    .filter((hit): hit is CanvasHit => hit !== null)
+    .filter(accepts);
   const unique = hits.filter(
     (hit, index) =>
       hits.findIndex(
@@ -75,8 +79,9 @@ export function rankCanvasHits(elements: readonly Element[]): CanvasHit[] {
 export function resolveCanvasHit(
   elements: readonly Element[],
   cycle = 0,
+  accepts?: (hit: CanvasHit) => boolean,
 ): CanvasHit | null {
-  const hits = rankCanvasHits(elements);
+  const hits = rankCanvasHits(elements, accepts);
   if (hits.length === 0) return null;
   return hits[Math.min(Math.max(0, cycle), hits.length - 1)]!;
 }
@@ -85,10 +90,12 @@ export function resolveCanvasHitAtPoint(
   owner: { elementsFromPoint?(x: number, y: number): Element[] },
   client: { x: number; y: number },
   cycle = 0,
+  accepts?: (hit: CanvasHit) => boolean,
 ): CanvasHit | null {
   return resolveCanvasHit(
     owner.elementsFromPoint?.(client.x, client.y) ?? [],
     cycle,
+    accepts,
   );
 }
 

--- a/apps/editor/src/canvas/editor-canvas-hit-layer.tsx
+++ b/apps/editor/src/canvas/editor-canvas-hit-layer.tsx
@@ -22,6 +22,10 @@ import {
   instanceHitBox,
 } from "../features/wiring/route-interaction-geometry";
 import type { EditorTool } from "../interaction/interaction-state";
+import {
+  DEFAULT_SELECTION_FILTER,
+  type SelectionFilter,
+} from "../features/selection/selection-filter";
 import { serializePolylinePoints } from "./canvas-geometry";
 
 type Instance = SchematicDocument["instances"][number];
@@ -90,6 +94,7 @@ interface EndpointHitTargetProps {
   selectedRouteSegmentIndex: number | null;
   selectedEndpoint: WireSource | null;
   supplementalJunctionIds: readonly string[];
+  selectionFilter?: SelectionFilter;
   endpointLabel: (endpoint: WireSource["endpoint"]) => string;
   onEndpointActions: (
     endpoint: WireSource,
@@ -306,6 +311,7 @@ function EndpointHitTargets({
   selectedRouteSegmentIndex,
   selectedEndpoint,
   supplementalJunctionIds,
+  selectionFilter = DEFAULT_SELECTION_FILTER,
   endpointLabel,
   endpointHitRadius,
   onEndpointActions,
@@ -424,6 +430,14 @@ function EndpointHitTargets({
                 ? "resize-route-start"
                 : "resize-route-end",
             );
+            return;
+          }
+          if (
+            tool === "pointer" &&
+            !selectionFilter[
+              candidate.endpoint.kind === "junction" ? "junction" : "terminal"
+            ]
+          ) {
             return;
           }
           if (tool === "pointer" && candidate.endpoint.kind === "junction") {

--- a/apps/editor/src/canvas/editor-canvas-surface.tsx
+++ b/apps/editor/src/canvas/editor-canvas-surface.tsx
@@ -73,6 +73,7 @@ export interface EditorCanvasSurfaceProps {
 }
 
 const CADENCE_QUICK_SHORTCUTS = [
+  { keys: ["Ctrl", "F"], action: "Selection filter" },
   { keys: ["F"], action: "Fit view" },
   { keys: ["I"], action: "Insert component" },
   { keys: ["R"], action: "Rotate" },

--- a/apps/editor/src/commands/editor-command.test.ts
+++ b/apps/editor/src/commands/editor-command.test.ts
@@ -43,6 +43,8 @@ function fixture(overrides: Partial<EditorCommandContext> = {}) {
     deleteSelection: vi.fn(),
     beginCopy: vi.fn(),
     copyVisualSelection: vi.fn(),
+    openSelectionFilter: vi.fn(),
+    openSearch: vi.fn(),
     beginMove: vi.fn(),
     alignSelection: vi.fn(),
     rotatePlacement: vi.fn(),
@@ -77,6 +79,15 @@ function fixture(overrides: Partial<EditorCommandContext> = {}) {
 }
 
 describe("editor command router", () => {
+  it("routes Search and Selection Filter through distinct commands", () => {
+    const { router, operations } = fixture();
+    router.execute({ id: "selection.filter.open" });
+    expect(operations.openSelectionFilter).toHaveBeenCalledOnce();
+    expect(operations.openSearch).not.toHaveBeenCalled();
+    router.execute({ id: "search.open" });
+    expect(operations.openSearch).toHaveBeenCalledOnce();
+  });
+
   it("copies visual content without arming circuit copy or mutating history", () => {
     const { router, operations } = fixture();
     router.execute({ id: "selection.copy-image", format: "svg" });

--- a/apps/editor/src/commands/editor-command.ts
+++ b/apps/editor/src/commands/editor-command.ts
@@ -15,6 +15,8 @@ export type EditorCommandRequest =
   | { id: "selection.delete" }
   | { id: "selection.copy" }
   | { id: "selection.copy-image"; format: "png" | "svg" }
+  | { id: "selection.filter.open" }
+  | { id: "search.open" }
   /**
    * `detach` follows Virtuoso's Shift+M: the parts move on their own and each
    * connected wire stays exactly where it was, re-anchored to a Junction stub.
@@ -82,6 +84,8 @@ export interface EditorCommandOperations {
   deleteSelection(): void;
   beginCopy(): void;
   copyVisualSelection(format: "png" | "svg"): void;
+  openSelectionFilter(): void;
+  openSearch(): void;
   beginMove(detach: boolean): void;
   alignSelection(mode: EdgeAlignmentMode): void;
   rotatePlacement(deltaDegrees: 90 | -90): void;
@@ -198,6 +202,8 @@ export function createEditorCommandRouter(
         return context.canRedo ? enabled() : disabled("Nothing to redo");
       case "selection.select-all":
       case "selection.clear":
+      case "selection.filter.open":
+      case "search.open":
         return enabled();
       case "selection.delete":
         // With nothing selected while idle, Delete arms the verb (Cadence
@@ -340,6 +346,12 @@ export function createEditorCommandRouter(
         break;
       case "selection.copy-image":
         options.operations.copyVisualSelection(request.format);
+        break;
+      case "selection.filter.open":
+        options.operations.openSelectionFilter();
+        break;
+      case "search.open":
+        options.operations.openSearch();
         break;
       case "selection.move":
         options.operations.beginMove(request.detach === true);

--- a/apps/editor/src/features/editor-shell/editor-statusbar.test.tsx
+++ b/apps/editor/src/features/editor-shell/editor-statusbar.test.tsx
@@ -22,6 +22,8 @@ describe("editor statusbar", () => {
         onDrawAngleModeChange={vi.fn()}
         annotationGrid={5}
         zoomPercent={100}
+        selectionFilterSummary={null}
+        onOpenSelectionFilter={vi.fn()}
         onToggleWireOptions={vi.fn()}
         onWireRoutingModeChange={vi.fn()}
         onWireCornerOrderChange={vi.fn()}
@@ -62,6 +64,8 @@ describe("editor statusbar", () => {
         onDrawAngleModeChange={vi.fn()}
         annotationGrid={5}
         zoomPercent={100}
+        selectionFilterSummary={null}
+        onOpenSelectionFilter={vi.fn()}
         issues={issues}
         onToggleWireOptions={vi.fn()}
         onWireRoutingModeChange={vi.fn()}
@@ -86,6 +90,41 @@ describe("editor statusbar", () => {
     expect(markup).toContain('data-severity="error"');
     expect(markup).toContain("2 errors, 1 warning");
     expect(markup).toContain("Action required");
+  });
+
+  it("shows a compact entry point only while selection is filtered", () => {
+    const markup = renderToStaticMarkup(
+      <EditorStatusbar
+        status="Ready"
+        tool="pointer"
+        vddRailMode={false}
+        pendingSymbolId={null}
+        wireOptionsOpen={false}
+        wireRoutingMode="orthogonal"
+        wireCornerOrder="auto"
+        recoveryLabel={null}
+        gridDotsVisible
+        drawAngleMode="free"
+        wheelBehavior="auto"
+        onWheelBehaviorChange={vi.fn()}
+        onDrawAngleModeChange={vi.fn()}
+        annotationGrid={5}
+        zoomPercent={100}
+        selectionFilterSummary="Filter: Wires"
+        onOpenSelectionFilter={vi.fn()}
+        onToggleWireOptions={vi.fn()}
+        onWireRoutingModeChange={vi.fn()}
+        onWireCornerOrderChange={vi.fn()}
+        onToggleGridDots={vi.fn()}
+        onOpenAnalytics={vi.fn()}
+        onAnnotationGridChange={vi.fn()}
+        onZoomOut={vi.fn()}
+        onZoomIn={vi.fn()}
+        onFitView={vi.fn()}
+      />,
+    );
+    expect(markup).toContain('data-testid="selection-filter-status"');
+    expect(markup).toContain("Filter: Wires");
   });
 
   it.each(["unchecked", "checking", "stale", "failed"] as const)(

--- a/apps/editor/src/features/editor-shell/editor-statusbar.tsx
+++ b/apps/editor/src/features/editor-shell/editor-statusbar.tsx
@@ -80,6 +80,8 @@ export function EditorStatusbar({
   wheelBehavior,
   zoomPercent,
   issues,
+  selectionFilterSummary,
+  onOpenSelectionFilter,
   onToggleWireOptions,
   onWireRoutingModeChange,
   onWireCornerOrderChange,
@@ -106,6 +108,7 @@ export function EditorStatusbar({
   drawAngleMode: "free" | "45" | "orthogonal";
   wheelBehavior: "auto" | "zoom" | "pan";
   zoomPercent: number;
+  selectionFilterSummary: string | null;
   issues?: {
     errorCount: number;
     warningCount: number;
@@ -123,6 +126,7 @@ export function EditorStatusbar({
   onZoomOut: () => void;
   onZoomIn: () => void;
   onFitView: () => void;
+  onOpenSelectionFilter: () => void;
 }) {
   return (
     <footer className="app-statusbar">
@@ -133,6 +137,17 @@ export function EditorStatusbar({
         <span className="statusbar-tool" data-testid="statusbar-tool">
           {toolLabel(tool, vddRailMode, pendingSymbolId)}
         </span>
+        {selectionFilterSummary ? (
+          <button
+            type="button"
+            className="statusbar-tool"
+            data-testid="selection-filter-status"
+            onClick={onOpenSelectionFilter}
+            title="Open Selection Filter (Ctrl+F)"
+          >
+            {selectionFilterSummary}
+          </button>
+        ) : null}
         {tool === "wire" ? (
           <button
             type="button"

--- a/apps/editor/src/features/selection/marquee-selection.test.ts
+++ b/apps/editor/src/features/selection/marquee-selection.test.ts
@@ -16,6 +16,7 @@ import {
   type RouteGeometryRecord,
 } from "../wiring/route-interaction-geometry";
 import { marqueeMode, marqueeSelection } from "./marquee-selection";
+import { NO_SELECTION_FILTER } from "./selection-filter";
 
 const resolver = new InMemorySymbolResolver(builtInSymbols);
 const styleProfile = resolveSchematicStyleProfile("razavi-textbook-v1");
@@ -250,5 +251,23 @@ describe("marquee crossing selection (right-to-left)", () => {
       expect(selection.annotationIds).toEqual([]);
       expect(selection.draftingIds).toEqual([]);
     }
+  });
+
+  it("applies the filter without changing marquee geometry", () => {
+    const { document, records } = fixtureCache;
+    const selection = marqueeSelection(
+      document,
+      resolver,
+      records,
+      styleProfile,
+      { x: -100, y: -100, width: 1000, height: 500 },
+      "crossing",
+      { ...NO_SELECTION_FILTER, route: true },
+    );
+    expect(selection.routeIds).toEqual(["route-1"]);
+    expect(selection.instanceIds).toEqual([]);
+    expect(selection.junctionIds).toEqual([]);
+    expect(selection.annotationIds).toEqual([]);
+    expect(selection.draftingIds).toEqual([]);
   });
 });

--- a/apps/editor/src/features/selection/marquee-selection.ts
+++ b/apps/editor/src/features/selection/marquee-selection.ts
@@ -21,6 +21,12 @@ import {
   instanceHitBox,
   type RouteGeometryRecord,
 } from "../wiring/route-interaction-geometry";
+import {
+  DEFAULT_SELECTION_FILTER,
+  selectionFilterAllowsAnnotation,
+  selectionFilterAllowsDrafting,
+  type SelectionFilter,
+} from "./selection-filter";
 
 /**
  * Classic drafting-tool marquee semantics: dragging left-to-right is a
@@ -55,19 +61,20 @@ export function marqueeSelection(
   styleProfile: SchematicStyleProfile,
   rect: Rect,
   mode: MarqueeMode,
+  filter: SelectionFilter = DEFAULT_SELECTION_FILTER,
 ): MarqueeSelectionSet {
   const window = mode === "window";
   const boxSelected = (bounds: Rect): boolean =>
     window ? rectContainsRect(rect, bounds) : rectsIntersect(bounds, rect);
 
   return {
-    instanceIds: document.instances
+    instanceIds: (filter.instance ? document.instances : [])
       .filter((instance) => {
         const bounds = instanceHitBox(instance, resolver);
         return bounds !== null && boxSelected(bounds);
       })
       .map((instance) => instance.id),
-    routeIds: routeGeometryRecords
+    routeIds: (filter.route ? routeGeometryRecords : [])
       .filter(({ geometry }) =>
         window
           ? polylineInRect(geometry.centerline, rect)
@@ -82,12 +89,13 @@ export function marqueeSelection(
               ),
       )
       .map(({ route }) => route.id),
-    junctionIds: document.junctions
+    junctionIds: (filter.junction ? document.junctions : [])
       .filter((junction) => pointInRect(junction.position, rect))
       .map((junction) => junction.id),
     annotationIds: document.annotations
       .filter(
         (annotation) =>
+          selectionFilterAllowsAnnotation(filter, annotation) &&
           isSchematicAnnotationVisible(document, annotation) &&
           boxSelected(
             annotationHitBox(
@@ -108,6 +116,7 @@ export function marqueeSelection(
       .map((annotation) => annotation.id),
     draftingIds: (document.drafting?.objects ?? [])
       .filter((object) => {
+        if (!selectionFilterAllowsDrafting(filter, object)) return false;
         const geometry = resolveDraftingObjectGeometry(
           document,
           resolver,

--- a/apps/editor/src/features/selection/selection-filter-popover.test.tsx
+++ b/apps/editor/src/features/selection/selection-filter-popover.test.tsx
@@ -1,0 +1,40 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { SelectionFilterPopover } from "./selection-filter-popover";
+import { DEFAULT_SELECTION_FILTER } from "./selection-filter";
+
+describe("SelectionFilterPopover", () => {
+  it("exposes grouped current selection classes and presets", () => {
+    const markup = renderToStaticMarkup(
+      <SelectionFilterPopover
+        open
+        filter={DEFAULT_SELECTION_FILTER}
+        onChange={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(markup).toContain('data-testid="selection-filter-popover"');
+    expect(markup).toContain("Selection Filter");
+    expect(markup).toContain("Instances");
+    expect(markup).toContain("Wires");
+    expect(markup).toContain("Net / power names");
+    expect(markup).toContain("Note text / callouts");
+    expect(markup).toContain(">All<");
+    expect(markup).toContain(">None<");
+    expect(markup).toContain(">Default<");
+  });
+
+  it("renders nothing while closed", () => {
+    expect(
+      renderToStaticMarkup(
+        <SelectionFilterPopover
+          open={false}
+          filter={DEFAULT_SELECTION_FILTER}
+          onChange={vi.fn()}
+          onClose={vi.fn()}
+        />,
+      ),
+    ).toBe("");
+  });
+});

--- a/apps/editor/src/features/selection/selection-filter-popover.tsx
+++ b/apps/editor/src/features/selection/selection-filter-popover.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useRef } from "react";
+
+import {
+  ALL_SELECTION_FILTER,
+  DEFAULT_SELECTION_FILTER,
+  NO_SELECTION_FILTER,
+  type SelectionClass,
+  type SelectionFilter,
+} from "./selection-filter";
+
+const GROUPS: readonly {
+  title: string;
+  items: readonly { kind: SelectionClass; label: string }[];
+}[] = [
+  {
+    title: "Circuit",
+    items: [
+      { kind: "instance", label: "Instances" },
+      { kind: "route", label: "Wires" },
+      { kind: "junction", label: "Junctions" },
+      { kind: "terminal", label: "Pins" },
+    ],
+  },
+  {
+    title: "Electrical text",
+    items: [
+      { kind: "instance-name", label: "Instance names" },
+      { kind: "instance-value", label: "Instance values" },
+      { kind: "net-name", label: "Net / power names" },
+      { kind: "pin-name", label: "Pin names" },
+      { kind: "route-marker", label: "Route markers" },
+    ],
+  },
+  {
+    title: "Markup",
+    items: [
+      { kind: "drafting-text", label: "Note text / callouts" },
+      { kind: "drafting-line", label: "Lines / arrows" },
+      { kind: "drafting-shape", label: "Shapes" },
+    ],
+  },
+] as const;
+
+export function SelectionFilterPopover({
+  open,
+  filter,
+  onChange,
+  onClose,
+}: {
+  open: boolean;
+  filter: SelectionFilter;
+  onChange: (filter: SelectionFilter) => void;
+  onClose: () => void;
+}) {
+  const rootRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const dismiss = (event: PointerEvent): void => {
+      if (
+        event.target instanceof Node &&
+        !rootRef.current?.contains(event.target)
+      ) {
+        onClose();
+      }
+    };
+    document.addEventListener("pointerdown", dismiss, true);
+    return () => document.removeEventListener("pointerdown", dismiss, true);
+  }, [onClose, open]);
+
+  if (!open) return null;
+  return (
+    <aside
+      ref={rootRef}
+      className="selection-filter-popover"
+      data-testid="selection-filter-popover"
+      role="dialog"
+      aria-modal="false"
+      aria-labelledby="selection-filter-title"
+    >
+      <header>
+        <div>
+          <p className="selection-filter-kicker">Selection</p>
+          <h2 id="selection-filter-title">Selection Filter</h2>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close selection filter"
+        >
+          Close
+        </button>
+      </header>
+      <div className="selection-filter-presets" aria-label="Filter presets">
+        <button type="button" onClick={() => onChange(ALL_SELECTION_FILTER)}>
+          All
+        </button>
+        <button type="button" onClick={() => onChange(NO_SELECTION_FILTER)}>
+          None
+        </button>
+        <button
+          type="button"
+          onClick={() => onChange(DEFAULT_SELECTION_FILTER)}
+        >
+          Default
+        </button>
+      </div>
+      {GROUPS.map((group) => (
+        <fieldset key={group.title}>
+          <legend>{group.title}</legend>
+          {group.items.map((item) => (
+            <label key={item.kind}>
+              <input
+                type="checkbox"
+                checked={filter[item.kind]}
+                onChange={(event) =>
+                  onChange({
+                    ...filter,
+                    [item.kind]: event.currentTarget.checked,
+                  })
+                }
+              />
+              <span>{item.label}</span>
+            </label>
+          ))}
+        </fieldset>
+      ))}
+      <small>
+        Affects new selections only. Drawing, simulation, visibility, and
+        connectivity stay unchanged.
+      </small>
+    </aside>
+  );
+}

--- a/apps/editor/src/features/selection/selection-filter.test.ts
+++ b/apps/editor/src/features/selection/selection-filter.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createEmptyProject,
+  type Annotation,
+  type DraftingObject,
+} from "@icm/model";
+
+import {
+  DEFAULT_SELECTION_FILTER,
+  NO_SELECTION_FILTER,
+  selectionClassForAnnotation,
+  selectionClassForDrafting,
+  selectionFilterSummary,
+  selectionForDocument,
+} from "./selection-filter";
+
+const anchor = { kind: "free" as const, position: { x: 0, y: 0 } };
+const content = { runs: [{ kind: "text" as const, value: "text" }] };
+
+describe("selection filter", () => {
+  it("classifies electrical text by semantic owner", () => {
+    const annotations: Annotation[] = [
+      {
+        id: "name",
+        kind: "instance-label",
+        binding: { kind: "instance-reference", instanceId: "R1" },
+        anchor,
+        alignment: "start",
+        rotation: 0,
+        locked: false,
+      },
+      {
+        id: "value",
+        kind: "instance-value",
+        content,
+        anchor,
+        alignment: "start",
+        rotation: 0,
+        locked: false,
+      },
+      {
+        id: "pin-name",
+        kind: "instance-label",
+        binding: { kind: "cell-terminal-name", terminalId: "pin-1" },
+        anchor,
+        alignment: "start",
+        rotation: 0,
+        locked: false,
+      },
+      {
+        id: "net-name",
+        kind: "net-label",
+        binding: { kind: "net-name", netId: "net-1" },
+        netId: "net-1",
+        anchor,
+        alignment: "start",
+        rotation: 0,
+        locked: false,
+      },
+      {
+        id: "marker",
+        kind: "route-marker",
+        markerKind: "current",
+        content,
+        anchor,
+        alignment: "start",
+        rotation: 0,
+        locked: false,
+      },
+    ];
+    expect(annotations.map(selectionClassForAnnotation)).toEqual([
+      "instance-name",
+      "instance-value",
+      "pin-name",
+      "net-name",
+      "route-marker",
+    ]);
+  });
+
+  it("classifies drafting text, paths, and shapes", () => {
+    const base = { id: "d", locked: false, zIndex: 0, anchor };
+    const objects = [
+      {
+        ...base,
+        kind: "text",
+        content,
+        alignment: "start",
+        rotation: 0,
+      },
+      { ...base, kind: "arrow", from: anchor, to: anchor },
+      {
+        ...base,
+        kind: "rectangle",
+        center: { x: 0, y: 0 },
+        width: 10,
+        height: 10,
+        rotation: 0,
+        lineStyle: "solid",
+      },
+    ] as DraftingObject[];
+    expect(objects.map(selectionClassForDrafting)).toEqual([
+      "drafting-text",
+      "drafting-line",
+      "drafting-shape",
+    ]);
+  });
+
+  it("collects only enabled object families for Select All", () => {
+    const document = createEmptyProject("p", "P").documents[0]!;
+    document.instances.push({
+      id: "R1",
+      symbolId: "resistor",
+      placement: {
+        position: { x: 0, y: 0 },
+        rotation: 0,
+        mirror: "none",
+      },
+    });
+    document.annotations.push({
+      id: "value",
+      kind: "instance-value",
+      content,
+      anchor,
+      alignment: "start",
+      rotation: 0,
+      locked: false,
+    });
+    const wiresOnly = { ...NO_SELECTION_FILTER, route: true };
+    expect(selectionForDocument(document, wiresOnly)).toEqual({
+      instanceIds: [],
+      routeIds: [],
+      junctionIds: [],
+      annotationIds: [],
+      draftingIds: [],
+    });
+    expect(
+      selectionForDocument(document, DEFAULT_SELECTION_FILTER).instanceIds,
+    ).toEqual(["R1"]);
+  });
+
+  it("summarizes only non-default filters", () => {
+    expect(selectionFilterSummary(DEFAULT_SELECTION_FILTER)).toBeNull();
+    expect(selectionFilterSummary(NO_SELECTION_FILTER)).toBe("Filter: None");
+    expect(
+      selectionFilterSummary({ ...NO_SELECTION_FILTER, route: true }),
+    ).toBe("Filter: Wires");
+  });
+});

--- a/apps/editor/src/features/selection/selection-filter.ts
+++ b/apps/editor/src/features/selection/selection-filter.ts
@@ -1,0 +1,194 @@
+import type { Annotation, DraftingObject, SchematicDocument } from "@icm/model";
+
+import type { VisualSelection } from "./visual-selection";
+
+export const SELECTION_CLASSES = [
+  "instance",
+  "route",
+  "junction",
+  "terminal",
+  "instance-name",
+  "instance-value",
+  "net-name",
+  "pin-name",
+  "route-marker",
+  "drafting-text",
+  "drafting-line",
+  "drafting-shape",
+] as const;
+
+export type SelectionClass = (typeof SELECTION_CLASSES)[number];
+export type SelectionFilter = Readonly<Record<SelectionClass, boolean>>;
+
+function uniformSelectionFilter(enabled: boolean): SelectionFilter {
+  return Object.fromEntries(
+    SELECTION_CLASSES.map((kind) => [kind, enabled]),
+  ) as Record<SelectionClass, boolean>;
+}
+
+/** The product default preserves every selectable surface that exists now. */
+export const DEFAULT_SELECTION_FILTER = Object.freeze(
+  uniformSelectionFilter(true),
+);
+export const ALL_SELECTION_FILTER = Object.freeze(uniformSelectionFilter(true));
+export const NO_SELECTION_FILTER = Object.freeze(uniformSelectionFilter(false));
+
+export function selectionFilterIsDefault(filter: SelectionFilter): boolean {
+  return SELECTION_CLASSES.every(
+    (kind) => filter[kind] === DEFAULT_SELECTION_FILTER[kind],
+  );
+}
+
+export function selectionFilterSummary(filter: SelectionFilter): string | null {
+  if (selectionFilterIsDefault(filter)) return null;
+  const enabled = SELECTION_CLASSES.filter((kind) => filter[kind]);
+  if (enabled.length === 0) return "Filter: None";
+  if (enabled.length === 1) {
+    const labels: Record<SelectionClass, string> = {
+      instance: "Instances",
+      route: "Wires",
+      junction: "Junctions",
+      terminal: "Pins",
+      "instance-name": "Instance names",
+      "instance-value": "Instance values",
+      "net-name": "Net names",
+      "pin-name": "Pin names",
+      "route-marker": "Markers",
+      "drafting-text": "Note text",
+      "drafting-line": "Drawing lines",
+      "drafting-shape": "Shapes",
+    };
+    return `Filter: ${labels[enabled[0]!]}`;
+  }
+  return `Filter: ${enabled.length}/${SELECTION_CLASSES.length}`;
+}
+
+export function selectionClassForAnnotation(
+  annotation: Annotation,
+): SelectionClass {
+  if (annotation.binding?.kind === "cell-terminal-name") return "pin-name";
+  switch (annotation.kind) {
+    case "instance-label":
+      return "instance-name";
+    case "instance-value":
+      return "instance-value";
+    case "net-label":
+    case "power-label":
+      return "net-name";
+    case "route-marker":
+      return "route-marker";
+  }
+}
+
+export function selectionClassForDrafting(
+  object: DraftingObject,
+): SelectionClass {
+  switch (object.kind) {
+    case "text":
+    case "callout":
+      return "drafting-text";
+    case "arrow":
+    case "leader":
+    case "construction-line":
+      return "drafting-line";
+    case "rectangle":
+    case "circle":
+    case "floating-symbol":
+      return "drafting-shape";
+  }
+}
+
+type SelectableCanvasHit = {
+  kind:
+    | "handle"
+    | "annotation"
+    | "instance-label"
+    | "instance"
+    | "drafting"
+    | "route"
+    | "junction";
+  id: string;
+};
+
+/** Classify one existing canvas hit without adding a second object model. */
+export function selectionClassForCanvasHit(
+  document: SchematicDocument,
+  hit: SelectableCanvasHit,
+): SelectionClass | null {
+  switch (hit.kind) {
+    case "handle":
+      return null;
+    case "instance":
+      return "instance";
+    case "instance-label":
+      return "instance-name";
+    case "route":
+      return "route";
+    case "junction":
+      return "junction";
+    case "annotation": {
+      const annotation = document.annotations.find(
+        (candidate) => candidate.id === hit.id,
+      );
+      return annotation ? selectionClassForAnnotation(annotation) : null;
+    }
+    case "drafting": {
+      const object = document.drafting?.objects.find(
+        (candidate) => candidate.id === hit.id,
+      );
+      return object ? selectionClassForDrafting(object) : null;
+    }
+  }
+}
+
+export function selectionFilterAllowsCanvasHit(
+  filter: SelectionFilter,
+  document: SchematicDocument,
+  hit: SelectableCanvasHit,
+): boolean {
+  if (hit.kind === "handle") return true;
+  const kind = selectionClassForCanvasHit(document, hit);
+  // A stale DOM node is not an eligible target; filtering it lets the next
+  // live object in the paint stack answer the press instead.
+  return kind !== null && filter[kind];
+}
+
+export function selectionFilterAllowsAnnotation(
+  filter: SelectionFilter,
+  annotation: Annotation,
+): boolean {
+  return filter[selectionClassForAnnotation(annotation)];
+}
+
+export function selectionFilterAllowsDrafting(
+  filter: SelectionFilter,
+  object: DraftingObject,
+): boolean {
+  return filter[selectionClassForDrafting(object)];
+}
+
+/** Collect the same five persisted selection families as Ctrl/Cmd+A. */
+export function selectionForDocument(
+  document: SchematicDocument,
+  filter: SelectionFilter,
+): VisualSelection {
+  return {
+    instanceIds: filter.instance
+      ? document.instances
+          .filter((instance) => instance.placement)
+          .map((instance) => instance.id)
+      : [],
+    routeIds: filter.route ? document.routes.map((route) => route.id) : [],
+    junctionIds: filter.junction
+      ? document.junctions.map((junction) => junction.id)
+      : [],
+    annotationIds: document.annotations
+      .filter((annotation) =>
+        selectionFilterAllowsAnnotation(filter, annotation),
+      )
+      .map((annotation) => annotation.id),
+    draftingIds: (document.drafting?.objects ?? [])
+      .filter((object) => selectionFilterAllowsDrafting(filter, object))
+      .map((object) => object.id),
+  };
+}

--- a/apps/editor/src/interaction/editor-shortcuts.test.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.test.ts
@@ -79,6 +79,18 @@ describe("editor shortcut contract", () => {
     }
   });
 
+  it("gives Ctrl/Cmd+F to Selection Filter and shifts schematic Search", () => {
+    for (const modifiers of [{ ctrlKey: true }, { metaKey: true }]) {
+      expect(resolve("f", {}, modifiers)).toEqual(
+        command({ id: "selection.filter.open" }),
+      );
+      expect(resolve("f", {}, { ...modifiers, shiftKey: true })).toEqual(
+        command({ id: "search.open" }),
+      );
+    }
+    expect(resolve("f", { isTyping: true }, { ctrlKey: true })).toBeNull();
+  });
+
   it("arbitrates browser refresh chords before blocking their defaults", () => {
     for (const modifiers of [
       { ctrlKey: true },

--- a/apps/editor/src/interaction/editor-shortcuts.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.ts
@@ -99,6 +99,15 @@ export function resolveEditorShortcut(
 
   if (context.isTyping) return null;
 
+  if (commandModifier && key === "f") {
+    return {
+      kind: "run-command",
+      command: {
+        id: event.shiftKey ? "search.open" : "selection.filter.open",
+      },
+    };
+  }
+
   const plain = !event.ctrlKey && !event.metaKey && !event.altKey;
   const interactionActive = context.interactionMode !== "idle";
 

--- a/apps/editor/src/styles/editor-overlays.css
+++ b/apps/editor/src/styles/editor-overlays.css
@@ -562,3 +562,90 @@
     grid-template-columns: minmax(0, 1fr);
   }
 }
+.selection-filter-popover {
+  position: fixed;
+  z-index: 12;
+  top: 7.25rem;
+  right: var(--icm-space-4);
+  display: grid;
+  width: min(300px, calc(100vw - var(--icm-space-6)));
+  max-height: calc(100vh - 9rem);
+  gap: var(--icm-space-3);
+  padding: var(--icm-space-4);
+  overflow: auto;
+  border: 1px solid var(--icm-border-strong);
+  border-radius: var(--icm-radius-md);
+  background: rgb(255 255 255 / 97%);
+  box-shadow: var(--icm-shadow-md);
+  color: var(--icm-text);
+  backdrop-filter: blur(10px);
+}
+
+.selection-filter-popover > header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--icm-space-3);
+}
+
+.selection-filter-popover h2,
+.selection-filter-popover p {
+  margin: 0;
+}
+
+.selection-filter-popover h2 {
+  font-size: var(--icm-font-lg);
+}
+
+.selection-filter-kicker,
+.selection-filter-popover legend,
+.selection-filter-popover small {
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+}
+
+.selection-filter-popover button {
+  min-height: 28px;
+  padding: 3px 8px;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  background: var(--icm-surface);
+  color: inherit;
+}
+
+.selection-filter-popover button:hover {
+  background: var(--icm-surface-hover);
+}
+
+.selection-filter-presets {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--icm-space-2);
+}
+
+.selection-filter-popover fieldset {
+  display: grid;
+  gap: var(--icm-space-2);
+  margin: 0;
+  padding: var(--icm-space-2) 0 0;
+  border: 0;
+  border-top: 1px solid var(--icm-border);
+}
+
+.selection-filter-popover legend {
+  padding: 0 var(--icm-space-2) 0 0;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.selection-filter-popover fieldset label {
+  display: flex;
+  align-items: center;
+  gap: var(--icm-space-2);
+  font-size: var(--icm-font-sm);
+}
+
+.selection-filter-popover input {
+  margin: 0;
+}


### PR DESCRIPTION
## Summary
- add a session-only Selection Filter for instances, wires, junctions, terminals, labels, markers, and drafting objects
- apply the filter consistently to click selection, marquee selection, Select All, and verb-first pickup without changing existing object semantics
- move schematic search to Ctrl/Cmd+Shift+F and assign Ctrl/Cmd+F to the filter, with Edit-menu, Quick Start, and non-default status affordances

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
- 427 workspace test files passed (2833 tests; 22 skipped)
- all selected Playwright regressions passed, including 136 manual-editor scenarios

Closes #690