### PR TITLE
Fold simulation ground probes into constants

### DIFF
--- a/packages/netlist/src/simulation-compile.test.ts
+++ b/packages/netlist/src/simulation-compile.test.ts
@@ -401,10 +401,14 @@ describe("compiling a structured simulation setup", () => {
     ).toBe(true);
     const vectors = result.vectors.map((vector) => vector.vector);
     expect(vectors).toEqual(
-      expect.arrayContaining(["v(vinp)", "v(vdd)", "v(0)", "v(xdut.tail)"]),
+      expect.arrayContaining(["v(vinp)", "v(vdd)", "v(xdut.tail)"]),
     );
+    expect(vectors).not.toContain("v(0)");
     expect(vectors).not.toContain("v(xdut.vinp)");
     expect(vectors).not.toContain("v(xdut.vdd)");
+    expect(JSON.stringify(result.deviceOperatingPoints)).toContain(
+      '"kind":"constant","value":0',
+    );
     expect(result.request.netlist).toContain("VICMPRB");
   });
 

--- a/packages/netlist/src/simulation-compile.ts
+++ b/packages/netlist/src/simulation-compile.ts
@@ -697,30 +697,6 @@ function netVoltageNode(
   return resolvedName.toLowerCase();
 }
 
-function netVoltageVector(
-  measurement: Extract<SimulationExpression, { kind: "voltage" }>,
-  acquisitionId: string,
-  outputId: string,
-  occurrence: ResolvedOccurrence,
-  cellsById: ReadonlyMap<string, DesignNetlistCell>,
-  diagnostics: NetlistDiagnostic[],
-): CompiledSimulationVector | null {
-  const node = netVoltageNode(
-    measurement,
-    outputId,
-    occurrence,
-    cellsById,
-    diagnostics,
-  );
-  return node
-    ? {
-        probeId: acquisitionId,
-        vector: `v(${node})`,
-        quantity: "voltage",
-      }
-    : null;
-}
-
 function terminalCurrentVector(
   measurement: Extract<SimulationExpression, { kind: "current" }>,
   acquisitionId: string,
@@ -1031,32 +1007,36 @@ export async function compileStructuredSimulation(
           expression === topExpression
             ? ownerId
             : `${ownerId}:input:${leafIndex++}`;
-        const resolved: ResolvedSimulationProbe | null =
-          expression.kind === "voltage"
-            ? (() => {
-                const vector = netVoltageVector(
-                  expression,
-                  candidateId,
-                  ownerId,
-                  occurrence,
-                  cellsById,
-                  diagnostics,
-                );
-                return vector
-                  ? {
-                      binding: vector,
-                      writeVector: vector.vector,
-                    }
-                  : null;
-              })()
-            : terminalCurrentVector(
-                expression,
-                candidateId,
-                ownerId,
-                occurrence,
-                diagnostics,
-                terminalCurrentInstrumentations,
-              );
+        let resolved: ResolvedSimulationProbe | null;
+        if (expression.kind === "voltage") {
+          const node = netVoltageNode(
+            expression,
+            ownerId,
+            occurrence,
+            cellsById,
+            diagnostics,
+          );
+          if (!node) return null;
+          // Ground is a SPICE constant, not a writable rawfile vector.
+          // Folding it here also keeps every derived expression independent of
+          // simulator-specific attempts to expose `v(0)`.
+          if (node === "0") return { kind: "constant", value: 0 };
+          const binding: CompiledSimulationVector = {
+            probeId: candidateId,
+            vector: `v(${node})`,
+            quantity: "voltage",
+          };
+          resolved = { binding, writeVector: binding.vector };
+        } else {
+          resolved = terminalCurrentVector(
+            expression,
+            candidateId,
+            ownerId,
+            occurrence,
+            diagnostics,
+            terminalCurrentInstrumentations,
+          );
+        }
         if (!resolved) return null;
         const identity = `${resolved.binding.quantity}\u0000${resolved.binding.vector}`;
         const existing = vectorByIdentity.get(identity);


### PR DESCRIPTION
## Summary
- fold SPICE ground voltage into compile-time constant zero
- stop requesting the nonexistent (0) rawfile vector
- preserve ordinary root, formal-port, and internal hierarchy voltage probes

## Root cause
The terminal operating-point compiler derived VGS/VDS/VBS through ordinary voltage acquisitions. Ground reached the deck as write v(0), but ngspice 46 treats ground as a constant rather than a writable vector, so an otherwise successful OTA run ended with 
o such vector 0.

## Validation
- focused compiler tests: 36 passed, 4 skipped
- static contracts and all 2857 unit tests
- workspace build and release verification
- isolated browser suite: 360/360 passed

Test-Impact: tests-updated