### PR TITLE
feat(simulation): compose bounded sweeps in the editor

### DIFF
--- a/apps/editor/src/features/simulation/simulation-sweep-dialog.test.tsx
+++ b/apps/editor/src/features/simulation/simulation-sweep-dialog.test.tsx
@@ -1,0 +1,78 @@
+import { createEmptyProject } from "@icm/model";
+import type { Capabilities } from "@icm/simulation-service/contract";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { SimulationSweepDialog } from "./simulation-sweep-dialog";
+
+describe("SimulationSweepDialog", () => {
+  it("offers run-only corner, temperature, and existing parameter axes", () => {
+    const project = createEmptyProject("sweep-project", "Sweep");
+    const document = project.documents[0]!;
+    document.instances.push({
+      id: "m1",
+      symbolId: "nmos-3t",
+      reference: "M1",
+      placement: null,
+      netlist: {
+        binding: { kind: "primitive", deviceClass: "mos" },
+        parameters: { w: "1u", l: "0.15u" },
+      },
+    });
+    const setup = {
+      id: "setup-ac",
+      name: "AC response",
+      version: 2 as const,
+      input: {
+        kind: "structured" as const,
+        rootDocumentId: document.id,
+        analyses: [
+          {
+            kind: "ac" as const,
+            sweep: "dec" as const,
+            points: 10,
+            startHz: 1,
+            stopHz: 1e6,
+          },
+        ],
+        outputs: [],
+        environment: { profileId: "sky130" },
+      },
+    };
+    project.simulationSetups.push(setup);
+    const capabilities: Capabilities = {
+      configured: true,
+      inputs: ["structured"],
+      analyses: ["ac"],
+      parsedAnalyses: ["ac"],
+      profiles: [{ id: "sky130", corners: ["TT", "FF", "SS"] }],
+      maxTimeoutMs: 120000,
+      maxInputBytes: 1_048_576,
+      cancel: true,
+      batch: {
+        maxItems: 16,
+        execution: "sequential",
+        sweepAxes: ["corner", "temperature", "parameter"],
+      },
+    };
+
+    const markup = renderToStaticMarkup(
+      <SimulationSweepDialog
+        open
+        project={project}
+        setup={setup}
+        capabilities={capabilities}
+        onClose={() => undefined}
+        onRun={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain('role="dialog"');
+    expect(markup).toContain("Sweep · AC response");
+    expect(markup).toContain('aria-label="Sweep corner FF"');
+    expect(markup).toContain('aria-label="Sweep temperatures"');
+    expect(markup).toContain('aria-label="Sweep instance parameter"');
+    expect(markup).toContain("Main · M1 · w");
+    expect(markup).toContain("Run-only variants");
+  });
+});

--- a/apps/editor/src/features/simulation/simulation-sweep-dialog.tsx
+++ b/apps/editor/src/features/simulation/simulation-sweep-dialog.tsx
@@ -1,0 +1,246 @@
+import { useEffect, useMemo, useState } from "react";
+import type { CircuitProject, ProjectSimulationSetup } from "@icm/model";
+import type {
+  Capabilities,
+  SimulationOperation,
+} from "@icm/simulation-service/contract";
+
+export type SimulationSweepAxis = Extract<
+  SimulationOperation,
+  { operation: "prepare-sweep" }
+>["axes"][number];
+
+interface SimulationSweepDialogProps {
+  open: boolean;
+  project: CircuitProject;
+  setup: ProjectSimulationSetup;
+  capabilities: Capabilities;
+  disabled?: boolean;
+  onClose(): void;
+  onRun(axes: readonly SimulationSweepAxis[]): void;
+}
+
+function commaValues(value: string): readonly string[] {
+  return value
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+export function SimulationSweepDialog(props: SimulationSweepDialogProps) {
+  const input = props.setup.input;
+  const profile =
+    input.kind === "structured"
+      ? props.capabilities.profiles.find(
+          (candidate) => candidate.id === input.environment.profileId,
+        )
+      : undefined;
+  const parameterChoices = useMemo(
+    () =>
+      props.project.documents.flatMap((document) =>
+        document.instances.flatMap((instance) =>
+          Object.keys(instance.netlist?.parameters ?? {}).map((parameter) => ({
+            id: `${document.id}\u0000${instance.id}\u0000${parameter}`,
+            documentId: document.id,
+            instanceId: instance.id,
+            parameter,
+            label: `${document.name} · ${instance.reference ?? instance.id} · ${parameter}`,
+          })),
+        ),
+      ),
+    [props.project],
+  );
+  const [cornerEnabled, setCornerEnabled] = useState(true);
+  const [corners, setCorners] = useState<readonly string[]>([]);
+  const [temperatureEnabled, setTemperatureEnabled] = useState(false);
+  const [temperatures, setTemperatures] = useState("-40, 27, 125");
+  const [parameterEnabled, setParameterEnabled] = useState(false);
+  const [parameterChoiceId, setParameterChoiceId] = useState("");
+  const [parameterValues, setParameterValues] = useState("");
+
+  useEffect(() => {
+    if (!props.open) return;
+    const currentCorner =
+      input.kind === "structured" ? input.environment.corner : undefined;
+    setCorners(
+      currentCorner && profile?.corners.includes(currentCorner)
+        ? [currentCorner]
+        : (profile?.corners.slice(0, 1) ?? []),
+    );
+    setParameterChoiceId(parameterChoices[0]?.id ?? "");
+  }, [props.open, props.setup.id, profile, parameterChoices, input]);
+
+  if (!props.open || input.kind !== "structured") return null;
+  const temperatureValues = commaValues(temperatures).map(Number);
+  const parameter = parameterChoices.find(
+    (candidate) => candidate.id === parameterChoiceId,
+  );
+  const parsedParameterValues = commaValues(parameterValues);
+  const pointCount =
+    (cornerEnabled ? corners.length : 1) *
+    (temperatureEnabled ? temperatureValues.length : 1) *
+    (parameterEnabled ? parsedParameterValues.length : 1);
+  const axisCount =
+    Number(cornerEnabled) +
+    Number(temperatureEnabled) +
+    Number(parameterEnabled);
+  const maxItems = props.capabilities.batch?.maxItems ?? 16;
+  const valid =
+    axisCount > 0 &&
+    pointCount >= 2 &&
+    pointCount <= maxItems &&
+    (!cornerEnabled || corners.length > 0) &&
+    (!temperatureEnabled ||
+      (temperatureValues.length > 0 &&
+        temperatureValues.every(Number.isFinite))) &&
+    (!parameterEnabled || Boolean(parameter && parsedParameterValues.length));
+
+  return (
+    <div className="simulation-sweep-backdrop" role="presentation">
+      <form
+        className="simulation-sweep-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Run parameter sweep"
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (!valid) return;
+          const axes: SimulationSweepAxis[] = [];
+          if (cornerEnabled)
+            axes.push({ kind: "corner", values: [...corners] });
+          if (temperatureEnabled)
+            axes.push({ kind: "temperature", values: temperatureValues });
+          if (parameterEnabled && parameter)
+            axes.push({
+              kind: "parameter",
+              documentId: parameter.documentId,
+              instanceId: parameter.instanceId,
+              parameter: parameter.parameter,
+              values: [...parsedParameterValues],
+            });
+          props.onRun(axes);
+        }}
+      >
+        <header>
+          <div>
+            <strong>Sweep · {props.setup.name}</strong>
+            <span>Run-only variants; the saved Setup is unchanged.</span>
+          </div>
+          <button
+            type="button"
+            aria-label="Close sweep"
+            onClick={props.onClose}
+          >
+            ×
+          </button>
+        </header>
+
+        <div className="simulation-sweep-axis">
+          <input
+            type="checkbox"
+            aria-label="Enable corner sweep"
+            checked={cornerEnabled}
+            onChange={(event) => setCornerEnabled(event.currentTarget.checked)}
+          />
+          <span>Corner</span>
+          <span className="simulation-sweep-corners">
+            {(profile?.corners ?? []).map((corner) => (
+              <label key={corner}>
+                <input
+                  type="checkbox"
+                  aria-label={`Sweep corner ${corner}`}
+                  checked={corners.includes(corner)}
+                  disabled={!cornerEnabled}
+                  onChange={(event) =>
+                    setCorners((current) =>
+                      event.currentTarget.checked
+                        ? [...current, corner]
+                        : current.filter((value) => value !== corner),
+                    )
+                  }
+                />
+                {corner}
+              </label>
+            ))}
+          </span>
+        </div>
+
+        <div className="simulation-sweep-axis">
+          <input
+            type="checkbox"
+            aria-label="Enable temperature sweep"
+            checked={temperatureEnabled}
+            onChange={(event) =>
+              setTemperatureEnabled(event.currentTarget.checked)
+            }
+          />
+          <span>Temperature / °C</span>
+          <input
+            aria-label="Sweep temperatures"
+            value={temperatures}
+            disabled={!temperatureEnabled}
+            onChange={(event) => setTemperatures(event.currentTarget.value)}
+            placeholder="-40, 27, 125"
+          />
+        </div>
+
+        <div className="simulation-sweep-axis">
+          <input
+            type="checkbox"
+            aria-label="Enable instance parameter sweep"
+            checked={parameterEnabled}
+            onChange={(event) =>
+              setParameterEnabled(event.currentTarget.checked)
+            }
+          />
+          <span>Instance parameter</span>
+          <span className="simulation-sweep-parameter">
+            <select
+              aria-label="Sweep instance parameter"
+              value={parameterChoiceId}
+              disabled={!parameterEnabled}
+              onChange={(event) =>
+                setParameterChoiceId(event.currentTarget.value)
+              }
+            >
+              {parameterChoices.map((choice) => (
+                <option key={choice.id} value={choice.id}>
+                  {choice.label}
+                </option>
+              ))}
+            </select>
+            <input
+              aria-label="Sweep parameter values"
+              value={parameterValues}
+              disabled={!parameterEnabled}
+              onChange={(event) =>
+                setParameterValues(event.currentTarget.value)
+              }
+              placeholder="1u, 2u, 5u"
+            />
+          </span>
+        </div>
+
+        <footer>
+          <span>
+            {valid
+              ? `${pointCount} sequential runs`
+              : pointCount > maxItems
+                ? `${pointCount} runs exceeds ${maxItems}`
+                : "Choose at least two valid points"}
+          </span>
+          <button type="button" onClick={props.onClose}>
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className="simulation-primary-button"
+            disabled={!valid || props.disabled}
+          >
+            Run sweep
+          </button>
+        </footer>
+      </form>
+    </div>
+  );
+}

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -53,6 +53,10 @@ import {
 } from "./simulation-run-comparison";
 import { createBrowserSimulationArchiveStore } from "./browser-simulation-archive-store";
 import {
+  SimulationSweepDialog,
+  type SimulationSweepAxis,
+} from "./simulation-sweep-dialog";
+import {
   captureSimulationRunArchive,
   restoreSimulationRunArchive,
   type SimulationRunArchiveSummary,
@@ -121,7 +125,9 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
   const [run, setRun] = useState<Run>();
   const [batch, setBatch] = useState<SimulationBatch>();
   const [batchSelection, setBatchSelection] = useState<readonly string[]>([]);
+  const [sweepOpen, setSweepOpen] = useState(false);
   const hydratedBatchRuns = useRef(new Set<string>());
+  const batchRuns = useRef(new Map<string, { prepared: Prepared; run: Run }>());
   const runDetails = useRef(new SimulationRunDetails());
   const [problem, setProblem] = useState<Problem>();
   const [busy, setBusy] = useState(false);
@@ -354,6 +360,10 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
         });
         if (!runReply.ok || !("run" in runReply)) continue;
         hydratedBatchRuns.current.add(item.runId);
