### PR TITLE
fix(simulation): compact settings and preserve PNG plot styles

### DIFF
--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -46,6 +46,69 @@ const ota = JSON.parse(
   ),
 );
 
+test("plot PNG export retains every curve when the source charts rerender", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await expect(page.getByTestId("schematic-canvas")).toBeVisible();
+  const bytes = await page.evaluate(async () => {
+    const plotModule = "/src/features/simulation/ac-response-plot.ts";
+    const exportModule = "/src/features/simulation/simulation-plot-export.ts";
+    const { acResponseSvg } = await import(plotModule);
+    const { buildVisibleSimulationPlotDownload } = await import(exportModule);
+    const root = document.createElement("div");
+    document.body.append(root);
+    const points = [1, 10, 100, 1000, 10000].map((frequency, index) => ({
+      frequency,
+      real: 1,
+      imaginary: 0,
+      magnitude: [0, 1, 0.2, 0.8, 0][index],
+      magnitudeDb: [0, 20, 4, 16, 0][index],
+      phaseDeg: [0, -90, -20, -70, 0][index],
+    }));
+    root.innerHTML = ["db20", "phase"]
+      .map((kind) =>
+        acResponseSvg(
+          [{ label: "v(out)", unit: "V", points }],
+          { width: 600, height: 340 },
+          { kind },
+        ),
+      )
+      .join("");
+    try {
+      const pending = buildVisibleSimulationPlotDownload(root, "png");
+      // Busy-state/plot updates replace innerHTML while the first image decodes.
+      // The second chart must not read styles from its now-detached SVG.
+      root.replaceChildren();
+      return Array.from((await pending).bytes as Uint8Array);
+    } finally {
+      root.remove();
+    }
+  });
+  const entries = unzipSync(Uint8Array.from(bytes));
+  expect(Object.keys(entries)).toHaveLength(2);
+  for (const [name, bytes] of Object.entries(entries)) {
+    await test
+      .info()
+      .attach(name, { body: Buffer.from(bytes), contentType: "image/png" });
+    const png = PNG.sync.read(Buffer.from(bytes));
+    let blue = 0;
+    let dark = 0;
+    for (let index = 0; index < png.data.length; index += 4) {
+      const r = png.data[index]!;
+      const g = png.data[index + 1]!;
+      const b = png.data[index + 2]!;
+      if (b > 140 && r < 60 && g > 60 && g < 140) blue++;
+      if (r < 32 && g < 32 && b < 32) dark++;
+    }
+    expect(blue, `${name}: curve remains visible`).toBeGreaterThan(500);
+    expect(
+      dark / (png.width * png.height),
+      `${name}: no filled black region`,
+    ).toBeLessThan(0.03);
+  }
+});
+
 test("the qualified OTA setup opens unchanged and preserves all root and hierarchical outputs", async ({
   page,
 }) => {
@@ -573,6 +636,50 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   await panel.getByLabel("Start (Hz)").last().fill("1");
   await panel.getByLabel("Stop (Hz)").last().fill("1000000");
   await panel.getByLabel(/Output name for/).fill("first-output");
+  const analysisBoxes = await panel
+    .locator(".simulation-analysis-options > label")
+    .all();
+  const firstAnalysisBox = (await analysisBoxes[0]!.boundingBox())!;
+  expect(analysisBoxes).toHaveLength(5);
+  for (const option of analysisBoxes) {
+    expect((await option.boundingBox())!.y).toBeCloseTo(firstAnalysisBox.y, 0);
+  }
+  await panel
+    .locator('details[aria-label="Measurements settings"] > summary')
+    .click();
+  const measurementEditor = panel.locator(".simulation-measurement-editor");
+  await measurementEditor
+    .getByRole("button", { name: "Add measurement" })
+    .click();
+  await measurementEditor
+    .getByLabel("Name", { exact: true })
+    .fill("Peak output");
+  await measurementEditor
+    .getByRole("combobox", { name: "Analysis", exact: true })
+    .selectOption("tran");
+  await measurementEditor
+    .getByRole("combobox", { name: "Measure", exact: true })
+    .selectOption("rms");
+  await measurementEditor.getByLabel("Window stop / SI").fill("1e-6");
+  const addBox = (await measurementEditor
+    .getByRole("button", { name: "Add measurement" })
+    .boundingBox())!;
+  const removeBox = (await measurementEditor
+    .getByRole("button", { name: "Remove measurement" })
+    .boundingBox())!;
+  expect(addBox.y).toBeCloseTo(removeBox.y, 0);
+  expect(
+    await measurementEditor.evaluate(
+      (element) => element.scrollWidth <= element.clientWidth,
+    ),
+  ).toBe(true);
+  await measurementEditor.screenshot({
+    path: test.info().outputPath("measurement-settings.png"),
+  });
+  await measurementEditor
+    .getByRole("button", { name: "Remove measurement" })
+    .click();
+  await expect(measurementEditor.locator("fieldset")).toHaveCount(0);
   await panel.getByRole("button", { name: "Apply setup" }).click();
   await panel.getByRole("button", { name: "Run", exact: true }).click();
   await expect.poll(() => executions).toBe(1);

--- a/apps/editor/src/features/simulation/simulation-measurement-editor.tsx
+++ b/apps/editor/src/features/simulation/simulation-measurement-editor.tsx
@@ -75,13 +75,36 @@ export function SimulationMeasurementEditor({
       ),
     );
   const canAdd = analyses.length > 0 && outputs.length > 0;
+  const addButton = (
+    <button
+      type="button"
+      aria-label="Add measurement"
+      disabled={!canAdd}
+      onClick={() => {
+        const analysis = analyses[0]!;
+        const output = outputs[0]!;
+        onChange([
+          ...measurements,
+          {
+            id: `measurement-${crypto.randomUUID()}`,
+            label: `Measurement ${measurements.length + 1}`,
+            analysis,
+            outputId: output.id,
+            method: defaultMethod(analysis),
+          },
+        ]);
+      }}
+    >
+      Add
+    </button>
+  );
 
   return (
     <div className="simulation-measurement-editor">
       {!outputs.length ? (
         <small>Add an Output signal before defining a measurement.</small>
       ) : null}
-      {measurements.map((measurement) => {
+      {measurements.map((measurement, index) => {
         const method = measurement.method;
         const window = methodWindow(method);
         const supportsOptionalWindow =
@@ -94,20 +117,22 @@ export function SimulationMeasurementEditor({
             key={measurement.id}
             className="simulation-measurement-rule"
           >
-            <legend>{measurement.label || "Measurement"}</legend>
-            <label>
-              Name
-              <input
-                value={measurement.label}
-                onChange={(event) =>
-                  update(measurement.id, (current) => ({
-                    ...current,
-                    label: event.currentTarget.value,
-                  }))
-                }
-              />
-            </label>
-            <div className="simulation-inline-fields columns-2">
+            <legend className="simulation-visually-hidden">
+              {measurement.label || "Measurement"}
+            </legend>
+            <div className="simulation-measurement-fields">
+              <label>
+                Name
+                <input
+                  value={measurement.label}
+                  onChange={(event) =>
+                    update(measurement.id, (current) => ({
+                      ...current,
+                      label: event.currentTarget.value,
+                    }))
+                  }
+                />
+              </label>
               <label>
                 Analysis
                 <select
@@ -146,155 +171,141 @@ export function SimulationMeasurementEditor({
                   ))}
                 </select>
               </label>
-            </div>
-            <label>
-              Measure
-              <select
-                value={method.kind}
-                onChange={(event) => {
-                  const kind = event.currentTarget
-                    .value as keyof typeof METHOD_LABELS;
-                  const nextMethod: SimulationMeasurementMethod =
-                    kind === "sample-at"
-                      ? { kind, coordinate: 0 }
-                      : kind === "mean" || kind === "rms"
-                        ? { kind, window: { start: 0, stop: 1 } }
-                        : kind === "value"
-                          ? { kind }
-                          : { kind };
-                  update(measurement.id, (current) => ({
-                    ...current,
-                    method: nextMethod,
-                  }));
-                }}
-              >
-                {methodsFor(measurement.analysis).map((kind) => (
-                  <option key={kind} value={kind}>
-                    {METHOD_LABELS[kind]}
-                  </option>
-                ))}
-              </select>
-            </label>
-            {method.kind === "sample-at" ? (
               <label>
-                {coordinateLabel(measurement.analysis)}
-                <input
-                  type="number"
-                  step="any"
-                  value={method.coordinate}
-                  onChange={(event) =>
-                    update(measurement.id, (current) => ({
-                      ...current,
-                      method: {
-                        kind: "sample-at",
-                        coordinate: Number(event.currentTarget.value),
-                      },
-                    }))
-                  }
-                />
-              </label>
-            ) : null}
-            {supportsOptionalWindow ? (
-              <label>
-                Range
+                Measure
                 <select
-                  value={showWindow ? "window" : "all"}
+                  value={method.kind}
                   onChange={(event) => {
-                    const useWindow = event.currentTarget.value === "window";
+                    const kind = event.currentTarget
+                      .value as keyof typeof METHOD_LABELS;
+                    const nextMethod: SimulationMeasurementMethod =
+                      kind === "sample-at"
+                        ? { kind, coordinate: 0 }
+                        : kind === "mean" || kind === "rms"
+                          ? { kind, window: { start: 0, stop: 1 } }
+                          : kind === "value"
+                            ? { kind }
+                            : { kind };
                     update(measurement.id, (current) => ({
                       ...current,
-                      method: {
-                        kind: method.kind,
-                        ...(useWindow ? { window: { start: 0, stop: 1 } } : {}),
-                      },
+                      method: nextMethod,
                     }));
                   }}
                 >
-                  <option value="all">Entire analysis</option>
-                  <option value="window">Window</option>
+                  {methodsFor(measurement.analysis).map((kind) => (
+                    <option key={kind} value={kind}>
+                      {METHOD_LABELS[kind]}
+                    </option>
+                  ))}
                 </select>
               </label>
-            ) : null}
-            {showWindow ? (
-              <div className="simulation-inline-fields columns-2">
+              {method.kind === "sample-at" ? (
                 <label>
-                  Window start / SI
+                  {coordinateLabel(measurement.analysis)}
                   <input
                     type="number"
                     step="any"
-                    value={window?.start ?? 0}
+                    value={method.coordinate}
                     onChange={(event) =>
                       update(measurement.id, (current) => ({
                         ...current,
                         method: {
-                          ...current.method,
-                          window: {
-                            start: Number(event.currentTarget.value),
-                            stop: methodWindow(current.method)?.stop ?? 1,
-                          },
-                        } as SimulationMeasurementMethod,
+                          kind: "sample-at",
+                          coordinate: Number(event.currentTarget.value),
+                        },
                       }))
                     }
                   />
                 </label>
+              ) : null}
+              {supportsOptionalWindow ? (
                 <label>
-                  Window stop / SI
-                  <input
-                    type="number"
-                    step="any"
-                    value={window?.stop ?? 1}
-                    onChange={(event) =>
+                  Range
+                  <select
+                    value={showWindow ? "window" : "all"}
+                    onChange={(event) => {
+                      const useWindow = event.currentTarget.value === "window";
                       update(measurement.id, (current) => ({
                         ...current,
                         method: {
-                          ...current.method,
-                          window: {
-                            start: methodWindow(current.method)?.start ?? 0,
-                            stop: Number(event.currentTarget.value),
-                          },
-                        } as SimulationMeasurementMethod,
-                      }))
-                    }
-                  />
+                          kind: method.kind,
+                          ...(useWindow
+                            ? { window: { start: 0, stop: 1 } }
+                            : {}),
+                        },
+                      }));
+                    }}
+                  >
+                    <option value="all">Entire analysis</option>
+                    <option value="window">Window</option>
+                  </select>
                 </label>
-              </div>
-            ) : null}
-            <button
-              type="button"
-              onClick={() =>
-                onChange(
-                  measurements.filter(
-                    (candidate) => candidate.id !== measurement.id,
-                  ),
-                )
-              }
-            >
-              Remove measurement
-            </button>
+              ) : null}
+              {showWindow ? (
+                <div className="simulation-inline-fields columns-2">
+                  <label>
+                    Window start / SI
+                    <input
+                      type="number"
+                      step="any"
+                      value={window?.start ?? 0}
+                      onChange={(event) =>
+                        update(measurement.id, (current) => ({
+                          ...current,
+                          method: {
+                            ...current.method,
+                            window: {
+                              start: Number(event.currentTarget.value),
+                              stop: methodWindow(current.method)?.stop ?? 1,
+                            },
+                          } as SimulationMeasurementMethod,
+                        }))
+                      }
+                    />
+                  </label>
+                  <label>
+                    Window stop / SI
+                    <input
+                      type="number"
+                      step="any"
+                      value={window?.stop ?? 1}
+                      onChange={(event) =>
+                        update(measurement.id, (current) => ({
+                          ...current,
+                          method: {
+                            ...current.method,
+                            window: {
+                              start: methodWindow(current.method)?.start ?? 0,
+                              stop: Number(event.currentTarget.value),
+                            },
+                          } as SimulationMeasurementMethod,
+                        }))
+                      }
+                    />
+                  </label>
+                </div>
+              ) : null}
+            </div>
+            <div className="simulation-measurement-actions">
+              <button
+                type="button"
+                aria-label="Remove measurement"
+                onClick={() =>
+                  onChange(
+                    measurements.filter(
+                      (candidate) => candidate.id !== measurement.id,
+                    ),
+                  )
+                }
+              >
+                Remove
+              </button>
+              {index === measurements.length - 1 ? addButton : null}
+            </div>
           </fieldset>
         );
       })}
-      <button
-        type="button"
-        disabled={!canAdd}
-        onClick={() => {
-          const analysis = analyses[0]!;
-          const output = outputs[0]!;
-          const ordinal = measurements.length + 1;
-          onChange([
-            ...measurements,
-            {
-              id: `measurement-${crypto.randomUUID()}`,
-              label: `Measurement ${ordinal}`,
-              analysis,
-              outputId: output.id,
-              method: defaultMethod(analysis),
-            },
-          ]);
-        }}
-      >
-        Add measurement
-      </button>
+      {!measurements.length ? addButton : null}
     </div>
   );
 }

