### PR TITLE
Fix Preview MOS bulk result evaluation and acceptance

### DIFF
--- a/packages/netlist/src/simulation-compile.test.ts
+++ b/packages/netlist/src/simulation-compile.test.ts
@@ -407,7 +407,7 @@ describe("compiling a structured simulation setup", () => {
     expect(vectors).not.toContain("v(xdut.vinp)");
     expect(vectors).not.toContain("v(xdut.vdd)");
     expect(JSON.stringify(result.deviceOperatingPoints)).toContain(
-      '"kind":"constant","value":0',
+      '"kind":"constant","value":0,"unit":"V"',
     );
     expect(result.request.netlist).toContain("VICMPRB");
   });

--- a/packages/netlist/src/simulation-compile.ts
+++ b/packages/netlist/src/simulation-compile.ts
@@ -124,7 +124,12 @@ export type CompiledSimulationExpression =
       readonly acquisitionId: string;
       readonly quantity: "voltage" | "current";
     }
-  | { readonly kind: "constant"; readonly value: number }
+  | {
+      readonly kind: "constant";
+      readonly value: number;
+      /** Physical unit assigned by compilation; authored constants default to 1. */
+      readonly unit?: string | undefined;
+    }
   | {
       readonly kind:
         | "negate"
@@ -1020,7 +1025,7 @@ export async function compileStructuredSimulation(
           // Ground is a SPICE constant, not a writable rawfile vector.
           // Folding it here also keeps every derived expression independent of
           // simulator-specific attempts to expose `v(0)`.
-          if (node === "0") return { kind: "constant", value: 0 };
+          if (node === "0") return { kind: "constant", value: 0, unit: "V" };
           const binding: CompiledSimulationVector = {
             probeId: candidateId,
             vector: `v(${node})`,

--- a/packages/simulation-service/src/contract.ts
+++ b/packages/simulation-service/src/contract.ts
@@ -73,6 +73,7 @@ export const CompiledOutputExpressionSchema: z.ZodType<CompiledSimulationExpress
       z.strictObject({
         kind: z.literal("constant"),
         value: z.number().finite(),
+        unit: z.string().min(1).optional(),
       }),
       ...(
         [

--- a/packages/simulation-service/src/output-evaluation.test.ts
+++ b/packages/simulation-service/src/output-evaluation.test.ts
@@ -95,6 +95,59 @@ describe("simulation output evaluation", () => {
     );
   });
 
+  it("evaluates a dimensioned ground constant in terminal-derived voltage", () => {
+    const result = evaluateSimulationOutputs(
+      {
+        schemaVersion: 1,
+        analyses: [
+          {
+            analysis: "op",
+            plotName: "Operating Point",
+            probes: [
+              { name: "v(s)", quantity: "voltage", value: 0.2, unit: "V" },
+            ],
+          },
+        ],
+      },
+      [{ probeId: "vs", vector: "v(s)", quantity: "voltage" }],
+      [],
+      [],
+      [
+        {
+          id: "op-m1",
+          documentId: "dut",
+          instanceId: "M1",
+          occurrence: ["XDUT"],
+          reference: "XM1",
+          polarity: "nmos",
+          values: [
+            {
+              parameter: "vbs",
+              label: "VBS",
+              unit: "V",
+              expression: {
+                kind: "subtract",
+                left: { kind: "constant", value: 0, unit: "V" },
+                right: {
+                  kind: "acquisition",
+                  acquisitionId: "vs",
+                  quantity: "voltage",
+                },
+              },
+            },
+          ],
+        },
+      ],
+    );
+
+    expect(result.deviceOperatingPoints?.[0]?.values[0]).toMatchObject({
+      parameter: "vbs",
+      status: "available",
+      value: -0.2,
+      unit: "V",
+    });
+  });
+
   it("publishes Noise density and integrated values without ngspice vector names", () => {
     const result = evaluateSimulationOutputs(
       {

--- a/packages/simulation-service/src/output-evaluation.ts
+++ b/packages/simulation-service/src/output-evaluation.ts
@@ -64,7 +64,7 @@ function evaluate(
     return {
       real: Array.from({ length: pointCount }, () => expression.value),
       imaginary: Array.from({ length: pointCount }, () => 0),
-      unit: "1",
+      unit: expression.unit ?? "1",
       complex: false,
     };
   }

--- a/scripts/preview-agent-simulation-journey.mjs
+++ b/scripts/preview-agent-simulation-journey.mjs
@@ -525,9 +525,13 @@ try {
   assert(mosValue("M1", "id") > 0, "NMOS drain-entering ID is incorrect");
   assert(mosValue("M3", "vgs") < 0, "PMOS VGS polarity is incorrect");
   assert(mosValue("M3", "id") < 0, "PMOS drain-entering ID is incorrect");
+  const tailVoltage = fullRun.outputData.analyses
+    .find((analysis) => analysis.analysis === "op")
+    ?.outputs.find((output) => output.id === "probe-tail")?.values[0];
+  assert(Number.isFinite(tailVoltage), "OTA tail OP voltage is unavailable");
   assert(
-    Math.abs(mosValue("M1", "vbs")) < 1e-9,
-    "NMOS cell-default Bulk did not resolve to its source supply",
+    Math.abs(mosValue("M1", "vbs") + tailVoltage) < 1e-9,
+    "NMOS Bulk is grounded: VBS must equal minus the tail voltage",
   );
   assert(
     Math.abs(mosValue("M3", "vbs")) < 1e-9,


### PR DESCRIPTION
The Preview Agent/MCP OTA journey failed because compiled ground was dimensionless, making `0 - Vs` unavailable. Compiled constants now preserve their physical unit, so ground remains 0 V through result evaluation.

The journey also incorrectly expected M1 VBS to be zero. Its bulk is grounded and its source is the OTA tail. Acceptance now checks VBS = -V(tail); the PMOS zero-VBS check remains intact.

Validation: 44 focused compiler/evaluator tests passed (4 skipped), typecheck, and replay of the actual pinned ngspice 46 Preview receipt. All eight MOS values are available; M1 VBS = -0.2848671983 V. The full local delivery gate passed: 2858 unit tests, all build/release/performance checks, and 360 browser tests. All seven required PR checks passed.

Test-Impact: tests-updated
