### PR TITLE
Fix hierarchical simulation probes at Cell boundaries

### DIFF
--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -196,7 +196,7 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
     "v(ibias)",
     "v(xdut.tail)",
     "v(xdut.nleft)",
-    "v(xdut.vinp)",
+    "v(vinp)",
   ])
     expect(deck).toContain(vector);
   expect(deck).toMatch(/i\(vicmprb\d+\)/u);

--- a/packages/netlist/src/simulation-compile.test.ts
+++ b/packages/netlist/src/simulation-compile.test.ts
@@ -399,6 +399,12 @@ describe("compiling a structured simulation setup", () => {
     expect(
       result.vectors.some((vector) => vector.vector.includes("xdut")),
     ).toBe(true);
+    const vectors = result.vectors.map((vector) => vector.vector);
+    expect(vectors).toEqual(
+      expect.arrayContaining(["v(vinp)", "v(vdd)", "v(0)", "v(xdut.tail)"]),
+    );
+    expect(vectors).not.toContain("v(xdut.vinp)");
+    expect(vectors).not.toContain("v(xdut.vdd)");
     expect(result.request.netlist).toContain("VICMPRB");
   });
 

--- a/packages/netlist/src/simulation-compile.ts
+++ b/packages/netlist/src/simulation-compile.ts
@@ -588,6 +588,7 @@ function netVoltageNode(
   measurement: SimulationVoltageProbe,
   outputId: string,
   occurrence: ResolvedOccurrence,
+  cellsById: ReadonlyMap<string, DesignNetlistCell>,
   diagnostics: NetlistDiagnostic[],
 ): string | null {
   const { document, cell, path, hierarchyPath } = occurrence;
@@ -654,7 +655,46 @@ function netVoltageNode(
     );
     return null;
   }
-  return [...path, netName].join(".").toLowerCase();
+  let resolvedName = netName;
+  let depth = hierarchyPath.length;
+  let resolvedCell = cell;
+  while (depth > 0) {
+    const boundaryPort = resolvedCell.ports.find(
+      (port) => port.netName.toLowerCase() === resolvedName.toLowerCase(),
+    );
+    if (!boundaryPort)
+      return [...path.slice(0, depth), resolvedName].join(".").toLowerCase();
+
+    const frame = hierarchyPath[depth - 1]!;
+    const parentCell = cellsById.get(frame.parentDocumentId);
+    const caller = parentCell?.instances.find(
+      (instance) => instance.id === frame.instanceId,
+    );
+    const callerNode = caller?.nodes.find(
+      (node) => node.pinName.toLowerCase() === boundaryPort.name.toLowerCase(),
+    )?.netName;
+    if (!parentCell || !callerNode) {
+      diagnostics.push(
+        diagnostic(
+          "SIMULATION_PROBE_HIERARCHY_BOUNDARY_UNAVAILABLE",
+          occurrence.document.id,
+          `Output ${outputId} cannot map formal terminal ${boundaryPort.name} through hierarchy Instance ${frame.instanceId}`,
+          locator(
+            frame.parentDocumentId,
+            hierarchyPath.slice(0, depth - 1),
+            "instance",
+            frame.instanceId,
+          ),
+          [frame.instanceId],
+        ),
+      );
+      return null;
+    }
+    resolvedName = callerNode;
+    resolvedCell = parentCell;
+    depth -= 1;
+  }
+  return resolvedName.toLowerCase();
 }
 
 function netVoltageVector(
@@ -662,9 +702,16 @@ function netVoltageVector(
   acquisitionId: string,
   outputId: string,
   occurrence: ResolvedOccurrence,
+  cellsById: ReadonlyMap<string, DesignNetlistCell>,
   diagnostics: NetlistDiagnostic[],
 ): CompiledSimulationVector | null {
-  const node = netVoltageNode(measurement, outputId, occurrence, diagnostics);
+  const node = netVoltageNode(
+    measurement,
+    outputId,
+    occurrence,
+    cellsById,
+    diagnostics,
+  );
   return node
     ? {
         probeId: acquisitionId,
@@ -927,7 +974,7 @@ export async function compileStructuredSimulation(
         diagnostics,
       );
       return occurrence
-        ? netVoltageNode(measurement, label, occurrence, diagnostics)
+        ? netVoltageNode(measurement, label, occurrence, cellsById, diagnostics)
         : null;
     };
     const positive = resolveNoiseNode(item.output.positive, "positive");
@@ -992,6 +1039,7 @@ export async function compileStructuredSimulation(
                   candidateId,
                   ownerId,
                   occurrence,
+                  cellsById,
                   diagnostics,
                 );
                 return vector

--- a/scripts/preview-agent-simulation-journey.mjs
+++ b/scripts/preview-agent-simulation-journey.mjs
@@ -375,7 +375,11 @@ try {
   assert.equal(fixedPrepared.ok, true);
   const fixedRun = await startAndRead(fixedPrepared.prepared);
   assert.equal(fixedRun.state, "finished");
-  assert.equal(fixedRun.result?.outcome.status, "completed");
+  assert.equal(
+    fixedRun.result?.outcome.status,
+    "completed",
+    `Recovered raw run failed: ${JSON.stringify(fixedRun.result?.outcome)}`,
+  );
 
   const invalidSetup = structuredClone(qualifiedSetup);
   assert.equal(
@@ -472,7 +476,11 @@ try {
         : SimulationOutputDataSchema.parse(value);
     },
   );
-  assert.equal(fullRun.result?.outcome.status, "completed");
+  assert.equal(
+    fullRun.result?.outcome.status,
+    "completed",
+    `Qualified OTA run failed: ${JSON.stringify(fullRun.result)}`,
+  );
   const accepted = validateHostedSky130Result(
     fullRun.result,
     "operator-host",


### PR DESCRIPTION
## Summary
- map formal-port voltage probes back to their caller Net instead of emitting invalid child-local vectors
- preserve occurrence-qualified vectors for true internal Cell Nets
- apply the same boundary mapping to ordinary probes, Noise outputs, and MOS terminal operating-point expressions
- improve the Preview Agent journey failure evidence

## Root cause
The compiler emitted expressions such as (xdut.vinp) for a child Cell formal port. In ngspice, formal-port aliases are represented by the caller node ((vinp)); only internal child Nets use the occurrence prefix ((xdut.tail)). This made the prepared deck compile but fail during write because the requested vector did not exist.

## Validation
- pnpm gate:preflight -- --base origin/main
- ICM_E2E_PORT=4274 ICM_E2E_ISOLATED=1 pnpm gate:full
- 2857 unit tests passed; 360 browser tests passed

Test-Impact: tests-updated