### PR TITLE
feat: qualify extended SKY130 modeled devices

### DIFF
--- a/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
@@ -59,7 +59,7 @@ describe("SpiceSimulationSurface workspace", () => {
     expect(markup).toContain('<input type="hidden" name="profileId"');
     expect(markup).not.toContain("<datalist");
     expect(markup).toContain("sky130-core-continuous-ngspice46-v1");
-    expect(markup).toContain("SKY130 1.8 V · ngspice 46");
+    expect(markup).toContain("SKY130 qualified devices · ngspice 46");
     expect(markup).toContain("Process corner");
     for (const corner of ["TT", "FF", "SS", "FS", "SF"])
       expect(markup).toContain(`>${corner}</option>`);

--- a/containers/ngspice/hosted-sky130-profile.json
+++ b/containers/ngspice/hosted-sky130-profile.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "sky130-core-continuous-ngspice46-v1",
-  "displayName": "SKY130 1.8 V · ngspice 46",
+  "displayName": "SKY130 qualified devices · ngspice 46",
   "sourceImage": "ghcr.io/arcadia-1/circuit-bench-sky130-ngspice@sha256:2da03dc7f1ead7ddc33f2f930a0487ae8618e51518009344584a98fca41a621d",
   "platform": "linux/x64",
   "simulator": {
@@ -23,7 +23,15 @@
     "contentSha256": "5ad94681e17bba379ac84d01fe7773458b34f9bbd77c127a3738f1af47ad5634"
   },
   "qualifiedScope": {
-    "devices": ["sky130_fd_pr__nfet_01v8", "sky130_fd_pr__pfet_01v8"],
+    "devices": [
+      "sky130_fd_pr__nfet_01v8",
+      "sky130_fd_pr__pfet_01v8",
+      "sky130_fd_pr__nfet_01v8_lvt",
+      "sky130_fd_pr__pfet_01v8_lvt",
+      "sky130_fd_pr__res_high_po",
+      "sky130_fd_pr__cap_mim_m3_1",
+      "sky130_fd_pr__pnp_05v5_W0p68L0p68"
+    ],
     "sections": ["tt", "ff", "ss", "fs", "sf"],
     "analyses": ["op", "dc", "ac", "tran", "noise"]
   }

--- a/containers/ngspice/profile-contract.test.mjs
+++ b/containers/ngspice/profile-contract.test.mjs
@@ -15,7 +15,7 @@ const dockerfile = await readFile(join(directory, "Dockerfile"), "utf8");
 describe("the hosted SKY130 Profile", () => {
   it("pins the exact base image, startup policy and runtime paths", () => {
     expect(profile.id).toBe("sky130-core-continuous-ngspice46-v1");
-    expect(profile.displayName).toBe("SKY130 1.8 V · ngspice 46");
+    expect(profile.displayName).toBe("SKY130 qualified devices · ngspice 46");
     expect(dockerfile).toContain(`ARG BASE_IMAGE=${profile.sourceImage}`);
     expect(createHash("sha256").update(startup).digest("hex")).toBe(
       profile.startup.contentSha256,
@@ -35,7 +35,15 @@ describe("the hosted SKY130 Profile", () => {
 
   it("qualifies only the scope backed by tracked hosted acceptance", () => {
     expect(profile.qualifiedScope).toEqual({
-      devices: ["sky130_fd_pr__nfet_01v8", "sky130_fd_pr__pfet_01v8"],
+      devices: [
+        "sky130_fd_pr__nfet_01v8",
+        "sky130_fd_pr__pfet_01v8",
+        "sky130_fd_pr__nfet_01v8_lvt",
+        "sky130_fd_pr__pfet_01v8_lvt",
+        "sky130_fd_pr__res_high_po",
+        "sky130_fd_pr__cap_mim_m3_1",
+        "sky130_fd_pr__pnp_05v5_W0p68L0p68",
+      ],
       sections: ["tt", "ff", "ss", "fs", "sf"],
       analyses: ["op", "dc", "ac", "tran", "noise"],
     });

--- a/docs/agent/knowledge/pdk-and-symbols.md
+++ b/docs/agent/knowledge/pdk-and-symbols.md
@@ -15,16 +15,23 @@ existing Net membership. Prefer mappings in this order:
 3. primitive mapping supported by the parsed model type;
 4. unresolved generic symbol.
 
-Only the four released exact SKY130 masters are mapped: the 1.8 V NFET/PFET,
-`res_high_po`, and `cap_mim_m3_1`. Both exact master name and ordered public
-interface must match. No `sky130_fd_pr__nfet_*`, resistor, or capacitor family
-regular expression is an electrical authority.
+Only the seven released exact SKY130 masters are mapped: the core and LVT
+1.8 V NFET/PFET pairs, `res_high_po`, `cap_mim_m3_1`, and the fixed
+`pnp_05v5_W0p68L0p68`. Both exact master name and ordered public interface must
+match. No SKY130 family regular expression is an electrical authority.
 
 The mapped instance keeps its external binding while borrowing native artwork.
-Its authored reference remains in the native M/R/C domain; SPICE derives the X
-card. MOS exposes D/G/S/B electrically, resistor R0/R1 map to frozen pins 1/2
-and B is property-only, and MIM C0/C1 map to frozen pins 1/2. An explicit
-external block presentation overrides automatic artwork choice.
+Its authored reference remains in the native M/R/C/Q domain; SPICE derives the
+X card. MOS exposes D/G/S/B electrically, resistor R0/R1 map to frozen pins
+1/2 and B is property-only, MIM C0/C1 map to frozen pins 1/2, and the fixed PNP
+maps C/B/E directly to the existing PNP symbol. An explicit external block
+presentation overrides automatic artwork choice.
+
+The hosted Profile qualifies those same seven exact names. The continuous
+library does not expose `sky130_fd_pr__diode_pw2nd_05v5`, while the available
+four-terminal `sky130_fd_pr__npn_05v5_W1p00L1p00` makes ngspice 46 discard
+model parameters. Neither is advertised as qualified merely because a generic
+Diode or NPN symbol can print a model-bearing SPICE card.
 
 ## Safe symbol replacement
 

--- a/docs/specs/simulation-execution.md
+++ b/docs/specs/simulation-execution.md
@@ -96,10 +96,12 @@ mismatched Profile leaves `/health` and `/run` not ready; it is never silently
 downgraded to an observed hosted run. Local deployment is an optional adapter,
 not an implicit fallback to a program found on the user's machine.
 
-The first qualified scope is deliberately narrow and factual: the continuous
-`sky130_fd_pr__nfet_01v8` and `sky130_fd_pr__pfet_01v8` wrappers, the
-Profile's qualified sections (`tt/ff/ss/fs/sf`), and
-OP/DC/AC/TRAN/Noise covered by the hosted model acceptance fixture. A separate
+The qualified scope is deliberately exact and factual: core and LVT 1.8 V
+NFET/PFET wrappers, `res_high_po`, `cap_mim_m3_1`, and the fixed
+`pnp_05v5_W0p68L0p68` wrapper, over the Profile's qualified sections
+(`tt/ff/ss/fs/sf`). OP/DC/AC/TRAN/Noise remain covered by the hosted core-model
+acceptance fixture; a second OP/AC fixture verifies every added device at every
+advertised corner. A separate
 independent-source divider smoke gives DC parsing and numerical sweep behavior
 an exact closed-form check on the same pinned runtime. TRAN qualification includes an ideal RC
 step and a structured SKY130 OTA pulse response on the pinned ngspice 46
@@ -108,6 +110,11 @@ and the structured OTA's input/output spectral densities and integrated totals.
 Adding another corner or device family extends this same Profile
 contract only after a model-backed fixture passes the hosted
 gate; a locally available PDK is not evidence by itself.
+
+The Profile deliberately excludes a SKY130 diode because the selected
+continuous library does not resolve the candidate model. It also excludes the
+available four-terminal NPN because ngspice 46 reports discarded model
+parameters. These are model-environment limits, not missing symbol artwork.
 
 It must not include that top-level sectioned library with `.include`, because
 doing so expands multiple corner sections into the same deck and redefines

--- a/docs/user/spice-compatibility.md
+++ b/docs/user/spice-compatibility.md
@@ -13,8 +13,9 @@ turns them into a primitive model call.
 For the exact reviewed SKY130 targets, the editor uses the existing NMOS,
 PMOS, resistor, and capacitor artwork while retaining an external definition.
 A user may place the ordinary NMOS/PMOS with the unchanged Insert flow, then choose
-`sky130_fd_pr__nfet_01v8` or `sky130_fd_pr__pfet_01v8` from the existing Model
-field. The edit creates or reuses the project-local external definition,
+`sky130_fd_pr__nfet_01v8`, `sky130_fd_pr__pfet_01v8`, or their exact
+`01v8_lvt` variants from the existing Model field. The edit creates or reuses
+the project-local external definition,
 preserves connectivity and the authored `M` reference, and exposes `w`, `l`,
 `nf`, and `m`. SPICE derives `XM1` from authored `M1`; it does not convert `m`
 into `nf`.
@@ -25,6 +26,13 @@ icons and visible pins do not change. The resistor's real B substrate terminal
 is selected from existing Nets through `Body/Substrate Net` in Properties and
 has no canvas pin or wire. Physical R/C geometry is `w/l/mult` or `w/l/mf`;
 the editor never derives it from an ideal scalar value.
+
+The ordinary PNP symbol similarly offers the exact fixed
+`sky130_fd_pr__pnp_05v5_W0p68L0p68` wrapper. It keeps the visible C/B/E pins
+and prints an external X call; arbitrary model names continue to use the
+ordinary three-terminal Q card. The generic Diode and NPN symbols remain
+model-bearing structural devices, but this hosted environment does not claim
+a qualified SKY130 diode or NPN target.
 
 This convenience is structural only. It does not install SKY130, resolve a
 local `.include`, supply foundry models or corners, or make the exported

--- a/fixtures/simulation-acceptance/hosted-sky130-core-continuous-v1.json
+++ b/fixtures/simulation-acceptance/hosted-sky130-core-continuous-v1.json
@@ -2,6 +2,7 @@
   "schemaVersion": 4,
   "fixtureId": "ota-5t-structured-op-dc-ac-tran-noise-v3",
   "profileId": "sky130-core-continuous-ngspice46-v1",
+  "devices": ["sky130_fd_pr__nfet_01v8", "sky130_fd_pr__pfet_01v8"],
   "analyses": ["op", "dc", "ac", "tran", "noise"],
   "inputs": {
     "project": "apps/editor/src/examples/five-transistor-ota-sky130.icproj.json",

--- a/fixtures/simulation-acceptance/hosted-sky130-extended-devices-v1.json
+++ b/fixtures/simulation-acceptance/hosted-sky130-extended-devices-v1.json
@@ -1,0 +1,78 @@
+{
+  "schemaVersion": 1,
+  "fixtureId": "sky130-extended-devices-op-ac-v1",
+  "profileId": "sky130-core-continuous-ngspice46-v1",
+  "devices": [
+    "sky130_fd_pr__nfet_01v8_lvt",
+    "sky130_fd_pr__pfet_01v8_lvt",
+    "sky130_fd_pr__res_high_po",
+    "sky130_fd_pr__cap_mim_m3_1",
+    "sky130_fd_pr__pnp_05v5_W0p68L0p68"
+  ],
+  "analyses": ["op", "ac"],
+  "modelLibrary": { "directive": "lib" },
+  "expectedCorners": {
+    "tt": {
+      "lvtNfetCurrentA": -0.000112452140824601,
+      "lvtPfetSourceCurrentA": -0.00005228921265621606,
+      "resistorOutputV": 0.3158305326064023,
+      "resistorSupplyCurrentA": -0.0003158305326064026,
+      "pnpEmitterCurrentA": -2.128666657177924e-7,
+      "pnpCollectorCurrentA": 1.986898949829154e-7,
+      "mimOutputReal": 9.002255934489363e-12,
+      "mimOutputImag": -0.00000300037596550971
+    },
+    "ff": {
+      "lvtNfetCurrentA": -0.0001329127936535723,
+      "lvtPfetSourceCurrentA": -0.00006968745845296193,
+      "resistorOutputV": 0.313487576360055,
+      "resistorSupplyCurrentA": -0.000313487576360055,
+      "pnpEmitterCurrentA": -2.149132309996193e-7,
+      "pnpCollectorCurrentA": 1.983406510684755e-7,
+      "mimOutputReal": 9.002255934489363e-12,
+      "mimOutputImag": -0.00000300037596550971
+    },
+    "ss": {
+      "lvtNfetCurrentA": -0.000094209857384564,
+      "lvtPfetSourceCurrentA": -0.0000369833947106088,
+      "resistorOutputV": 0.3181574381225752,
+      "resistorSupplyCurrentA": -0.0003181574381225754,
+      "pnpEmitterCurrentA": -2.110363791392456e-7,
+      "pnpCollectorCurrentA": 1.992089077115006e-7,
+      "mimOutputReal": 9.002255934489363e-12,
+      "mimOutputImag": -0.00000300037596550971
+    },
+    "fs": {
+      "lvtNfetCurrentA": -0.00009368284623006984,
+      "lvtPfetSourceCurrentA": -0.0000750196770909553,
+      "resistorOutputV": 0.3158305326064023,
+      "resistorSupplyCurrentA": -0.0003158305326064026,
+      "pnpEmitterCurrentA": -2.093903619399679e-7,
+      "pnpCollectorCurrentA": 2.002390409575156e-7,
+      "mimOutputReal": 9.002255934489363e-12,
+      "mimOutputImag": -0.00000300037596550971
+    },
+    "sf": {
+      "lvtNfetCurrentA": -0.0001326085710116887,
+      "lvtPfetSourceCurrentA": -0.00003164163586561602,
+      "resistorOutputV": 0.3158305326064023,
+      "resistorSupplyCurrentA": -0.0003158305326064026,
+      "pnpEmitterCurrentA": -2.238876271182244e-7,
+      "pnpCollectorCurrentA": 1.97657179798784e-7,
+      "mimOutputReal": 9.002255934489363e-12,
+      "mimOutputImag": -0.00000300037596550971
+    }
+  },
+  "tolerances": {
+    "mosCurrentA": 1e-10,
+    "resistorVoltageV": 1e-9,
+    "resistorCurrentA": 1e-10,
+    "pnpCurrentA": 1e-11,
+    "mimComplex": 1e-12
+  },
+  "evidence": {
+    "observedAt": "2026-09-08",
+    "executor": "operator-host",
+    "environmentFingerprint": "33c245e5df6dc12077b6a2e4ebf308777b0e9014fe9bfdafc3285c614688561d"
+  }
+}

--- a/packages/devices/src/reviewed-external.test.ts
+++ b/packages/devices/src/reviewed-external.test.ts
@@ -34,6 +34,17 @@ describe("reviewed external device bindings", () => {
     expect(
       reviewedExternalBindingForMaster("sky130_fd_pr__nfet_g5v0d10v5"),
     ).toBeUndefined();
+    expect(
+      resolveReviewedExternalBinding("sky130_fd_pr__pnp_05v5_W0p68L0p68", [
+        "C",
+        "B",
+        "E",
+      ]),
+    ).toMatchObject({
+      id: "sky130-pnp-05v5-w0p68l0p68",
+      symbolId: "pnp",
+      deviceClass: "bjt",
+    });
   });
 
   it("converts reviewed geometry in both directions without aliasing counts", () => {
@@ -61,6 +72,20 @@ describe("reviewed external device bindings", () => {
       ["l", "0.15"],
       ["nf", "1"],
       ["m", "1"],
+    ]);
+    expect(
+      reviewedExternalBindingForMaster(
+        "sky130_fd_pr__pfet_01v8_lvt",
+      )?.parameters.map((parameter) => [
+        parameter.name,
+        parameter.defaultValue,
+        parameter.targetDefaultValue,
+      ]),
+    ).toEqual([
+      ["w", "3u", "3"],
+      ["l", "350n", "0.35"],
+      ["nf", "1", "1"],
+      ["m", "1", "1"],
     ]);
   });
 });

--- a/packages/devices/src/reviewed-external.ts
+++ b/packages/devices/src/reviewed-external.ts
@@ -3,8 +3,11 @@ import type { DeviceParameterDefinition } from "./contract.js";
 export type ReviewedExternalBindingId =
   | "sky130-nfet-01v8"
   | "sky130-pfet-01v8"
+  | "sky130-nfet-01v8-lvt"
+  | "sky130-pfet-01v8-lvt"
   | "sky130-res-high-po"
-  | "sky130-cap-mim-m3-1";
+  | "sky130-cap-mim-m3-1"
+  | "sky130-pnp-05v5-w0p68l0p68";
 
 export interface ReviewedExternalTerminalBinding {
   /** Public target terminal spelling and order from the external wrapper. */
@@ -27,8 +30,8 @@ export interface ReviewedExternalDeviceBinding {
   readonly libraryId: "sky130_fd_pr";
   readonly masterName: string;
   readonly invocationKind: "external-subcircuit";
-  readonly symbolId: "nmos" | "pmos" | "resistor" | "capacitor";
-  readonly deviceClass: "mos" | "resistor" | "capacitor";
+  readonly symbolId: "nmos" | "pmos" | "resistor" | "capacitor" | "pnp";
+  readonly deviceClass: "mos" | "resistor" | "capacitor" | "bjt";
   readonly terminals: readonly ReviewedExternalTerminalBinding[];
   readonly parameters: readonly ReviewedExternalParameterBinding[];
 }
@@ -113,6 +116,44 @@ export const reviewedExternalDeviceBindings: readonly ReviewedExternalDeviceBind
       ],
     },
     {
+      id: "sky130-nfet-01v8-lvt",
+      libraryId: "sky130_fd_pr",
+      masterName: "sky130_fd_pr__nfet_01v8_lvt",
+      invocationKind: "external-subcircuit",
+      symbolId: "nmos",
+      deviceClass: "mos",
+      terminals: ["D", "G", "S", "B"].map((name) => ({
+        targetName: name,
+        pinName: name,
+        interaction: "canvas" as const,
+      })),
+      parameters: [
+        geometry("w", "W", "1.65u", "1.65", 1),
+        geometry("l", "L", "150n", "0.15", 0),
+        count("nf", "NF", "Finger count", 2),
+        count("m", "M", "ngspice X-line parallel multiplier", 3),
+      ],
+    },
+    {
+      id: "sky130-pfet-01v8-lvt",
+      libraryId: "sky130_fd_pr",
+      masterName: "sky130_fd_pr__pfet_01v8_lvt",
+      invocationKind: "external-subcircuit",
+      symbolId: "pmos",
+      deviceClass: "mos",
+      terminals: ["D", "G", "S", "B"].map((name) => ({
+        targetName: name,
+        pinName: name,
+        interaction: "canvas" as const,
+      })),
+      parameters: [
+        geometry("w", "W", "3u", "3", 1),
+        geometry("l", "L", "350n", "0.35", 0),
+        count("nf", "NF", "Finger count", 2),
+        count("m", "M", "ngspice X-line parallel multiplier", 3),
+      ],
+    },
+    {
       id: "sky130-res-high-po",
       libraryId: "sky130_fd_pr",
       masterName: "sky130_fd_pr__res_high_po",
@@ -151,6 +192,20 @@ export const reviewedExternalDeviceBindings: readonly ReviewedExternalDeviceBind
         geometry("l", "L", "5u", "5", 1),
         count("mf", "MF", "SKY130 MIM wrapper multiplicity", 2),
       ],
+    },
+    {
+      id: "sky130-pnp-05v5-w0p68l0p68",
+      libraryId: "sky130_fd_pr",
+      masterName: "sky130_fd_pr__pnp_05v5_W0p68L0p68",
+      invocationKind: "external-subcircuit",
+      symbolId: "pnp",
+      deviceClass: "bjt",
+      terminals: ["C", "B", "E"].map((name) => ({
+        targetName: name,
+        pinName: name,
+        interaction: "canvas" as const,
+      })),
+      parameters: [],
     },
   ];
 

--- a/packages/edit-engine/src/hierarchy-planner.test.ts
+++ b/packages/edit-engine/src/hierarchy-planner.test.ts
@@ -638,6 +638,69 @@ describe("reviewed external MOS model targets", () => {
     }
   });
 
+  it("switches the ordinary PNP between a primitive model and its exact SKY130 wrapper", () => {
+    const project = createEmptyProject("project", "Project");
+    project.documents[0]!.instances.push({
+      id: "Q1",
+      symbolId: "pnp",
+      placement: null,
+      reference: "Q1",
+      netlist: {
+        binding: { kind: "model", deviceClass: "bjt", name: "generic_pnp" },
+        parameters: {},
+      },
+    });
+    const external = executeProjectTransaction(project, {
+      transactionId: "set-sky130-pnp",
+      projectId: project.id,
+      expectedStructureRevision: project.structureRevision,
+      actor: { kind: "human", id: "test" },
+      edits: planSetDeviceModelTarget(
+        project,
+        project.topDocumentId,
+        "Q1",
+        "sky130_fd_pr__pnp_05v5_W0p68L0p68",
+      ),
+    });
+    expect(external.ok).toBe(true);
+    if (!external.ok) return;
+    expect(external.project.documents[0]!.instances[0]).toMatchObject({
+      symbolId: "pnp",
+      reference: "XQ1",
+      netlist: {
+        binding: { kind: "external-subcircuit" },
+        parameters: {},
+      },
+    });
+    expect(external.project.externalSubcircuitDefinitions[0]).toMatchObject({
+      name: "sky130_fd_pr__pnp_05v5_W0p68L0p68",
+      terminals: [{ name: "C" }, { name: "B" }, { name: "E" }],
+    });
+
+    const ordinary = executeProjectTransaction(external.project, {
+      transactionId: "set-generic-pnp",
+      projectId: external.project.id,
+      expectedStructureRevision: external.project.structureRevision,
+      actor: { kind: "human", id: "test" },
+      edits: planSetDeviceModelTarget(
+        external.project,
+        external.project.topDocumentId,
+        "Q1",
+        "generic_pnp",
+      ),
+    });
+    expect(ordinary.ok).toBe(true);
+    if (!ordinary.ok) return;
+    expect(ordinary.project.documents[0]!.instances[0]).toMatchObject({
+      symbolId: "pnp",
+      reference: "Q1",
+      netlist: {
+        binding: { kind: "model", deviceClass: "bjt", name: "generic_pnp" },
+        parameters: {},
+      },
+    });
+  });
+
   it("refuses a Model transition when its canonical X reference is occupied", () => {
     const project = projectWithNmos();
     project.documents[0]!.instances.push({

--- a/packages/edit-engine/src/hierarchy-planner.test.ts
+++ b/packages/edit-engine/src/hierarchy-planner.test.ts
@@ -635,6 +635,29 @@ describe("reviewed external MOS model targets", () => {
           (terminal) => terminal.name,
         ),
       ).toEqual(fixture.terminalNames);
+
+      const cleared = executeProjectTransaction(result.project, {
+        transactionId: `clear-${fixture.symbolId}-target`,
+        projectId: result.project.id,
+        expectedStructureRevision: result.project.structureRevision,
+        actor: { kind: "human", id: "test" },
+        edits: planSetDeviceModelTarget(
+          result.project,
+          result.project.topDocumentId,
+          fixture.reference,
+          "",
+        ),
+      });
+      expect(cleared.ok).toBe(true);
+      if (!cleared.ok) continue;
+      expect(cleared.project.documents[0]!.instances[0]).toMatchObject({
+        symbolId: fixture.symbolId,
+        reference: fixture.reference,
+        netlist: {
+          binding: { kind: "primitive", deviceClass: fixture.symbolId },
+          parameters: {},
+        },
+      });
     }
   });
 

--- a/packages/edit-engine/src/hierarchy-planner.ts
+++ b/packages/edit-engine/src/hierarchy-planner.ts
@@ -8,6 +8,7 @@ import type {
 } from "@icm/model";
 import { deriveStableId, projectCellInterface, routeEnd } from "@icm/model";
 import {
+  deviceDescriptor,
   resolveReviewedExternalBinding,
   reviewedExternalBindingForMaster,
 } from "@icm/devices";
@@ -349,9 +350,13 @@ export function planSetDeviceModelTarget(
         )
       : undefined;
   const sourceSymbolId = currentExternal?.binding.symbolId ?? instance.symbolId;
-  if (!["nmos", "pmos", "resistor", "capacitor"].includes(sourceSymbolId)) {
+  const sourceDescriptor = deviceDescriptor(sourceSymbolId);
+  if (
+    !sourceDescriptor ||
+    (!targetBinding && sourceDescriptor.targetPolicy !== "required-model")
+  ) {
     throw new Error(
-      "Only reviewed MOS, resistor, and capacitor targets use this Model field",
+      "The selected device does not accept an explicit model target",
     );
   }
 
@@ -469,12 +474,10 @@ export function planSetDeviceModelTarget(
   }
 
   const symbolId = sourceSymbolId;
-  const nativePrefix =
-    sourceSymbolId === "nmos" || sourceSymbolId === "pmos"
-      ? "M"
-      : sourceSymbolId === "resistor"
-        ? "R"
-        : "C";
+  const nativePrefix = sourceDescriptor.referencePrefix;
+  if (!nativePrefix) {
+    throw new Error(`The selected ${sourceSymbolId} has no netlist Reference`);
+  }
   const externalBody = currentExternal
     ? instance.reference!.replace(/^x/iu, "")
     : instance.reference!;
@@ -491,25 +494,28 @@ export function planSetDeviceModelTarget(
       `Cannot clear external target because Reference ${reference} is already used`,
     );
   }
-  if (normalizedName && symbolId !== "nmos" && symbolId !== "pmos") {
+  if (normalizedName && sourceDescriptor.targetPolicy !== "required-model") {
     throw new Error(
       `${symbolId} supports only the reviewed model suggestion in this release`,
     );
   }
   const binding =
-    symbolId === "nmos" || symbolId === "pmos"
+    sourceDescriptor.targetPolicy === "required-model"
       ? normalizedName
-        ? ({ kind: "model", deviceClass: "mos", name: normalizedName } as const)
+        ? ({
+            kind: "model",
+            deviceClass: sourceDescriptor.deviceClass,
+            name: normalizedName,
+          } as const)
         : undefined
       : ({
           kind: "primitive",
-          deviceClass: symbolId === "resistor" ? "resistor" : "capacitor",
+          deviceClass: sourceDescriptor.deviceClass,
         } as const);
   const ordinaryParameterNames = new Set(
-    (symbolId === "nmos" || symbolId === "pmos"
-      ? ["w", "l", "nf", "m"]
-      : ["value"]
-    ).map((name) => name.toLowerCase()),
+    sourceDescriptor.parameters.map((parameter) =>
+      parameter.name.toLowerCase(),
+    ),
   );
   const unset = Object.keys(instance.netlist.parameters).filter(
     (name) => !ordinaryParameterNames.has(name.toLowerCase()),

--- a/packages/edit-engine/src/hierarchy-planner.ts
+++ b/packages/edit-engine/src/hierarchy-planner.ts
@@ -353,7 +353,9 @@ export function planSetDeviceModelTarget(
   const sourceDescriptor = deviceDescriptor(sourceSymbolId);
   if (
     !sourceDescriptor ||
-    (!targetBinding && sourceDescriptor.targetPolicy !== "required-model")
+    (!targetBinding &&
+      !currentExternal &&
+      sourceDescriptor.targetPolicy !== "required-model")
   ) {
     throw new Error(
       "The selected device does not accept an explicit model target",

--- a/packages/netlist/src/current-contract.test.ts
+++ b/packages/netlist/src/current-contract.test.ts
@@ -1238,6 +1238,15 @@ describe("voltage-controlled switch", () => {
         pinNames: ["1", "2"],
         parameters: { w: "5u", l: "5u", mf: "4" },
       },
+      {
+        id: "sky-pnp",
+        name: "sky130_fd_pr__pnp_05v5_W0p68L0p68",
+        symbolId: "pnp",
+        reference: "XQ1",
+        terminalNames: ["C", "B", "E"],
+        pinNames: ["C", "B", "E"],
+        parameters: {},
+      },
     ] as const;
     for (const item of definitions) {
       project.externalSubcircuitDefinitions.push({
@@ -1283,8 +1292,11 @@ describe("voltage-controlled switch", () => {
     expect(text).toContain(
       "XC1 XC1_0 XC1_1 sky130_fd_pr__cap_mim_m3_1 w=5 l=5 mf=4",
     );
+    expect(text).toContain(
+      "XQ1 XQ1_0 XQ1_1 XQ1_2 sky130_fd_pr__pnp_05v5_W0p68L0p68",
+    );
     expect(
       analysis.ir?.cells[0]?.instances.map((instance) => instance.reference),
-    ).toEqual(["XC1", "XM1", "XR1"]);
+    ).toEqual(["XC1", "XM1", "XQ1", "XR1"]);
   });
 });

--- a/packages/simulation-service/src/contract.ts
+++ b/packages/simulation-service/src/contract.ts
@@ -318,6 +318,8 @@ export const CapabilitiesSchema = z.strictObject({
       /** Human-facing name. Automation continues to select the stable id. */
       label: z.string().min(1).max(128).optional(),
       corners: z.array(z.string()),
+      /** Exact model or wrapper names qualified on this hosted environment. */
+      devices: z.array(z.string().min(1).max(256)).optional(),
       /** Environment-owned files addressable by raw Project dependencies. */
       dependencies: z
         .array(z.strictObject({ id: Id, sha256: Digest }))

--- a/packages/symbols/src/pdk-registry.test.ts
+++ b/packages/symbols/src/pdk-registry.test.ts
@@ -7,12 +7,14 @@ import {
 } from "./pdk-registry.js";
 
 describe("PDK symbol mapping registry", () => {
-  it("offers one bounded reviewed target per MOS polarity", () => {
+  it("offers the qualified core and LVT targets per MOS polarity", () => {
     expect(reviewedSky130MosModelSuggestions("nmos")).toEqual([
       "sky130_fd_pr__nfet_01v8",
+      "sky130_fd_pr__nfet_01v8_lvt",
     ]);
     expect(reviewedSky130MosModelSuggestions("pmos")).toEqual([
       "sky130_fd_pr__pfet_01v8",
+      "sky130_fd_pr__pfet_01v8_lvt",
     ]);
     expect(reviewedSky130MosModelSuggestions("resistor")).toEqual([]);
   });
@@ -30,6 +32,9 @@ describe("PDK symbol mapping registry", () => {
     expect(
       resolvePdkSymbolMapping("sky130_fd_pr__res_high_po", 3),
     ).toMatchObject({ symbolId: "resistor", pinNames: ["1", "2", "B"] });
+    expect(
+      resolvePdkSymbolMapping("sky130_fd_pr__pnp_05v5_W0p68L0p68", 3),
+    ).toMatchObject({ symbolId: "pnp", pinNames: ["C", "B", "E"] });
   });
 
   it("does not guess an unknown namespace or conflicting terminal count", () => {

--- a/scripts/preview-simulation-smoke.mjs
+++ b/scripts/preview-simulation-smoke.mjs
@@ -30,15 +30,48 @@ const qualification = JSON.parse(
     "utf8",
   ),
 );
+const extendedQualification = JSON.parse(
+  readFileSync(
+    new URL(
+      "../fixtures/simulation-acceptance/hosted-sky130-extended-devices-v1.json",
+      import.meta.url,
+    ),
+    "utf8",
+  ),
+);
 if (qualification.profileId !== profile.id) {
   throw new Error(
     `Qualification ${qualification.fixtureId} targets ${String(qualification.profileId)}, not Profile ${profile.id}.`,
+  );
+}
+if (extendedQualification.profileId !== profile.id) {
+  throw new Error(
+    `Qualification ${extendedQualification.fixtureId} targets ${String(extendedQualification.profileId)}, not Profile ${profile.id}.`,
+  );
+}
+const evidencedDevices = new Set([
+  ...(qualification.devices ?? []),
+  ...(extendedQualification.devices ?? []),
+]);
+if (
+  evidencedDevices.size !== profile.qualifiedScope.devices.length ||
+  profile.qualifiedScope.devices.some((device) => !evidencedDevices.has(device))
+) {
+  throw new Error(
+    `Profile ${profile.id} device scope is not fully backed by tracked qualification fixtures.`,
   );
 }
 for (const analysis of qualification.analyses) {
   if (!profile.qualifiedScope.analyses.includes(analysis)) {
     throw new Error(
       `Qualification ${qualification.fixtureId} uses undeclared analysis ${String(analysis)}.`,
+    );
+  }
+}
+for (const analysis of extendedQualification.analyses) {
+  if (!profile.qualifiedScope.analyses.includes(analysis)) {
+    throw new Error(
+      `Qualification ${extendedQualification.fixtureId} uses undeclared analysis ${String(analysis)}.`,
     );
   }
 }
@@ -62,6 +95,24 @@ if (
 ) {
   throw new Error(
     `Qualification ${qualification.fixtureId} does not cover every declared Profile corner.`,
+  );
+}
+const extendedQualificationCorners = Object.keys(
+  extendedQualification.expectedCorners ?? {},
+);
+if (
+  extendedQualification.modelLibrary?.directive !==
+    profile.models.library.directive ||
+  extendedQualificationCorners.length === 0 ||
+  extendedQualificationCorners.some(
+    (corner) => !profile.qualifiedScope.sections.includes(corner),
+  ) ||
+  profile.qualifiedScope.sections.some(
+    (corner) => !extendedQualificationCorners.includes(corner),
+  )
+) {
+  throw new Error(
+    `Qualification ${extendedQualification.fixtureId} does not cover the Profile model selection.`,
   );
 }
 
@@ -172,6 +223,48 @@ export function hostedSky130CornerRequest(corner) {
     ].join("\n"),
     timeoutMs: 110_000,
     inputRevision: `preview-sky130-corner-${corner}`,
+    environment: { profileId: profile.id, corner },
+  };
+}
+
+export function hostedSky130ExtendedDeviceRequest(corner) {
+  return {
+    netlist: [
+      ".subckt extended_models gnl dnl gpl spl dpl rin rout capin capout pc pb pe",
+      "XMNL dnl gnl 0 0 sky130_fd_pr__nfet_01v8_lvt L=0.5 W=3 nf=2",
+      "XMPL dpl gpl spl spl sky130_fd_pr__pfet_01v8_lvt L=0.5 W=3 nf=2",
+      "XR1 rin rout 0 sky130_fd_pr__res_high_po w=1 l=5.5 mult=1",
+      "XC1 capout 0 sky130_fd_pr__cap_mim_m3_1 w=5 l=5 mf=1",
+      "XQP pc pb pe sky130_fd_pr__pnp_05v5_W0p68L0p68",
+      ".ends extended_models",
+    ].join("\n"),
+    testbench: [
+      "* Extended device qualification",
+      "VGNL gnl 0 0.9",
+      "VDNL dnl 0 1.8",
+      "VGPL gpl 0 0.9",
+      "VSPL spl 0 1.8",
+      "VDPL dpl 0 0",
+      "VRIN rin 0 1",
+      "RLOAD rout 0 1k",
+      "VAC capin 0 DC 0 AC 1",
+      "RCAP capin capout 1g",
+      "VPE pe 0 1.8",
+      "VPB pb 0 1.1",
+      "VPC pc 0 0",
+      "XDUT gnl dnl gpl spl dpl rin rout capin capout pc pb pe extended_models",
+      ".control",
+      "set filetype=ascii",
+      "op",
+      "write out.raw i(vdnl) i(vspl) v(rout) i(vrin) i(vpe) i(vpc)",
+      "set appendwrite",
+      "ac lin 1 1g 1g",
+      "write out.raw v(capout)",
+      ".endc",
+      ".end",
+    ].join("\n"),
+    timeoutMs: 110_000,
+    inputRevision: `preview-sky130-extended-${corner}`,
     environment: { profileId: profile.id, corner },
   };
 }
@@ -1119,6 +1212,125 @@ export async function runHostedSky130CornerAcceptance({
   return validateHostedSky130CornerResult(payload, target, corner);
 }
 
+export function validateHostedSky130ExtendedDeviceResult(
+  payload,
+  expectedTarget,
+  corner,
+) {
+  const expected = extendedQualification.expectedCorners?.[corner];
+  if (!expected)
+    throw new Error(`No extended-device evidence exists for ${corner}.`);
+  const result = object(payload, "simulation response");
+  if (object(result.execution, "execution metadata").target !== expectedTarget)
+    throw new Error(
+      `${expectedTarget} did not execute extended devices at ${corner}.`,
+    );
+  if (object(result.outcome, "simulation outcome").status !== "completed")
+    throw new Error(
+      `${expectedTarget} did not complete extended devices at ${corner}.`,
+    );
+  const metadata = object(result.metadata, "run metadata");
+  const modelLibrary = object(
+    object(metadata.configuration, "configuration metadata").modelLibrary,
+    "model selection",
+  );
+  if (
+    modelLibrary.directive !== profile.models.library.directive ||
+    modelLibrary.section !== corner
+  )
+    throw new Error(
+      `${expectedTarget} loaded ${String(modelLibrary.section)}, expected corner ${corner}.`,
+    );
+  const environment = object(metadata.environment, "environment metadata");
+  validatePinnedEnvironment(environment, expectedTarget);
+  if (
+    environment.fingerprint !==
+    extendedQualification.evidence.environmentFingerprint
+  )
+    throw new Error(
+      `${expectedTarget} extended-device evidence came from a different environment.`,
+    );
+  const data = object(result.data, "parsed result data");
+  const analyses = Array.isArray(data.analyses) ? data.analyses : [];
+  const operatingPoint = analyses.find(
+    (analysis) => analysis?.analysis === "op",
+  );
+  const ac = analyses.find((analysis) => analysis?.analysis === "ac");
+  if (!Array.isArray(operatingPoint?.probes) || !Array.isArray(ac?.probes))
+    throw new Error(
+      `${expectedTarget} returned incomplete extended-device analyses for ${corner}.`,
+    );
+  const scalar = (name) => {
+    const probe = operatingPoint.probes.find(
+      (candidate) => candidate?.name === name,
+    );
+    if (typeof probe?.value !== "number")
+      throw new Error(`${expectedTarget} returned no ${name} for ${corner}.`);
+    return probe.value;
+  };
+  const cap = ac.probes.find((candidate) => candidate?.name === "v(capout)");
+  if (
+    !Array.isArray(cap?.real) ||
+    !Array.isArray(cap?.imag) ||
+    typeof cap.real[0] !== "number" ||
+    typeof cap.imag[0] !== "number"
+  )
+    throw new Error(
+      `${expectedTarget} returned no MIM AC response for ${corner}.`,
+    );
+  const actual = {
+    lvtNfetCurrentA: scalar("i(vdnl)"),
+    lvtPfetSourceCurrentA: scalar("i(vspl)"),
+    resistorOutputV: scalar("v(rout)"),
+    resistorSupplyCurrentA: scalar("i(vrin)"),
+    pnpEmitterCurrentA: scalar("i(vpe)"),
+    pnpCollectorCurrentA: scalar("i(vpc)"),
+    mimOutputReal: cap.real[0],
+    mimOutputImag: cap.imag[0],
+  };
+  const tolerances = extendedQualification.tolerances;
+  const checks = [
+    ["lvtNfetCurrentA", tolerances.mosCurrentA],
+    ["lvtPfetSourceCurrentA", tolerances.mosCurrentA],
+    ["resistorOutputV", tolerances.resistorVoltageV],
+    ["resistorSupplyCurrentA", tolerances.resistorCurrentA],
+    ["pnpEmitterCurrentA", tolerances.pnpCurrentA],
+    ["pnpCollectorCurrentA", tolerances.pnpCurrentA],
+    ["mimOutputReal", tolerances.mimComplex],
+    ["mimOutputImag", tolerances.mimComplex],
+  ];
+  for (const [name, tolerance] of checks) {
+    if (Math.abs(actual[name] - expected[name]) > tolerance)
+      throw new Error(
+        `${expectedTarget} solved ${name} at ${corner} as ${actual[name]}, expected ${expected[name]} ± ${tolerance}.`,
+      );
+  }
+  return { corner, ...actual };
+}
+
+export async function runHostedSky130ExtendedDeviceAcceptance({
+  baseUrl,
+  target,
+  corner,
+  fetchImpl = fetch,
+}) {
+  const response = await fetchImpl(new URL("/api/simulate", baseUrl), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      ...hostedSky130ExtendedDeviceRequest(corner),
+      executorTarget: target,
+    }),
+    signal: AbortSignal.timeout(120_000),
+  });
+  const payload = await response.json();
+  if (!response.ok)
+    throw new Error(
+      `[infrastructure:http-${response.status}] ${target} ${corner} extended-device qualification failed.`,
+    );
+  return validateHostedSky130ExtendedDeviceResult(payload, target, corner);
+}
+
 export async function runHostedSky130TransientAcceptance({
   baseUrl,
   target,
@@ -1365,6 +1577,14 @@ async function main() {
       console.log(
         `${target}: SKY130 ${result.corner.toUpperCase()} corner passed ` +
           `(NFET=${result.nfetCurrentA}, PFET=${result.pfetSourceCurrentA})`,
+      );
+      const extended = await runHostedSky130ExtendedDeviceAcceptance({
+        baseUrl,
+        target,
+        corner,
+      });
+      console.log(
+        `${target}: SKY130 ${extended.corner.toUpperCase()} extended devices passed`,
       );
     }
   }

--- a/scripts/preview-simulation-smoke.test.mjs
+++ b/scripts/preview-simulation-smoke.test.mjs
@@ -5,8 +5,10 @@ import {
   compileHostedSky130NoiseProject,
   compileHostedSky130TransientProject,
   hostedSky130CornerRequest,
+  hostedSky130ExtendedDeviceRequest,
   runHostedSky130Acceptance,
   runHostedSky130CornerAcceptance,
+  runHostedSky130ExtendedDeviceAcceptance,
   runHostedSky130NoiseAcceptance,
   runHostedSky130TransientAcceptance,
   runPreviewSimulationSmoke,
@@ -17,6 +19,7 @@ import {
   validateExecutorParity,
   validateHostedSky130Result,
   validateHostedSky130CornerResult,
+  validateHostedSky130ExtendedDeviceResult,
   validatePreviewSimulationResult,
 } from "./preview-simulation-smoke.mjs";
 
@@ -195,6 +198,60 @@ function cornerResult(target, corner = "ff") {
           probes: [
             { name: "i(vdn)", value: -0.0002526337154561964 },
             { name: "i(vsp)", value: -9.451994627332483e-7 },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+function extendedDeviceResult(target, corner = "ff") {
+  const base = result(target);
+  const expected = {
+    lvtNfetCurrentA: -0.0001329127936535723,
+    lvtPfetSourceCurrentA: -0.00006968745845296193,
+    resistorOutputV: 0.313487576360055,
+    resistorSupplyCurrentA: -0.000313487576360055,
+    pnpEmitterCurrentA: -2.149132309996193e-7,
+    pnpCollectorCurrentA: 1.983406510684755e-7,
+    mimOutputReal: 9.002255934489363e-12,
+    mimOutputImag: -0.00000300037596550971,
+  };
+  return {
+    ...base,
+    metadata: {
+      ...base.metadata,
+      input: { inputRevision: `preview-sky130-extended-${corner}` },
+      configuration: {
+        modelLibrary: { directive: "lib", section: corner },
+      },
+      environment: {
+        ...base.metadata.environment,
+        fingerprint: CORNER_ENVIRONMENT_SHA,
+      },
+    },
+    data: {
+      analyses: [
+        {
+          analysis: "op",
+          probes: [
+            { name: "i(vdnl)", value: expected.lvtNfetCurrentA },
+            { name: "i(vspl)", value: expected.lvtPfetSourceCurrentA },
+            { name: "v(rout)", value: expected.resistorOutputV },
+            { name: "i(vrin)", value: expected.resistorSupplyCurrentA },
+            { name: "i(vpe)", value: expected.pnpEmitterCurrentA },
+            { name: "i(vpc)", value: expected.pnpCollectorCurrentA },
+          ],
+        },
+        {
+          analysis: "ac",
+          frequencyHz: [1e9],
+          probes: [
+            {
+              name: "v(capout)",
+              real: [expected.mimOutputReal],
+              imag: [expected.mimOutputImag],
+            },
           ],
         },
       ],
@@ -471,6 +528,52 @@ describe("the hosted SKY130 qualification", () => {
     expect(() =>
       validateHostedSky130CornerResult(candidate, "operator-host", "ff"),
     ).toThrow(/unexpected ff currents/u);
+  });
+
+  it("qualifies every newly exposed wrapper from one OP/AC deck", async () => {
+    const request = hostedSky130ExtendedDeviceRequest("ff");
+    expect(request.netlist).toContain("sky130_fd_pr__nfet_01v8_lvt");
+    expect(request.netlist).toContain("sky130_fd_pr__pfet_01v8_lvt");
+    expect(request.netlist).toContain("sky130_fd_pr__res_high_po");
+    expect(request.netlist).toContain("sky130_fd_pr__cap_mim_m3_1");
+    expect(request.netlist).toContain("sky130_fd_pr__pnp_05v5_W0p68L0p68");
+    expect(
+      validateHostedSky130ExtendedDeviceResult(
+        extendedDeviceResult("operator-host"),
+        "operator-host",
+        "ff",
+      ),
+    ).toMatchObject({
+      corner: "ff",
+      resistorOutputV: 0.313487576360055,
+    });
+
+    let submitted;
+    await runHostedSky130ExtendedDeviceAcceptance({
+      baseUrl: "https://preview.example",
+      target: "operator-host",
+      corner: "ff",
+      fetchImpl: async (_url, init) => {
+        submitted = JSON.parse(init.body);
+        return Response.json(extendedDeviceResult("operator-host"));
+      },
+    });
+    expect(submitted.environment).toEqual({
+      profileId: PROFILE_ID,
+      corner: "ff",
+    });
+  });
+
+  it("refuses extended-device numerical drift", () => {
+    const candidate = extendedDeviceResult("operator-host");
+    candidate.data.analyses[0].probes[0].value = -0.001;
+    expect(() =>
+      validateHostedSky130ExtendedDeviceResult(
+        candidate,
+        "operator-host",
+        "ff",
+      ),
+    ).toThrow(/lvtNfetCurrentA/u);
   });
 
   it("accepts the model-backed OTA operating point", () => {

--- a/worker/simulation.test.ts
+++ b/worker/simulation.test.ts
@@ -81,6 +81,7 @@ describe("simulation route", () => {
           id: hostedSky130Profile.id,
           label: hostedSky130Profile.displayName,
           corners: hostedSky130Profile.qualifiedScope.sections,
+          devices: hostedSky130Profile.qualifiedScope.devices,
           dependencies: [
             {
               id: hostedSky130Profile.models.id,

--- a/worker/simulation.ts
+++ b/worker/simulation.ts
@@ -310,6 +310,7 @@ export async function routeSimulationRequest(
           id: hostedSky130Profile.id,
           label: hostedSky130Profile.displayName ?? hostedSky130Profile.id,
           corners: hostedSky130Profile.qualifiedScope.sections,
+          devices: hostedSky130Profile.qualifiedScope.devices,
           dependencies: [
             {
               id: hostedSky130Profile.models.id,


### PR DESCRIPTION
## Summary
- add exact reviewed model bindings for SKY130 LVT NFET/PFET and the qualified fixed PNP
- expose the hosted Profile device scope through simulation capabilities
- add five-corner OP/AC acceptance evidence and Preview smoke coverage
- keep existing symbols, Project schema, model bytes, and execution image unchanged

## Explicit exclusions
- SKY130 diode is not resolvable in the hosted continuous model library
- SKY130 NPN emits unsupported-parameter drops under pinned ngspice 46

## Validation
- real Preview qualification passed at TT/FF/SS/FS/SF
- pnpm gate:full -- --base origin/main
- 2866 unit tests passed, 23 skipped
- 361 browser tests passed
- build, release, performance, visual/export golden, MCP distribution and smoke checks passed