--- a/apps/editor/src/features/simulation/simulation-plot-export.ts
+++ b/apps/editor/src/features/simulation/simulation-plot-export.ts
@@ -69,13 +69,6 @@ export function standaloneSimulationPlotSvg(svg: SVGSVGElement): string {
   clone
     .querySelectorAll(".ac-trace-hit, .ac-cursor-hit")
     .forEach((element) => element.remove());
-  clone.querySelectorAll<SVGElement>(".ac-frame").forEach((element) => {
-    // The live frame is transparent. Give the standalone artifact an explicit
-    // background because SVG-to-Canvas otherwise resolves `fill: none` to the
-    // inherited default in Chromium and produces a black plot panel.
-    element.setAttribute("fill", "white");
-    element.style.setProperty("fill", "white");
-  });
   const size = dimensions(svg);
   clone.setAttribute("xmlns", "http://www.w3.org/2000/svg");
   clone.setAttribute("width", String(size.width));
@@ -141,12 +134,18 @@ export async function buildVisibleSimulationPlotDownload(
   const plots = [...root.querySelectorAll<SVGSVGElement>("svg[role='img']")];
   if (!plots.length) return null;
   const entries: { name: string; bytes: Uint8Array }[] = [];
-  for (let index = 0; index < plots.length; index++) {
-    const plot = plots[index]!;
+  // Freeze every plot while its nodes still belong to the styled document.
+  // Rasterization yields to React: a busy-state render can replace the SVGs,
+  // after which getComputedStyle on a later plot returns empty presentation.
+  const snapshots = plots.map((plot, index) => {
     const label = plot.getAttribute("aria-label") ?? `Plot ${index + 1}`;
-    const name = `${String(index + 1).padStart(2, "0")}-${safeName(label)}.${format}`;
-    const svg = standaloneSimulationPlotSvg(plot);
-    const size = dimensions(plot);
+    return {
+      name: `${String(index + 1).padStart(2, "0")}-${safeName(label)}.${format}`,
+      svg: standaloneSimulationPlotSvg(plot),
+      size: dimensions(plot),
+    };
+  });
+  for (const { name, svg, size } of snapshots) {
     entries.push({
       name,
       bytes:

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -412,14 +412,34 @@
 }
 .simulation-measurement-rule {
   margin: 0;
+  min-width: 0;
   padding: 8px;
   border: 1px solid var(--icm-border);
   border-radius: var(--icm-radius-sm);
 }
-.simulation-measurement-rule > legend {
-  padding: 0 4px;
+.simulation-measurement-fields {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+.simulation-setup-panel .simulation-measurement-fields > label {
+  grid-template-columns: minmax(0, 1fr);
+  align-content: start;
+  gap: 4px;
+  min-width: 0;
+  margin: 0;
   color: var(--icm-text-muted);
   font-size: var(--icm-font-xs);
+}
+.simulation-measurement-fields > .simulation-inline-fields {
+  grid-column: 1 / -1;
+  margin: 0;
+}
+.simulation-measurement-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 8px;
 }
 .simulation-setup-panel label {
   display: grid;
@@ -567,18 +587,18 @@
 }
 .simulation-analysis-options {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 6px;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 4px;
   min-width: 0;
 }
 .simulation-analysis-options > label {
   display: flex;
-  gap: 5px;
+  gap: 3px;
   justify-content: center;
   min-width: 0;
   min-height: 30px;
   margin: 0;
-  padding: 4px 6px;
+  padding: 4px 2px;
   border: 1px solid var(--icm-border);
   border-radius: var(--icm-radius-sm);
   background: var(--icm-surface-muted);


### PR DESCRIPTION
## Changes
- Align measurement fields in two columns, remove redundant captions, and share a row for Add/Remove.
- Keep all five analysis toggles on one row.
- Capture every plot's computed presentation before asynchronous PNG encoding. React rerenders can otherwise detach later SVGs and produce black filled curves.
- Remove the ineffective frame-fill workaround.

## Validation
- Static contracts and test-impact passed.
- 2858 unit tests passed, 23 skipped.
- All 7 selected Agent/simulation browser tests passed, including detached-chart PNG pixel checks and settings layout/interactions.
- Final typecheck, formatting and diff checks passed.
- No simulation protocol, model, or electrical behavior changes.