### PR TITLE
docs(simulation): record cross-project reuse implementation

### DIFF
--- a/docs/roadmap/simulation-remaining-work.md
+++ b/docs/roadmap/simulation-remaining-work.md
@@ -17,12 +17,18 @@ This plan retains the integration and acceptance obligations that are not
 closed merely by those modules existing. It does not assert that a remote
 issue is open or closed; the candidate's evidence decides completion.
 
-## 1. Cross-Project reuse and Project operations
+## 1. Cross-Project reuse acceptance closure
 
-Reuse must import a local, independent Cell closure, not a live reference to a
-different Project. It includes called Cells, formal interfaces and pin order,
-presentation, netlist bindings, source/provenance, and required symbol locks.
-The source stays unchanged and later edits do not synchronize the copies.
+Cross-Project reuse is implemented through the Editor's **Import Cell** flow
+and the Agent's `project_cells` resource. Both call the same atomic planner and
+import a local, independent Cell closure rather than creating a live reference
+to another Project. The closure includes called Cells, formal interfaces and
+pin order, presentation, netlist bindings, source/provenance, and required
+symbol locks. The source stays unchanged and later edits do not synchronize the
+copies.
+
+The remaining work is integrated acceptance of that implementation, not a new
+Project store, library protocol, or second import path.
 
 Acceptance:
 
@@ -40,11 +46,12 @@ Acceptance:
   consistency. Reject hierarchy cycles; do not conflate two reused occurrences.
 - Save/reload and undo/redo the operations through existing Project transactions.
 
-Project roster/read/create/save/rename/delete and Cell retrieval for an Agent,
-where still required, must wrap existing authorized storage and shared services.
-Do not build another Cloud Project store, broad file API, or Library/Cell/View
-platform. Capability absence must be explicit; simulation execution authority
-does not implicitly authorize Project management.
+Project roster and Cell retrieval already wrap the authorized Cloud Project
+service. Any later create/save/rename/delete exposure must continue to wrap
+existing shared services. Do not build another Cloud Project store, broad file
+API, or Library/Cell/View platform. Capability absence must be explicit;
+simulation execution authority does not implicitly authorize Project
+management.
 
 ## 2. One-candidate vertical acceptance
 

--- a/docs/user/analog-simulation.md
+++ b/docs/user/analog-simulation.md
@@ -150,9 +150,12 @@ are transient, not saved inside the Project.
 
 ## Current boundary
 
-The current UI supports local DUT/Testbench reuse and named saved setups.
-The [simulation roadmap](../roadmap/simulation-remaining-work.md) identifies
-the remaining cross-Project and integrated acceptance boundaries.
+The current UI supports local DUT/Testbench reuse, named saved setups, and
+independent Cell-closure imports from authorized Cloud Projects. The GUI uses
+**Import Cell**; Agents use `project_cells`; both call the same import planner.
+The [simulation roadmap](../roadmap/simulation-remaining-work.md) retains the
+integrated cross-Project acceptance boundary rather than treating that
+implemented flow as future functionality.
 Persistent Project result archives and overlaid multi-run waveforms are not
 provided by the session comparison view. Raw/Agent workflows retain their
 advertised capabilities.


### PR DESCRIPTION
## Summary
- record GUI Import Cell and Agent project_cells as implemented shared behavior
- retain cross-Project work as integrated acceptance rather than future implementation
- keep later Project operations on existing authorized services

## Validation
- Markdown link check
- git diff --check