### PR TITLE
Fix Preview reconciliation and clarify Result comparison

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -60,17 +60,20 @@ jobs:
           ensure_queue() {
             name="$1"
             retention="$2"
-            if ! $wrangler queues info "$name" >/dev/null 2>&1; then
-              $wrangler queues create "$name" --message-retention-period-secs "$retention"
-            else
-              $wrangler queues update "$name" --message-retention-period-secs "$retention"
-            fi
+            # Update is the steady-state operation. If the Queue is absent,
+            # create it; if another deploy created it between those calls,
+            # the final update proves that the requested resource now exists.
+            $wrangler queues update "$name" --message-retention-period-secs "$retention" && return
+            $wrangler queues create "$name" --message-retention-period-secs "$retention" && return
+            $wrangler queues update "$name" --message-retention-period-secs "$retention"
           }
           ensure_queue analog-canvas-simulation-preview 900
           ensure_queue analog-canvas-simulation-preview-dlq 604800
           bucket=analog-canvas-simulation-artifacts-preview
           if ! $wrangler r2 bucket info "$bucket" >/dev/null 2>&1; then
-            $wrangler r2 bucket create "$bucket"
+            # A concurrent reconcile can win after the info request. In that
+            # case a second info request is the successful idempotent result.
+            $wrangler r2 bucket create "$bucket" || $wrangler r2 bucket info "$bucket" >/dev/null
           fi
           if ! $wrangler r2 bucket lifecycle list "$bucket" | grep -Fq simulation-artifact-retention; then
             $wrangler r2 bucket lifecycle add "$bucket" simulation-artifact-retention --expire-days 1 --force

--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -678,7 +678,9 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   await expect(panel.locator('svg[aria-label="AC magnitude"]')).toBeVisible();
   await expect(panel.locator('svg[aria-label="AC phase"]')).toHaveCount(0);
   await panel.getByRole("tab", { name: "Compare" }).click();
-  await expect(panel.getByText("Session only", { exact: false })).toBeVisible();
+  await expect(
+    panel.getByRole("columnheader", { name: "Maximum" }).first(),
+  ).toBeVisible();
   await panel.getByRole("button", { name: "Keep current" }).click();
   await expect(
     panel.getByRole("button", { name: "Current kept" }),
@@ -1049,16 +1051,52 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
     panel.getByRole("button", { name: "Hide new-output" }),
   ).toHaveCount(2);
   await panel.getByRole("tab", { name: "Compare" }).click();
