### PR TITLE
feat(simulation): qualify structured noise analysis

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -169,7 +169,7 @@ jobs:
             exit 1
           fi
       # A divider checks the transport and the persisted OTA Project checks the
-      # product compiler plus OP/DC/AC/TRAN model evidence. Both run on the preview's
+      # product compiler plus OP/DC/AC/TRAN/Noise model evidence. Both run on the preview's
       # simulator host; a green status without numbers is not acceptance.
       - name: Run the preview's numerical and vertical simulation acceptance
         run: node scripts/preview-simulation-smoke.mjs "$PREVIEW_URL"

--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -411,8 +411,8 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
         json: {
           configured: true,
           inputs: ["structured", "raw"],
-          analyses: ["op", "ac", "tran"],
-          parsedAnalyses: ["op", "ac", "tran"],
+          analyses: ["op", "ac", "tran", "noise"],
+          parsedAnalyses: ["op", "ac", "tran", "noise"],
           profiles: [{ id: profile.id, corners: ["tt"] }],
           maxTimeoutMs: 120000,
           maxInputBytes: 1048576,
@@ -484,6 +484,21 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
                 },
               ],
             },
+            {
+              analysis: "noise",
+              plotName: "Noise Analysis",
+              frequencyHz: [1, 10, 100],
+              outputNoiseDensity: [1e-9, 8e-10, 6e-10],
+              inputNoiseDensity: [2e-9, 1.6e-9, 1.2e-9],
+              integratedOutputNoise: 9e-8,
+              integratedInputNoise: 1.8e-7,
+              units: {
+                outputDensity: "V/sqrt(Hz)",
+                inputDensity: "V/sqrt(Hz)",
+                integratedOutput: "V",
+                integratedInput: "V",
+              },
+            },
           ],
         },
         rawfile,
@@ -548,6 +563,15 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   await panel.getByLabel("TRAN step (s)").fill("1e-9");
   await panel.getByLabel("TRAN stop (s)").fill("1e-6");
   await panel.getByLabel("TRAN maximum step (s)").fill("5e-10");
+  await panel.getByLabel("Noise", { exact: true }).check();
+  await panel
+    .getByLabel("Noise output positive")
+    .selectOption({ label: "Testbench · vout" });
+  await panel.getByLabel("Noise output negative").selectOption("");
+  await panel.getByLabel("Input source").selectOption({ index: 0 });
+  await panel.getByLabel("Noise sweep").selectOption("dec");
+  await panel.getByLabel("Start (Hz)").last().fill("1");
+  await panel.getByLabel("Stop (Hz)").last().fill("1000000");
   await panel.getByLabel(/Output name for/).fill("first-output");
   await panel.getByRole("button", { name: "Apply setup" }).click();
   await panel.getByRole("button", { name: "Run", exact: true }).click();
@@ -598,14 +622,20 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   await expect(
     panel.getByRole("heading", { name: "Transient Analysis" }),
   ).toBeVisible();
+  await expect(
+    panel.getByRole("heading", { name: "Noise Analysis" }),
+  ).toBeVisible();
+  await expect(
+    panel.getByRole("region", { name: "Integrated noise" }),
+  ).toContainText("Integrated input-referred noise");
   const plotMeasurements = panel.locator(
     "details.simulation-measurement-results",
   );
   await expect(plotMeasurements).toHaveCount(1);
   await expect(plotMeasurements.locator(":scope > summary")).toContainText(
-    "8 values",
+    "14 values",
   );
-  await expect(panel.locator(".spice-ac-plot svg")).toHaveCount(2);
+  await expect(panel.locator(".spice-ac-plot svg")).toHaveCount(3);
   await expect(panel.locator('svg[aria-label="AC magnitude"]')).toBeVisible();
   await expect(panel.locator('svg[aria-label="AC phase"]')).toHaveCount(0);
   const acDisplay = panel.getByRole("group", { name: "Voltage display" });
@@ -630,7 +660,7 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   const svgBundle = await svgBundlePromise;
   expect(svgBundle.suggestedFilename()).toBe("simulation-plots-svg.zip");
   const svgEntries = unzipSync(readFileSync((await svgBundle.path())!));
-  expect(Object.keys(svgEntries)).toHaveLength(3);
+  expect(Object.keys(svgEntries)).toHaveLength(4);
   const exportedSvg = strFromU8(Object.values(svgEntries)[0]!);
   expect(exportedSvg).toContain('<?xml version="1.0"');
   expect(exportedSvg).toContain('fill="white"');
@@ -642,7 +672,7 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   const pngBundle = await pngBundlePromise;
   expect(pngBundle.suggestedFilename()).toBe("simulation-plots-png.zip");
   const pngEntries = unzipSync(readFileSync((await pngBundle.path())!));
-  expect(Object.keys(pngEntries)).toHaveLength(3);
+  expect(Object.keys(pngEntries)).toHaveLength(4);
   expect([...Object.values(pngEntries)[0]!.slice(0, 8)]).toEqual([
     137, 80, 78, 71, 13, 10, 26, 10,
   ]);
@@ -672,6 +702,13 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   expect(measurementDownload.suggestedFilename()).toBe("measurements.csv");
   expect(readFileSync((await measurementDownload.path())!, "utf8")).toContain(
     '"TRAN","Transient response","first-output","Time-weighted RMS"',
+  );
+  const noiseCsvPromise = page.waitForEvent("download");
+  await resultExport
+    .getByRole("button", { name: /outputs-noise-\d+\.csv/u })
+    .click();
+  expect((await noiseCsvPromise).suggestedFilename()).toMatch(
+    /outputs-noise-\d+\.csv/u,
   );
   resultExport.evaluate((element) => element.removeAttribute("open"));
   await acDisplay.getByRole("button", { name: "Magnitude" }).click();

--- a/apps/editor/src/agent/use-agent-session.ts
+++ b/apps/editor/src/agent/use-agent-session.ts
@@ -382,7 +382,7 @@ export function useAgentSession(
                           "cancel",
                           "export",
                         ] as const,
-                        analyses: ["op", "dc", "ac", "tran"] as const,
+                        analyses: ["op", "dc", "ac", "tran", "noise"] as const,
                         maxTimeoutMs: AGENT_SIMULATION_MAX_TIMEOUT_MS,
                         synchronous: false as const,
                       },