+        batchRuns.current.set(item.runId, {
+          prepared: item.prepared,
+          run: runReply.run,
+        });
         setupResults.current.set(item.setupId, {
           prepared: item.prepared,
           run: runReply.run,
@@ -484,6 +494,75 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
       lock.current = false;
       if (alive.current) setBusy(false);
     }
+  };
+  const executeSweep = async (axes: readonly SimulationSweepAxis[]) => {
+    if (
+      lock.current ||
+      !selectedSetup ||
+      selectedSetup.input.kind !== "structured"
+    )
+      return;
+    lock.current = true;
+    setBusy(true);
+    setProblem(undefined);
+    hydratedBatchRuns.current.clear();
+    batchRuns.current.clear();
+    try {
+      const preparedReply = await session.handle({
+        operation: "prepare-sweep",
+        setupId: selectedSetup.id,
+        expectedStructureRevision: project.structureRevision,
+        axes: [...axes],
+      });
+      receive(preparedReply);
+      if (!preparedReply.ok || !("batch" in preparedReply)) return;
+      for (const item of preparedReply.batch.items) {
+        preparedPresentations.current.set(item.prepared.id, {
+          setupId: selectedSetup.id,
+          prepared: structuredClone(item.prepared),
+          outputs: structuredClone(selectedSetup.input.outputs),
+          analysisLabel: selectedSetup.input.analyses
+            .map((analysis) => analysis.kind.toUpperCase())
+            .join(" + "),
+          setupName: item.label ?? selectedSetup.name,
+          rootDocumentId: selectedSetup.input.rootDocumentId,
+        });
+      }
+      receive(
+        await session.handle({
+          operation: "start-batch",
+          batchId: preparedReply.batch.id,
+        }),
+      );
+      setSweepOpen(false);
+      setupMenuRef.current?.removeAttribute("open");
+    } finally {
+      lock.current = false;
+      if (alive.current) setBusy(false);
+    }
+  };
+  const showBatchItem = async (item: SimulationBatch["items"][number]) => {
+    if (!item.runId) return;
+    let resolved = batchRuns.current.get(item.runId);
+    if (!resolved) {
+      const reply = await session.handle({
+        operation: "read",
+        runId: item.runId,
+      });
+      if (!reply.ok || !("run" in reply)) {
+        receive(reply);
+        return;
+      }
+      resolved = { prepared: item.prepared, run: reply.run };
+      batchRuns.current.set(item.runId, resolved);
+    }
+    if (item.setupId !== activeSetupId.current)
+      props.onSelectSetupId(item.setupId);
+    setPrepared(resolved.prepared);
+    setRun(resolved.run);
+    setSetupOpen(false);
+    setResultsOpen(true);
+    setResultTab(preferredResultTab(resolved.run));
   };
   const download = async (artifact: ArtifactRef) => {
     setArtifactBusy(`download:${artifact.id}`);
@@ -899,6 +978,20 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
                   Run selected ({batchSelection.length})
                 </button>
               ) : null}