-  const comparisonTable = panel.locator(".simulation-run-comparison-table");
-  await expect(comparisonTable.locator("thead th")).toHaveCount(3);
-  await expect(comparisonTable).toContainText("Current");
-  await expect(comparisonTable).toContainText("Transient Analysis");
-  await expect(comparisonTable).toContainText("Time-weighted RMS");
+  const comparisonRuns = panel.locator(".simulation-comparison-run");
+  await expect(comparisonRuns).toHaveCount(2);
+  await expect(comparisonRuns.first()).toContainText("Previous 1");
+  await expect(comparisonRuns.last()).toContainText("Current");
   await expect(
-    comparisonTable.getByRole("button", {
+    comparisonRuns
+      .last()
+      .getByRole("columnheader", { name: "Maximum" })
+      .first(),
+  ).toBeVisible();
+  await expect(
+    comparisonRuns
+      .last()
+      .getByRole("columnheader", { name: "Minimum" })
+      .first(),
+  ).toBeVisible();
+  await expect(
+    comparisonRuns
+      .last()
+      .getByRole("columnheader", { name: "Peak to peak" })
+      .first(),
+  ).toBeVisible();
+  await expect(comparisonRuns.last()).toContainText(
+    "Transient · Transient response",
+  );
+  await expect(comparisonRuns.last()).not.toContainText("Time-weighted RMS");
+  await expect(
+    comparisonRuns.getByRole("button", {
       name: "Remove E2E setup from comparison",
     }),
   ).toBeVisible();
+  await panel.getByRole("button", { name: "Maximize simulation" }).click();
+  const maximizedResultHeader = await panel
+    .locator(".simulation-results-header")
+    .boundingBox();
+  const maximizedComparison = await panel
+    .locator(".simulation-comparison-view")
+    .boundingBox();
+  expect(maximizedResultHeader).not.toBeNull();
+  expect(maximizedComparison).not.toBeNull();
+  expect(maximizedResultHeader!.x).toBeCloseTo(maximizedComparison!.x, 0);
+  expect(maximizedResultHeader!.width).toBeCloseTo(
+    maximizedComparison!.width,
+    0,
+  );
+  await panel.getByRole("button", { name: "Restore simulation panel" }).click();
   pending = new Promise<void>((r) => {
     release = r;
   });

--- a/apps/editor/src/features/simulation/simulation-run-comparison.test.tsx
+++ b/apps/editor/src/features/simulation/simulation-run-comparison.test.tsx
@@ -33,6 +33,32 @@ function run(
         value,
       },
       {
+        id: `0:out:minimum:${id}`,
+        analysisIndex: 0,
+        analysis: "tran",
+        plotName: "Transient",
+        outputId: "out",
+        outputLabel: "Vout",
+        metric: "minimum",
+        label: "Minimum",
+        unit: "V",
+        status: "available",
+        value: value / 2,
+      },
+      {
+        id: `0:out:peak-to-peak:${id}`,
+        analysisIndex: 0,
+        analysis: "tran",
+        plotName: "Transient",
+        outputId: "out",
+        outputLabel: "Vout",
+        metric: "peak-to-peak",
+        label: "Peak to peak",
+        unit: "V",
+        status: "available",
+        value: value / 2,
+      },
+      {
         id: `1:out:maximum:${id}`,
         analysisIndex: 1,
         analysis: "ac",
@@ -50,7 +76,7 @@ function run(
 }
 
 describe("SimulationRunComparison", () => {
-  it("aligns measurements by stable output identity, analysis, metric and unit", () => {
+  it("pivots each run into signal rows and metric columns", () => {
     const markup = renderToStaticMarkup(
       <SimulationRunComparison
         runs={[
@@ -60,20 +86,25 @@ describe("SimulationRunComparison", () => {
         onRemove={() => undefined}
       />,
     );
-    expect(markup).toContain("Before");
-    expect(markup).toContain("After");
-    expect(markup).toContain("Transient Analysis");
-    expect(markup).toContain("AC Analysis");
-    expect(markup).toContain('aria-label="Transient analysis"');
-    expect(markup).toContain('aria-label="AC analysis"');
-    expect(markup).toContain("<small>Maximum</small>");
+    expect(markup).toContain("Previous 1");
+    expect(markup).toContain("Current");
+    expect(markup).toContain(
+      "<th>Signal</th><th>Maximum</th><th>Minimum</th><th>Peak to peak</th>",
+    );
+    expect(markup).toContain(">Transient<");
+    expect(markup).toContain(">AC<");
+    expect(markup).toContain(
+      'aria-label="Transient comparison for previous run 1"',
+    );
+    expect(markup).toContain('aria-label="AC comparison for current run"');
+    expect(markup).toContain("<th>Vout</th>");
     expect(markup).toContain("1 V");
     expect(markup).toContain("1.2 V");
     expect(markup).toContain("Remove Before from comparison");
     expect(markup).not.toContain("Remove After from comparison");
   });
 
-  it("keeps distinct saved rules even when they use the same output and metric", () => {
+  it("keeps distinct saved rules as additional signal-table columns", () => {
     const base = run("current", "Current", 1.2, true);
     const current: SimulationComparisonRun = {
       ...base,
@@ -97,7 +128,8 @@ describe("SimulationRunComparison", () => {
     const markup = renderToStaticMarkup(
       <SimulationRunComparison runs={[current]} />,
     );
-    expect(markup).toContain("Early peak");
-    expect(markup).toContain("Late peak");
+    expect(markup).toContain("<th>Early peak</th>");
+    expect(markup).toContain("<th>Late peak</th>");
+    expect(markup.match(/<th>Vout<\/th>/g)).toHaveLength(1);
   });
 });

--- a/apps/editor/src/features/simulation/simulation-run-comparison.tsx
+++ b/apps/editor/src/features/simulation/simulation-run-comparison.tsx
@@ -14,6 +14,30 @@ export interface SimulationComparisonRun {
   readonly current: boolean;
 }
 
+interface ComparisonColumn {
+  readonly key: string;
+  readonly label: string;
+}
+
+interface ComparisonSignal {
+  readonly key: string;
+  readonly label: string;
+  readonly measurements: Map<string, Measurement>;
+}
+
+interface ComparisonSection {
+  readonly key: string;
+  readonly label: string;
+  readonly columns: readonly ComparisonColumn[];
+  readonly signals: readonly ComparisonSignal[];
+}
+
+const SUMMARY_COLUMNS: readonly ComparisonColumn[] = [
+  { key: "automatic\u0000maximum", label: "Maximum" },
+  { key: "automatic\u0000minimum", label: "Minimum" },
+  { key: "automatic\u0000peak-to-peak", label: "Peak to peak" },
+];
+
 function condition(run: SimulationComparisonRun): string {
   return [
     run.environment.corner?.toUpperCase(),
@@ -29,16 +53,69 @@ function format(value: number, unit: string): string {
   return `${Number(value.toPrecision(6))}${unit === "1" ? "" : ` ${unit}`}`;
 }
 
-function measurementKey(measurement: Measurement): string {
+function columnKey(measurement: Measurement): string {
   return (measurement.origin ?? "automatic") === "authored"
     ? `authored\u0000${measurement.measurementId}`
-    : `automatic\u0000${measurement.analysis}\u0000${measurement.outputId}\u0000${measurement.metric}\u0000${measurement.unit}`;
+    : `automatic\u0000${measurement.metric}`;
 }
 
 function analysisTitle(analysis: Measurement["analysis"]): string {
   if (analysis === "op") return "Operating Point";
   if (analysis === "tran") return "Transient";
   return analysis.toUpperCase();
+}
+
+function sectionsForRun(run: SimulationComparisonRun): ComparisonSection[] {
+  const groups = new Map<string, Measurement[]>();
+  for (const measurement of run.measurements) {
+    const key = `${measurement.analysis}\u0000${measurement.plotName}`;
+    const group = groups.get(key) ?? [];
+    group.push(measurement);
+    groups.set(key, group);
+  }
+
+  return [...groups.entries()].map(([key, measurements]) => {
+    const first = measurements[0]!;
+    const automaticColumns: readonly ComparisonColumn[] =
+      first.analysis === "op"
+        ? [{ key: "automatic\u0000operating-point", label: "Value" }]
+        : SUMMARY_COLUMNS;
+    const authoredColumns = new Map<string, ComparisonColumn>();
+    const signals = new Map<string, ComparisonSignal>();
+
+    for (const measurement of measurements) {
+      const metricKey = columnKey(measurement);
+      if ((measurement.origin ?? "automatic") === "authored")
+        authoredColumns.set(metricKey, {
+          key: metricKey,
+          label: measurement.label,
+        });
+      if (
+        !automaticColumns.some((column) => column.key === metricKey) &&
+        !authoredColumns.has(metricKey)
+      )
+        continue;
+
+      const signalKey = `${measurement.outputId}\u0000${measurement.unit}`;
+      const signal = signals.get(signalKey) ?? {
+        key: signalKey,
+        label: measurement.outputLabel,
+        measurements: new Map<string, Measurement>(),
+      };
+      signal.measurements.set(metricKey, measurement);
+      signals.set(signalKey, signal);
+    }
+
+    return {
+      key,
+      label:
+        first.plotName === analysisTitle(first.analysis)
+          ? first.plotName
+          : `${analysisTitle(first.analysis)} · ${first.plotName}`,
+      columns: [...automaticColumns, ...authoredColumns.values()],
+      signals: [...signals.values()],
+    };
+  });
 }
 
 export function SimulationRunComparison({
@@ -54,86 +131,81 @@ export function SimulationRunComparison({
         Complete a structured run to compare its measurements.
       </p>
     );
-  const rowGroups = new Map<
-    Measurement["analysis"],
-    Map<string, Measurement>
-  >();
-  for (const run of runs)
-    for (const measurement of run.measurements) {
-      const rows = rowGroups.get(measurement.analysis) ?? new Map();
-      rows.set(measurementKey(measurement), measurement);
-      rowGroups.set(measurement.analysis, rows);
-    }
+
   return (
-    <div className="simulation-run-comparison-table-wrap">
-      <table className="simulation-run-comparison-table">
-        <thead>
-          <tr>
-            <th>Measurement</th>
-            {runs.map((run) => (
-              <th key={run.id}>
-                <span>
-                  <strong>{run.label}</strong>
-                  <small>
-                    {condition(run) || run.environment.profileId}
-                    {run.current ? " · Current" : ""}
-                  </small>
-                </span>
-                {!run.current && onRemove ? (
-                  <button
-                    type="button"
-                    aria-label={`Remove ${run.label} from comparison`}
-                    onClick={() => onRemove(run.id)}
-                  >
-                    ×
-                  </button>
-                ) : null}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        {[...rowGroups.entries()].map(([analysis, rows]) => (
-          <tbody
-            key={analysis}
-            aria-label={`${analysisTitle(analysis)} analysis`}
-          >
-            <tr className="simulation-comparison-analysis-row">
-              <th colSpan={runs.length + 1}>
-                {analysisTitle(analysis)} Analysis
-              </th>
-            </tr>
-            {[...rows.entries()].map(([key, row]) => (
-              <tr key={key}>
-                <th>
-                  <strong>{row.outputLabel}</strong>
-                  <small>{row.label}</small>
-                </th>
-                {runs.map((run) => {
-                  const item = run.measurements.find(
-                    (candidate) => measurementKey(candidate) === key,
-                  );
-                  return (
-                    <td key={run.id}>
-                      {!item ? (
-                        <span className="simulation-comparison-missing">—</span>
-                      ) : item.status === "available" ? (
-                        format(item.value, item.unit)
-                      ) : (
-                        <span
-                          className="simulation-comparison-unavailable"
-                          title={item.reason}
-                        >
-                          Unavailable
-                        </span>
-                      )}
-                    </td>
-                  );
-                })}
-              </tr>
-            ))}
-          </tbody>
-        ))}
-      </table>
+    <div className="simulation-comparison-runs">
+      {runs.map((run, runIndex) => (
+        <section className="simulation-comparison-run" key={run.id}>
+          <header>
+            <span>
+              <strong>
+                {run.current ? "Current" : `Previous ${runIndex + 1}`}
+              </strong>
+              <small>{condition(run) || run.environment.profileId}</small>
+            </span>
+            {!run.current && onRemove ? (
+              <button
+                type="button"
+                aria-label={`Remove ${run.label} from comparison`}
+                onClick={() => onRemove(run.id)}
+              >
+                ×
+              </button>
+            ) : null}
+          </header>
+          {sectionsForRun(run).map((section) => (
+            <section
+              className="simulation-comparison-analysis"
+              key={section.key}
+            >
+              <h3>{section.label}</h3>
+              <div className="simulation-run-comparison-table-wrap">
+                <table
+                  className="simulation-run-comparison-table"
+                  aria-label={`${section.label} comparison for ${run.current ? "current run" : `previous run ${runIndex + 1}`}`}
+                >
+                  <thead>
+                    <tr>
+                      <th>Signal</th>
+                      {section.columns.map((column) => (
+                        <th key={column.key}>{column.label}</th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {section.signals.map((signal) => (
+                      <tr key={signal.key}>
+                        <th>{signal.label}</th>
+                        {section.columns.map((column) => {
+                          const item = signal.measurements.get(column.key);
+                          return (
+                            <td key={column.key}>
+                              {!item ? (
+                                <span className="simulation-comparison-missing">
+                                  —
+                                </span>
+                              ) : item.status === "available" ? (
+                                format(item.value, item.unit)
+                              ) : (
+                                <span
+                                  className="simulation-comparison-unavailable"
+                                  title={item.reason}
+                                >
+                                  Unavailable
+                                </span>
+                              )}
+                            </td>
+                          );
+                        })}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </section>
+          ))}
+        </section>
+      ))}
     </div>
   );
 }

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -1127,13 +1127,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
 
             {resultTab === "compare" ? (
               <div className="simulation-comparison-view">
-                <header>
-                  <span>
-                    <strong>Run comparison</strong>
-                    <small>
-                      Session only · matches stable output and measurement IDs
-                    </small>
-                  </span>
+                <div className="simulation-comparison-actions">
                   <button
                     type="button"
                     disabled={
@@ -1159,7 +1153,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
                       Clear kept
                     </button>
                   ) : null}
-                </header>
+                </div>
                 {comparisonRuns.length < 2 && currentComparisonRun ? (
                   <p className="simulation-comparison-hint">
                     Keep this result, change the circuit or conditions, then run

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -248,6 +248,19 @@
   border-right: 0;
 }
 
+.spice-simulation-surface.maximized .simulation-taskbar {
+  grid-template-columns: minmax(140px, 1fr) auto minmax(140px, 1fr);
+  align-items: center;
+}
+
+.spice-simulation-surface.maximized .simulation-task-actions {
+  justify-self: center;
+}
+
+.spice-simulation-surface.maximized .simulation-window-actions {
+  justify-self: end;
+}
+
 .spice-simulation-surface.maximized .simulation-setup-panel form {
   box-sizing: border-box;
   width: min(100%, 960px);
@@ -262,7 +275,7 @@
 
 .spice-simulation-surface.maximized .simulation-results-header {
   box-sizing: border-box;
-  width: min(100%, 960px);
+  width: min(calc(100% - 32px), 1440px);
   margin-inline: auto;
 }
 
@@ -923,15 +936,12 @@
 .simulation-measurement-results tr[data-status="unavailable"] td:last-child {
   color: var(--icm-danger);
 }
-.simulation-comparison-view > header {
+.simulation-comparison-actions {
   display: flex;
   align-items: center;
+  justify-content: flex-end;
   gap: 6px;
   margin-bottom: 10px;
-}
-.simulation-comparison-view > header > span {
-  display: grid;
-  margin-right: auto;
 }
 .simulation-comparison-view small,
 .simulation-comparison-hint {
@@ -941,54 +951,77 @@
 .simulation-comparison-hint {
   margin: 0 0 10px;
 }
-.simulation-run-comparison-table-wrap {
-  overflow: auto;
+.simulation-comparison-runs {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 520px), 1fr));
+  gap: 12px;
+  align-items: start;
+}
+.simulation-comparison-run {
+  min-width: 0;
+  overflow: hidden;
   border: 1px solid var(--icm-border);
   border-radius: var(--icm-radius-sm);
+  background: var(--icm-surface);
+}
+.simulation-comparison-run > header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 40px;
+  padding: 6px 9px;
+  border-bottom: 1px solid var(--icm-border);
+  background: var(--icm-surface-muted);
+}
+.simulation-comparison-run > header > span {
+  display: grid;
+  min-width: 0;
+  line-height: 1.2;
+}
+.simulation-comparison-run > header button {
+  width: 26px;
+  min-height: 26px;
+  margin-left: auto;
+  padding: 0;
+}
+.simulation-comparison-analysis + .simulation-comparison-analysis {
+  border-top: 1px solid var(--icm-border);
+}
+.simulation-comparison-analysis > h3 {
+  margin: 0;
+  padding: 7px 9px 4px;
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+  font-weight: 650;
+}
+.simulation-run-comparison-table-wrap {
+  overflow: auto;
 }
 .simulation-run-comparison-table {
   width: 100%;
-  min-width: 520px;
+  min-width: 440px;
   border-collapse: collapse;
   font-size: var(--icm-font-xs);
 }
 .simulation-run-comparison-table th,
 .simulation-run-comparison-table td {
-  min-width: 130px;
-  padding: 7px 9px;
+  min-width: 105px;
+  padding: 6px 9px;
   border-right: 1px solid var(--icm-border);
   border-bottom: 1px solid var(--icm-border);
-  text-align: left;
-  vertical-align: top;
+  text-align: right;
+  vertical-align: middle;
 }
 .simulation-run-comparison-table thead th {
   position: sticky;
   top: 0;
   background: var(--icm-surface-muted);
+  color: var(--icm-text-muted);
+  font-weight: 600;
 }
-.simulation-run-comparison-table thead th:not(:first-child) {
-  padding-right: 30px;
-}
-.simulation-run-comparison-table .simulation-comparison-analysis-row th {
-  display: table-cell;
-  padding: 7px 9px;
-  border-right: 0;
-  color: var(--icm-text);
-  background: color-mix(in srgb, var(--icm-surface-muted) 58%, white);
-  font-size: var(--icm-font-sm);
-  font-weight: 700;
-}
-.simulation-run-comparison-table thead th > span,
-.simulation-run-comparison-table tbody th {
-  display: grid;
-}
-.simulation-run-comparison-table thead button {
-  position: absolute;
-  top: 4px;
-  right: 4px;
-  min-width: 24px;
-  min-height: 24px;
-  padding: 0;
+.simulation-run-comparison-table th:first-child {
+  min-width: 120px;
+  text-align: left;
 }
 .simulation-run-comparison-table td:last-child,
 .simulation-run-comparison-table th:last-child {

--- a/scripts/preview-workflow.test.mjs
+++ b/scripts/preview-workflow.test.mjs
@@ -40,6 +40,12 @@ describe("the preview deploy", () => {
     expect(deploy).toBeGreaterThan(resources);
     expect(preview).toContain("analog-canvas-simulation-preview-dlq");
     expect(preview).toContain("--message-retention-period-secs");
+    expect(preview).toMatch(
+      /queues update[\s\S]+queues create[\s\S]+queues update/u,
+    );
+    expect(preview).toContain(
+      'r2 bucket create "$bucket" || $wrangler r2 bucket info',
+    );
     expect(preview).toContain("simulation-artifact-retention");
     expect(preview).toContain("--expire-days 1");
   });


### PR DESCRIPTION
## Summary\n- make Preview Queue and R2 reconciliation idempotent when resources already exist or another deploy wins the create race\n- pivot Compare into compact signal rows with Maximum, Minimum, and Peak-to-peak columns\n- align maximized Simulation task controls, Result navigation, and Result content bounds\n\n## Root cause\nDeploy Preview run 34132666991 misread the existing Queue as absent, attempted to create it, and failed on Cloudflare error 11009. The missing receipt artifact was only a downstream consequence because simulation acceptance never ran.\n\n## Validation\n- pnpm gate:full (428 unit files / 2840 tests, all builds and release checks, 359 browser tests)\n- focused human simulation Playwright flow, including Compare and maximized alignment\n- Preview workflow contract test\n