### PR TITLE
feat(project): import reusable cells across cloud projects

### DIFF
--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -19,6 +19,7 @@ import type {
 import {
   planCellReset,
   planCreateCell,
+  planProjectCellImport,
   planSetCellSymbolPresentation,
   type CellResetPlan,
   type WireSource,
@@ -188,6 +189,7 @@ import { ExamplesPanel } from "../features/editor-shell/examples-panel";
 import { createGalleryExampleCommands } from "../features/editor-shell/gallery-example-commands";
 import { createEditorNavigationController } from "../features/hierarchy/editor-navigation-controller";
 import { createProjectStructureCommands } from "../features/hierarchy/project-structure-commands";
+import { loadCloudProjectForCellImport } from "../features/hierarchy/cloud-cell-import";
 import type { PublishGalleryDraft } from "../features/editor-shell/publish-gallery-dialog";
 import {
   publishProjectToGallery,
@@ -4762,6 +4764,49 @@ export function App({
                       presentation,
                     ),
                   );
+                },
+                cloudProjects,
+                activeCloudProjectId: cloudBinding?.id ?? null,
+                onLoadCloudProject: loadCloudProjectForCellImport,
+                onImportCloudCell: async (source, sourceDocumentId) => {
+                  const plan = planProjectCellImport(
+                    project,
+                    source,
+                    sourceDocumentId,
+                  );
+                  if (!plan.ok) {
+                    return { ok: false, message: plan.message };
+                  }
+                  if (plan.status === "already-imported") {
+                    setStatus(
+                      "Cell is already imported; opened the existing copy",
+                    );
+                    return {
+                      ok: true,
+                      message: "Cell already imported",
+                      documentId: plan.rootDocumentId,
+                    };
+                  }
+                  const committed = commitStructure(
+                    "import-cloud-cell",
+                    [...plan.edits],
+                    plan.rootDocumentId,
+                  );
+                  if (!committed) {
+                    return {
+                      ok: false,
+                      message:
+                        "Cell import was rejected; refresh and try again",
+                    };
+                  }
+                  setStatus(
+                    `Imported ${plan.importedDocumentIds.length} Cell${plan.importedDocumentIds.length === 1 ? "" : "s"} from ${source.name}`,
+                  );
+                  return {
+                    ok: true,
+                    message: "Cell imported",
+                    documentId: plan.rootDocumentId,
+                  };
                 },
               }
             : null

--- a/apps/editor/src/features/hierarchy/cell-manager-dialog.tsx
+++ b/apps/editor/src/features/hierarchy/cell-manager-dialog.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useState } from "react";
 
 import type {
+  CircuitProject,
   ExternalSubcircuitDefinition,
   CellSymbolPresentation,
   SchematicDocument,
 } from "@icm/model";
+import type { CloudProjectSummary } from "../editor-shell/cloud-projects";
 
 import { CellInterfaceEditor } from "./cell-interface-dialog";
 import { CellSymbolReview } from "./cell-symbol-review";