+              {selectedSetup?.input.kind === "structured" &&
+              capabilities?.batch ? (
+                <button
+                  type="button"
+                  className="simulation-setup-menu-batch"
+                  disabled={dirty || busy || !!running}
+                  onClick={() => {
+                    setSweepOpen(true);
+                    setupMenuRef.current?.removeAttribute("open");
+                  }}
+                >
+                  Sweep…
+                </button>
+              ) : null}
               {project.simulationSetups.map((setup) => (
                 <div
                   key={setup.id}
@@ -1087,7 +1180,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
                   key={item.id}
                   data-state={item.state}
                   disabled={!item.runId}
-                  onClick={() => props.onSelectSetupId(item.setupId)}
+                  onClick={() => void showBatchItem(item)}
                 >
                   {item.label ?? setup?.name ?? item.setupId} · {item.state}
                 </button>
@@ -1100,6 +1193,18 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
             </button>
           ) : null}
         </div>
+      ) : null}
+
+      {sweepOpen && selectedSetup && capabilities ? (
+        <SimulationSweepDialog
+          open
+          project={project}
+          setup={selectedSetup}
+          capabilities={capabilities}
+          disabled={busy || !!running}
+          onClose={() => setSweepOpen(false)}
+          onRun={(axes) => void executeSweep(axes)}
+        />
       ) : null}
 
       {!selectedSetup && !hasDutInstance ? (

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -244,6 +244,71 @@
   color: #b42318;
   border-color: #fda29b;
 }
+.simulation-sweep-backdrop {
+  position: absolute;
+  z-index: 30;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 16px;
+  background: color-mix(in srgb, var(--icm-text) 24%, transparent);
+}
+.simulation-sweep-dialog {
+  display: grid;
+  gap: 10px;
+  width: min(620px, 100%);
+  max-height: 90%;
+  padding: 14px;
+  overflow: auto;
+  border: 1px solid var(--icm-border-strong);
+  border-radius: var(--icm-radius-md);
+  background: var(--icm-surface);
+  box-shadow: var(--icm-shadow-lg);
+}
+.simulation-sweep-dialog > header,
+.simulation-sweep-dialog > footer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.simulation-sweep-dialog > header > div {
+  display: grid;
+  gap: 2px;
+  margin-right: auto;
+}
+.simulation-sweep-dialog > header span,
+.simulation-sweep-dialog > footer > span {
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+}
+.simulation-sweep-dialog > footer {
+  justify-content: flex-end;
+}
+.simulation-sweep-dialog > footer > span {
+  margin-right: auto;
+}
+.simulation-sweep-axis {
+  display: grid;
+  grid-template-columns: auto 130px minmax(0, 1fr);
+  gap: 8px;
+  align-items: center;
+  min-height: 34px;
+}
+.simulation-sweep-corners,
+.simulation-sweep-parameter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.simulation-sweep-corners label {
+  display: inline-flex;
+  gap: 3px;
+  align-items: center;
+}
+.simulation-sweep-parameter > * {
+  flex: 1 1 150px;
+  min-width: 0;
+}
 .simulation-primary-button {
   border-color: var(--icm-accent) !important;
   color: #fff !important;


### PR DESCRIPTION
## Summary
- add an on-demand sweep composer for structured simulation setups
- expose corner, temperature, and one existing instance-parameter axis without mutating the saved setup
- prepare canonical variants and launch them through the existing batch service
- retain run-id-specific presentations so each sweep result can be reopened independently

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
- pnpm build
- git diff --check