--- a/apps/editor/src/features/simulation/noise-results-explorer.tsx
+++ b/apps/editor/src/features/simulation/noise-results-explorer.tsx
@@ -1,0 +1,79 @@
+import type { SimulationOutputData } from "@icm/simulation-service/contract";
+
+import { ScalarResultsExplorer } from "./transient-results-explorer";
+
+type EvaluatedAnalysis = SimulationOutputData["analyses"][number];
+
+function displayNumber(value: number): string {
+  if (value === 0) return "0";
+  return value.toExponential(5);
+}
+
+/**
+ * Noise owns both spectral curves and integrated scalars. Keep them together
+ * in one result surface so the two ngspice plots never leak into the UI as
+ * unrelated analyses.
+ */
+export function NoiseResultsExplorer({
+  analysis,
+  resultKey,
+}: {
+  analysis: EvaluatedAnalysis;
+  resultKey: string;
+}) {
+  if (analysis.analysis !== "noise" || !analysis.domain) return null;
+  const byUnit = new Map<string, typeof analysis.outputs>();
+  for (const output of analysis.outputs)
+    byUnit.set(output.unit, [...(byUnit.get(output.unit) ?? []), output]);
+
+  return (
+    <div className="noise-results-explorer">
+      {[...byUnit.entries()].map(([unit, outputs]) => (
+        <ScalarResultsExplorer
+          key={unit}
+          resultKey={`${resultKey}:${unit}`}
+          plotName={analysis.plotName}
+          domain={analysis.domain!.values}
+          analysisLabel="Noise"
+          domainLabel={analysis.domain!.name}
+          domainUnit={analysis.domain!.unit}
+          logarithmicX
+          traces={outputs.map((output, colorIndex) => ({
+            id: output.id,
+            label: output.label,
+            colorIndex,
+            quantity: "noise-density",
+            unit,
+            values: output.values.map((value) => value ?? Number.NaN),
+          }))}
+        />
+      ))}
+      {analysis.integrated?.length ? (
+        <section
+          className="simulation-integrated-results"
+          aria-label="Integrated noise"
+        >
+          <h4>Integrated noise</h4>
+          <table>
+            <thead>
+              <tr>
+                <th>Quantity</th>
+                <th>Value</th>
+              </tr>
+            </thead>
+            <tbody>
+              {analysis.integrated.map((item) => (
+                <tr key={item.id}>
+                  <td>{item.label}</td>
+                  <td>
+                    {displayNumber(item.value)} {item.unit}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/editor/src/features/simulation/simulation-measurement-editor.tsx
+++ b/apps/editor/src/features/simulation/simulation-measurement-editor.tsx
@@ -1,10 +1,14 @@
 import type {
   SimulationMeasurementMethod,
   SimulationMeasurementSpec,
-  SimulationOutputSpec,
 } from "@icm/model";
 
 type AnalysisKind = SimulationMeasurementSpec["analysis"];
+
+export interface SimulationMeasurementOutputOption {
+  readonly id: string;
+  readonly label: string;
+}
 
 const METHOD_LABELS = {
   value: "Value",
@@ -35,7 +39,7 @@ function defaultMethod(analysis: AnalysisKind): SimulationMeasurementMethod {
 }
 
 function coordinateLabel(analysis: AnalysisKind): string {
-  if (analysis === "ac") return "Frequency / Hz";
+  if (analysis === "ac" || analysis === "noise") return "Frequency / Hz";
   if (analysis === "tran") return "Time / s";
   return "Sweep value / SI";
 }
@@ -55,7 +59,7 @@ export function SimulationMeasurementEditor({
   onChange,
 }: {
   analyses: readonly AnalysisKind[];
-  outputs: readonly SimulationOutputSpec[];
+  outputs: readonly SimulationMeasurementOutputOption[];
   measurements: readonly SimulationMeasurementSpec[];
   onChange(next: SimulationMeasurementSpec[]): void;
 }) {

--- a/apps/editor/src/features/simulation/simulation-output-results.test.tsx
+++ b/apps/editor/src/features/simulation/simulation-output-results.test.tsx
@@ -54,4 +54,59 @@ describe("Simulation Output Results", () => {
       markup.indexOf("</section>"),
     );
   });
+
+  it("keeps Noise spectra and integrated totals in one dedicated result", () => {
+    const markup = renderToStaticMarkup(
+      <SimulationOutputResults
+        resultKey="run-noise"
+        outputs={[]}
+        data={{
+          schemaVersion: 1,
+          diagnostics: [],
+          analyses: [
+            {
+              analysis: "noise",
+              plotName: "Noise Analysis",
+              domain: { name: "Frequency", unit: "Hz", values: [1, 10] },
+              outputs: [
+                {
+                  id: "noise-output-density",
+                  label: "Output noise density",
+                  unit: "V/sqrt(Hz)",
+                  values: [1e-9, 2e-9],
+                },
+                {
+                  id: "noise-input-density",
+                  label: "Input-referred noise density",
+                  unit: "V/sqrt(Hz)",
+                  values: [3e-9, 4e-9],
+                },
+              ],
+              integrated: [
+                {
+                  id: "noise-integrated-output",
+                  label: "Integrated output noise",
+                  unit: "V",
+                  value: 9e-8,
+                },
+                {
+                  id: "noise-integrated-input",
+                  label: "Integrated input-referred noise",
+                  unit: "V",
+                  value: 1.8e-7,
+                },
+              ],
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(markup).toContain("Noise Analysis");
+    expect(markup).toContain('class="noise-results-explorer"');
+    expect(markup).toContain('aria-label="Integrated noise"');
+    expect(markup).toContain("Output noise density");
+    expect(markup).toContain("Integrated input-referred noise");
+    expect(markup).toContain("1.80000e-7 V");
+  });
 });

--- a/apps/editor/src/features/simulation/simulation-output-results.tsx
+++ b/apps/editor/src/features/simulation/simulation-output-results.tsx
@@ -13,6 +13,7 @@ import {
 } from "./ac-results-explorer";
 import { ScalarResultsExplorer } from "./transient-results-explorer";
 import { SimulationMeasurementResults } from "./simulation-measurement-results";
+import { NoiseResultsExplorer } from "./noise-results-explorer";
 
 export type SimulationAnalysisKind = "op" | "dc" | "ac" | "tran" | "noise";
 
@@ -106,6 +107,15 @@ export function SimulationOutputResults({
               </table>
             </SimulationAnalysisCard>
           );
+        if (analysis.analysis === "noise")
+          return (
+            <SimulationAnalysisCard key={`noise-${analysisIndex}`} kind="noise">
+              <NoiseResultsExplorer
+                analysis={analysis}
+                resultKey={`${resultKey}:noise:${analysisIndex}`}
+              />
+            </SimulationAnalysisCard>
+          );
         if (!analysis.domain) return null;
         const complex = analysis.outputs.filter((output) => output.imaginary);
         const scalar = analysis.outputs.filter((output) => !output.imaginary);
@@ -178,9 +188,7 @@ export function SimulationOutputResults({
                   }
                   domainLabel={analysis.domain!.name}
                   domainUnit={analysis.domain!.unit}
-                  logarithmicX={
-                    analysis.analysis === "ac" || analysis.analysis === "noise"
-                  }
+                  logarithmicX={analysis.analysis === "ac"}
                   traces={unitOutputs.map((output, colorIndex) => ({
                     id: output.id,
                     label: output.label,

--- a/apps/editor/src/features/simulation/simulation-setup-editor.tsx
+++ b/apps/editor/src/features/simulation/simulation-setup-editor.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useId, useState, type ReactNode } from "react";
 import authoringProfile from "../../../../../containers/ngspice/hosted-sky130-profile.json";
 import {
+  SIMULATION_NOISE_INPUT_DENSITY_ID,
+  SIMULATION_NOISE_OUTPUT_DENSITY_ID,
   SimulationSetupSchema,
   parseSimulationExpression,
   type ProjectSimulationSetup,
@@ -8,6 +10,7 @@ import {
   type SimulationExpression,
   type SimulationOutputSpec,
   type SimulationStructuredInput,
+  type SimulationVoltageProbe,
 } from "@icm/model";
 import type { Capabilities, Problem } from "@icm/simulation-service/contract";
 import type { SpiceSimulationSurfaceProps } from "./simulation-surface-types";
@@ -138,12 +141,23 @@ export function SetupEditor({
   const dc = saved?.analyses.find((a) => a.kind === "dc");
   const ac = saved?.analyses.find((a) => a.kind === "ac");
   const tran = saved?.analyses.find((a) => a.kind === "tran");
+  const noise = saved?.analyses.find((a) => a.kind === "noise");
   const [dcEnabled, setDcEnabled] = useState(!!dc);
   const [dcSourceId, setDcSourceId] = useState(
     dc?.sourceInstanceId ?? dcSources[0]?.id ?? "",
   );
   const [acEnabled, setAcEnabled] = useState(!!ac);
   const [tranEnabled, setTranEnabled] = useState(!!tran);
+  const [noiseEnabled, setNoiseEnabled] = useState(!!noise);
+  const [noiseInputSourceId, setNoiseInputSourceId] = useState(
+    noise?.inputSourceInstanceId ?? dcSources[0]?.id ?? "",
+  );
+  const [noisePositive, setNoisePositive] = useState<
+    SimulationVoltageProbe | undefined
+  >(noise?.output.positive);
+  const [noiseNegative, setNoiseNegative] = useState<
+    SimulationVoltageProbe | undefined
+  >(noise?.output.negative);
   const [opEnabled, setOpEnabled] = useState(
     !saved || saved.analyses.some((analysis) => analysis.kind === "op"),
   );
@@ -203,6 +217,7 @@ export function SetupEditor({
     opEnabled ? "OP" : undefined,
     acEnabled ? "AC" : undefined,
     tranEnabled ? "TRAN" : undefined,
+    noiseEnabled ? "Noise" : undefined,
   ]
     .filter(Boolean)
     .join(" + ");
@@ -211,6 +226,17 @@ export function SetupEditor({
   )
     ? dcSourceId
     : (dcSources[0]?.id ?? "");
+  const selectedNoiseSourceId = dcSources.some(
+    (source) => source.id === noiseInputSourceId,
+  )
+    ? noiseInputSourceId
+    : (dcSources[0]?.id ?? "");
+  const noisePositiveKey = noisePositive
+    ? simulationProbeTargetKey({ kind: "voltage", ...noisePositive })
+    : "";
+  const noiseNegativeKey = noiseNegative
+    ? simulationProbeTargetKey({ kind: "voltage", ...noiseNegative })
+    : "";
   useEffect(() => {
     if (!pickedNet) return;
     const candidates = matchSimulationVoltageProbeOptions(
@@ -341,6 +367,15 @@ export function SetupEditor({
         onSubmit={(event) => {
           event.preventDefault();
           const data = new FormData(event.currentTarget);
+          if (data.has("noise") && !noisePositive) {
+            onProblem(
+              uiProblem(
+                "SIMULATION_NOISE_OUTPUT_REQUIRED",
+                "Choose a positive Noise output Net.",
+              ),
+            );
+            return;
+          }
           const parsed = SimulationSetupSchema.safeParse({
             version: 2,
             input: {
@@ -386,6 +421,24 @@ export function SetupEditor({
                           "tranMaxStepSeconds",
                           "maxStepSeconds",
                         ),
+                      },
+                    ]
+                  : []),
+                ...(data.has("noise") && noisePositive
+                  ? [
+                      {
+                        kind: "noise",
+                        output: {
+                          positive: noisePositive,
+                          ...(noiseNegative ? { negative: noiseNegative } : {}),
+                        },
+                        inputSourceInstanceId: data.get(
+                          "noiseInputSourceInstanceId",
+                        ),
+                        sweep: data.get("noiseSweep"),
+                        points: Number(data.get("noisePoints")),
+                        startHz: Number(data.get("noiseStartHz")),
+                        stopHz: Number(data.get("noiseStopHz")),
                       },
                     ]
                   : []),
@@ -593,6 +646,22 @@ export function SetupEditor({
                 />
                 TRAN
               </label>
+              <label>
+                <input
+                  name="noise"
+                  type="checkbox"
+                  checked={noiseEnabled}
+                  onChange={(event) => {
+                    const enabled = event.currentTarget.checked;
+                    setNoiseEnabled(enabled);
+                    if (enabled && !noisePositive) {
+                      const first = probeOptions.voltage[0];
+                      if (first) setNoisePositive(voltageProbe(first));
+                    }
+                  }}
+                />
+                Noise
+              </label>
             </div>
           </fieldset>
           {dcEnabled ? (
@@ -740,6 +809,130 @@ export function SetupEditor({
                   placeholder="Simulator default"
                 />
               </label>
+            </div>
+          ) : null}
+          {noiseEnabled ? (
+            <div className="simulation-setup-group simulation-analysis-settings">
+              <div className="simulation-inline-fields columns-2">
+                <label>
+                  Output +
+                  <select
+                    aria-label="Noise output positive"
+                    value={noisePositiveKey}
+                    required
+                    onChange={(event) => {
+                      const option = probeOptions.voltage.find(
+                        (candidate) =>
+                          simulationProbeTargetKey(candidate.target) ===
+                          event.currentTarget.value,
+                      );
+                      setNoisePositive(
+                        option ? voltageProbe(option) : undefined,
+                      );
+                    }}
+                  >
+                    <option value="">Choose a Net</option>
+                    {probeOptions.voltage.map((option) => (
+                      <option
+                        key={option.key}
+                        value={simulationProbeTargetKey(option.target)}
+                      >
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label>
+                  Output −
+                  <select
+                    aria-label="Noise output negative"
+                    value={noiseNegativeKey}
+                    onChange={(event) => {
+                      const option = probeOptions.voltage.find(
+                        (candidate) =>
+                          simulationProbeTargetKey(candidate.target) ===
+                          event.currentTarget.value,
+                      );
+                      setNoiseNegative(
+                        option ? voltageProbe(option) : undefined,
+                      );
+                    }}
+                  >
+                    <option value="">Ground</option>
+                    {probeOptions.voltage.map((option) => (
+                      <option
+                        key={option.key}
+                        value={simulationProbeTargetKey(option.target)}
+                        disabled={
+                          simulationProbeTargetKey(option.target) ===
+                          noisePositiveKey
+                        }
+                      >
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+              <label>
+                Input source
+                <select
+                  name="noiseInputSourceInstanceId"
+                  required
+                  value={selectedNoiseSourceId}
+                  onChange={(event) =>
+                    setNoiseInputSourceId(event.currentTarget.value)
+                  }
+                >
+                  {dcSources.length === 0 ? (
+                    <option value="">
+                      No independent sources in Testbench
+                    </option>
+                  ) : null}
+                  {dcSources.map((source) => (
+                    <option key={source.id} value={source.id}>
+                      {source.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Noise sweep
+                <select name="noiseSweep" defaultValue={noise?.sweep ?? "dec"}>
+                  <option value="dec">Decade</option>
+                  <option value="oct">Octave</option>
+                  <option value="lin">Linear</option>
+                </select>
+              </label>
+              <div className="simulation-inline-fields columns-3">
+                <label>
+                  Points
+                  <input
+                    name="noisePoints"
+                    type="number"
+                    min="1"
+                    defaultValue={noise?.points ?? 20}
+                  />
+                </label>
+                <label>
+                  Start (Hz)
+                  <input
+                    name="noiseStartHz"
+                    type="number"
+                    step="any"
+                    defaultValue={noise?.startHz ?? 1}
+                  />
+                </label>
+                <label>
+                  Stop (Hz)
+                  <input
+                    name="noiseStopHz"
+                    type="number"
+                    step="any"
+                    defaultValue={noise?.stopHz ?? 1e6}
+                  />
+                </label>
+              </div>
             </div>
           ) : null}
         </SimulationSettingsSection>
@@ -1000,8 +1193,23 @@ export function SetupEditor({
               ...(dcEnabled ? (["dc"] as const) : []),
               ...(acEnabled ? (["ac"] as const) : []),
               ...(tranEnabled ? (["tran"] as const) : []),
+              ...(noiseEnabled ? (["noise"] as const) : []),
             ]}
-            outputs={outputs}
+            outputs={[
+              ...outputs,
+              ...(noiseEnabled
+                ? [
+                    {
+                      id: SIMULATION_NOISE_OUTPUT_DENSITY_ID,
+                      label: "Output noise density",
+                    },
+                    {
+                      id: SIMULATION_NOISE_INPUT_DENSITY_ID,
+                      label: "Input-referred noise density",
+                    },
+                  ]
+                : []),
+            ]}
             measurements={measurements}
             onChange={(next) => {
               setMeasurements(next);
@@ -1015,6 +1223,15 @@ export function SetupEditor({
       </form>
     </aside>
   );
+}
+
+function voltageProbe(
+  option: SimulationProbeOption<
+    Extract<SimulationExpression, { kind: "voltage" }>
+  >,
+): SimulationVoltageProbe {
+  const { kind: _kind, ...probe } = option.target;
+  return structuredClone(probe);
 }
 
 function optionalFormNumber(

--- a/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
@@ -202,4 +202,105 @@ describe("SpiceSimulationSurface workspace", () => {
     expect(markup).not.toContain("authored file(s)");
     expect(markup).not.toContain("Profile: raw-profile");
   });
+
+  it("edits a saved Noise analysis with stable density measurement targets", () => {
+    const project = createEmptyProject("noise-simulation", "Noise");
+    const root = project.documents[0]!;
+    root.instances.push(
+      {
+        id: "source-v1",
+        symbolId: "voltage-source",
+        reference: "V1",
+        placement: null,
+        netlist: {
+          binding: { kind: "primitive", deviceClass: "voltage-source" },
+          parameters: { dc: "0", acMagnitude: "1" },
+        },
+      },
+      {
+        id: "resistor-r1",
+        symbolId: "resistor",
+        reference: "R1",
+        placement: null,
+        netlist: {
+          binding: { kind: "primitive", deviceClass: "resistor" },
+          parameters: { resistance: "1k" },
+        },
+      },
+    );
+    root.nets.push({
+      id: "net-out",
+      terminals: [
+        { instanceId: "source-v1", pinName: "P" },
+        { instanceId: "resistor-r1", pinName: "1" },
+      ],
+    });
+    project.simulationSetups.push({
+      id: "setup-noise",
+      name: "Noise",
+      version: 2,
+      input: {
+        kind: "structured",
+        rootDocumentId: root.id,
+        analyses: [
+          {
+            kind: "noise",
+            output: {
+              positive: {
+                documentId: root.id,
+                occurrence: [],
+                anchor: {
+                  kind: "terminal",
+                  instanceId: "source-v1",
+                  pinName: "P",
+                },
+              },
+            },
+            inputSourceInstanceId: "source-v1",
+            sweep: "dec",
+            points: 20,
+            startHz: 10,
+            stopHz: 1e6,
+          },
+        ],
+        outputs: [],
+        measurements: [
+          {
+            id: "noise-at-1k",
+            label: "Noise at 1 kHz",
+            analysis: "noise",
+            outputId: "noise-output-density",
+            method: { kind: "sample-at", coordinate: 1e3 },
+          },
+        ],
+        environment: { profileId: "sky130-core-continuous-ngspice46-v1" },
+      },
+    });
+
+    const markup = renderToStaticMarkup(
+      <SpiceSimulationSurface
+        open
+        maximized={false}
+        project={project}
+        activeDocumentId={root.id}
+        selectedSetupId="setup-noise"
+        onSelectSetupId={() => undefined}
+        session={{} as BrowserSimulationSession}
+        onToggleMaximized={() => undefined}
+        onMinimize={() => undefined}
+        onExit={() => undefined}
+        onSaveSetup={() => ({ status: "applied" })}
+        onDeleteSetup={() => true}
+      />,
+    );
+
+    expect(markup).toContain('type="checkbox" name="noise" checked=""');
+    expect(markup).toContain('aria-label="Noise output positive"');
+    expect(markup).toContain('name="noiseInputSourceInstanceId"');
+    expect(markup).toContain('name="noiseStartHz"');
+    expect(markup).toContain('value="10"');
+    expect(markup).toContain("Output noise density");
+    expect(markup).toContain("Input-referred noise density");
+    expect(markup).toContain("Noise at 1 kHz");
+  });
 });

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -787,6 +787,41 @@
 .simulation-analysis-card-body > .transient-results-explorer > header {
   display: none;
 }
+.noise-results-explorer {
+  display: grid;
+  gap: 14px;
+  min-width: 0;
+}
+.noise-results-explorer > .transient-results-explorer > header {
+  display: none;
+}
+.simulation-integrated-results {
+  overflow: hidden;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  background: var(--icm-surface);
+}
+.simulation-integrated-results h4 {
+  margin: 0;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--icm-border);
+  background: var(--icm-surface-muted);
+  font-size: var(--icm-font-sm);
+}
+.simulation-integrated-results table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.simulation-integrated-results th,
+.simulation-integrated-results td {
+  padding: 7px 10px;
+  text-align: left;
+}
+.simulation-integrated-results th:last-child,
+.simulation-integrated-results td:last-child {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
 .simulation-output-results > .simulation-measurement-results {
   margin-top: 0;
 }

--- a/containers/ngspice/hosted-sky130-profile.json
+++ b/containers/ngspice/hosted-sky130-profile.json
@@ -25,6 +25,6 @@
   "qualifiedScope": {
     "devices": ["sky130_fd_pr__nfet_01v8", "sky130_fd_pr__pfet_01v8"],
     "sections": ["tt", "ff", "ss", "fs", "sf"],
-    "analyses": ["op", "dc", "ac", "tran"]
+    "analyses": ["op", "dc", "ac", "tran", "noise"]
   }
 }

--- a/containers/ngspice/profile-contract.test.mjs
+++ b/containers/ngspice/profile-contract.test.mjs
@@ -37,7 +37,7 @@ describe("the hosted SKY130 Profile", () => {
     expect(profile.qualifiedScope).toEqual({
       devices: ["sky130_fd_pr__nfet_01v8", "sky130_fd_pr__pfet_01v8"],
       sections: ["tt", "ff", "ss", "fs", "sf"],
-      analyses: ["op", "dc", "ac", "tran"],
+      analyses: ["op", "dc", "ac", "tran", "noise"],
     });
   });
 });

--- a/docs/specs/project-file-format.md
+++ b/docs/specs/project-file-format.md
@@ -131,6 +131,9 @@ are rejected.
   `output.label` is the sole authored name used by OP/DC/AC/TRAN results,
   plots, CSV, and MCP. Optional measurement rules reference one enabled
   analysis and one Output and persist a scalar reduction, never a Run result.
+  Noise owns a differential voltage target and root independent input source;
+  its two density curves use stable protocol output ids instead of duplicating
+  ordinary Output expressions.
   A raw input owns bounded author
   files in the shared virtual relative namespace and declares external bytes
   by logical identity, mount path, and digest; it never stores a host path. Both

--- a/docs/specs/simulation.md
+++ b/docs/specs/simulation.md
@@ -72,11 +72,13 @@ not an implicit fallback to a program found on the user's machine.
 The first qualified scope is deliberately narrow and factual: the continuous
 `sky130_fd_pr__nfet_01v8` and `sky130_fd_pr__pfet_01v8` wrappers, the
 Profile's qualified sections (`tt/ff/ss/fs/sf`), and
-OP/DC/AC/TRAN covered by the hosted model acceptance fixture. A separate
+OP/DC/AC/TRAN/Noise covered by the hosted model acceptance fixture. A separate
 independent-source divider smoke gives DC parsing and numerical sweep behavior
 an exact closed-form check on the same pinned runtime. TRAN qualification includes an ideal RC
 step and a structured SKY130 OTA pulse response on the pinned ngspice 46
-environment. Adding another corner or device family extends this same Profile
+environment. Noise qualification includes a closed-form resistor `4kTR` check
+and the structured OTA's input/output spectral densities and integrated totals.
+Adding another corner or device family extends this same Profile
 contract only after a model-backed fixture passes the hosted
 gate; a locally available PDK is not evidence by itself.
 
@@ -470,11 +472,13 @@ into the Project, undo history, Gallery, or recovery copy.
 - `containers/ngspice/profile-contract.test.mjs` binds the Profile to the
   digest-pinned image and exact startup bytes. The Preview gate opens the
   tracked five-transistor OTA Project, compiles its persisted structured setup,
-  and sends that exact prepared OP/DC/AC/TRAN request through the operator-host
+  and sends the prepared OP/DC/AC/TRAN/Noise requests through the operator-host
   executor. It requires the Profile identity and `tt` model selection, checks
   all four compile-time output bindings, compares four OP voltages, selected DC
-  transfer points, representative complex AC samples, and transient extrema
-  against the recorded qualification fixture. Missing local ngspice never
+  transfer points, representative complex AC and Noise samples, transient
+  extrema, and integrated Noise totals against the recorded qualification
+  fixture. A separate resistor run checks spectral and integrated values against
+  `sqrt(4 k T R)`. Missing local ngspice never
   skips this hosted gate.
 - The pinned local authority pack under ignored `.reference-src/` demonstrates
   that ngspice 47 completes a Sky130 NFET operating-point deck with
@@ -586,7 +590,7 @@ reads both plots back.
 
 ## Sources and analyses
 
-`SimulationAnalysis` is `"op" | "dc" | "ac" | "tran"`.
+`SimulationAnalysis` is `"op" | "dc" | "ac" | "tran" | "noise"`.
 
 - `.op` has no parameters.
 - `.dc` sweeps exactly one independent voltage or current source in the
@@ -600,6 +604,11 @@ reads both plots back.
   unless the author asks. `tstart` does not move the start of integration,
   and `tstep` does not make the output equally spaced; the solver's time
   axis is returned as computed.
+- `.noise` selects a hierarchy-aware positive and optional negative voltage
+  anchor, one independent voltage/current source in the Testbench root, and a
+  `dec`/`oct`/`lin` frequency sweep. One user analysis owns both ngspice Noise
+  plots: spectral densities use the stable output ids `noise-output-density`
+  and `noise-input-density`, while integrated input/output noise are scalars.
 
 A voltage or current source instance carries its DC value, its AC magnitude
 and phase, and its transient waveform as formal parameters printed by the
@@ -1161,7 +1170,7 @@ release. A deployment without the binding answers
 - `scripts/preview-simulation-smoke.mjs`: the bundled five-transistor OTA
   Project is the vertical acceptance asset. Its saved `SimulationSetup` is
   parsed and compiled by the production Project/netlist packages before the
-  generated OP/DC/AC/TRAN request reaches Preview. The same gate
+  generated OP/DC/AC/TRAN/Noise requests reach Preview. The same gate
   also runs an ideal RC pulse deck. Returned input revisions, environment
   Profile, model corner, frequency/time axes, probe series, OP values,
   selected AC complex samples, and OTA transient extrema must agree with the

--- a/docs/user/analog-simulation.md
+++ b/docs/user/analog-simulation.md
@@ -43,13 +43,17 @@ same hierarchy, followed by the existing simulation configure operation.
 
 ## Setup, run and results
 
-Open **Setup**, create or select a named setup, then set OP/DC/AC/TRAN,
+Open **Setup**, create or select a named setup, then set OP/DC/AC/TRAN/Noise,
 process corner, optional temperature, and outputs. The current SKY130
 environment offers TT, FF, SS, FS, and SF. New setups use TT. The runtime
 Profile is selected automatically and shown by a friendly environment name;
 its stable ID remains saved in the Project and visible to Agent/API clients for
 reproducibility. A Profile picker appears only when several compatible
 environments are advertised or a saved environment is no longer available.
+Noise asks for the positive output Net, an optional negative output Net
+(Ground when omitted), the Testbench-root independent input source, and a
+frequency sweep. Its result keeps output/input-referred density curves and
+integrated totals together in one Noise analysis.
 Voltage
 outputs may target a Net at the Testbench root or in a concrete DUT occurrence;
 current outputs may target circuit terminals. Each choice is written to the

--- a/fixtures/simulation-acceptance/hosted-sky130-core-continuous-v1.json
+++ b/fixtures/simulation-acceptance/hosted-sky130-core-continuous-v1.json
@@ -1,8 +1,8 @@
 {
-  "schemaVersion": 3,
-  "fixtureId": "ota-5t-structured-op-dc-ac-tran-v2",
+  "schemaVersion": 4,
+  "fixtureId": "ota-5t-structured-op-dc-ac-tran-noise-v3",
   "profileId": "sky130-core-continuous-ngspice46-v1",
-  "analyses": ["op", "dc", "ac", "tran"],
+  "analyses": ["op", "dc", "ac", "tran", "noise"],
   "inputs": {
     "project": "apps/editor/src/examples/five-transistor-ota-sky130.icproj.json",
     "netlist": "fixtures/simulation-acceptance/ota-5t.spi",
@@ -149,6 +149,60 @@
         "last": 0.7732444834989551,
         "absoluteTolerance": 1e-8
       }
+    }
+  },
+  "expectedNoise": {
+    "analysis": {
+      "kind": "noise",
+      "outputProbeId": "probe-vout",
+      "inputSourceInstanceId": "VINP",
+      "sweep": "dec",
+      "points": 20,
+      "startHz": 1,
+      "stopHz": 1000000000
+    },
+    "pointCount": 181,
+    "frequencyRelativeTolerance": 1e-12,
+    "valueRelativeTolerance": 1e-8,
+    "valueAbsoluteTolerance": 1e-15,
+    "samples": [
+      {
+        "index": 0,
+        "frequencyHz": 1,
+        "outputNoiseDensity": 0.0003527268281019868,
+        "inputNoiseDensity": 0.000002936387001390052
+      },
+      {
+        "index": 80,
+        "frequencyHz": 9999.999999999938,
+        "outputNoiseDensity": 0.000006728436964105413,
+        "inputNoiseDensity": 5.603672350495118e-8
+      },
+      {
+        "index": 120,
+        "frequencyHz": 999999.9999999905,
+        "outputNoiseDensity": 6.807410088432378e-7,
+        "inputNoiseDensity": 1.743688273418767e-8
+      },
+      {
+        "index": 180,
+        "frequencyHz": 999999999.9999859,
+        "outputNoiseDensity": 6.221508309545533e-10,
+        "inputNoiseDensity": 1.524689249398183e-8
+      }
+    ],
+    "integratedOutputNoise": 0.002464690192665594,
+    "integratedInputNoise": 0.0007312163500832933,
+    "units": {
+      "outputDensity": "V/sqrt(Hz)",
+      "inputDensity": "V/sqrt(Hz)",
+      "integratedOutput": "V",
+      "integratedInput": "V"
+    },
+    "evidence": {
+      "observedAt": "2026-09-07",
+      "executor": "operator-host",
+      "environmentFingerprint": "33c245e5df6dc12077b6a2e4ebf308777b0e9014fe9bfdafc3285c614688561d"
     }
   }
 }

--- a/packages/spice-run/src/environment-profile.test.ts
+++ b/packages/spice-run/src/environment-profile.test.ts
@@ -36,6 +36,7 @@ describe("hosted simulation Profile", () => {
       "dc",
       "ac",
       "tran",
+      "noise",
     ]);
   });
 

--- a/scripts/preview-agent-simulation-journey.mjs
+++ b/scripts/preview-agent-simulation-journey.mjs
@@ -11,7 +11,10 @@ import { parseProject } from "../packages/project-protocol/dist/index.js";
 import { SimulationOutputDataSchema } from "../packages/simulation-service/dist/contract.js";
 import { SimulationResultSchema } from "../packages/spice-run/dist/index.js";
 import { materializeSimulationRunEvidence } from "./lib/simulation-run-evidence.mjs";
-import { validateHostedSky130Result } from "./preview-simulation-smoke.mjs";
+import {
+  validateHostedSky130NoiseResult,
+  validateHostedSky130Result,
+} from "./preview-simulation-smoke.mjs";
 
 const baseUrl = new URL(
   process.argv[2] ?? "https://analog-canvas-preview.tokenzhang.com",
@@ -30,7 +33,23 @@ const projectText = await readFile(
 const project = parseProject(projectText);
 const setup = project.simulationSetups[0];
 assert(setup, "The acceptance Project has no saved setup");
-const compiled = await compileStructuredSimulation(project, setup);
+assert.equal(setup.input.kind, "structured");
+const qualifiedSetup = structuredClone(setup);
+const noiseOutput = qualifiedSetup.input.outputs.find(
+  (output) => output.id === "probe-vout",
+);
+assert.equal(noiseOutput?.expression.kind, "voltage");
+const { kind: _noiseExpressionKind, ...noisePositive } = noiseOutput.expression;
+qualifiedSetup.input.analyses.push({
+  kind: "noise",
+  output: { positive: noisePositive },
+  inputSourceInstanceId: "VINP",
+  sweep: "dec",
+  points: 20,
+  startHz: 1,
+  stopHz: 1e9,
+});
+const compiled = await compileStructuredSimulation(project, qualifiedSetup);
 assert(compiled.ok, "The acceptance Project no longer compiles");
 
 await mkdir(outputDirectory, { recursive: true });
@@ -157,6 +176,27 @@ async function exportArtifact(artifact, name) {
   };
 }
 
+async function startAndRead(prepared) {
+  const started = await tool("simulation", {
+    request: {
+      operation: "start",
+      preparedId: prepared.id,
+      digest: prepared.digest,
+    },
+  });
+  assert.equal(started.ok, true);
+  for (let attempt = 0; attempt < 180; attempt++) {
+    const reading = await tool("simulation", {
+      request: { operation: "read", runId: started.run.id },
+    });
+    assert.equal(reading.ok, true);
+    if (!["running", "cancelling"].includes(reading.run.state))
+      return reading.run;
+    await new Promise((resolveWait) => setTimeout(resolveWait, 500));
+  }
+  throw new Error(`Run ${started.run.id} did not reach a terminal state.`);
+}
+
 try {
   browser = await chromium.launch({ headless: true });
   const context = await browser.newContext({
@@ -221,11 +261,102 @@ try {
   assert.equal(capabilityReply.ok, true);
   assert.deepEqual(
     capabilityReply.capabilities.analyses,
-    ["op", "dc", "ac", "tran"],
-    "The deployed Profile does not advertise all four qualified analyses",
+    ["op", "dc", "ac", "tran", "noise"],
+    "The deployed Profile does not advertise all five qualified analyses",
   );
 
-  const invalidSetup = structuredClone(discoveredSetup);
+  // A bad model is a recoverable run result, not an MCP-session failure. Fix
+  // the same graphless workspace and prove a second run can complete before
+  // the full Project-owned structured journey continues.
+  const rawWorkspace = await tool("simulation_files", {
+    request: { action: "create" },
+  });
+  assert.equal(rawWorkspace.ok, true);
+  const workspaceId = rawWorkspace.workspace.id;
+  const badRaw = await tool("simulation_files", {
+    request: {
+      action: "update",
+      workspaceId,
+      expectedRevision: 0,
+      entry: "main.cir",
+      writes: [
+        {
+          path: "main.cir",
+          text: [
+            "Missing model recovery acceptance",
+            "V1 out 0 DC 1",
+            "D1 out 0 acceptance_model_missing",
+            ".control",
+            "set filetype=ascii",
+            "op",
+            "write out.raw v(out)",
+            ".endc",
+            ".end",
+          ].join("\n"),
+        },
+      ],
+    },
+  });
+  assert.equal(badRaw.ok, true);
+  const badPrepared = await tool("simulation", {
+    request: {
+      operation: "prepare",
+      source: {
+        kind: "workspace",
+        workspaceId,
+        expectedRevision: badRaw.workspace.revision,
+        environment: { profileId: capabilityReply.capabilities.profiles[0].id },
+      },
+    },
+  });
+  assert.equal(badPrepared.ok, true);
+  const badRun = await startAndRead(badPrepared.prepared);
+  assert.equal(badRun.state, "finished");
+  assert.equal(badRun.result?.outcome.status, "failed");
+
+  const fixedRaw = await tool("simulation_files", {
+    request: {
+      action: "update",
+      workspaceId,
+      expectedRevision: badRaw.workspace.revision,
+      entry: "main.cir",
+      writes: [
+        {
+          path: "main.cir",
+          text: [
+            "Recovered divider",
+            "V1 in 0 DC 1",
+            "R1 in out 1k",
+            "R2 out 0 1k",
+            ".control",
+            "set filetype=ascii",
+            "op",
+            "write out.raw v(out)",
+            ".endc",
+            ".end",
+          ].join("\n"),
+        },
+      ],
+    },
+  });
+  assert.equal(fixedRaw.ok, true);
+  const fixedPrepared = await tool("simulation", {
+    request: {
+      operation: "prepare",
+      source: {
+        kind: "workspace",
+        workspaceId,
+        expectedRevision: fixedRaw.workspace.revision,
+        environment: { profileId: capabilityReply.capabilities.profiles[0].id },
+      },
+    },
+  });
+  assert.equal(fixedPrepared.ok, true);
+  const fixedRun = await startAndRead(fixedPrepared.prepared);
+  assert.equal(fixedRun.state, "finished");
+  assert.equal(fixedRun.result?.outcome.status, "completed");
+
+  const invalidSetup = structuredClone(qualifiedSetup);
   assert.equal(
     invalidSetup.input.kind,
     "structured",
@@ -265,7 +396,7 @@ try {
 
   const restored = await tool("advanced_transact", {
     structureEdits: [
-      { kind: "upsert_simulation_setup", setup: discoveredSetup },
+      { kind: "upsert_simulation_setup", setup: qualifiedSetup },
     ],
   });
   assert.equal(restored.ok, true);
@@ -281,30 +412,12 @@ try {
   });
   assert.equal(prepared.ok, true);
   assert.deepEqual(prepared.prepared.vectors, compiled.vectors);
-  const started = await tool("simulation", {
-    request: {
-      operation: "start",
-      preparedId: prepared.prepared.id,
-      digest: prepared.prepared.digest,
-    },
-  });
-  assert.equal(started.ok, true);
-
-  let finished;
-  for (let attempt = 0; attempt < 180; attempt++) {
-    finished = await tool("simulation", {
-      request: { operation: "read", runId: started.run.id },
-    });
-    assert.equal(finished.ok, true);
-    if (!["running", "cancelling"].includes(finished.run.state)) break;
-    await new Promise((resolveWait) => setTimeout(resolveWait, 500));
-  }
-  assert(finished, "The run returned no final state");
-  assert.equal(finished.run.state, "finished");
+  const finished = await startAndRead(prepared.prepared);
+  assert.equal(finished.state, "finished");
   const exports = [];
   const exportedArtifactNames = new Set();
   const fullRun = await materializeSimulationRunEvidence(
-    finished.run,
+    finished,
     async (artifact) => {
       exports.push(await exportArtifact(artifact, artifact.name));
       exportedArtifactNames.add(artifact.name);
@@ -323,6 +436,11 @@ try {
     prepared.prepared.inputRevision,
     prepared.prepared.vectors,
   );
+  const acceptedNoise = validateHostedSky130NoiseResult(
+    fullRun.result,
+    "operator-host",
+    prepared.prepared.inputRevision,
+  );
   assert(
     fullRun.outputData?.analyses.length,
     "The completed OTA run returned no evaluated named outputs",
@@ -332,7 +450,7 @@ try {
     "The completed OTA run returned no automatic measurements",
   );
 
-  const resultArtifacts = finished.run.artifacts
+  const resultArtifacts = finished.artifacts
     .filter(
       (artifact) =>
         artifact.name === "out.raw" ||
@@ -364,8 +482,8 @@ try {
       id: discoveredSetup.id,
       name: discoveredSetup.name,
       rootDocumentId: discoveredSetup.input.rootDocumentId,
-      analyses: discoveredSetup.input.analyses,
-      outputs: discoveredSetup.input.outputs.map((output) => ({
+      analyses: qualifiedSetup.input.analyses,
+      outputs: qualifiedSetup.input.outputs.map((output) => ({
         id: output.id,
         label: output.label,
         expressionKind: output.expression.kind,
@@ -393,6 +511,11 @@ try {
     recovery: refused.error.recovery,
     diagnostics: refused.error.diagnostics,
   };
+  report.modelRecovery = {
+    failedOutcome: badRun.result?.outcome.status,
+    correctedOutcome: fixedRun.result?.outcome.status,
+    workspaceId,
+  };
   report.prepared = {
     id: prepared.prepared.id,
     digest: prepared.prepared.digest,
@@ -410,7 +533,7 @@ try {
     environmentFingerprint: accepted.environmentFingerprint,
     inputRevision: prepared.prepared.inputRevision,
     preparedId: prepared.prepared.id,
-    runId: finished.run.id,
+    runId: finished.id,
     analyses: fullRun.result.data?.analyses.map((analysis) => ({
       kind: analysis.analysis,
       plotName: analysis.plotName,
@@ -421,14 +544,23 @@ try {
             ? analysis.sweep.values.length
             : analysis.analysis === "ac"
               ? analysis.frequencyHz.length
-              : analysis.timeSeconds.length,
-      outputs: analysis.probes.map((probe) => probe.name),
+              : analysis.analysis === "noise"
+                ? analysis.frequencyHz.length
+                : analysis.timeSeconds.length,
+      outputs:
+        analysis.analysis === "noise"
+          ? ["noise-output-density", "noise-input-density"]
+          : analysis.probes.map((probe) => probe.name),
     })),
     namedOutputs: fullRun.outputData.analyses.map((analysis) => ({
       kind: analysis.analysis,
       outputs: analysis.outputs.map((output) => output.label),
     })),
     measurementCount: fullRun.outputData.measurements?.length ?? 0,
+    integratedNoise: {
+      output: acceptedNoise.integratedOutputNoise,
+      input: acceptedNoise.integratedInputNoise,
+    },
   };
   report.exports = exports;
   await tool("disconnect");

--- a/scripts/preview-agent-simulation-journey.mjs
+++ b/scripts/preview-agent-simulation-journey.mjs
@@ -91,14 +91,21 @@ function rpc(method, params) {
 }
 
 async function tool(name, args = {}, allowProblem = false) {
-  const reply = await rpc("tools/call", { name, arguments: args });
-  const text = reply.content?.find((item) => item.type === "text")?.text;
-  assert.equal(typeof text, "string", `${name} returned no text result`);
-  const value = JSON.parse(text);
-  if (reply.isError && !allowProblem) {
-    throw new Error(`${name} failed: ${text}`);
+  for (let attempt = 0; ; attempt++) {
+    const reply = await rpc("tools/call", { name, arguments: args });
+    const text = reply.content?.find((item) => item.type === "text")?.text;
+    assert.equal(typeof text, "string", `${name} returned no text result`);
+    const value = JSON.parse(text);
+    if (reply.isError && value.error?.code === "RATE_LIMITED" && attempt < 12) {
+      const retryAfterMs = Math.max(value.error.retryAfterMs ?? 5_000, 1_000);
+      await new Promise((resolveWait) => setTimeout(resolveWait, retryAfterMs));
+      continue;
+    }
+    if (reply.isError && !allowProblem) {
+      throw new Error(`${name} failed: ${text}`);
+    }
+    return value;
   }
-  return value;
 }
 
 async function startMcp() {
@@ -192,7 +199,7 @@ async function startAndRead(prepared) {
     assert.equal(reading.ok, true);
     if (!["running", "cancelling"].includes(reading.run.state))
       return reading.run;
-    await new Promise((resolveWait) => setTimeout(resolveWait, 500));
+    await new Promise((resolveWait) => setTimeout(resolveWait, 1_500));
   }
   throw new Error(`Run ${started.run.id} did not reach a terminal state.`);
 }

--- a/scripts/preview-simulation-smoke.mjs
+++ b/scripts/preview-simulation-smoke.mjs
@@ -130,6 +130,24 @@ export const DIVIDER_DC_REQUEST = {
   timeoutMs: 30_000,
 };
 
+export const RESISTOR_NOISE_REQUEST = {
+  mode: "raw",
+  netlist: "",
+  testbench: [
+    "Resistor thermal-noise qualification",
+    "V1 in 0 DC 0 AC 1",
+    "R1 in out 1k",
+    "R2 out 0 1k",
+    ".control",
+    "set filetype=ascii",
+    "noise v(out) V1 dec 3 10 1k",
+    "write out.raw noise1.all noise2.all",
+    ".endc",
+    ".end",
+  ].join("\n"),
+  timeoutMs: 30_000,
+};
+
 export function hostedSky130CornerRequest(corner) {
   return {
     netlist: [
@@ -225,6 +243,60 @@ export async function compileHostedSky130TransientProject() {
   if (!compiled.ok) {
     throw new Error(
       `Qualification ${qualification.fixtureId} TRAN did not compile: ${compiled.diagnostics
+        .map((diagnostic) => `${diagnostic.code}: ${diagnostic.message}`)
+        .join(" | ")}`,
+    );
+  }
+  return compiled;
+}
+
+export async function compileHostedSky130NoiseProject() {
+  const [{ compileStructuredSimulation }, { parseProject }] = await Promise.all(
+    [import("@icm/netlist"), import("@icm/project-protocol")],
+  );
+  const project = parseProject(
+    readFileSync(
+      new URL(`../${qualification.inputs.project}`, import.meta.url),
+      "utf8",
+    ),
+  );
+  const expected = qualification.expectedNoise;
+  const setup = project.simulationSetups[0];
+  const output =
+    setup?.input.kind === "structured"
+      ? setup.input.outputs.find(
+          (candidate) => candidate.id === expected.analysis.outputProbeId,
+        )
+      : undefined;
+  if (
+    !setup ||
+    setup.input.kind !== "structured" ||
+    !output ||
+    output.expression.kind !== "voltage"
+  ) {
+    throw new Error(
+      `Qualification ${qualification.fixtureId} has no Noise output probe.`,
+    );
+  }
+  const { kind: _kind, ...positive } = output.expression;
+  setup.input.analyses = [
+    {
+      kind: "noise",
+      output: { positive },
+      inputSourceInstanceId: expected.analysis.inputSourceInstanceId,
+      sweep: expected.analysis.sweep,
+      points: expected.analysis.points,
+      startHz: expected.analysis.startHz,
+      stopHz: expected.analysis.stopHz,
+    },
+  ];
+  setup.input.outputs = [];
+  const compiled = await compileStructuredSimulation(project, setup, {
+    timeoutMs: 110_000,
+  });
+  if (!compiled.ok) {
+    throw new Error(
+      `Qualification ${qualification.fixtureId} Noise did not compile: ${compiled.diagnostics
         .map((diagnostic) => `${diagnostic.code}: ${diagnostic.message}`)
         .join(" | ")}`,
     );
@@ -533,6 +605,171 @@ export function validateHostedSky130TransientResult(
 
 function relativeError(actual, expected) {
   return Math.abs(actual - expected) / Math.max(Math.abs(expected), 1);
+}
+
+function relativeValueError(actual, expected, absoluteTolerance = 0) {
+  return (
+    Math.abs(actual - expected) /
+    Math.max(Math.abs(expected), absoluteTolerance || Number.MIN_VALUE)
+  );
+}
+
+function parsedNoiseAnalysis(payload, expectedTarget) {
+  const result = object(payload, "simulation response");
+  if (object(result.execution, "execution metadata").target !== expectedTarget)
+    throw new Error(`${expectedTarget} did not execute the Noise analysis.`);
+  if (object(result.outcome, "simulation outcome").status !== "completed")
+    throw new Error(
+      `[simulation:noise] ${expectedTarget} did not complete: ${diagnosticSummary(result)}`,
+    );
+  const environment = object(
+    object(result.metadata, "run metadata").environment,
+    "environment",
+  );
+  validatePinnedEnvironment(environment, expectedTarget);
+  const data = object(result.data, "parsed result data");
+  const noise = Array.isArray(data.analyses)
+    ? data.analyses.find((analysis) => analysis?.analysis === "noise")
+    : null;
+  if (
+    !noise ||
+    !Array.isArray(noise.frequencyHz) ||
+    !Array.isArray(noise.outputNoiseDensity) ||
+    !Array.isArray(noise.inputNoiseDensity)
+  )
+    throw new Error(`${expectedTarget} returned no structured Noise result.`);
+  return { result, environment, noise };
+}
+
+export function validateResistorNoiseResult(payload, expectedTarget) {
+  const { noise } = parsedNoiseAnalysis(payload, expectedTarget);
+  if (noise.frequencyHz.length !== 7)
+    throw new Error(`${expectedTarget} returned an unexpected Noise axis.`);
+  const kelvin = 273.15 + 27;
+  const boltzmann = 1.380649e-23;
+  const expectedOutputDensity = Math.sqrt(4 * boltzmann * kelvin * 500);
+  const firstOutput = noise.outputNoiseDensity[0];
+  const firstInput = noise.inputNoiseDensity[0];
+  if (
+    typeof firstOutput !== "number" ||
+    relativeValueError(firstOutput, expectedOutputDensity) > 2e-4 ||
+    typeof firstInput !== "number" ||
+    relativeValueError(firstInput, expectedOutputDensity * 2) > 2e-4
+  )
+    throw new Error(
+      `${expectedTarget} returned resistor Noise inconsistent with 4kTR.`,
+    );
+  const expectedIntegrated = expectedOutputDensity * Math.sqrt(990);
+  if (
+    typeof noise.integratedOutputNoise !== "number" ||
+    relativeValueError(noise.integratedOutputNoise, expectedIntegrated) >
+      2e-4 ||
+    typeof noise.integratedInputNoise !== "number" ||
+    relativeValueError(noise.integratedInputNoise, expectedIntegrated * 2) >
+      2e-4
+  )
+    throw new Error(`${expectedTarget} returned incorrect integrated Noise.`);
+  return {
+    target: expectedTarget,
+    pointCount: noise.frequencyHz.length,
+    outputDensity: firstOutput,
+  };
+}
+
+export function validateHostedSky130NoiseResult(
+  payload,
+  expectedTarget,
+  expectedInputRevision,
+) {
+  const { result, environment, noise } = parsedNoiseAnalysis(
+    payload,
+    expectedTarget,
+  );
+  const metadata = object(result.metadata, "run metadata");
+  if (
+    object(metadata.input, "input metadata").inputRevision !==
+    expectedInputRevision
+  )
+    throw new Error(`${expectedTarget} returned stale structured Noise data.`);
+  const modelLibrary = object(
+    object(metadata.configuration, "configuration metadata").modelLibrary,
+    "model selection",
+  );
+  if (
+    modelLibrary.directive !== qualification.modelLibrary.directive ||
+    modelLibrary.section !== qualification.modelLibrary.section
+  )
+    throw new Error(
+      `${expectedTarget} did not run Noise with the qualified model-library section.`,
+    );
+  const expected = qualification.expectedNoise;
+  if (environment.fingerprint !== expected.evidence.environmentFingerprint)
+    throw new Error(
+      `${expectedTarget} Noise evidence came from a different environment.`,
+    );
+  if (
+    noise.frequencyHz.length !== expected.pointCount ||
+    noise.outputNoiseDensity.length !== expected.pointCount ||
+    noise.inputNoiseDensity.length !== expected.pointCount
+  )
+    throw new Error(
+      `${expectedTarget} returned an incomplete OTA Noise result.`,
+    );
+  for (const sample of expected.samples) {
+    const frequency = noise.frequencyHz[sample.index];
+    const output = noise.outputNoiseDensity[sample.index];
+    const input = noise.inputNoiseDensity[sample.index];
+    if (
+      typeof frequency !== "number" ||
+      relativeValueError(frequency, sample.frequencyHz) >
+        expected.frequencyRelativeTolerance ||
+      typeof output !== "number" ||
+      (Math.abs(output - sample.outputNoiseDensity) >
+        expected.valueAbsoluteTolerance &&
+        relativeValueError(
+          output,
+          sample.outputNoiseDensity,
+          expected.valueAbsoluteTolerance,
+        ) > expected.valueRelativeTolerance) ||
+      typeof input !== "number" ||
+      (Math.abs(input - sample.inputNoiseDensity) >
+        expected.valueAbsoluteTolerance &&
+        relativeValueError(
+          input,
+          sample.inputNoiseDensity,
+          expected.valueAbsoluteTolerance,
+        ) > expected.valueRelativeTolerance)
+    )
+      throw new Error(
+        `${expectedTarget} returned unexpected OTA Noise at index ${sample.index}.`,
+      );
+  }
+  for (const [key, expectedValue] of [
+    ["integratedOutputNoise", expected.integratedOutputNoise],
+    ["integratedInputNoise", expected.integratedInputNoise],
+  ]) {
+    const actual = noise[key];
+    if (
+      typeof actual !== "number" ||
+      relativeValueError(
+        actual,
+        expectedValue,
+        expected.valueAbsoluteTolerance,
+      ) > expected.valueRelativeTolerance
+    )
+      throw new Error(
+        `${expectedTarget} returned unexpected OTA ${key}: ${String(actual)}.`,
+      );
+  }
+  if (JSON.stringify(noise.units) !== JSON.stringify(expected.units))
+    throw new Error(`${expectedTarget} returned unexpected Noise units.`);
+  return {
+    target: expectedTarget,
+    pointCount: noise.frequencyHz.length,
+    integratedOutputNoise: noise.integratedOutputNoise,
+    integratedInputNoise: noise.integratedInputNoise,
+    environmentFingerprint: environment.fingerprint,
+  };
 }
 
 export function validateHostedSky130Result(
@@ -908,6 +1145,53 @@ export async function runHostedSky130TransientAcceptance({
   );
 }
 
+export async function runHostedSky130NoiseAcceptance({
+  baseUrl,
+  target,
+  fetchImpl = fetch,
+}) {
+  const compiled = await compileHostedSky130NoiseProject();
+  const response = await fetchImpl(new URL("/api/simulate", baseUrl), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ ...compiled.request, executorTarget: target }),
+    signal: AbortSignal.timeout(120_000),
+  });
+  const payload = await response.json();
+  if (!response.ok)
+    throw new Error(
+      `[infrastructure:http-${response.status}] ${target} Noise qualification failed.`,
+    );
+  return validateHostedSky130NoiseResult(
+    payload,
+    target,
+    compiled.request.inputRevision,
+  );
+}
+
+export async function runPreviewResistorNoiseSmoke({
+  baseUrl,
+  target,
+  fetchImpl = fetch,
+}) {
+  const response = await fetchImpl(new URL("/api/simulate", baseUrl), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      ...RESISTOR_NOISE_REQUEST,
+      inputRevision: `preview-resistor-noise-${target}`,
+      executorTarget: target,
+    }),
+    signal: AbortSignal.timeout(60_000),
+  });
+  const payload = await response.json();
+  if (!response.ok)
+    throw new Error(
+      `[infrastructure:http-${response.status}] ${target} resistor Noise smoke failed.`,
+    );
+  return validateResistorNoiseResult(payload, target);
+}
+
 export async function runPreviewTransientSmoke({
   baseUrl,
   target,
@@ -1039,6 +1323,13 @@ async function main() {
     );
   }
 
+  for (const target of EXECUTORS) {
+    const result = await runPreviewResistorNoiseSmoke({ baseUrl, target });
+    console.log(
+      `${result.target}: resistor Noise ${result.pointCount} points passed`,
+    );
+  }
+
   const qualifications = [];
   for (const target of EXECUTORS) {
     const result = await runHostedSky130Acceptance({ baseUrl, target });
@@ -1055,6 +1346,13 @@ async function main() {
     });
     console.log(
       `${result.target}: SKY130 OTA TRAN ${result.pointCount} points passed`,
+    );
+  }
+  for (const target of EXECUTORS) {
+    const result = await runHostedSky130NoiseAcceptance({ baseUrl, target });
+    console.log(
+      `${result.target}: SKY130 OTA Noise ${result.pointCount} points passed ` +
+        `(onoise=${result.integratedOutputNoise}, inoise=${result.integratedInputNoise})`,
     );
   }
   for (const target of EXECUTORS) {

--- a/scripts/preview-simulation-smoke.test.mjs
+++ b/scripts/preview-simulation-smoke.test.mjs
@@ -2,13 +2,17 @@ import { describe, expect, it } from "vitest";
 
 import {
   compileHostedSky130Project,
+  compileHostedSky130NoiseProject,
   compileHostedSky130TransientProject,
   hostedSky130CornerRequest,
   runHostedSky130Acceptance,
   runHostedSky130CornerAcceptance,
+  runHostedSky130NoiseAcceptance,
   runHostedSky130TransientAcceptance,
   runPreviewSimulationSmoke,
   validateHostedSky130TransientResult,
+  validateHostedSky130NoiseResult,
+  validateResistorNoiseResult,
   validateDcDividerResult,
   validateExecutorParity,
   validateHostedSky130Result,
@@ -192,6 +196,80 @@ function cornerResult(target, corner = "ff") {
             { name: "i(vdn)", value: -0.0002526337154561964 },
             { name: "i(vsp)", value: -9.451994627332483e-7 },
           ],
+        },
+      ],
+    },
+  };
+}
+
+function noiseResult(target, inputRevision = `preview-sky130-noise-${target}`) {
+  const base = modelResult(target, {}, inputRevision);
+  const frequencyHz = Array.from(
+    { length: 181 },
+    (_, index) => 10 ** (index / 20),
+  );
+  const outputNoiseDensity = Array(181).fill(1e-9);
+  const inputNoiseDensity = Array(181).fill(1e-9);
+  for (const [index, frequency, output, input] of [
+    [0, 1, 0.0003527268281019868, 0.000002936387001390052],
+    [80, 9999.999999999938, 0.000006728436964105413, 5.603672350495118e-8],
+    [120, 999999.9999999905, 6.807410088432378e-7, 1.743688273418767e-8],
+    [180, 999999999.9999859, 6.221508309545533e-10, 1.524689249398183e-8],
+  ]) {
+    frequencyHz[index] = frequency;
+    outputNoiseDensity[index] = output;
+    inputNoiseDensity[index] = input;
+  }
+  return {
+    ...base,
+    metadata: {
+      ...base.metadata,
+      environment: {
+        ...base.metadata.environment,
+        fingerprint: CORNER_ENVIRONMENT_SHA,
+      },
+    },
+    data: {
+      analyses: [
+        {
+          analysis: "noise",
+          frequencyHz,
+          outputNoiseDensity,
+          inputNoiseDensity,
+          integratedOutputNoise: 0.002464690192665594,
+          integratedInputNoise: 0.0007312163500832933,
+          units: {
+            outputDensity: "V/sqrt(Hz)",
+            inputDensity: "V/sqrt(Hz)",
+            integratedOutput: "V",
+            integratedInput: "V",
+          },
+        },
+      ],
+    },
+  };
+}
+
+function resistorNoiseResult(target) {
+  const base = result(target);
+  const density = Math.sqrt(4 * 1.380649e-23 * (273.15 + 27) * 500);
+  return {
+    ...base,
+    data: {
+      analyses: [
+        {
+          analysis: "noise",
+          frequencyHz: [10, 21.5, 46.4, 100, 215, 464, 1000],
+          outputNoiseDensity: Array(7).fill(density),
+          inputNoiseDensity: Array(7).fill(density * 2),
+          integratedOutputNoise: density * Math.sqrt(990),
+          integratedInputNoise: density * Math.sqrt(990) * 2,
+          units: {
+            outputDensity: "V/sqrt(Hz)",
+            inputDensity: "V/sqrt(Hz)",
+            integratedOutput: "V",
+            integratedInput: "V",
+          },
         },
       ],
     },
@@ -405,7 +483,7 @@ describe("the hosted SKY130 qualification", () => {
       ),
     ).toMatchObject({
       target: "cloudflare-container",
-      fixtureId: "ota-5t-structured-op-dc-ac-tran-v2",
+      fixtureId: "ota-5t-structured-op-dc-ac-tran-noise-v3",
       environmentFingerprint: SHA,
       values: { "v(vout)": 0.7589797395133877 },
     });
@@ -480,7 +558,7 @@ describe("the hosted SKY130 qualification", () => {
     expect(submitted.testbench).toContain("set appendwrite");
     expect(submitted.testbench).toContain("write out.raw v(vout)");
     expect(submitted.testbench).toContain("ac dec 10 1 1000000000");
-    expect(accepted.fixtureId).toBe("ota-5t-structured-op-dc-ac-tran-v2");
+    expect(accepted.fixtureId).toBe("ota-5t-structured-op-dc-ac-tran-noise-v3");
   }, 15_000);
 
   it("compiles the persisted Project setup into the qualified request", async () => {
@@ -568,5 +646,57 @@ describe("the hosted SKY130 qualification", () => {
     expect(submitted.inputRevision).toBe(compiled.request.inputRevision);
     expect(submitted.executorTarget).toBe("operator-host");
     expect(accepted.pointCount).toBe(232);
+  });
+
+  it("compiles and validates the model-backed structured Noise slice", async () => {
+    const compiled = await compileHostedSky130NoiseProject();
+    expect(compiled.request.analyses).toEqual(["noise"]);
+    expect(compiled.request.testbench).toContain(
+      "noise v(vout) VINP dec 20 1 1000000000",
+    );
+    expect(compiled.request.testbench).toContain(
+      "write out.raw noise1.all noise2.all",
+    );
+    expect(
+      validateHostedSky130NoiseResult(
+        noiseResult("operator-host", compiled.request.inputRevision),
+        "operator-host",
+        compiled.request.inputRevision,
+      ),
+    ).toMatchObject({
+      pointCount: 181,
+      integratedOutputNoise: 0.002464690192665594,
+    });
+  });
+
+  it("sends the structured Noise slice through the selected executor", async () => {
+    let submitted;
+    const accepted = await runHostedSky130NoiseAcceptance({
+      baseUrl: "https://preview.example",
+      target: "operator-host",
+      fetchImpl: async (_url, init) => {
+        submitted = JSON.parse(init.body);
+        return Response.json(
+          noiseResult("operator-host", submitted.inputRevision),
+        );
+      },
+    });
+    expect(submitted.executorTarget).toBe("operator-host");
+    expect(submitted.analyses).toEqual(["noise"]);
+    expect(accepted.pointCount).toBe(181);
+  });
+
+  it("checks resistor Noise against the 4kTR thermal-noise law", () => {
+    expect(
+      validateResistorNoiseResult(
+        resistorNoiseResult("operator-host"),
+        "operator-host",
+      ),
+    ).toMatchObject({ target: "operator-host", pointCount: 7 });
+    const drifted = resistorNoiseResult("operator-host");
+    drifted.data.analyses[0].outputNoiseDensity[0] *= 2;
+    expect(() => validateResistorNoiseResult(drifted, "operator-host")).toThrow(
+      /inconsistent with 4kTR/u,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add saved structured Noise authoring and a dedicated density/integrated-results surface
- qualify Noise in the pinned hosted SKY130 profile with resistor and five-transistor OTA numerical evidence
- exercise the same OP/DC/AC/TRAN/Noise setup through the public Agent resource, including recoverable failure and deck/raw/CSV export

## Validation
- `pnpm gate:full` (static, 2834 unit tests, workspace build, release/goldens/performance passed; shared localhost server was stopped externally during browser phase)
- isolated full browser rerun: 357/358 passed; the sole unrelated formula-alert timing failure passed on immediate isolated rerun
- `pnpm test:local scripts/preview-simulation-smoke.test.mjs containers/ngspice/profile-contract.test.mjs apps/editor/src/features/simulation/simulation-output-results.test.tsx apps/editor/src/features/simulation/simulation-setup-surface.test.tsx`
- `pnpm typecheck`
- `pnpm test:impact -- --base origin/main`
- `pnpm test:e2e:local apps/editor/e2e/agent-simulation.spec.ts --grep "human simulation uses saved setup"`
- pinned Preview numerical smoke on the PR4 runtime: resistor thermal density plus SKY130 OTA Noise, 181 points from 1 Hz to 1 GHz; integrated output 0.002464690192665594 V and input 0.0007312163500832933 V

Test-Impact: tests-updated