@@ -39,6 +41,10 @@ export function CellManagerDialog({
   externalDefinitions,
   onSetExternalDefinition,
   onSetSymbolPresentation,
+  cloudProjects,
+  activeCloudProjectId,
+  onLoadCloudProject,
+  onImportCloudCell,
 }: {
   open: boolean;
   cells: readonly CellManagerEntry[];
@@ -69,12 +75,29 @@ export function CellManagerDialog({
     documentId: string,
     presentation: CellSymbolPresentation | null,
   ): void;
+  cloudProjects: readonly CloudProjectSummary[];
+  activeCloudProjectId: string | null;
+  onLoadCloudProject(
+    projectId: string,
+  ): Promise<
+    { ok: true; project: CircuitProject } | { ok: false; message: string }
+  >;
+  onImportCloudCell(
+    source: CircuitProject,
+    documentId: string,
+  ): Promise<{ ok: boolean; message: string; documentId?: string }>;
 }) {
   const [selectedId, setSelectedId] = useState(activeDocumentId);
   const [draftName, setDraftName] = useState("");
   const [creating, setCreating] = useState(false);
   const [renameId, setRenameId] = useState<string | null>(null);
   const [deleteId, setDeleteId] = useState<string | null>(null);
+  const [importing, setImporting] = useState(false);
+  const [importProjectId, setImportProjectId] = useState("");
+  const [importSource, setImportSource] = useState<CircuitProject | null>(null);
+  const [importCellId, setImportCellId] = useState("");
+  const [importBusy, setImportBusy] = useState(false);
+  const [importMessage, setImportMessage] = useState("");
 
   useEffect(() => {
     if (open) {
@@ -85,6 +108,12 @@ export function CellManagerDialog({
     setCreating(false);
     setRenameId(null);
     setDeleteId(null);
+    setImporting(false);
+    setImportProjectId("");
+    setImportSource(null);
+    setImportCellId("");
+    setImportBusy(false);
+    setImportMessage("");
   }, [activeDocumentId, open]);
 
   const selectedEntry =
@@ -100,6 +129,7 @@ export function CellManagerDialog({
     setCreating(false);
     setRenameId(null);
     setDeleteId(null);
+    setImporting(false);
   }
 
   function submitCellName(): void {
@@ -175,6 +205,23 @@ export function CellManagerDialog({
               }}
             >
               New Cell
+            </button>
+            <button
+              type="button"
+              className="cell-manager-new"
+              disabled={cloudProjects.length === 0}
+              onClick={() => {
+                setCreating(false);
+                setRenameId(null);
+                setDeleteId(null);
+                setImporting(true);
+                setImportProjectId("");
+                setImportSource(null);
+                setImportCellId("");
+                setImportMessage("");
+              }}
+            >
+              Import Cell
             </button>
           </aside>
 
@@ -282,14 +329,106 @@ export function CellManagerDialog({
           </div>
         </div>
 
-        {deleteTarget || creating || renameTarget ? (
+        {deleteTarget || creating || renameTarget || importing ? (
           <div
             className="cell-manager-dialog-layer"
             onPointerDown={(event) =>
               event.target === event.currentTarget && dismissActionDialog()
             }
           >
-            {deleteTarget ? (
+            {importing ? (
+              <section
+                className="editor-action-dialog"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="import-cell-dialog-title"
+              >
+                <header className="editor-action-dialog-header">
+                  <p>Project hierarchy</p>
+                  <h2 id="import-cell-dialog-title">Import Cloud Cell</h2>
+                </header>
+                <div className="editor-action-dialog-body">
+                  <label>
+                    Source Project
+                    <select
+                      value={importProjectId}
+                      disabled={importBusy}
+                      onChange={async (event) => {
+                        const projectId = event.target.value;
+                        setImportProjectId(projectId);
+                        setImportSource(null);
+                        setImportCellId("");
+                        setImportMessage("");
+                        if (!projectId) return;
+                        setImportBusy(true);
+                        const loaded = await onLoadCloudProject(projectId);
+                        setImportBusy(false);
+                        if (!loaded.ok) {
+                          setImportMessage(loaded.message);
+                          return;
+                        }
+                        setImportSource(loaded.project);
+                        setImportCellId(loaded.project.topDocumentId);
+                      }}
+                    >
+                      <option value="">Choose a saved Project…</option>
+                      {cloudProjects
+                        .filter((cloud) => cloud.id !== activeCloudProjectId)
+                        .map((cloud) => (
+                          <option key={cloud.id} value={cloud.id}>
+                            {cloud.name}
+                          </option>
+                        ))}
+                    </select>
+                  </label>
+                  <label>
+                    Cell
+                    <select
+                      value={importCellId}
+                      disabled={!importSource || importBusy}
+                      onChange={(event) => setImportCellId(event.target.value)}
+                    >
+                      {(importSource?.documents ?? []).map((document) => (
+                        <option key={document.id} value={document.id}>
+                          {document.name}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  {importMessage ? <p role="status">{importMessage}</p> : null}
+                  <p>
+                    The Cell and its child Cells are copied into this Project.
+                    The source stays unchanged.
+                  </p>
+                </div>
+                <footer className="editor-action-dialog-actions">
+                  <button type="button" onClick={dismissActionDialog}>
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    disabled={!importSource || !importCellId || importBusy}
+                    onClick={async () => {
+                      if (!importSource || !importCellId) return;
+                      setImportBusy(true);
+                      const outcome = await onImportCloudCell(
+                        importSource,
+                        importCellId,
+                      );
+                      setImportBusy(false);
+                      if (!outcome.ok) {
+                        setImportMessage(outcome.message);
+                        return;
+                      }
+                      dismissActionDialog();
+                      if (outcome.documentId) onOpen(outcome.documentId);
+                    }}
+                  >
+                    {importBusy ? "Importing…" : "Import"}
+                  </button>
+                </footer>
+              </section>
+            ) : deleteTarget ? (
               <section
                 className="editor-action-dialog"
                 role="dialog"

--- a/apps/editor/src/features/hierarchy/cloud-cell-import.ts
+++ b/apps/editor/src/features/hierarchy/cloud-cell-import.ts
@@ -1,0 +1,48 @@
+import { planProjectCellImport } from "@icm/edit-engine";
+import type { CircuitProject } from "@icm/model";
+import { builtInSymbols, findUnsupportedProjectSymbolIds } from "@icm/symbols";
+
+import { stageProjectFile } from "../../document/project-file-service";
+import { openCloudProject } from "../editor-shell/cloud-projects";
+
+export type CloudCellImportLoadResult =
+  { ok: true; project: CircuitProject } | { ok: false; message: string };
+
+export async function loadCloudProjectForCellImport(
+  cloudProjectId: string,
+): Promise<CloudCellImportLoadResult> {
+  const fetched = await openCloudProject(cloudProjectId);
+  if (fetched.status !== "opened") {
+    return {
+      ok: false,
+      message:
+        fetched.status === "signed-out"
+          ? "Sign in again to import Cloud Project Cells"
+          : fetched.status === "not-found"
+            ? "That Cloud Project no longer exists"
+            : `Could not reach Cloud Projects (${fetched.message})`,
+    };
+  }
+  const staged = await stageProjectFile(
+    {
+      name: `${fetched.project.name}.icproj.json`,
+      text: () => Promise.resolve(fetched.project.projectText),
+    },
+    (candidate) => findUnsupportedProjectSymbolIds(candidate, builtInSymbols),
+  );
+  if (staged.status === "rejected") {
+    return {
+      ok: false,
+      message: staged.diagnostics[0]?.message ?? "Cloud Project is invalid",
+    };
+  }
+  return { ok: true, project: staged.project };
+}
+
+export function planLoadedCloudCellImport(
+  destination: CircuitProject,
+  source: CircuitProject,
+  sourceDocumentId: string,
+) {
+  return planProjectCellImport(destination, source, sourceDocumentId);
+}

--- a/docs/specs/edit-engine.md
+++ b/docs/specs/edit-engine.md
@@ -199,6 +199,14 @@ own UI state, or define another hierarchy representation. Canvas-dependent
 contact detection and placement previews remain consumer concerns; read-only
 Cell/caller summaries are derived data owned by `@icm/derived`.
 
+`project-cell-import.ts` is the corresponding cross-Project composition
+planner. It reads two already-authorized Projects and emits only ordinary
+Project structure edits: source-file records, compatible external interfaces,
+and copied Documents. The destination transaction validates the complete
+closure once. Deterministic remapping makes re-import idempotent without a
+persistent cross-Project pointer; no import lifecycle manager or live Library
+link exists.
+
 ## Invariants
 
 - A Schematic transaction targets exactly one Document. A Project structural

--- a/docs/user/schematic-hierarchy.md
+++ b/docs/user/schematic-hierarchy.md
@@ -21,6 +21,17 @@ position. **Enter Cell** opens the child of a selected hierarchical Instance.
 Opening a shared Cell from the selector has no caller context when more than
 one path reaches it, which is reported in the status bar.
 
+Use **Import Cell** in the Cell Manager to copy a Cell from another signed-in
+Cloud Project. The import includes every child Cell it calls, compatible
+external-subcircuit interfaces, formal ports, presentation, and referenced
+source metadata. It is one ordinary undoable Project transaction: the source
+Project is never modified, and the destination copy does not follow later
+source changes. Identity and colliding Cell names are remapped
+deterministically; importing the same source Cell again opens the existing
+copy rather than creating another hidden duplicate. The first release requires
+the source and destination to use the same exact Symbol Library lock and
+reports incompatible external interfaces without changing either Project.
+
 The top Cell is the Project export root and is not instantiated as a symbol,
 but it is still emitted as a reusable structural subcircuit. **Port** and
 **Filled Port** are hollow and filled artwork for the same **Cell Pin** concept.
@@ -89,6 +100,13 @@ Agents use the existing `create-cell` action and `place-cell` with
 `childDocumentId`, `instanceId`, optional `reference`, and `placement`, targeting
 the parent Document. The same Project transaction owns validation and history;
 these actions do not create or modify a SimulationSetup.
+
+The import planner and its small Project edits are also public API contracts.
+An Agent that already holds an authorized source Project can plan the same
+independent closure and submit it through the standard structural transaction;
+the transaction remains revision-guarded and atomic. Reading a private Cloud
+Project is a separate account-authorized operation and is never implied by
+simulation permission.
 
 Hierarchy presentation is saved as definition-level size and pin-placement
 intent in current Project schema 26. Schema-25 projects open through the

--- a/packages/agent-adapter/src/service.test.ts
+++ b/packages/agent-adapter/src/service.test.ts
@@ -273,8 +273,11 @@ describe("current Agent Circuit API service", () => {
     // (about 2.5 KB), including its bounded measurement-method union and the
     // hierarchy-aware Noise selector. This raised the ceiling; it still guards
     // accidental projection bloat.
+    // Project source-file provenance is now an editable structural record so
+    // imported Cell closures can remain source-addressable without bypassing
+    // the canonical transaction contract.
     expect(JSON.stringify(AgentCircuitRequestJsonSchema).length).toBeLessThan(
-      167_000,
+      168_000,
     );
     expect(JSON.stringify(AgentCircuitResponseJsonSchema).length).toBeLessThan(
       180_000,

--- a/packages/edit-engine/src/index.ts
+++ b/packages/edit-engine/src/index.ts
@@ -22,6 +22,7 @@ export * from "./instance-lifecycle.js";
 export * from "./transaction.js";
 export * from "./transaction-preflight.js";
 export * from "./project-transaction.js";
+export * from "./project-cell-import.js";
 export * from "./hierarchy-planner.js";
 export * from "./cell-reset-planner.js";
 export * from "./conductor-topology.js";

--- a/packages/edit-engine/src/project-cell-import.test.ts
+++ b/packages/edit-engine/src/project-cell-import.test.ts
@@ -1,0 +1,191 @@
+import {
+  createEmptyDocument,
+  createEmptyProject,
+  type CircuitProject,
+} from "@icm/model";
+import { externalSubcircuitSymbolId, hierarchicalSymbolId } from "@icm/symbols";
+import { describe, expect, it } from "vitest";
+
+import { planProjectCellImport } from "./project-cell-import.js";
+import { executeProjectTransaction } from "./project-transaction.js";
+
+function importProject(
+  destination: CircuitProject,
+  source: CircuitProject,
+  sourceDocumentId: string,
+) {
+  const plan = planProjectCellImport(destination, source, sourceDocumentId);
+  expect(plan.ok).toBe(true);
+  expect(plan.ok && plan.status).toBe("ready");
+  if (!plan.ok || plan.status !== "ready") throw new Error("Import not ready");
+  const result = executeProjectTransaction(destination, {
+    transactionId: "import-cell",
+    projectId: destination.id,
+    expectedStructureRevision: destination.structureRevision,
+    actor: { kind: "human", id: "test" },
+    edits: [...plan.edits],
+  });
+  expect(result.ok).toBe(true);
+  if (!result.ok) throw new Error(result.error.message);
+  return { plan, project: result.project };
+}
+
+describe("cross-Project Cell import", () => {
+  it("copies a complete child closure and remaps every hierarchy identity", () => {
+    const destination = createEmptyProject("destination", "Destination");
+    const source = createEmptyProject("source", "Source", "source-top");
+    const child = createEmptyDocument("source-child", "GainStage");
+    child.sourceBinding = {
+      cellName: "GainStage",
+      sourceRef: {
+        fileId: "source-file",
+        start: { offset: 0, line: 1, column: 1 },
+        end: { offset: 10, line: 1, column: 11 },
+      },
+    };
+    source.source.files.push({
+      id: "source-file",
+      path: "cells/gain-stage.spi",
+      hash: "sha256-source",
+    });
+    source.documents.push(child);
+    source.documents[0]!.instances.push({
+      id: "source-x1",
+      symbolId: hierarchicalSymbolId(child.netlist!.name),
+      placement: null,
+      reference: "X1",
+      netlist: {
+        parameters: {},
+        binding: { kind: "subcircuit", childDocumentId: child.id },
+      },
+    });
+
+    const { plan, project } = importProject(
+      destination,
+      source,
+      source.topDocumentId,
+    );
+
+    expect(plan.importedDocumentIds).toHaveLength(2);
+    expect(project.documents).toHaveLength(3);
+    const importedRoot = project.documents.find(
+      (document) => document.id === plan.rootDocumentId,
+    )!;
+    const importedChildId = importedRoot.instances[0]!.netlist!.binding;
+    expect(importedChildId).toMatchObject({ kind: "subcircuit" });
+    if (importedChildId?.kind !== "subcircuit") return;
+    const importedChild = project.documents.find(
+      (document) => document.id === importedChildId.childDocumentId,
+    )!;
+    expect(importedChild.id).not.toBe(child.id);
+    expect(importedRoot.instances[0]!.symbolId).toBe(
+      hierarchicalSymbolId(importedChild.netlist!.name),
+    );
+    expect(importedChild.sourceBinding?.sourceRef.fileId).not.toBe(
+      "source-file",
+    );
+    expect(importedChild.sourceBinding?.cellName).toBe(
+      importedChild.netlist?.name,
+    );
+    expect(project.source.files).toContainEqual(
+      expect.objectContaining({ path: "cells/gain-stage.spi" }),
+    );
+    expect(source.documents.map((document) => document.id)).toEqual([
+      "source-top",
+      "source-child",
+    ]);
+  });
+
+  it("uses deterministic names and treats a repeated import as idempotent", () => {
+    const destination = createEmptyProject("destination", "Destination");
+    const source = createEmptyProject("source", "Source", "source-main");
+    source.documents[0]!.name = "Main";
+    source.documents[0]!.netlist!.name = "Main";
+
+    const first = importProject(destination, source, source.topDocumentId);
+    const imported = first.project.documents.find(
+      (document) => document.id === first.plan.rootDocumentId,
+    )!;
+    expect(imported.name).toMatch(/^Main_[a-f0-9]{8}$/u);
+
+    imported.presentation.compactness = "compact";
+    const repeated = planProjectCellImport(
+      first.project,
+      source,
+      source.topDocumentId,
+    );
+    expect(repeated).toMatchObject({
+      ok: true,
+      status: "already-imported",
+      rootDocumentId: imported.id,
+      edits: [],
+    });
+  });
+
+  it("reuses a compatible external interface and rejects a conflicting one", () => {
+    const destination = createEmptyProject("destination", "Destination");
+    const source = createEmptyProject("source", "Source", "source-main");
+    const definition = {
+      id: "source-opamp",
+      name: "OPAMP",
+      terminals: [
+        { id: "source-opamp-in", name: "IN", direction: "input" as const },
+        { id: "source-opamp-out", name: "OUT", direction: "output" as const },
+      ],
+      formalParameters: [],
+      interfaceStatus: "declared" as const,
+    };
+    source.externalSubcircuitDefinitions.push(definition);
+    source.documents[0]!.instances.push({
+      id: "source-x1",
+      symbolId: externalSubcircuitSymbolId(definition.id),
+      placement: null,
+      reference: "X1",
+      netlist: {
+        parameters: {},
+        binding: {
+          kind: "external-subcircuit",
+          definitionId: definition.id,
+        },
+      },
+    });
+    destination.externalSubcircuitDefinitions.push({
+      ...structuredClone(definition),
+      id: "destination-opamp",
+      terminals: definition.terminals.map((terminal, index) => ({
+        ...terminal,
+        id: `destination-terminal-${index}`,
+      })),
+    });
+
+    const imported = importProject(destination, source, source.topDocumentId);
+    expect(imported.project.externalSubcircuitDefinitions).toHaveLength(1);
+    const binding = imported.project.documents.find(
+      (document) => document.id === imported.plan.rootDocumentId,
+    )!.instances[0]!.netlist!.binding;
+    expect(binding).toEqual({
+      kind: "external-subcircuit",
+      definitionId: "destination-opamp",
+    });
+
+    const conflictDestination = structuredClone(destination);
+    conflictDestination.externalSubcircuitDefinitions[0]!.terminals[1]!.name =
+      "NEG";
+    expect(
+      planProjectCellImport(conflictDestination, source, source.topDocumentId),
+    ).toMatchObject({ ok: false, code: "EXTERNAL_DEFINITION_CONFLICT" });
+  });
+
+  it("rejects an incompatible symbol-library lock before any mutation", () => {
+    const destination = createEmptyProject("destination", "Destination");
+    const source = createEmptyProject("source", "Source");
+    source.symbolLibrary = {
+      id: "other-symbols",
+      version: "2",
+      hash: "other-hash",
+    };
+    expect(
+      planProjectCellImport(destination, source, source.topDocumentId),
+    ).toMatchObject({ ok: false, code: "SYMBOL_LIBRARY_MISMATCH" });
+  });
+});

--- a/packages/edit-engine/src/project-cell-import.ts
+++ b/packages/edit-engine/src/project-cell-import.ts
@@ -1,0 +1,477 @@
+import {
+  CircuitProjectSchema,
+  deriveStableId,
+  type CircuitProject,
+  type ExternalSubcircuitDefinition,
+  type SchematicDocument,
+} from "@icm/model";
+import {
+  externalSubcircuitSymbolId,
+  hierarchicalSymbolId,
+  resolvePdkSymbolMappingForTerminalOrder,
+} from "@icm/symbols";
+
+import type { ProjectStructureEdit } from "./project-transaction.js";
+
+export type ProjectCellImportFailureCode =
+  | "SOURCE_CELL_NOT_FOUND"
+  | "SYMBOL_LIBRARY_MISMATCH"
+  | "SOURCE_DEPENDENCY_MISSING"
+  | "EXTERNAL_DEFINITION_CONFLICT"
+  | "PARTIAL_IMPORT_CONFLICT"
+  | "IMPORT_TOO_LARGE";
+
+export type ProjectCellImportPlan =
+  | {
+      ok: true;
+      status: "ready";
+      rootDocumentId: string;
+      importedDocumentIds: readonly string[];
+      edits: readonly ProjectStructureEdit[];
+    }
+  | {
+      ok: true;
+      status: "already-imported";
+      rootDocumentId: string;
+      importedDocumentIds: readonly string[];
+      edits: readonly [];
+    }
+  | {
+      ok: false;
+      code: ProjectCellImportFailureCode;
+      message: string;
+    };
+
+const ID_VALUE_KEYS = new Set([
+  "annotationId",
+  "bendId",
+  "childDocumentId",
+  "definitionId",
+  "fileId",
+  "id",
+  "instanceId",
+  "junctionId",
+  "legId",
+  "netId",
+  "nmosNetId",
+  "objectId",
+  "pmosNetId",
+  "routeId",
+  "sourceNetId",
+  "terminalId",
+]);
+const ID_ARRAY_KEYS = new Set(["interfaceInstanceIds", "objectIds"]);
+
+function importId(
+  destinationProjectId: string,
+  sourceProjectId: string,
+  rootDocumentId: string,
+  sourceId: string,
+): string {
+  return deriveStableId(
+    "import",
+    destinationProjectId,
+    sourceProjectId,
+    rootDocumentId,
+    sourceId,
+  );
+}
+
+function collectIdentifierValues(value: unknown, output: Set<string>): void {
+  if (Array.isArray(value)) {
+    for (const item of value) collectIdentifierValues(item, output);
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+  for (const [key, item] of Object.entries(value)) {
+    if (ID_VALUE_KEYS.has(key) && typeof item === "string") output.add(item);
+    if (ID_ARRAY_KEYS.has(key) && Array.isArray(item)) {
+      for (const id of item) if (typeof id === "string") output.add(id);
+    }
+    collectIdentifierValues(item, output);
+  }
+}
+
+function collectFileIds(value: unknown, output: Set<string>): void {
+  if (Array.isArray(value)) {
+    for (const item of value) collectFileIds(item, output);
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+  for (const [key, item] of Object.entries(value)) {
+    if (key === "fileId" && typeof item === "string") output.add(item);
+    collectFileIds(item, output);
+  }
+}
+
+function remapIdentifierValues(
+  value: unknown,
+  identifiers: ReadonlyMap<string, string>,
+): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => remapIdentifierValues(item, identifiers));
+  }
+  if (!value || typeof value !== "object") return value;
+  const output: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value)) {
+    if (ID_VALUE_KEYS.has(key) && typeof item === "string") {
+      output[key] = identifiers.get(item) ?? item;
+    } else if (ID_ARRAY_KEYS.has(key) && Array.isArray(item)) {
+      output[key] = item.map((id) =>
+        typeof id === "string" ? (identifiers.get(id) ?? id) : id,
+      );
+    } else {
+      output[key] = remapIdentifierValues(item, identifiers);
+    }
+  }
+  return output;
+}
+
+function cellClosure(
+  source: CircuitProject,
+  rootDocumentId: string,
+): SchematicDocument[] | null {
+  const byId = new Map(
+    source.documents.map((document) => [document.id, document]),
+  );
+  if (!byId.has(rootDocumentId)) return null;
+  const ordered: SchematicDocument[] = [];
+  const visited = new Set<string>();
+  const visit = (documentId: string): boolean => {
+    if (visited.has(documentId)) return true;
+    const document = byId.get(documentId);
+    if (!document) return false;
+    visited.add(documentId);
+    for (const instance of document.instances) {
+      const binding = instance.netlist?.binding;
+      if (binding?.kind === "subcircuit" && !visit(binding.childDocumentId)) {
+        return false;
+      }
+    }
+    ordered.push(document);
+    return true;
+  };
+  return visit(rootDocumentId) ? ordered : null;
+}
+
+function externalDefinitionShape(
+  definition: ExternalSubcircuitDefinition,
+): unknown {
+  const terminalName = new Map(
+    definition.terminals.map((terminal) => [terminal.id, terminal.name]),
+  );
+  return {
+    name: definition.name.toLocaleLowerCase("en-US"),
+    terminals: definition.terminals.map(({ name, direction }) => ({
+      name,
+      direction,
+    })),
+    formalParameters: definition.formalParameters,
+    interfaceStatus: definition.interfaceStatus,
+    presentation: definition.presentation
+      ? {
+          ...definition.presentation,
+          pinPlacements: definition.presentation.pinPlacements?.map(
+            ({ terminalId, ...placement }) => ({
+              ...placement,
+              terminalName: terminalName.get(terminalId),
+            }),
+          ),
+        }
+      : undefined,
+  };
+}
+
+function compatibleExternalDefinition(
+  left: ExternalSubcircuitDefinition,
+  right: ExternalSubcircuitDefinition,
+): boolean {
+  return (
+    JSON.stringify(externalDefinitionShape(left)) ===
+    JSON.stringify(externalDefinitionShape(right))
+  );
+}
+
+function importedCellNames(
+  destination: CircuitProject,
+  source: CircuitProject,
+  closure: readonly SchematicDocument[],
+): Map<string, string> {
+  const used = new Set(
+    destination.documents.flatMap((document) =>
+      document.netlist
+        ? [document.netlist.name.toLocaleLowerCase("en-US")]
+        : [],
+    ),
+  );
+  const names = new Map<string, string>();
+  const suffix = deriveStableId("cell", source.id).slice(-8);
+  for (const document of closure) {
+    const base = document.netlist?.name ?? document.name;
+    let candidate = base;
+    if (used.has(candidate.toLocaleLowerCase("en-US"))) {
+      candidate = `${base}_${suffix}`.slice(0, 128);
+    }
+    let sequence = 2;
+    while (used.has(candidate.toLocaleLowerCase("en-US"))) {
+      const tail = `_${suffix}_${sequence++}`;
+      candidate = `${base.slice(0, 128 - tail.length)}${tail}`;
+    }
+    used.add(candidate.toLocaleLowerCase("en-US"));
+    names.set(document.id, candidate);
+  }
+  return names;
+}
+
+/**
+ * Plans one independent, project-local copy of a Cell and every local Cell it
+ * calls. The returned edit is atomic at the existing Project transaction
+ * boundary; no persistent cross-Project reference or live synchronization is
+ * created.
+ */
+export function planProjectCellImport(
+  destinationInput: CircuitProject,
+  sourceInput: CircuitProject,
+  sourceDocumentId: string,
+): ProjectCellImportPlan {
+  const destination = CircuitProjectSchema.parse(destinationInput);
+  const source = CircuitProjectSchema.parse(sourceInput);
+  const sourceRoot = source.documents.find(
+    (document) => document.id === sourceDocumentId,
+  );
+  if (!sourceRoot) {
+    return {
+      ok: false,
+      code: "SOURCE_CELL_NOT_FOUND",
+      message: `Source Cell does not exist: ${sourceDocumentId}`,
+    };
+  }
+  if (
+    JSON.stringify(destination.symbolLibrary) !==
+    JSON.stringify(source.symbolLibrary)
+  ) {
+    return {
+      ok: false,
+      code: "SYMBOL_LIBRARY_MISMATCH",
+      message: `Source uses Symbol Library ${source.symbolLibrary.id}@${source.symbolLibrary.version}; destination requires ${destination.symbolLibrary.id}@${destination.symbolLibrary.version}`,
+    };
+  }
+  const closure = cellClosure(source, sourceDocumentId);
+  if (!closure) {
+    return {
+      ok: false,
+      code: "SOURCE_DEPENDENCY_MISSING",
+      message: `Source Cell ${sourceRoot.name} has a missing child Cell`,
+    };
+  }
+
+  const expectedDocumentIds = closure.map((document) =>
+    importId(destination.id, source.id, sourceDocumentId, document.id),
+  );
+  const existingDocumentIds = new Set(
+    destination.documents.map((document) => document.id),
+  );
+  const existingCount = expectedDocumentIds.filter((id) =>
+    existingDocumentIds.has(id),
+  ).length;
+  if (existingCount === expectedDocumentIds.length) {
+    return {
+      ok: true,
+      status: "already-imported",
+      rootDocumentId: importId(
+        destination.id,
+        source.id,
+        sourceDocumentId,
+        sourceDocumentId,
+      ),
+      importedDocumentIds: expectedDocumentIds,
+      edits: [],
+    };
+  }
+  if (existingCount > 0) {
+    return {
+      ok: false,
+      code: "PARTIAL_IMPORT_CONFLICT",
+      message: "Part of this Cell closure already exists in the destination",
+    };
+  }
+
+  const referencedExternalIds = new Set<string>();
+  for (const document of closure) {
+    for (const instance of document.instances) {
+      const binding = instance.netlist?.binding;
+      if (binding?.kind === "external-subcircuit") {
+        referencedExternalIds.add(binding.definitionId);
+      }
+    }
+  }
+  const sourceExternalById = new Map(
+    source.externalSubcircuitDefinitions.map((definition) => [
+      definition.id,
+      definition,
+    ]),
+  );
+  const externalIdMap = new Map<string, string>();
+  const newExternalDefinitions: ExternalSubcircuitDefinition[] = [];
+  for (const definitionId of referencedExternalIds) {
+    const definition = sourceExternalById.get(definitionId);
+    if (!definition) {
+      return {
+        ok: false,
+        code: "SOURCE_DEPENDENCY_MISSING",
+        message: `Source Cell references missing external subcircuit ${definitionId}`,
+      };
+    }
+    const existing = destination.externalSubcircuitDefinitions.find(
+      (candidate) =>
+        candidate.name.toLocaleLowerCase("en-US") ===
+        definition.name.toLocaleLowerCase("en-US"),
+    );
+    if (existing && !compatibleExternalDefinition(existing, definition)) {
+      return {
+        ok: false,
+        code: "EXTERNAL_DEFINITION_CONFLICT",
+        message: `External subcircuit ${definition.name} has a different interface in the destination`,
+      };
+    }
+    externalIdMap.set(
+      definition.id,
+      existing?.id ??
+        importId(destination.id, source.id, sourceDocumentId, definition.id),
+    );
+  }
+
+  const referencedFileIds = new Set<string>();
+  for (const document of closure) collectFileIds(document, referencedFileIds);
+  const sourceFileById = new Map(
+    source.source.files.map((file) => [file.id, file]),
+  );
+  const fileIdMap = new Map<string, string>();
+  const newSourceFiles: CircuitProject["source"]["files"] = [];
+  for (const sourceFileId of referencedFileIds) {
+    const sourceFile = sourceFileById.get(sourceFileId);
+    if (!sourceFile) {
+      return {
+        ok: false,
+        code: "SOURCE_DEPENDENCY_MISSING",
+        message: `Source metadata is missing file ${sourceFileId}`,
+      };
+    }
+    const identical = destination.source.files.find(
+      (candidate) =>
+        candidate.path === sourceFile.path &&
+        candidate.hash === sourceFile.hash,
+    );
+    const mappedId =
+      identical?.id ??
+      importId(destination.id, source.id, sourceDocumentId, sourceFile.id);
+    fileIdMap.set(sourceFile.id, mappedId);
+    if (!identical) newSourceFiles.push({ ...sourceFile, id: mappedId });
+  }
+
+  const identifiers = new Set<string>();
+  for (const document of closure)
+    collectIdentifierValues(document, identifiers);
+  for (const definitionId of referencedExternalIds) {
+    const definition = sourceExternalById.get(definitionId)!;
+    collectIdentifierValues(definition, identifiers);
+  }
+  const identifierMap = new Map<string, string>();
+  for (const identifier of identifiers) {
+    identifierMap.set(
+      identifier,
+      importId(destination.id, source.id, sourceDocumentId, identifier),
+    );
+  }
+  for (const [sourceId, targetId] of externalIdMap) {
+    identifierMap.set(sourceId, targetId);
+  }
+  for (const [sourceId, targetId] of fileIdMap)
+    identifierMap.set(sourceId, targetId);
+
+  for (const definitionId of referencedExternalIds) {
+    if (
+      destination.externalSubcircuitDefinitions.some(
+        (candidate) => candidate.id === externalIdMap.get(definitionId),
+      )
+    )
+      continue;
+    const remapped = remapIdentifierValues(
+      sourceExternalById.get(definitionId)!,
+      identifierMap,
+    ) as ExternalSubcircuitDefinition;
+    newExternalDefinitions.push(remapped);
+  }
+
+  const names = importedCellNames(destination, source, closure);
+  const importedDocuments = closure.map((document) => {
+    const remapped = remapIdentifierValues(
+      document,
+      identifierMap,
+    ) as SchematicDocument;
+    const name = names.get(document.id)!;
+    remapped.name = name;
+    if (remapped.netlist) remapped.netlist.name = name;
+    // Imported Cells are independent destination definitions. Keep the
+    // source span for provenance, but bind the definition to its destination
+    // Cell name so hierarchical symbol resolution and emitted `.subckt`
+    // identity continue to agree after a collision rename.
+    if (remapped.sourceBinding) remapped.sourceBinding.cellName = name;
+    for (const instance of remapped.instances) {
+      const binding = instance.netlist?.binding;
+      if (binding?.kind === "subcircuit") {
+        const child = closure.find(
+          (candidate) =>
+            identifierMap.get(candidate.id) === binding.childDocumentId,
+        );
+        if (child)
+          instance.symbolId = hierarchicalSymbolId(names.get(child.id)!);
+      } else if (binding?.kind === "external-subcircuit") {
+        const definition = [
+          ...destination.externalSubcircuitDefinitions,
+          ...newExternalDefinitions,
+        ].find((candidate) => candidate.id === binding.definitionId);
+        const reviewed = definition
+          ? resolvePdkSymbolMappingForTerminalOrder(
+              definition.name,
+              definition.terminals.map((terminal) => terminal.name),
+            )
+          : undefined;
+        instance.symbolId =
+          reviewed?.symbolId === instance.symbolId
+            ? instance.symbolId
+            : externalSubcircuitSymbolId(binding.definitionId);
+      }
+    }
+    return remapped;
+  });
+  const rootDocumentId = identifierMap.get(sourceDocumentId)!;
+  const edits: ProjectStructureEdit[] = [
+    ...newSourceFiles.map((sourceFile): ProjectStructureEdit => ({
+      kind: "add_source_file",
+      sourceFile,
+    })),
+    ...newExternalDefinitions.map((definition): ProjectStructureEdit => ({
+      kind: "upsert_external_subcircuit_definition",
+      definition,
+    })),
+    ...importedDocuments.map((document): ProjectStructureEdit => ({
+      kind: "add_document",
+      document,
+    })),
+  ];
+  if (edits.length > 256) {
+    return {
+      ok: false,
+      code: "IMPORT_TOO_LARGE",
+      message: `Cell closure requires ${edits.length} Project edits; the limit is 256`,
+    };
+  }
+  return {
+    ok: true,
+    status: "ready",
+    rootDocumentId,
+    importedDocumentIds: importedDocuments.map((document) => document.id),
+    edits,
+  };
+}

--- a/packages/edit-engine/src/project-transaction.ts
+++ b/packages/edit-engine/src/project-transaction.ts
@@ -1,6 +1,7 @@
 import {
   CircuitProjectSchema,
   ExternalSubcircuitDefinitionSchema,
+  SourceFileRecordSchema,
   SchematicDocumentSchema,
   ProjectSimulationSetupSchema,
   type CircuitProject,
@@ -30,6 +31,10 @@ import type {
 } from "./transaction-result.js";
 
 export const ProjectStructureEditSchema = z.discriminatedUnion("kind", [
+  z.strictObject({
+    kind: z.literal("add_source_file"),
+    sourceFile: SourceFileRecordSchema,
+  }),
   z.strictObject({
     kind: z.literal("add_document"),
     document: SchematicDocumentSchema,
@@ -297,6 +302,22 @@ export function executeProjectTransaction(
   let structuralChange = false;
 
   for (const [editIndex, edit] of transaction.edits.entries()) {
+    if (edit.kind === "add_source_file") {
+      const existing = candidate.source.files.find(
+        (sourceFile) => sourceFile.id === edit.sourceFile.id,
+      );
+      if (existing) {
+        return rejectProjectTransaction(
+          project,
+          "EDIT_PRECONDITION",
+          `Source file already exists: ${edit.sourceFile.id}`,
+        );
+      }
+      candidate.source.files.push(structuredClone(edit.sourceFile));
+      structuralChange = true;
+      continue;
+    }
+
     if (edit.kind === "add_document") {
       if (
         candidate.documents.some((document) => document.id === edit.document.id)


### PR DESCRIPTION
## Summary
- import an authorized Cloud Project Cell plus its complete local hierarchy closure
- preserve/remap source metadata and compatible external interfaces through the existing atomic Project transaction
- expose deterministic, idempotent import in Cell Manager without live cross-Project references

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm ci:check (2863 unit tests; 361 browser tests)

Test-Impact: tests-updated