### PR TITLE
fix(release): freeze MCP packaging on Node 24.20.0

### DIFF
--- a/.github/workflows/mcp-release.yml
+++ b/.github/workflows/mcp-release.yml
@@ -22,7 +22,8 @@ jobs:
           version: 11.16.0
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          # npm pack metadata is part of the immutable tarball digest.
+          node-version: 24.20.0
           cache: pnpm
           registry-url: https://registry.npmjs.org
       - run: pnpm install --frozen-lockfile

--- a/config/agent-mcp-distribution.json
+++ b/config/agent-mcp-distribution.json
@@ -11,6 +11,6 @@
     "repository": "cascode-ai/analog-canvas",
     "tag": "mcp-v0.5.0",
     "asset": "analog-canvas-mcp-server-0.5.0.tgz",
-    "sha256": "b5b7d6ec7dbdaeb284706730832e79bd050069e7e85c8073441fc537a66be24a"
+    "sha256": "a27d20b86123a07816d280bc7b104030b13f25164e2ca0c1571f58f9d807c05c"
   }
 }


### PR DESCRIPTION
## Summary
- pin MCP publication to Node 24.20.0
- use the digest produced by that exact GitHub Linux build
- remove the patch-version drift that blocked 0.5.0 publication

## Evidence
Failed publication run 34300695091 completed packaging and reported actual SHA-256 a27d20b86123a07816d280bc7b104030b13f25164e2ca0c1571f58f9d807c05c on Node 24.20.0.