### PR TITLE
Unify Selection Filter enforcement

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -5481,11 +5481,136 @@ test("opens Selection Filter with Ctrl+F and filters Select All", async ({
   await filter.getByRole("button", { name: "None" }).click();
   await filter.getByLabel("Instances").check();
   await filter.getByRole("button", { name: "Close" }).click();
+  await expect(page.locator(".route-handle")).toHaveCount(0);
   await page.keyboard.press("Control+d");
   await page.getByTestId("route-hit-route-ui-1").click({ force: true });
   await expect(page.getByTestId("route-hit-route-ui-1")).not.toHaveClass(
     /selected/,
   );
+});
+
+test("Selection Filter blocks direct wire, junction, and shape operations", async ({
+  page,
+}) => {
+  const project = createEmptyProject("selection-policy", "Selection policy");
+  const document = project.documents[0]!;
+  document.nets.push({ id: "net-1", terminals: [] });
+  document.junctions.push(
+    {
+      id: "left",
+      netId: "net-1",
+      position: { x: 240, y: 220 },
+      role: "route-anchor",
+    },
+    {
+      id: "right",
+      netId: "net-1",
+      position: { x: 440, y: 220 },
+      role: "route-anchor",
+    },
+  );
+  document.routes.push(
+    createRoutePath({
+      id: "filtered-wire",
+      netId: "net-1",
+      start: { kind: "junction", junctionId: "left" },
+      end: { kind: "junction", junctionId: "right" },
+      bends: [],
+      modes: ["manual"],
+    }),
+  );
+  document.drafting = {
+    objects: [
+      {
+        id: "filtered-shape",
+        kind: "rectangle",
+        locked: false,
+        zIndex: 0,
+        anchor: { kind: "free", position: { x: 340, y: 340 } },
+        center: { x: 340, y: 340 },
+        width: 160,
+        height: 80,
+        rotation: 0,
+        lineStyle: "solid",
+      },
+    ],
+  };
+  await page.goto("/editor");
+  await page.getByTestId("project-file").setInputFiles({
+    name: "selection-policy.icproj.json",
+    mimeType: "application/json",
+    buffer: Buffer.from(JSON.stringify(project)),
+  });
+
+  await page.keyboard.press("Control+f");
+  const filter = page.getByTestId("selection-filter-popover");
+  await filter.getByRole("button", { name: "None" }).click();
+  await filter.getByRole("button", { name: "Close" }).click();
+
+  const screenPoint = async (locator: Locator, pointIndex = 0) =>
+    locator.evaluate((element, index) => {
+      const svg = (element as SVGGraphicsElement).ownerSVGElement;
+      const matrix = (element as SVGGraphicsElement).getScreenCTM();
+      if (!svg || !matrix) throw new Error("SVG hit target is not measurable");
+      const point = svg.createSVGPoint();
+      if (element instanceof SVGCircleElement) {
+        point.x = element.cx.baseVal.value;
+        point.y = element.cy.baseVal.value;
+      } else {
+        const vertex = (element as SVGPolylineElement).points[index];
+        if (!vertex) throw new Error("SVG hit target has no point");
+        point.x = vertex.x;
+        point.y = vertex.y;
+      }
+      const screen = point.matrixTransform(matrix);
+      return { x: screen.x, y: screen.y };
+    }, pointIndex);
+
+  const route = page.getByTestId("route-hit-filtered-wire");
+  const routeStart = await screenPoint(route);
+  const routeEnd = await screenPoint(route, 1);
+  const routeCenter = {
+    x: (routeStart.x + routeEnd.x) / 2,
+    y: (routeStart.y + routeEnd.y) / 2,
+  };
+  const shape = page.getByTestId("drafting-hit-filtered-shape");
+  const shapeCorner = await screenPoint(shape);
+  const junction = page.getByTestId("junction-left");
+  const junctionPoint = await screenPoint(junction);
+
+  for (const point of [routeCenter, junctionPoint, shapeCorner]) {
+    await page.mouse.click(point.x, point.y);
+  }
+  await expect(route).not.toHaveClass(/selected/u);
+  await expect(junction).not.toHaveClass(/active/u);
+  await expect(shape).not.toHaveClass(/selected/u);
+
+  const routePointsBefore = await route.getAttribute("points");
+  const shapeBoundsBefore = await shape.boundingBox();
+  await page.mouse.move(routeCenter.x, routeCenter.y);
+  await page.mouse.down();
+  await page.mouse.move(routeCenter.x + 80, routeCenter.y + 50, { steps: 4 });
+  await page.mouse.up();
+  await page.mouse.move(shapeCorner.x, shapeCorner.y);
+  await page.mouse.down();
+  await page.mouse.move(shapeCorner.x + 80, shapeCorner.y + 50, { steps: 4 });
+  await page.mouse.up();
+  expect(await route.getAttribute("points")).toBe(routePointsBefore);
+  expect(await shape.boundingBox()).toEqual(shapeBoundsBefore);
+
+  await page.keyboard.press("Delete");
+  await page.mouse.click(routeCenter.x, routeCenter.y);
+  await page.mouse.click(shapeCorner.x, shapeCorner.y);
+  await page.keyboard.press("Escape");
+  await expect(route).toHaveCount(1);
+  await expect(shape).toHaveCount(1);
+
+  await page.mouse.dblclick(shapeCorner.x, shapeCorner.y);
+  await expect(page.locator('[data-testid^="drafting-hit-note-"]')).toHaveCount(
+    0,
+  );
+  await page.mouse.click(routeCenter.x, routeCenter.y, { button: "right" });
+  await expect(route).not.toHaveClass(/selected/u);
 });
 
 test("highlights the complete current-document Net from a selected route", async ({

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -261,9 +261,9 @@ import { useRecoveryCoordinator } from "../document/recovery-coordinator";
 import { useSelectionController } from "../features/selection/selection-controller";
 import { SelectionFilterPopover } from "../features/selection/selection-filter-popover";
 import {
+  createSelectionPolicy,
   DEFAULT_SELECTION_FILTER,
   selectionFilterSummary,
-  selectionForDocument,
   type SelectionFilter,
 } from "../features/selection/selection-filter";
 import { deriveSelectionInspectionModel } from "../features/selection/selection-inspection-model";
@@ -518,6 +518,14 @@ export function App({
     DEFAULT_SELECTION_FILTER,
   );
   const [selectionFilterOpen, setSelectionFilterOpen] = useState(false);
+  const selectionPolicy = useMemo(
+    () => createSelectionPolicy(document, selectionFilter),
+    [document, selectionFilter],
+  );
+  const unfilteredSelectionPolicy = useMemo(
+    () => createSelectionPolicy(document, DEFAULT_SELECTION_FILTER),
+    [document],
+  );
   const uniqueSuffixCounter = useRef(0);
   const [viewBox, setRawViewBox] = useState<GridRect>(DEFAULT_VIEWBOX);
   const cameraRuntimeRef = useRef<CameraRuntime | null>(null);
@@ -2835,7 +2843,7 @@ export function App({
       selectedInternalRouteIds,
       selectedInternalJunctionIds,
       selectedInternalObjectIds,
-      selectionFilter,
+      selectionPolicy,
     },
     session: {
       getInteractionKind: () => getCurrentInteractionState().kind,
@@ -2922,7 +2930,7 @@ export function App({
       resolver,
       routeGeometryRecords,
       styleProfile,
-      selectionFilter,
+      selectionPolicy,
     },
     viewport: {
       defaultViewBox: DEFAULT_VIEWBOX,
@@ -3138,8 +3146,23 @@ export function App({
   }
 
   function selectAllObjects(): void {
-    replaceSelection(selectionForDocument(document, selectionFilter));
+    replaceSelection(selectionPolicy.selectAll());
     setSelectedEndpoint(null);
+  }
+
+  function applySelectionFilter(nextFilter: SelectionFilter): void {
+    const nextPolicy = createSelectionPolicy(document, nextFilter);
+    setSelectionFilter(nextFilter);
+    replaceSelection(nextPolicy.retainSelection(visualSelection));
+    if (
+      selectedEndpoint &&
+      !nextPolicy.allowsEndpoint(selectedEndpoint.endpoint.kind, "select")
+    ) {
+      setSelectedEndpoint(null);
+    }
+    if (!nextPolicy.allowsClass("route", "handle")) {
+      setSelectedRouteSegmentIndex(null);
+    }
   }
 
   function clearEditorSelection(): void {
@@ -4156,7 +4179,7 @@ export function App({
   };
 
   const canvasEventHandlers = createEditorCanvasEventHandlers({
-    model: { tool, document, resolver },
+    model: { tool, document, resolver, selectionPolicy },
     session: {
       interactionKind: () => getCurrentInteractionState().kind,
       cellSymbolLayoutEnabled,
@@ -4201,6 +4224,19 @@ export function App({
         const hit = target.closest("[data-canvas-hit-kind]");
         const kind = hit?.getAttribute("data-canvas-hit-kind");
         const id = hit?.getAttribute("data-canvas-hit-id");
+        if (
+          kind &&
+          id &&
+          (kind === "route" ||
+            kind === "drafting" ||
+            kind === "junction" ||
+            kind === "instance" ||
+            kind === "annotation") &&
+          !selectionPolicy.allowsCanvasHit({ kind, id }, "context-menu")
+        ) {
+          setCanvasContextMenu({ x: clientX, y: clientY });
+          return;
+        }
         if (
           id &&
           (kind === "route" ||
@@ -5789,6 +5825,8 @@ export function App({
           }}
           wireUnderSymbol={{
             warnings: wireUnderSymbolWarnings,
+            canSelectRoute: () =>
+              selectionPolicy.allowsClass("route", "select"),
             onSelectRoute: (routeId) => {
               selectOnly("route", [routeId]);
               setStatus("Selected a wire buried under a symbol");
@@ -5878,6 +5916,7 @@ export function App({
                 ? (selectedInstance?.id ?? null)
                 : null,
               wouldMoveIds,
+              selectionPolicy,
               onInstanceClick: (instance, additive) => {
                 if (simulationPickActive) return;
                 if (suppressInstanceClick.current) {
@@ -5968,9 +6007,9 @@ export function App({
               selectedRouteSegmentIndex,
               selectedEndpoint,
               supplementalJunctionIds: supplementalSelection.junctionIds,
-              selectionFilter: simulationPickActive
-                ? DEFAULT_SELECTION_FILTER
-                : selectionFilter,
+              selectionPolicy: simulationPickActive
+                ? unfilteredSelectionPolicy
+                : selectionPolicy,
               endpointLabel: endpointTestId,
               ...(simulationPickTerminalsActive
                 ? {
@@ -6074,42 +6113,7 @@ export function App({
             tool,
             selectedDraftingId,
             supplementalDraftingIds: supplementalSelection.draftingIds,
-            onPointerDown: (event, object, draggable) => {
-              if (
-                event.button === 0 &&
-                consumeArmedDeleteOnObject("draftingIds", object.id)
-              ) {
-                event.stopPropagation();
-                event.preventDefault();
-                return;
-              }
-              const groupIds = draftingSelectionIds(object.id);
-              if (draggable && groupIds.length > 1) {
-                if (event.shiftKey || event.ctrlKey || event.metaKey) {
-                  selectDraftingObject(object.id, true);
-                  return;
-                }
-                selectVisualObjects("drafting", groupIds, false);
-                beginVisualSelectionMoveFromSelection(
-                  event,
-                  {
-                    instanceIds: [],
-                    routeIds: [],
-                    junctionIds: [],
-                    annotationIds: [],
-                    draftingIds: groupIds,
-                  },
-                  event.currentTarget,
-                );
-              } else if (draggable) beginDraftingDrag(event, object);
-              else {
-                event.stopPropagation();
-                selectDraftingObject(
-                  object.id,
-                  event.shiftKey || event.ctrlKey || event.metaKey,
-                );
-              }
-            },
+            selectionPolicy,
             onConstructionLineEdit: (event, object) => {
               event.stopPropagation();
               insertConstructionVertex(
@@ -6144,10 +6148,32 @@ export function App({
           draftingHandles={{
             document,
             resolver,
-            selectedDraftingId,
-            selectedDraftingIds: visualSelection.draftingIds,
-            onHandlePointerDown: beginDraftingHandleDrag,
-            onGroupScalePointerDown: beginWaveformGroupScale,
+            selectedDraftingId:
+              selectedDrafting &&
+              selectionPolicy.allowsDrafting(selectedDrafting, "handle")
+                ? selectedDraftingId
+                : null,
+            selectedDraftingIds:
+              selectionPolicy.retainSelection(visualSelection).draftingIds,
+            onHandlePointerDown: (event, object, handle) => {
+              if (!selectionPolicy.allowsDrafting(object, "handle")) return;
+              beginDraftingHandleDrag(event, object, handle);
+            },
+            onGroupScalePointerDown: (event, group, bounds) => {
+              if (
+                !group.objectIds.every((id) => {
+                  const object = document.drafting?.objects.find(
+                    (candidate) => candidate.id === id,
+                  );
+                  return (
+                    object !== undefined &&
+                    selectionPolicy.allowsDrafting(object, "handle")
+                  );
+                })
+              )
+                return;
+              beginWaveformGroupScale(event, group, bounds);
+            },
             onDeleteVertex: deleteConstructionVertex,
           }}
           interactionPreviews={{
@@ -6277,7 +6303,7 @@ export function App({
       <SelectionFilterPopover
         open={selectionFilterOpen}
         filter={selectionFilter}
-        onChange={setSelectionFilter}
+        onChange={applySelectionFilter}
         onClose={() => setSelectionFilterOpen(false)}
       />
       <EditorStatusbar

--- a/apps/editor/src/canvas/canvas-gesture-controller.ts
+++ b/apps/editor/src/canvas/canvas-gesture-controller.ts
@@ -15,8 +15,8 @@ import {
   marqueeSelection,
 } from "../features/selection/marquee-selection";
 import {
-  DEFAULT_SELECTION_FILTER,
-  type SelectionFilter,
+  type SelectableCanvasHit,
+  type SelectionPolicy,
 } from "../features/selection/selection-filter";
 import {
   EMPTY_VISUAL_SELECTION,
@@ -64,7 +64,7 @@ export interface CanvasGestureControllerDependencies {
     resolver: SymbolResolver;
     routeGeometryRecords: readonly RouteGeometryRecord[];
     styleProfile: SchematicStyleProfile;
-    selectionFilter?: SelectionFilter;
+    selectionPolicy: SelectionPolicy;
   };
   viewport: {
     defaultViewBox: GridRect;
@@ -225,7 +225,7 @@ export function createCanvasGestureController({
     resolver,
     routeGeometryRecords,
     styleProfile,
-    selectionFilter = DEFAULT_SELECTION_FILTER,
+    selectionPolicy,
   },
   viewport: {
     defaultViewBox,
@@ -428,13 +428,34 @@ export function createCanvasGestureController({
     ) {
       return;
     }
+    const directHitElement = (event.target as Element).closest?.(
+      "[data-canvas-hit-kind][data-canvas-hit-id]",
+    );
+    const directHitKind = directHitElement?.getAttribute(
+      "data-canvas-hit-kind",
+    ) as SelectableCanvasHit["kind"] | null;
+    const directHitId = directHitElement?.getAttribute("data-canvas-hit-id");
+    const directEndpointKind = (event.target as Element)
+      .closest?.("[data-endpoint-kind]")
+      ?.getAttribute("data-endpoint-kind") as "junction" | "terminal" | null;
+    const filteredTargetActsAsCanvas = Boolean(
+      (directHitKind &&
+        directHitId &&
+        !selectionPolicy.allowsCanvasHit(
+          { kind: directHitKind, id: directHitId },
+          "select",
+        )) ||
+      (directEndpointKind &&
+        !selectionPolicy.allowsEndpoint(directEndpointKind, "select")),
+    );
     const gesture = classifyCanvasGestureStart({
       button: event.button,
       altKey: event.altKey,
       interactionKind: getInteractionKind(),
       targetIsCanvas:
         event.target === event.currentTarget ||
-        (event.target as Element).tagName === "rect",
+        (event.target as Element).tagName === "rect" ||
+        filteredTargetActsAsCanvas,
       placementPending: componentPlacementPending || waveformPlacementPending,
       vddRailMode,
       copyPlacementPending,
@@ -643,7 +664,7 @@ export function createCanvasGestureController({
           styleProfile,
           rect,
           marqueeMode(boxPreview.start, boxPreview.end),
-          selectionFilter,
+          selectionPolicy,
         );
     replaceSelection(selection);
     clearSelectedEndpoint();

--- a/apps/editor/src/canvas/canvas-hit-controller.ts
+++ b/apps/editor/src/canvas/canvas-hit-controller.ts
@@ -5,11 +5,7 @@ import type { Annotation, DraftingObject, SchematicDocument } from "@icm/model";
 
 import type { EditorTool } from "../interaction/interaction-state";
 import { planSelectionMove } from "../features/selection/selection-move-plan";
-import {
-  DEFAULT_SELECTION_FILTER,
-  selectionFilterAllowsCanvasHit,
-  type SelectionFilter,
-} from "../features/selection/selection-filter";
+import { type SelectionPolicy } from "../features/selection/selection-filter";
 import type { VisualSelection } from "../features/selection/visual-selection";
 import {
   resolveCanvasHitAtPoint,
@@ -25,7 +21,7 @@ export interface CanvasHitControllerDependencies {
     selectedInternalRouteIds: ReadonlySet<string>;
     selectedInternalJunctionIds: ReadonlySet<string>;
     selectedInternalObjectIds: ReadonlySet<string>;
-    selectionFilter?: SelectionFilter;
+    selectionPolicy: SelectionPolicy;
   };
   session: {
     getInteractionKind: () => string;
@@ -90,7 +86,7 @@ export function createCanvasHitController({
     selectedInternalRouteIds,
     selectedInternalJunctionIds,
     selectedInternalObjectIds,
-    selectionFilter = DEFAULT_SELECTION_FILTER,
+    selectionPolicy,
   },
   session: {
     getInteractionKind,
@@ -184,12 +180,7 @@ export function createCanvasHitController({
           event.altKey ? 1 : 0,
           simulationPickMode === null
             ? (candidate) =>
-                candidate.selected ||
-                selectionFilterAllowsCanvasHit(
-                  selectionFilter,
-                  document,
-                  candidate,
-                )
+                selectionPolicy.allowsCanvasHit(candidate, "select")
             : undefined,
         )
       : null;

--- a/apps/editor/src/canvas/editor-canvas-event-handlers.ts
+++ b/apps/editor/src/canvas/editor-canvas-event-handlers.ts
@@ -14,6 +14,7 @@ import type { WireSource } from "@icm/edit-engine";
 import type { SymbolResolver } from "@icm/symbols";
 
 import type { EditorTool } from "../interaction/interaction-state";
+import type { SelectionPolicy } from "../features/selection/selection-filter";
 import { rankCanvasHits } from "./canvas-hit-resolver";
 import {
   proposeRectangleLabel,
@@ -34,6 +35,7 @@ interface CanvasEventHandlerDependencies {
     tool: EditorTool;
     document: SchematicDocument;
     resolver: SymbolResolver;
+    selectionPolicy: SelectionPolicy;
   };
   session: {
     interactionKind: () => string;
@@ -130,7 +132,7 @@ interface CanvasEventHandlerDependencies {
 
 /** DOM event boundary for the editor canvas; domain mutations stay injected. */
 export function createEditorCanvasEventHandlers({
-  model: { tool, document, resolver },
+  model: { tool, document, resolver, selectionPolicy },
   session: { interactionKind, cellSymbolLayoutEnabled, exitCellSymbolLayout },
   coordinates: {
     pointFromClient,
@@ -369,6 +371,7 @@ export function createEditorCanvasEventHandlers({
             event.clientX,
             event.clientY,
           ),
+          (hit) => selectionPolicy.allowsCanvasHit(hit, "edit"),
         );
         const annotationHit = pointHits.find(
           (hit) => hit.kind === "annotation",
@@ -399,7 +402,7 @@ export function createEditorCanvasEventHandlers({
         const rectangle = electricalHit
           ? null
           : rectangleInteriorAt(document, resolver, interiorPoint);
-        if (rectangle) {
+        if (rectangle && selectionPolicy.allowsDrafting(rectangle, "edit")) {
           event.preventDefault();
           event.stopPropagation();
           cancelCanvasDrag();
@@ -487,7 +490,19 @@ export function createEditorCanvasEventHandlers({
       }
       if (tool === "wire") cancelWire();
       if (tool === "pointer" && interactionKind() === "idle") {
-        openContextMenu(event.target as Element, event.clientX, event.clientY);
+        const hit = rankCanvasHits(
+          event.currentTarget.ownerDocument.elementsFromPoint(
+            event.clientX,
+            event.clientY,
+          ),
+          (candidate) =>
+            selectionPolicy.allowsCanvasHit(candidate, "context-menu"),
+        )[0];
+        openContextMenu(
+          hit?.element ?? event.currentTarget,
+          event.clientX,
+          event.clientY,
+        );
       }
     },
     onDragOver(event: ReactDragEvent<SVGSVGElement>) {

--- a/apps/editor/src/canvas/editor-canvas-hit-layer.test.tsx
+++ b/apps/editor/src/canvas/editor-canvas-hit-layer.test.tsx
@@ -10,6 +10,10 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
 import { EditorCanvasHitLayer } from "./editor-canvas-hit-layer";
+import {
+  createSelectionPolicy,
+  DEFAULT_SELECTION_FILTER,
+} from "../features/selection/selection-filter";
 
 function emptyEndpointProps(document = createEmptyDocument("cell", "Cell")) {
   return {
@@ -20,6 +24,7 @@ function emptyEndpointProps(document = createEmptyDocument("cell", "Cell")) {
     selectedRouteSegmentIndex: null,
     selectedEndpoint: null,
     supplementalJunctionIds: [],
+    selectionPolicy: createSelectionPolicy(document, DEFAULT_SELECTION_FILTER),
     endpointLabel: vi.fn(),
     endpointHitRadius: 6,
     onEndpointActions: vi.fn(),
@@ -44,6 +49,7 @@ function emptySelectionProps(document = createEmptyDocument("cell", "Cell")) {
     supplementalAnnotationIds: [],
     cellSymbolLayoutInstanceId: null,
     wouldMoveIds: new Set<string>(),
+    selectionPolicy: createSelectionPolicy(document, DEFAULT_SELECTION_FILTER),
     onInstanceClick: vi.fn(),
     onInstanceOpen: vi.fn(),
     onInstancePointerDown: vi.fn(),

--- a/apps/editor/src/canvas/editor-canvas-hit-layer.tsx
+++ b/apps/editor/src/canvas/editor-canvas-hit-layer.tsx
@@ -22,10 +22,7 @@ import {
   instanceHitBox,
 } from "../features/wiring/route-interaction-geometry";
 import type { EditorTool } from "../interaction/interaction-state";
-import {
-  DEFAULT_SELECTION_FILTER,
-  type SelectionFilter,
-} from "../features/selection/selection-filter";
+import type { SelectionPolicy } from "../features/selection/selection-filter";
 import { serializePolylinePoints } from "./canvas-geometry";
 
 type Instance = SchematicDocument["instances"][number];
@@ -60,6 +57,7 @@ interface SelectionHitTargetProps {
    * Members get the `would-move` tint so the moving body reads as one.
    */
   wouldMoveIds: ReadonlySet<string>;
+  selectionPolicy: SelectionPolicy;
   onInstanceClick: (instance: Instance, additive: boolean) => void;
   onInstanceOpen: (instance: Instance) => void;
   onInstanceContextMenu: (
@@ -94,7 +92,7 @@ interface EndpointHitTargetProps {
   selectedRouteSegmentIndex: number | null;
   selectedEndpoint: WireSource | null;
   supplementalJunctionIds: readonly string[];
-  selectionFilter?: SelectionFilter;
+  selectionPolicy: SelectionPolicy;
   endpointLabel: (endpoint: WireSource["endpoint"]) => string;
   onEndpointActions: (
     endpoint: WireSource,
@@ -152,6 +150,7 @@ function SelectionHitTargets({
   supplementalAnnotationIds,
   cellSymbolLayoutInstanceId,
   wouldMoveIds,
+  selectionPolicy,
   onInstanceClick,
   onInstanceOpen,
   onInstanceContextMenu,
@@ -186,14 +185,35 @@ function SelectionHitTargets({
                     : "hit-target"
               }
               onClick={(event) => {
+                if (
+                  !selectionPolicy.allowsCanvasHit(
+                    { kind: "instance", id: instance.id },
+                    "select",
+                  )
+                )
+                  return;
                 event.stopPropagation();
                 onInstanceClick(instance, event.shiftKey || event.ctrlKey);
               }}
               onDoubleClick={(event) => {
+                if (
+                  !selectionPolicy.allowsCanvasHit(
+                    { kind: "instance", id: instance.id },
+                    "edit",
+                  )
+                )
+                  return;
                 event.stopPropagation();
                 onInstanceOpen(instance);
               }}
               onContextMenu={(event) => {
+                if (
+                  !selectionPolicy.allowsCanvasHit(
+                    { kind: "instance", id: instance.id },
+                    "context-menu",
+                  )
+                )
+                  return;
                 event.preventDefault();
                 event.stopPropagation();
                 onInstanceContextMenu(instance, event.clientX, event.clientY);
@@ -222,10 +242,30 @@ function SelectionHitTargets({
           // Drawing tools only: under the pointer tool the capture-phase
           // router has already claimed this press and stopped it, so this
           // handler runs for the wire gesture and for nothing else.
-          onPointerDown={(event) => onRoutePointerDown(event, route.id)}
+          onPointerDown={(event) => {
+            if (
+              tool === "pointer" &&
+              !selectionPolicy.allowsCanvasHit(
+                { kind: "route", id: route.id },
+                "drag",
+              )
+            )
+              return;
+            onRoutePointerDown(event, route.id);
+          }}
           onPointerEnter={() => onNetPointerEnter?.(route.netId)}
           onPointerLeave={() => onNetPointerLeave?.()}
-          onClick={(event) => event.stopPropagation()}
+          onClick={(event) => {
+            if (
+              tool !== "pointer" ||
+              selectionPolicy.allowsCanvasHit(
+                { kind: "route", id: route.id },
+                "select",
+              )
+            ) {
+              event.stopPropagation();
+            }
+          }}
         />
       ))}
       {children}
@@ -277,12 +317,28 @@ function SelectionHitTargets({
                     : "hit-target annotation-text-hit"
               }
               {...hitBox}
-              onClick={(event) => event.stopPropagation()}
+              onClick={(event) => {
+                if (
+                  selectionPolicy.allowsCanvasHit(
+                    { kind: "annotation", id: annotation.id },
+                    "select",
+                  )
+                ) {
+                  event.stopPropagation();
+                }
+              }}
               onPointerEnter={() =>
                 annotation.netId && onNetPointerEnter?.(annotation.netId)
               }
               onPointerLeave={() => onNetPointerLeave?.()}
               onContextMenu={(event) => {
+                if (
+                  !selectionPolicy.allowsCanvasHit(
+                    { kind: "annotation", id: annotation.id },
+                    "context-menu",
+                  )
+                )
+                  return;
                 event.preventDefault();
                 event.stopPropagation();
                 onAnnotationContextMenu(
@@ -293,6 +349,13 @@ function SelectionHitTargets({
               }}
               pointerEvents={tool === "wire" ? "none" : undefined}
               onDoubleClick={(event) => {
+                if (
+                  !selectionPolicy.allowsCanvasHit(
+                    { kind: "annotation", id: annotation.id },
+                    "edit",
+                  )
+                )
+                  return;
                 event.stopPropagation();
                 onAnnotationEdit(annotation);
               }}
@@ -311,7 +374,7 @@ function EndpointHitTargets({
   selectedRouteSegmentIndex,
   selectedEndpoint,
   supplementalJunctionIds,
-  selectionFilter = DEFAULT_SELECTION_FILTER,
+  selectionPolicy,
   endpointLabel,
   endpointHitRadius,
   onEndpointActions,
@@ -397,13 +460,36 @@ function EndpointHitTargets({
         cx={candidate.connection.contactPoint.x}
         cy={candidate.connection.contactPoint.y}
         r={endpointHitRadius}
-        onClick={(event) => event.stopPropagation()}
+        onClick={(event) => {
+          if (
+            tool !== "pointer" ||
+            selectionPolicy.allowsEndpoint(candidate.endpoint.kind, "select")
+          ) {
+            event.stopPropagation();
+          }
+        }}
         onContextMenu={(event) => {
+          if (
+            tool === "pointer" &&
+            !selectionPolicy.allowsEndpoint(
+              candidate.endpoint.kind,
+              "context-menu",
+            )
+          )
+            return;
           event.preventDefault();
           event.stopPropagation();
           onEndpointActions(candidate, event.clientX, event.clientY);
         }}
         onPointerDown={(event) => {
+          if (
+            tool === "pointer" &&
+            selectedRoute &&
+            (powerRailEndIndex >= 0 || selectedRouteEndSide !== null) &&
+            !selectionPolicy.allowsClass("route", "handle")
+          ) {
+            return;
+          }
           if (tool === "pointer" && selectedRoute && powerRailEndIndex >= 0) {
             onRouteStretch(
               event,
@@ -434,9 +520,7 @@ function EndpointHitTargets({
           }
           if (
             tool === "pointer" &&
-            !selectionFilter[
-              candidate.endpoint.kind === "junction" ? "junction" : "terminal"
-            ]
+            !selectionPolicy.allowsEndpoint(candidate.endpoint.kind, "select")
           ) {
             return;
           }

--- a/apps/editor/src/canvas/editor-canvas-overlays.test.tsx
+++ b/apps/editor/src/canvas/editor-canvas-overlays.test.tsx
@@ -2,7 +2,10 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 import type { Diagnostic } from "@icm/derived";
 
-import { DiagnosticMarkersOverlay } from "./editor-canvas-overlays";
+import {
+  DiagnosticMarkersOverlay,
+  WireUnderSymbolOverlay,
+} from "./editor-canvas-overlays";
 
 const finding: Diagnostic = {
   id: "visual:doc:VISUAL_AMBIGUOUS_JUNCTION:J1",
@@ -76,5 +79,27 @@ describe("DiagnosticMarkersOverlay", () => {
         <DiagnosticMarkersOverlay markers={[]} onSelectMarker={vi.fn()} />,
       ),
     ).toBe("");
+  });
+});
+
+describe("WireUnderSymbolOverlay", () => {
+  it("makes its special hit span transparent when Wires are filtered", () => {
+    const markup = renderToStaticMarkup(
+      <WireUnderSymbolOverlay
+        warnings={[
+          {
+            routeId: "route-1",
+            instanceId: "M1",
+            from: { x: 0, y: 10 },
+            to: { x: 20, y: 10 },
+          },
+        ]}
+        canSelectRoute={() => false}
+        onSelectRoute={vi.fn()}
+      />,
+    );
+    expect(markup).toMatch(
+      /class="wire-under-symbol-hit"[^>]*pointer-events="none"/u,
+    );
   });
 });

--- a/apps/editor/src/canvas/editor-canvas-overlays.tsx
+++ b/apps/editor/src/canvas/editor-canvas-overlays.tsx
@@ -162,9 +162,11 @@ import type { WireUnderSymbolWarning } from "./wire-under-symbol";
  */
 export function WireUnderSymbolOverlay({
   warnings,
+  canSelectRoute,
   onSelectRoute,
 }: {
   warnings: readonly WireUnderSymbolWarning[];
+  canSelectRoute: (routeId: string) => boolean;
   onSelectRoute: (routeId: string) => void;
 }) {
   if (warnings.length === 0) return null;
@@ -190,12 +192,16 @@ export function WireUnderSymbolOverlay({
             y1={warning.from.y}
             x2={warning.to.x}
             y2={warning.to.y}
+            pointerEvents={canSelectRoute(warning.routeId) ? undefined : "none"}
             onPointerDown={(event) => {
+              if (!canSelectRoute(warning.routeId)) return;
               event.stopPropagation();
               event.preventDefault();
               onSelectRoute(warning.routeId);
             }}
-            onClick={(event) => event.stopPropagation()}
+            onClick={(event) => {
+              if (canSelectRoute(warning.routeId)) event.stopPropagation();
+            }}
           />
         </g>
       ))}

--- a/apps/editor/src/canvas/editor-drafting-hit-targets.test.tsx
+++ b/apps/editor/src/canvas/editor-drafting-hit-targets.test.tsx
@@ -7,6 +7,10 @@ import {
   EditorDraftingHandles,
   EditorDraftingHitTargets,
 } from "./editor-drafting-hit-targets";
+import {
+  createSelectionPolicy,
+  DEFAULT_SELECTION_FILTER,
+} from "../features/selection/selection-filter";
 
 const resolver = new InMemorySymbolResolver(builtInSymbols);
 
@@ -37,7 +41,10 @@ describe("EditorDraftingHitTargets", () => {
           tool="arrow"
           selectedDraftingId={null}
           supplementalDraftingIds={[]}
-          onPointerDown={vi.fn()}
+          selectionPolicy={createSelectionPolicy(
+            document,
+            DEFAULT_SELECTION_FILTER,
+          )}
           onConstructionLineEdit={vi.fn()}
           onArrowEdit={vi.fn()}
           onTextEdit={vi.fn()}

--- a/apps/editor/src/canvas/editor-drafting-hit-targets.tsx
+++ b/apps/editor/src/canvas/editor-drafting-hit-targets.tsx
@@ -16,16 +16,14 @@ import type {
 } from "@icm/model";
 import type { SymbolResolver } from "@icm/symbols";
 
-import {
-  draftingDragOrigin,
-  type DraftingHandle,
-} from "../features/drafting/drafting-manipulation";
+import { type DraftingHandle } from "../features/drafting/drafting-manipulation";
 import { draftingGroupBounds } from "../features/drafting/drafting-group-scale";
 import {
   draftingPathData,
   quadraticMidpoint,
 } from "../features/drafting/drafting-path";
 import type { EditorTool } from "../interaction/interaction-state";
+import type { SelectionPolicy } from "../features/selection/selection-filter";
 import { serializePolylinePoints } from "./canvas-geometry";
 
 export function EditorDraftingHitTargets({
@@ -34,7 +32,7 @@ export function EditorDraftingHitTargets({
   tool,
   selectedDraftingId,
   supplementalDraftingIds,
-  onPointerDown,
+  selectionPolicy,
   onConstructionLineEdit,
   onArrowEdit,
   onTextEdit,
@@ -45,11 +43,7 @@ export function EditorDraftingHitTargets({
   tool: EditorTool;
   selectedDraftingId: string | null;
   supplementalDraftingIds: readonly string[];
-  onPointerDown: (
-    event: ReactPointerEvent<SVGElement>,
-    object: DraftingObject,
-    draggable: boolean,
-  ) => void;
+  selectionPolicy: SelectionPolicy;
   onConstructionLineEdit: (
     event: ReactMouseEvent<SVGElement>,
     object: Extract<DraftingObject, { kind: "construction-line" }>,
@@ -73,7 +67,6 @@ export function EditorDraftingHitTargets({
       tool === "rectangle" ||
       tool === "circle";
     const geometry = resolveDraftingObjectGeometry(document, resolver, object);
-    const draggable = !object.locked && Boolean(draftingDragOrigin(object));
     const selected =
       selectedDraftingId === object.id ||
       supplementalDraftingIds.includes(object.id);
@@ -88,11 +81,11 @@ export function EditorDraftingHitTargets({
       "data-canvas-hit-kind": "drafting",
       "data-canvas-hit-id": object.id,
       "data-drag-object-id": object.id,
-      onPointerDown: (event: ReactPointerEvent<SVGElement>) =>
-        onPointerDown(event, object, draggable),
       ...(object.kind === "text"
         ? {
             onContextMenu: (event: ReactMouseEvent<SVGElement>) => {
+              if (!selectionPolicy.allowsDrafting(object, "context-menu"))
+                return;
               event.preventDefault();
               event.stopPropagation();
               onTextContextMenu(object, event.clientX, event.clientY);
@@ -108,7 +101,9 @@ export function EditorDraftingHitTargets({
       geometry.kind === "construction-line"
     ) {
       const doubleClick = (event: ReactMouseEvent<SVGElement>) =>
-        onConstructionLineEdit(event, object);
+        selectionPolicy.allowsDrafting(object, "edit")
+          ? onConstructionLineEdit(event, object)
+          : undefined;
       return geometry.curveControls.some(Boolean) ? (
         <path
           key={object.id}
@@ -149,7 +144,9 @@ export function EditorDraftingHitTargets({
           />
         );
       const doubleClick = (event: ReactMouseEvent<SVGElement>) =>
-        onArrowEdit(event, object);
+        selectionPolicy.allowsDrafting(object, "edit")
+          ? onArrowEdit(event, object)
+          : undefined;
       const { "data-testid": _testId, ...headCommon } = common;
       return (
         <g key={object.id}>
@@ -247,6 +244,7 @@ export function EditorDraftingHitTargets({
         {...geometry.bounds}
         onDoubleClick={(event) => {
           if (object.kind !== "text") return;
+          if (!selectionPolicy.allowsDrafting(object, "edit")) return;
           event.stopPropagation();
           onTextEdit(object);
         }}

--- a/apps/editor/src/features/selection/marquee-selection.test.ts
+++ b/apps/editor/src/features/selection/marquee-selection.test.ts
@@ -16,7 +16,7 @@ import {
   type RouteGeometryRecord,
 } from "../wiring/route-interaction-geometry";
 import { marqueeMode, marqueeSelection } from "./marquee-selection";
-import { NO_SELECTION_FILTER } from "./selection-filter";
+import { createSelectionPolicy, NO_SELECTION_FILTER } from "./selection-filter";
 
 const resolver = new InMemorySymbolResolver(builtInSymbols);
 const styleProfile = resolveSchematicStyleProfile("razavi-textbook-v1");
@@ -262,7 +262,10 @@ describe("marquee crossing selection (right-to-left)", () => {
       styleProfile,
       { x: -100, y: -100, width: 1000, height: 500 },
       "crossing",
-      { ...NO_SELECTION_FILTER, route: true },
+      createSelectionPolicy(document, {
+        ...NO_SELECTION_FILTER,
+        route: true,
+      }),
     );
     expect(selection.routeIds).toEqual(["route-1"]);
     expect(selection.instanceIds).toEqual([]);

--- a/apps/editor/src/features/selection/marquee-selection.ts
+++ b/apps/editor/src/features/selection/marquee-selection.ts
@@ -22,10 +22,9 @@ import {
   type RouteGeometryRecord,
 } from "../wiring/route-interaction-geometry";
 import {
+  createSelectionPolicy,
   DEFAULT_SELECTION_FILTER,
-  selectionFilterAllowsAnnotation,
-  selectionFilterAllowsDrafting,
-  type SelectionFilter,
+  type SelectionPolicy,
 } from "./selection-filter";
 
 /**
@@ -61,20 +60,29 @@ export function marqueeSelection(
   styleProfile: SchematicStyleProfile,
   rect: Rect,
   mode: MarqueeMode,
-  filter: SelectionFilter = DEFAULT_SELECTION_FILTER,
+  policy: SelectionPolicy = createSelectionPolicy(
+    document,
+    DEFAULT_SELECTION_FILTER,
+  ),
 ): MarqueeSelectionSet {
   const window = mode === "window";
   const boxSelected = (bounds: Rect): boolean =>
     window ? rectContainsRect(rect, bounds) : rectsIntersect(bounds, rect);
 
   return {
-    instanceIds: (filter.instance ? document.instances : [])
+    instanceIds: (policy.allowsClass("instance", "select")
+      ? document.instances
+      : []
+    )
       .filter((instance) => {
         const bounds = instanceHitBox(instance, resolver);
         return bounds !== null && boxSelected(bounds);
       })
       .map((instance) => instance.id),
-    routeIds: (filter.route ? routeGeometryRecords : [])
+    routeIds: (policy.allowsClass("route", "select")
+      ? routeGeometryRecords
+      : []
+    )
       .filter(({ geometry }) =>
         window
           ? polylineInRect(geometry.centerline, rect)
@@ -89,13 +97,16 @@ export function marqueeSelection(
               ),
       )
       .map(({ route }) => route.id),
-    junctionIds: (filter.junction ? document.junctions : [])
+    junctionIds: (policy.allowsClass("junction", "select")
+      ? document.junctions
+      : []
+    )
       .filter((junction) => pointInRect(junction.position, rect))
       .map((junction) => junction.id),
     annotationIds: document.annotations
       .filter(
         (annotation) =>
-          selectionFilterAllowsAnnotation(filter, annotation) &&
+          policy.allowsAnnotation(annotation, "select") &&
           isSchematicAnnotationVisible(document, annotation) &&
           boxSelected(
             annotationHitBox(
@@ -116,7 +127,7 @@ export function marqueeSelection(
       .map((annotation) => annotation.id),
     draftingIds: (document.drafting?.objects ?? [])
       .filter((object) => {
-        if (!selectionFilterAllowsDrafting(filter, object)) return false;
+        if (!policy.allowsDrafting(object, "select")) return false;
         const geometry = resolveDraftingObjectGeometry(
           document,
           resolver,

--- a/apps/editor/src/features/selection/selection-filter-popover.tsx
+++ b/apps/editor/src/features/selection/selection-filter-popover.tsx
@@ -126,8 +126,8 @@ export function SelectionFilterPopover({
         </fieldset>
       ))}
       <small>
-        Affects new selections only. Drawing, simulation, visibility, and
-        connectivity stay unchanged.
+        Controls direct selection and editing. Drawing, simulation, visibility,
+        connectivity, and wire follow during device moves stay unchanged.
       </small>
     </aside>
   );

--- a/apps/editor/src/features/selection/selection-filter.test.ts
+++ b/apps/editor/src/features/selection/selection-filter.test.ts
@@ -9,10 +9,12 @@ import {
 import {
   DEFAULT_SELECTION_FILTER,
   NO_SELECTION_FILTER,
+  createSelectionPolicy,
   selectionClassForAnnotation,
   selectionClassForDrafting,
   selectionFilterSummary,
   selectionForDocument,
+  type SelectionInteraction,
 } from "./selection-filter";
 
 const anchor = { kind: "free" as const, position: { x: 0, y: 0 } };
@@ -145,5 +147,79 @@ describe("selection filter", () => {
     expect(
       selectionFilterSummary({ ...NO_SELECTION_FILTER, route: true }),
     ).toBe("Filter: Wires");
+  });
+
+  it("uses the same class decision for every direct interaction", () => {
+    const document = createEmptyProject("p", "P").documents[0]!;
+    const policy = createSelectionPolicy(document, {
+      ...DEFAULT_SELECTION_FILTER,
+      route: false,
+    });
+    const interactions: SelectionInteraction[] = [
+      "select",
+      "drag",
+      "edit",
+      "context-menu",
+      "armed-verb",
+      "handle",
+    ];
+    for (const interaction of interactions) {
+      expect(
+        policy.allowsCanvasHit({ kind: "route", id: "route-1" }, interaction),
+      ).toBe(false);
+      expect(policy.allowsClass("route", interaction)).toBe(false);
+      expect(policy.allowsClass("instance", interaction)).toBe(true);
+    }
+  });
+
+  it("prunes an existing mixed selection when its classes are disabled", () => {
+    const document = createEmptyProject("p", "P").documents[0]!;
+    document.annotations.push({
+      id: "net-name",
+      kind: "net-label",
+      binding: { kind: "net-name", netId: "net-1" },
+      netId: "net-1",
+      anchor,
+      alignment: "start",
+      rotation: 0,
+      locked: false,
+    });
+    document.drafting = {
+      objects: [
+        {
+          id: "shape",
+          kind: "rectangle",
+          locked: false,
+          zIndex: 0,
+          anchor,
+          center: { x: 0, y: 0 },
+          width: 10,
+          height: 10,
+          rotation: 0,
+          lineStyle: "solid",
+        },
+      ],
+    };
+    const policy = createSelectionPolicy(document, {
+      ...DEFAULT_SELECTION_FILTER,
+      route: false,
+      "net-name": false,
+      "drafting-shape": false,
+    });
+    expect(
+      policy.retainSelection({
+        instanceIds: ["R1"],
+        routeIds: ["route-1"],
+        junctionIds: ["junction-1"],
+        annotationIds: ["net-name"],
+        draftingIds: ["shape"],
+      }),
+    ).toEqual({
+      instanceIds: ["R1"],
+      routeIds: [],
+      junctionIds: ["junction-1"],
+      annotationIds: [],
+      draftingIds: [],
+    });
   });
 });

--- a/apps/editor/src/features/selection/selection-filter.ts
+++ b/apps/editor/src/features/selection/selection-filter.ts
@@ -20,6 +20,15 @@ export const SELECTION_CLASSES = [
 export type SelectionClass = (typeof SELECTION_CLASSES)[number];
 export type SelectionFilter = Readonly<Record<SelectionClass, boolean>>;
 
+/**
+ * The ways an existing canvas object can become the direct target of a user
+ * operation. They deliberately share one class decision today: the enum makes
+ * every input surface state which interaction it is requesting, without
+ * allowing those surfaces to invent separate filter semantics later.
+ */
+export type SelectionInteraction =
+  "select" | "drag" | "edit" | "context-menu" | "armed-verb" | "handle";
+
 function uniformSelectionFilter(enabled: boolean): SelectionFilter {
   return Object.fromEntries(
     SELECTION_CLASSES.map((kind) => [kind, enabled]),
@@ -98,7 +107,7 @@ export function selectionClassForDrafting(
   }
 }
 
-type SelectableCanvasHit = {
+export type SelectableCanvasHit = {
   kind:
     | "handle"
     | "annotation"
@@ -109,6 +118,29 @@ type SelectableCanvasHit = {
     | "junction";
   id: string;
 };
+
+export interface SelectionPolicy {
+  readonly filter: SelectionFilter;
+  allowsClass(kind: SelectionClass, interaction: SelectionInteraction): boolean;
+  allowsCanvasHit(
+    hit: SelectableCanvasHit,
+    interaction: SelectionInteraction,
+  ): boolean;
+  allowsAnnotation(
+    annotation: Annotation,
+    interaction: SelectionInteraction,
+  ): boolean;
+  allowsDrafting(
+    object: DraftingObject,
+    interaction: SelectionInteraction,
+  ): boolean;
+  allowsEndpoint(
+    kind: "junction" | "terminal",
+    interaction: SelectionInteraction,
+  ): boolean;
+  retainSelection(selection: VisualSelection): VisualSelection;
+  selectAll(): VisualSelection;
+}
 
 /** Classify one existing canvas hit without adding a second object model. */
 export function selectionClassForCanvasHit(
@@ -151,6 +183,73 @@ export function selectionFilterAllowsCanvasHit(
   // A stale DOM node is not an eligible target; filtering it lets the next
   // live object in the paint stack answer the press instead.
   return kind !== null && filter[kind];
+}
+
+function sameSelection(left: VisualSelection, right: VisualSelection): boolean {
+  return (Object.keys(left) as (keyof VisualSelection)[]).every(
+    (key) =>
+      left[key].length === right[key].length &&
+      left[key].every((id, index) => id === right[key][index]),
+  );
+}
+
+/**
+ * One editor-local authority for direct targetability. The policy is not a
+ * persisted model, Engine edit, or Agent contract. Drawing and Simulation
+ * pick modes bypass it explicitly; electrical movement closure is computed
+ * after selection and therefore remains intact when Wires or Junctions are
+ * disabled.
+ */
+export function createSelectionPolicy(
+  document: SchematicDocument,
+  filter: SelectionFilter,
+): SelectionPolicy {
+  const allowsClass = (kind: SelectionClass): boolean => filter[kind];
+  const allowsAnnotation = (annotation: Annotation): boolean =>
+    allowsClass(selectionClassForAnnotation(annotation));
+  const allowsDrafting = (object: DraftingObject): boolean =>
+    allowsClass(selectionClassForDrafting(object));
+  const allowsCanvasHit = (hit: SelectableCanvasHit): boolean => {
+    // A generic handle cannot establish its own class. Concrete route and
+    // drafting handles ask allowsClass() for their owner before they render or
+    // start an edit; a handle that exists is therefore already authorized and
+    // must remain a passthrough target for its specialized drag controller.
+    if (hit.kind === "handle") return true;
+    const kind = selectionClassForCanvasHit(document, hit);
+    return kind !== null && allowsClass(kind);
+  };
+  const retainSelection = (selection: VisualSelection): VisualSelection => {
+    const retained: VisualSelection = {
+      instanceIds: allowsClass("instance") ? selection.instanceIds : [],
+      routeIds: allowsClass("route") ? selection.routeIds : [],
+      junctionIds: allowsClass("junction") ? selection.junctionIds : [],
+      annotationIds: selection.annotationIds.filter((id) => {
+        const annotation = document.annotations.find(
+          (candidate) => candidate.id === id,
+        );
+        return annotation ? allowsAnnotation(annotation) : false;
+      }),
+      draftingIds: selection.draftingIds.filter((id) => {
+        const object = document.drafting?.objects.find(
+          (candidate) => candidate.id === id,
+        );
+        return object ? allowsDrafting(object) : false;
+      }),
+    };
+    return sameSelection(selection, retained) ? selection : retained;
+  };
+  return {
+    filter,
+    allowsClass: (kind, _interaction) => allowsClass(kind),
+    allowsCanvasHit: (hit, _interaction) => allowsCanvasHit(hit),
+    allowsAnnotation: (annotation, _interaction) =>
+      allowsAnnotation(annotation),
+    allowsDrafting: (object, _interaction) => allowsDrafting(object),
+    allowsEndpoint: (kind, _interaction) =>
+      allowsClass(kind === "junction" ? "junction" : "terminal"),
+    retainSelection,
+    selectAll: () => selectionForDocument(document, filter),
+  };
 }
 
 export function selectionFilterAllowsAnnotation(

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -309,6 +309,24 @@ never highlight or select labels outside the dragged rectangle.
 
 ## Selection alignment
 
+The session-only **Selection Filter** is enforced by one editor-local
+`SelectionPolicy`. Every direct acquisition surface asks that policy before an
+existing object can be selected, dragged, edited, opened by context menu,
+consumed by a verb-first command, or manipulated through a handle. Click,
+directional marquee, Select All, Wire/Junction endpoint hits, drafting shapes,
+and buried-wire warning spans therefore cannot disagree about selectability.
+Changing the filter immediately removes newly disabled classes from the
+current formal selection and dismisses their route or drafting handles.
+
+Filtering changes targetability, not the schematic model. Drawing tools,
+Simulation probe picking, visibility, connectivity, and creation remain
+unchanged. In particular, Wires and Junctions disabled in the filter still
+follow a selected device when the movement closure requires them; this is an
+electrical consequence of moving the selected device, not a second direct
+selection. Project Search and diagnostic navigation remain explicit locator
+operations rather than pointer acquisition and may focus their canonical
+object without changing the filter.
+
 The six visual alignment commands — left, horizontal center, right, top,
 vertical center, and bottom — share one editor command and one alignment
 planner. The Edit menu and the shared canvas context menu are presentation


### PR DESCRIPTION
## Summary
- establish one editor-local SelectionPolicy for direct target acquisition and editing
- enforce it across pointer hits, endpoints, drafting, context menus, verb-first commands, handles, marquee, Select All, and buried-wire spans
- keep drawing, Simulation picking, creation, connectivity, and routing movement closure outside the filter
- prune disabled classes and their handles immediately when the filter changes

## Validation
- pnpm gate:preflight -- --base origin/main
- isolated pnpm gate:affected -- --base origin/main
- 2848 unit tests passed, 23 skipped
- 137 manual editor browser tests passed
- diagnostics, selection, viewport, and thin-target browser gates passed

Addresses the Selection Filter behavior discussed around #690 without auto-closing the issue.