### PR TITLE
Fix voltage-source polarity after rotation and mirror

### DIFF
--- a/apps/editor/src/features/component-insert/component-placement-preview.tsx
+++ b/apps/editor/src/features/component-insert/component-placement-preview.tsx
@@ -65,6 +65,10 @@ export function ComponentPlacementPreview({
               definition,
               variant?.hiddenPrimitiveParts,
               variant?.additionalPrimitives,
+              razaviTextbookProfile,
+              undefined,
+              undefined,
+              { rotation, mirror },
             ) + formula,
         }}
       />

--- a/apps/editor/src/features/component-insert/symbol-artwork.test.tsx
+++ b/apps/editor/src/features/component-insert/symbol-artwork.test.tsx
@@ -96,6 +96,29 @@ describe("SymbolArtwork pin-name previews", () => {
     );
   });
 
+  it("keeps voltage-source polarity notation upright in a rotated mirrored placement preview", () => {
+    const symbol = requireRazaviCatalogSymbol("voltage-source");
+    const markup = renderToStaticMarkup(
+      <svg>
+        <ComponentPlacementPreview
+          styleProfileId="razavi-textbook-v1"
+          symbolId={symbol.id}
+          symbol={symbol}
+          position={{ x: 100, y: 80 }}
+          rotation={90}
+          mirror="x"
+        />
+      </svg>,
+    );
+
+    expect(markup).toContain(
+      'transform="translate(100 80) rotate(90) scale(-1 1)"',
+    );
+    expect(markup).toContain(
+      'data-part="upright-polarity-negative" x1="-15.988372" y1="17.44186" x2="-15.988372" y2="9.302326"',
+    );
+  });
+
   it.each([0, 90, 180, 270] as const)(
     "keeps visible pin names and Q-bar upright at %d degrees",
     (rotation) => {

--- a/apps/editor/src/features/component-insert/symbol-artwork.tsx
+++ b/apps/editor/src/features/component-insert/symbol-artwork.tsx
@@ -99,6 +99,10 @@ export function SymbolArtwork({
               symbol,
               variant?.hiddenPrimitiveParts,
               variant?.additionalPrimitives,
+              razaviTextbookProfile,
+              undefined,
+              undefined,
+              { rotation: previewRotation, mirror: "none" },
             ) + formula,
         }}
       />

--- a/packages/render-svg/src/instance-style-render.test.ts
+++ b/packages/render-svg/src/instance-style-render.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { createEmptyDocument, createRoutePath } from "@icm/model";
+import {
+  createEmptyDocument,
+  createRoutePath,
+  transformPoint,
+} from "@icm/model";
 import {
   ANALOG_CANVAS_MATH_PROFILE_ID,
   clearFormulaArtifactCacheForTests,
@@ -12,6 +16,61 @@ import { renderDocumentSvg, buildSvgScene } from "./render.js";
 const resolver = new InMemorySymbolResolver(builtInSymbols);
 
 describe("instance style override rendering", () => {
+  it("keeps a voltage source minus horizontal without moving or resizing it", () => {
+    const originalCenter = { x: -15.988372, y: 13.372093 };
+    const originalLength = 8.139534;
+    for (const rotation of [0, 90, 180, 270] as const) {
+      for (const mirror of ["none", "x"] as const) {
+        const placement = {
+          position: { x: 100, y: 80 },
+          rotation,
+          mirror,
+        };
+        const doc = createEmptyDocument("doc-1", "Voltage source polarity");
+        doc.instances.push({
+          id: "V1",
+          symbolId: "voltage-source",
+          placement,
+        });
+
+        const svg = renderDocumentSvg(doc, resolver);
+        const match = svg.match(
+          /<line data-part="upright-polarity-negative" x1="([^"]+)" y1="([^"]+)" x2="([^"]+)" y2="([^"]+)"/u,
+        );
+        expect(match).not.toBeNull();
+        const localStart = { x: Number(match![1]), y: Number(match![2]) };
+        const localEnd = { x: Number(match![3]), y: Number(match![4]) };
+        const worldStart = transformPoint(
+          localStart,
+          placement.position,
+          placement,
+        );
+        const worldEnd = transformPoint(
+          localEnd,
+          placement.position,
+          placement,
+        );
+        const worldCenter = {
+          x: (worldStart.x + worldEnd.x) / 2,
+          y: (worldStart.y + worldEnd.y) / 2,
+        };
+
+        expect(worldStart.y).toBeCloseTo(worldEnd.y, 6);
+        expect(Math.abs(worldEnd.x - worldStart.x)).toBeCloseTo(
+          originalLength,
+          6,
+        );
+        const expectedCenter = transformPoint(
+          originalCenter,
+          placement.position,
+          placement,
+        );
+        expect(worldCenter.x).toBeCloseTo(expectedCenter.x, 6);
+        expect(worldCenter.y).toBeCloseTo(expectedCenter.y, 6);
+      }
+    }
+  });
+
   it("inherits default text fill without a CSS rule overriding authored text colors", () => {
     const svg = renderDocumentSvg(
       createEmptyDocument("doc", "Colors"),

--- a/packages/render-svg/src/render.ts
+++ b/packages/render-svg/src/render.ts
@@ -2,6 +2,7 @@ import { arrowArtwork, arrowPathData } from "@icm/derived";
 import {
   RectSchema,
   SchematicDocumentSchema,
+  inverseTransformPoint,
   semanticTextDocument,
   transformPoint,
 } from "@icm/model";
@@ -41,6 +42,7 @@ import type {
   DerivedRect,
   DraftingObject,
   GridRect,
+  Orientation,
   Point,
   RichTextDocument,
   RichTextRun,
@@ -279,21 +281,69 @@ function renderPrimitive(
   primitive: SymbolPrimitive,
   profile: SchematicStyleProfile,
   foregroundOverride?: string,
+  orientation?: Pick<Orientation, "rotation" | "mirror">,
 ): string {
   const fg = foregroundOverride ?? profile.foreground;
   const style = primitiveStyle(primitive, profile);
-  switch (primitive.kind) {
+  const rendered = screenUprightPrimitive(primitive, orientation);
+  const uprightPart = rendered.part?.startsWith("upright-")
+    ? ` data-part="${escapeXml(rendered.part)}"`
+    : "";
+  switch (rendered.kind) {
     case "line":
-      return `<line x1="${primitive.from.x}" y1="${primitive.from.y}" x2="${primitive.to.x}" y2="${primitive.to.y}"${style}/>`;
+      return `<line${uprightPart} x1="${rendered.from.x}" y1="${rendered.from.y}" x2="${rendered.to.x}" y2="${rendered.to.y}"${style}/>`;
     case "polyline":
-      return `<polyline points="${pointList(primitive.points)}"${style}/>`;
+      return `<polyline points="${pointList(rendered.points)}"${style}/>`;
     case "circle":
-      return `<circle cx="${primitive.center.x}" cy="${primitive.center.y}" r="${primitive.radius}"${primitive.fill === undefined ? "" : ` fill="${primitive.fill === "foreground" ? fg : "none"}"`}${primitive.stroke === undefined ? "" : ` stroke="${primitive.stroke === "foreground" ? fg : "none"}"`}${style}/>`;
+      return `<circle cx="${rendered.center.x}" cy="${rendered.center.y}" r="${rendered.radius}"${rendered.fill === undefined ? "" : ` fill="${rendered.fill === "foreground" ? fg : "none"}"`}${rendered.stroke === undefined ? "" : ` stroke="${rendered.stroke === "foreground" ? fg : "none"}"`}${style}/>`;
     case "path":
-      return `<path d="${escapeXml(primitive.data)}"${style}/>`;
+      return `<path d="${escapeXml(rendered.data)}"${style}/>`;
     case "polygon":
-      return `<polygon points="${pointList(primitive.points)}" fill="${primitive.fill === "foreground" ? fg : "none"}"${primitive.stroke === undefined ? "" : ` stroke="${primitive.stroke === "foreground" ? fg : "none"}"`}${style}/>`;
+      return `<polygon points="${pointList(rendered.points)}" fill="${rendered.fill === "foreground" ? fg : "none"}"${rendered.stroke === undefined ? "" : ` stroke="${rendered.stroke === "foreground" ? fg : "none"}"`}${style}/>`;
   }
+}
+
+/**
+ * Polarity marks are notation, not device geometry: they move with a source,
+ * but a minus sign remains horizontal on the page. Pre-apply the inverse of
+ * the instance orientation around each marked line's centre; the parent SVG
+ * transform then restores the centre while cancelling rotation and mirror.
+ */
+function screenUprightPrimitive(
+  primitive: SymbolPrimitive,
+  orientation?: Pick<Orientation, "rotation" | "mirror">,
+): SymbolPrimitive {
+  if (
+    primitive.kind !== "line" ||
+    !primitive.part?.startsWith("upright-") ||
+    orientation === undefined
+  ) {
+    return primitive;
+  }
+  const center = {
+    x: (primitive.from.x + primitive.to.x) / 2,
+    y: (primitive.from.y + primitive.to.y) / 2,
+  };
+  const canonicalCoordinate = (value: number): number => {
+    const rounded = Math.round(value * 1_000_000) / 1_000_000;
+    return Object.is(rounded, -0) ? 0 : rounded;
+  };
+  const inverseVector = (point: Point): Point => {
+    const unrotated = inverseTransformPoint(
+      { x: point.x - center.x, y: point.y - center.y },
+      { x: 0, y: 0 },
+      orientation,
+    );
+    return {
+      x: canonicalCoordinate(center.x + unrotated.x),
+      y: canonicalCoordinate(center.y + unrotated.y),
+    };
+  };
+  return {
+    ...primitive,
+    from: inverseVector(primitive.from),
+    to: inverseVector(primitive.to),
+  };
 }
 
 function signalFlowFramePoints(body: {
@@ -325,6 +375,7 @@ export function renderSymbolDefinitionBody(
   profile: SchematicStyleProfile = razaviTextbookProfile,
   foregroundOverride?: string,
   signalFlowParameters?: SignalFlowLayoutParameters,
+  orientation?: Pick<Orientation, "rotation" | "mirror">,
 ): string {
   const adaptive = resolveAdaptiveSignalFlowBlockLayout(
     definition,
@@ -350,7 +401,9 @@ export function renderSymbolDefinitionBody(
   const hidden = new Set(hiddenPrimitiveParts);
   return [...definition.primitives, ...additionalPrimitives]
     .filter((primitive) => !primitive.part || !hidden.has(primitive.part))
-    .map((primitive) => renderPrimitive(primitive, profile, foregroundOverride))
+    .map((primitive) =>
+      renderPrimitive(primitive, profile, foregroundOverride, orientation),
+    )
     .join("");
 }
 
@@ -401,6 +454,7 @@ export function renderInstanceOutlineGeometry(
         profile,
         undefined,
         instance.signalFlowParameters,
+        instance.placement ?? undefined,
       );
       return `<g data-object-id="${escapeXml(instance.id)}"><g transform="${instanceTransform(instance)}">${primitives}</g></g>`;
     })
@@ -932,6 +986,7 @@ export function buildSvgScene(
         profile,
         foregroundOverride,
         instance.signalFlowParameters,
+        instance.placement ?? undefined,
       );
       const pinNames = renderVisiblePinNames(
         resolved.definition,
@@ -1594,6 +1649,9 @@ function renderFloatingSymbol(
     hidden,
     additional,
     profile,
+    undefined,
+    undefined,
+    object.transform,
   );
   return `<g data-object-id="${object.id}" data-kind="draft-floating-symbol"${unresolved} data-symbol-id="${escapeXml(object.symbolId)}"><g transform="translate(${position.x} ${position.y}) rotate(${rotation})${mirror}">${body}</g></g>`;
 }

--- a/packages/symbols/assets/razavi-v1/catalog.json
+++ b/packages/symbols/assets/razavi-v1/catalog.json
@@ -1327,7 +1327,7 @@
       "palette": true,
       "automaticMappings": ["spice:V"],
       "assetPath": "voltage-source.symbol.json",
-      "assetHash": "9f295fd28893155c8e3e73f26fd5f858f99a54b77b1917720ee2fbb02fb2942c",
+      "assetHash": "2feeef8f7e425cc38ba9de64ed9b81333ec4c53c3c553a030264c22a919e5402",
       "visualAuthority": {
         "kind": "razavi-reference-v1",
         "referenceManifestPath": "fixtures/visual-reference/razavi-reference-v1/manifest.json",
@@ -1341,7 +1341,7 @@
         "referenceManifestPath": "fixtures/visual-reference/razavi-reference-v1/manifest.json",
         "referencePath": "fixtures/visual-reference/razavi-reference-v1/razavi-six-panel.png",
         "converterPath": "scripts/generate-razavi-peripheral-assets.mjs",
-        "converterVersion": 1
+        "converterVersion": 2
       }
     },
     {

--- a/packages/symbols/assets/razavi-v1/voltage-source.symbol.json
+++ b/packages/symbols/assets/razavi-v1/voltage-source.symbol.json
@@ -60,6 +60,7 @@
         "x": -11.918605,
         "y": -14.534884
       },
+      "part": "upright-polarity-positive-horizontal",
       "style": {
         "strokeRole": "normal",
         "lineCap": "butt",
@@ -76,6 +77,7 @@
         "x": -15.988372,
         "y": -10.465117
       },
+      "part": "upright-polarity-positive-vertical",
       "style": {
         "strokeRole": "normal",
         "lineCap": "butt",
@@ -92,6 +94,7 @@
         "x": -11.918605,
         "y": 13.372093
       },
+      "part": "upright-polarity-negative",
       "style": {
         "strokeRole": "normal",
         "lineCap": "butt",

--- a/packages/symbols/src/razavi-catalog.generated.ts
+++ b/packages/symbols/src/razavi-catalog.generated.ts
@@ -1586,7 +1586,7 @@ export const razaviSymbolCatalogEntries: readonly RazaviSymbolCatalogEntry[] = [
     automaticMappings: ["spice:V"],
     assetPath: "voltage-source.symbol.json",
     assetHash:
-      "9f295fd28893155c8e3e73f26fd5f858f99a54b77b1917720ee2fbb02fb2942c",
+      "2feeef8f7e425cc38ba9de64ed9b81333ec4c53c3c553a030264c22a919e5402",
     visualAuthority: {
       kind: "razavi-reference-v1",
       referenceManifestPath:
@@ -1604,7 +1604,7 @@ export const razaviSymbolCatalogEntries: readonly RazaviSymbolCatalogEntry[] = [
       referencePath:
         "fixtures/visual-reference/razavi-reference-v1/razavi-six-panel.png",
       converterPath: "scripts/generate-razavi-peripheral-assets.mjs",
-      converterVersion: 1,
+      converterVersion: 2,
     },
   },
   {
@@ -9579,6 +9579,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
           x: -11.918605,
           y: -14.534884,
         },
+        part: "upright-polarity-positive-horizontal",
         style: {
           strokeRole: "normal",
           lineCap: "butt",
@@ -9595,6 +9596,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
           x: -15.988372,
           y: -10.465117,
         },
+        part: "upright-polarity-positive-vertical",
         style: {
           strokeRole: "normal",
           lineCap: "butt",
@@ -9611,6 +9613,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
           x: -11.918605,
           y: 13.372093,
         },
+        part: "upright-polarity-negative",
         style: {
           strokeRole: "normal",
           lineCap: "butt",

--- a/packages/symbols/src/razavi-catalog.test.ts
+++ b/packages/symbols/src/razavi-catalog.test.ts
@@ -1491,16 +1491,19 @@ describe("Razavi symbol catalog", () => {
         }),
         expect.objectContaining({
           kind: "line",
+          part: "upright-polarity-positive-horizontal",
           from: { x: -20.058139, y: -14.534884 },
           to: { x: -11.918605, y: -14.534884 },
         }),
         expect.objectContaining({
           kind: "line",
+          part: "upright-polarity-positive-vertical",
           from: { x: -15.988372, y: -18.604651 },
           to: { x: -15.988372, y: -10.465117 },
         }),
         expect.objectContaining({
           kind: "line",
+          part: "upright-polarity-negative",
           from: { x: -20.058139, y: 13.372093 },
           to: { x: -11.918605, y: 13.372093 },
         }),

--- a/scripts/generate-razavi-peripheral-assets.mjs
+++ b/scripts/generate-razavi-peripheral-assets.mjs
@@ -37,9 +37,15 @@ function logical(measurement, point) {
   };
 }
 
-function line(from, to, style = normal) {
+function line(from, to, style = normal, part) {
   const clean = (point) => ({ x: rounded(point.x), y: rounded(point.y) });
-  return { kind: "line", from: clean(from), to: clean(to), style };
+  return {
+    kind: "line",
+    from: clean(from),
+    to: clean(to),
+    ...(part === undefined ? {} : { part }),
+    style,
+  };
 }
 
 function polyline(points, style = normal) {
@@ -89,14 +95,20 @@ function voltageSource(measurement) {
       line(
         { x: plus.x - halfWidth, y: plus.y },
         { x: plus.x + halfWidth, y: plus.y },
+        normal,
+        "upright-polarity-positive-horizontal",
       ),
       line(
         { x: plus.x, y: plus.y - halfHeight },
         { x: plus.x, y: plus.y + halfHeight },
+        normal,
+        "upright-polarity-positive-vertical",
       ),
       line(
         { x: minus.x - halfWidth, y: minus.y },
         { x: minus.x + halfWidth, y: minus.y },
+        normal,
+        "upright-polarity-negative",
       ),
       line({ x: 0, y: -radius }, { x: 0, y: -20 }),
       line({ x: 0, y: radius }, { x: 0, y: 20 }),
@@ -315,7 +327,7 @@ for (const symbol of symbols) {
           referencePath:
             "fixtures/visual-reference/razavi-reference-v1/razavi-six-panel.png",
           converterPath: "scripts/generate-razavi-peripheral-assets.mjs",
-          converterVersion: 1,
+          converterVersion: symbol.id === "voltage-source" ? 2 : 1,
         };
 }
 const catalogSource = normalize(


### PR DESCRIPTION
## Summary
- keep the independent voltage source's plus/minus notation upright after rotation and mirroring
- preserve the calibrated polarity centers, stroke lengths, spacing, widths, circle, and leads
- apply the same orientation rule to placed scenes, selection outlines, insertion previews, and exported SVG

## Validation
- pnpm test:local apps/editor/src/features/component-insert/symbol-artwork.test.tsx packages/render-svg/src/instance-style-render.test.ts packages/symbols/src/razavi-catalog.test.ts
- pnpm symbols:razavi-peripherals:check
- pnpm typecheck
- pnpm gate:preflight -- --base origin/main
- pnpm gate:full (430 unit test files / 2860 tests; build, release, performance, visual and export goldens; 360 browser tests)
- git diff --check

Fixes #650