### PR TITLE
fix(simulation): use maximized plot space efficiently

### DIFF
--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -1268,6 +1268,16 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
       0,
     );
     await panel.getByRole("tab", { name: "Plot" }).click();
+    const plotCards = panel.locator(
+      ".simulation-plot-view .simulation-output-results > .simulation-analysis-card",
+    );
+    await expect(plotCards).toHaveCount(3);
+    const firstPlotCardBox = (await plotCards.nth(0).boundingBox())!;
+    const secondPlotCardBox = (await plotCards.nth(1).boundingBox())!;
+    expect(secondPlotCardBox.y).toBeCloseTo(firstPlotCardBox.y, 0);
+    expect(secondPlotCardBox.x).toBeGreaterThan(
+      firstPlotCardBox.x + firstPlotCardBox.width,
+    );
     const card = panel
       .locator(".simulation-analysis-card")
       .filter({
@@ -1277,7 +1287,7 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
     const shell = card.locator(".ac-plot-shell").first();
     await expect
       .poll(async () => (await shell.locator("svg").boundingBox())!.height)
-      .toBeGreaterThan(height > 800 ? 440 : 320);
+      .toBeGreaterThan(280);
     const shellBox = (await shell.boundingBox())!;
     const titleBox = (await card
       .locator(".simulation-analysis-card-header h3")
@@ -1288,6 +1298,15 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
       0,
     );
     expect(modeBox.x).toBeCloseTo(shellBox.x, 0);
+    const [resultsHeaderZIndex, plotToolbarZIndex] = await Promise.all([
+      panel
+        .locator(".simulation-results-header")
+        .evaluate((element) => Number(getComputedStyle(element).zIndex)),
+      shell
+        .locator(".ac-plot-toolbar")
+        .evaluate((element) => Number(getComputedStyle(element).zIndex)),
+    ]);
+    expect(resultsHeaderZIndex).toBeGreaterThan(plotToolbarZIndex);
     await expect
       .poll(() =>
         panel

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -922,7 +922,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
           </header>
           <div ref={resultsBodyRef} className="simulation-results-body">
             {resultTab === "plot" ? (
-              <div className="simulation-analysis-view">
+              <div className="simulation-analysis-view simulation-plot-view">
                 {run?.outputData ? (
                   <SimulationOutputResults
                     resultKey={run.id}

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -296,6 +296,41 @@
   background: var(--icm-surface);
 }
 
+@media (min-width: 1100px) {
+  .spice-simulation-surface.maximized .simulation-plot-view,
+  .spice-simulation-surface.maximized
+    .simulation-plot-view
+    > .simulation-output-results {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: start;
+  }
+
+  .spice-simulation-surface.maximized
+    .simulation-plot-view
+    > .simulation-output-results,
+  .spice-simulation-surface.maximized
+    .simulation-plot-view
+    > .simulation-empty-result,
+  .spice-simulation-surface.maximized
+    .simulation-plot-view
+    > .simulation-output-results
+    > .simulation-output-diagnostics,
+  .spice-simulation-surface.maximized
+    .simulation-plot-view
+    > .simulation-output-results
+    > .simulation-measurement-results {
+    grid-column: 1 / -1;
+  }
+
+  .spice-simulation-surface.maximized
+    .simulation-plot-view
+    .simulation-analysis-card
+    + .simulation-analysis-card {
+    padding-top: 0;
+    border-top: 0;
+  }
+}
+
 .spice-simulation-surface.maximized
   .simulation-analysis-card:has(.simulation-plot-layout)
   > .simulation-analysis-card-header {
@@ -385,6 +420,10 @@
   padding: 8px 10px;
   border-bottom: 1px solid var(--icm-border);
   background: var(--icm-surface-muted);
+}
+.simulation-results-header {
+  /* Keep the open Export menu above per-plot toolbars. */
+  z-index: 3;
 }
 .simulation-setup-panel > header > div {
   display: grid;


### PR DESCRIPTION
## Summary
- keep the expanded result Export menu above waveform toolbars
- arrange maximized Plot analysis cards in a responsive two-column grid
- preserve single-column layout for narrow screens and non-plot result tabs

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
- focused human simulation Playwright flow

Test-Impact: tests-updated