### PR TITLE
fix(simulation): align maximized results workspace

### DIFF
--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -1120,19 +1120,73 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
     }),
   ).toBeVisible();
   await panel.getByRole("button", { name: "Maximize simulation" }).click();
-  const maximizedResultHeader = await panel
-    .locator(".simulation-results-header")
-    .boundingBox();
-  const maximizedComparison = await panel
-    .locator(".simulation-comparison-view")
-    .boundingBox();
-  expect(maximizedResultHeader).not.toBeNull();
-  expect(maximizedComparison).not.toBeNull();
-  expect(maximizedResultHeader!.x).toBeCloseTo(maximizedComparison!.x, 0);
-  expect(maximizedResultHeader!.width).toBeCloseTo(
-    maximizedComparison!.width,
-    0,
-  );
+  const previousViewport = page.viewportSize()!;
+  for (const [width, height] of [
+    [1440, 1080],
+    [1920, 1080],
+    [1440, 800],
+  ] as const) {
+    await page.setViewportSize({ width, height });
+    await panel.getByRole("tab", { name: "Compare" }).click();
+    const surfaceBox = (await panel.boundingBox())!;
+    for (const selector of [
+      ".simulation-taskbar",
+      ".simulation-results-header",
+    ]) {
+      const headerBox = (await panel.locator(selector).boundingBox())!;
+      expect(headerBox.x).toBeCloseTo(surfaceBox.x, 0);
+      expect(headerBox.width).toBeCloseTo(surfaceBox.width, 0);
+    }
+    const comparisonBox = (await panel
+      .locator(".simulation-comparison-view")
+      .boundingBox())!;
+    expect(comparisonBox.width).toBeLessThan(surfaceBox.width);
+    expect(comparisonBox.x + comparisonBox.width / 2).toBeCloseTo(
+      surfaceBox.x + surfaceBox.width / 2,
+      0,
+    );
+    await panel.getByRole("tab", { name: "Plot" }).click();
+    const card = panel
+      .locator(".simulation-analysis-card")
+      .filter({
+        has: page.locator(".ac-view-toolbar"),
+      })
+      .first();
+    const shell = card.locator(".ac-plot-shell").first();
+    await expect
+      .poll(async () => (await shell.locator("svg").boundingBox())!.height)
+      .toBeGreaterThan(height > 800 ? 440 : 320);
+    const shellBox = (await shell.boundingBox())!;
+    const titleBox = (await card
+      .locator(".simulation-analysis-card-header h3")
+      .boundingBox())!;
+    const modeBox = (await card.locator(".ac-view-toolbar").boundingBox())!;
+    expect(titleBox.x + titleBox.width / 2).toBeCloseTo(
+      shellBox.x + shellBox.width / 2,
+      0,
+    );
+    expect(modeBox.x).toBeCloseTo(shellBox.x, 0);
+    await expect
+      .poll(() =>
+        panel
+          .locator(".simulation-results-body")
+          .evaluate((element) => element.scrollWidth <= element.clientWidth),
+      )
+      .toBe(true);
+    await panel.locator(".simulation-results-body").evaluate((element) => {
+      element.scrollTop = 0;
+    });
+    await expect
+      .poll(async () => {
+        const box = (await shell.boundingBox())!;
+        return box.y + box.height;
+      })
+      .toBeLessThan(height - 30);
+    await page.screenshot({
+      path: test.info().outputPath(`maximized-${width}-${height}.png`),
+    });
+  }
+  await page.setViewportSize(previousViewport);
   await panel.getByRole("button", { name: "Restore simulation panel" }).click();
   pending = new Promise<void>((r) => {
     release = r;

--- a/apps/editor/src/features/simulation/ac-results-explorer.tsx
+++ b/apps/editor/src/features/simulation/ac-results-explorer.tsx
@@ -306,7 +306,10 @@ export function ComplexResultsExplorer({
       : {
           ...PLOT_SIZE,
           width: Math.max(280, measured.width - 116),
-          height: responsiveWaveformHeight(Math.max(280, measured.width - 116)),
+          height: responsiveWaveformHeight(
+            Math.max(280, measured.width - 116),
+            measured.viewportHeight,
+          ),
         };
     const valueRange = valueRanges[plot.quantity + plot.kind];
     const layout = layoutAcPlot(

--- a/apps/editor/src/features/simulation/transient-results-explorer.tsx
+++ b/apps/editor/src/features/simulation/transient-results-explorer.tsx
@@ -297,7 +297,10 @@ export function ScalarResultsExplorer({
       : {
           ...PLOT,
           width: Math.max(280, measured.width - 116),
-          height: responsiveWaveformHeight(Math.max(280, measured.width - 116)),
+          height: responsiveWaveformHeight(
+            Math.max(280, measured.width - 116),
+            measured.viewportHeight,
+          ),
         };
     const range = timeRange ?? fullRange;
     const clipId = `${clipPrefix}-${quantity}-${expanded}`;

--- a/apps/editor/src/features/simulation/waveform-interaction.test.ts
+++ b/apps/editor/src/features/simulation/waveform-interaction.test.ts
@@ -10,7 +10,11 @@ describe("waveform axes", () => {
   it("grows docked plots with their panel without becoming unbounded", () => {
     expect(responsiveWaveformHeight(400)).toBe(320);
     expect(responsiveWaveformHeight(760)).toBe(395);
-    expect(responsiveWaveformHeight(1200)).toBe(440);
+    expect(responsiveWaveformHeight(1000)).toBe(520);
+    expect(responsiveWaveformHeight(1200)).toBe(600);
+    expect(responsiveWaveformHeight(2400)).toBe(600);
+    expect(responsiveWaveformHeight(1200, 800)).toBe(400);
+    expect(responsiveWaveformHeight(1200, 600)).toBe(320);
   });
 
   it("adapts tick spacing to nanoseconds and a zoomed small signal", () => {

--- a/apps/editor/src/features/simulation/waveform-interaction.tsx
+++ b/apps/editor/src/features/simulation/waveform-interaction.tsx
@@ -9,21 +9,34 @@ import {
 export function useWaveformWidth() {
   const ref = useRef<HTMLDivElement>(null);
   const [width, setWidth] = useState(760);
+  const [viewportHeight, setViewportHeight] = useState<number>(Infinity);
   useEffect(() => {
     if (!ref.current) return;
+    const resize = () => setViewportHeight(window.innerHeight);
+    resize();
+    window.addEventListener("resize", resize);
     const observer = new ResizeObserver(([entry]) => {
       if (entry && entry.contentRect.width > 0)
         setWidth(Math.max(280, Math.round(entry.contentRect.width)));
     });
     observer.observe(ref.current);
-    return () => observer.disconnect();
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", resize);
+    };
   }, []);
-  return { ref, width };
+  return { ref, width, viewportHeight };
 }
 
 /** Keep docked plots readable as the resizable Simulation workspace grows. */
-export function responsiveWaveformHeight(width: number): number {
-  return Math.round(Math.min(440, Math.max(320, width * 0.52)));
+export function responsiveWaveformHeight(
+  width: number,
+  viewportHeight = Infinity,
+): number {
+  // Leave room for editor chrome, result navigation, title and plot controls.
+  return Math.round(
+    Math.max(320, Math.min(600, width * 0.52, viewportHeight - 400)),
+  );
 }
 
 export interface WaveformPoint {

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -245,16 +245,31 @@
 }
 
 .spice-simulation-surface.maximized {
+  /* Full-width chrome; one shared, centered content rail below it. */
+  --simulation-content-inset: max(24px, calc((100% - 1600px) / 2));
   border-right: 0;
 }
 
 .spice-simulation-surface.maximized .simulation-taskbar {
-  grid-template-columns: minmax(140px, 1fr) auto minmax(140px, 1fr);
+  grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
+  gap: 24px;
+  padding: 10px 24px;
 }
 
 .spice-simulation-surface.maximized .simulation-task-actions {
-  justify-self: center;
+  justify-self: stretch;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.spice-simulation-surface.maximized .simulation-setup-menu {
+  flex-basis: 180px;
+}
+
+.spice-simulation-surface.maximized .simulation-task-actions > button {
+  min-height: 30px;
+  padding-inline: 10px;
 }
 
 .spice-simulation-surface.maximized .simulation-window-actions {
@@ -267,16 +282,46 @@
   margin-inline: auto;
 }
 
-.spice-simulation-surface.maximized .simulation-results-body > * {
+.spice-simulation-surface.maximized .simulation-results-body {
   box-sizing: border-box;
-  width: min(100%, 1440px);
-  margin-inline: auto;
+  padding: 18px var(--simulation-content-inset) 28px;
+  scrollbar-gutter: stable both-edges;
 }
 
 .spice-simulation-surface.maximized .simulation-results-header {
   box-sizing: border-box;
-  width: min(calc(100% - 32px), 1440px);
-  margin-inline: auto;
+  width: 100%;
+  margin: 0;
+  padding: 8px 24px;
+  background: var(--icm-surface);
+}
+
+.spice-simulation-surface.maximized
+  .simulation-analysis-card:has(.simulation-plot-layout)
+  > .simulation-analysis-card-header {
+  /* Center over the waveform, not waveform + the 108px signal rail. */
+  padding-left: 116px;
+}
+
+@media (max-width: 700px) {
+  .spice-simulation-surface.maximized {
+    --simulation-content-inset: 12px;
+  }
+
+  .spice-simulation-surface.maximized .simulation-taskbar {
+    gap: 8px;
+    padding-inline: 12px;
+  }
+
+  .spice-simulation-surface.maximized .simulation-results-header {
+    padding-inline: 12px;
+  }
+
+  .spice-simulation-surface.maximized
+    .simulation-analysis-card:has(.simulation-plot-layout)
+    > .simulation-analysis-card-header {
+    padding-left: 0;
+  }
 }
 
 .simulation-workspace-notice {


### PR DESCRIPTION
## Summary
- Full-width Simulation actions and result navigation replace the constrained maximized header.
- One centered content rail aligns plot titles and AC mode controls with waveforms.
- Plot proportions adapt to width and viewport height while preserving the reserved auto-hiding tools row.

## Validation
- Frozen dependency install and static preflight completed; corrected test tuple typing and reran typecheck successfully.
- Workspace unit: 2857 passed, 23 skipped; final affected waveform/explorer contracts: 11 passed.
- Selected agent/browser workflows: 6 passed, including geometry assertions at 1440x1080, 1920x1080, and 1440x800. Screenshots inspected.
- Editor build and diff checks passed.
- No persisted, electrical, or simulation API changes. Preview-only delivery via main; no production release requested.

Test-Impact: tests-updated