### PR TITLE
feat(simulation): overlay compatible run waveforms

### DIFF
--- a/apps/editor/src/features/simulation/simulation-run-comparison.test.tsx
+++ b/apps/editor/src/features/simulation/simulation-run-comparison.test.tsx
@@ -18,6 +18,11 @@ function run(
     inputRevision: `revision-${id}`,
     environment: { profileId: "sky130", corner: "tt", temperatureC: 27 },
     current,
+    outputData: {
+      schemaVersion: 1,
+      analyses: [],
+      diagnostics: [],
+    },
     measurements: [
       {
         id: `0:out:maximum:${id}`,

--- a/apps/editor/src/features/simulation/simulation-run-comparison.tsx
+++ b/apps/editor/src/features/simulation/simulation-run-comparison.tsx
@@ -10,6 +10,7 @@ export interface SimulationComparisonRun {
   readonly label: string;
   readonly inputRevision: string;
   readonly environment: Prepared["environment"];
+  readonly outputData: SimulationOutputData;
   readonly measurements: readonly Measurement[];
   readonly current: boolean;
 }
@@ -131,6 +132,7 @@ export function SimulationRunComparison({
         Complete a structured run to compare its measurements.
       </p>
     );
+  if (!runs.some((run) => run.measurements.length)) return null;
 
   return (
     <div className="simulation-comparison-runs">

--- a/apps/editor/src/features/simulation/simulation-waveform-comparison.test.ts
+++ b/apps/editor/src/features/simulation/simulation-waveform-comparison.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import type { SimulationComparisonRun } from "./simulation-run-comparison";
+import { buildComparisonWaveforms } from "./simulation-waveform-comparison";
+
+function run(
+  id: string,
+  domain: readonly number[],
+  scale: number,
+): SimulationComparisonRun {
+  return {
+    id,
+    label: `Run ${id}`,
+    inputRevision: `revision-${id}`,
+    environment: { profileId: "sky130", corner: id },
+    current: id === "ff",
+    measurements: [],
+    outputData: {
+      schemaVersion: 1,
+      diagnostics: [],
+      analyses: [
+        {
+          analysis: "tran",
+          plotName: "Transient",
+          domain: { name: "Time", unit: "s", values: [...domain] },
+          outputs: [
+            {
+              id: "vout",
+              label: "Vout",
+              unit: "V",
+              values: domain.map((value) => value * scale),
+            },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+describe("buildComparisonWaveforms", () => {
+  it("overlays matching outputs from separate runs with run-qualified labels", () => {
+    const result = buildComparisonWaveforms([
+      run("tt", [0, 1, 2], 1),
+      run("ff", [0, 1, 2], 2),
+    ]);
+    expect(result.complex).toEqual([]);
+    expect(result.scalar).toHaveLength(1);
+    expect(result.scalar[0]?.traces).toHaveLength(2);
+    expect(result.scalar[0]?.traces.map((trace) => trace.label)).toEqual([
+      "Vout — Run tt · TT",
+      "Vout — Run ff · FF",
+    ]);
+  });
+
+  it("does not place incompatible sampled domains on one axis", () => {
+    const result = buildComparisonWaveforms([
+      run("short", [0, 1], 1),
+      run("long", [0, 1, 2], 1),
+    ]);
+    expect(result.scalar).toEqual([]);
+  });
+});

--- a/apps/editor/src/features/simulation/simulation-waveform-comparison.tsx
+++ b/apps/editor/src/features/simulation/simulation-waveform-comparison.tsx
@@ -1,0 +1,199 @@
+import type { SimulationOutputData } from "@icm/simulation-service/contract";
+
+import {
+  ComplexResultsExplorer,
+  complexAcPoint,
+  unwrapPhaseDegrees,
+  type OutputTrace,
+} from "./ac-results-explorer";
+import type { SimulationComparisonRun } from "./simulation-run-comparison";
+import {
+  ScalarResultsExplorer,
+  type ScalarTrace,
+} from "./transient-results-explorer";
+
+type EvaluatedAnalysis = SimulationOutputData["analyses"][number];
+
+export interface ScalarComparisonGroup {
+  readonly key: string;
+  readonly label: string;
+  readonly analysis: EvaluatedAnalysis["analysis"];
+  readonly domain: EvaluatedAnalysis["domain"] & {};
+  readonly unit: string;
+  readonly traces: readonly ScalarTrace[];
+}
+
+export interface ComplexComparisonGroup {
+  readonly key: string;
+  readonly label: string;
+  readonly traces: readonly OutputTrace[];
+}
+
+export interface ComparisonWaveforms {
+  readonly scalar: readonly ScalarComparisonGroup[];
+  readonly complex: readonly ComplexComparisonGroup[];
+}
+
+function analysisTitle(analysis: EvaluatedAnalysis["analysis"]): string {
+  if (analysis === "dc") return "DC";
+  if (analysis === "ac") return "AC";
+  if (analysis === "tran") return "Transient";
+  if (analysis === "noise") return "Noise";
+  return "Operating Point";
+}
+
+function runLabel(run: SimulationComparisonRun): string {
+  const conditions = [
+    run.environment.corner?.toUpperCase(),
+    run.environment.temperatureC === undefined
+      ? undefined
+      : `${run.environment.temperatureC} °C`,
+  ].filter(Boolean);
+  return conditions.length
+    ? `${run.label} · ${conditions.join(" · ")}`
+    : run.label;
+}
+
+function quantity(unit: string): string {
+  if (unit === "V") return "voltage";
+  if (unit === "A") return "current";
+  if (unit === "1") return "Value";
+  return unit;
+}
+
+function domainIdentity(domain: NonNullable<EvaluatedAnalysis["domain"]>) {
+  return `${domain.name}\u0000${domain.unit}\u0000${domain.values.join(",")}`;
+}
+
+/**
+ * Build overlays only where the result contracts are compatible. Scalar runs
+ * need the same sampled domain; complex AC traces carry their own frequencies.
+ */
+export function buildComparisonWaveforms(
+  runs: readonly SimulationComparisonRun[],
+): ComparisonWaveforms {
+  const scalar = new Map<string, ScalarComparisonGroup>();
+  const complex = new Map<string, ComplexComparisonGroup>();
+  let colorIndex = 0;
+
+  for (const run of runs) {
+    for (const analysis of run.outputData.analyses) {
+      if (!analysis.domain || analysis.analysis === "op") continue;
+      for (const output of analysis.outputs) {
+        const label = `${output.label} — ${runLabel(run)}`;
+        if (analysis.analysis === "ac" && output.imaginary) {
+          const key = [
+            analysis.analysis,
+            analysis.plotName,
+            analysis.domain.name,
+            analysis.domain.unit,
+            output.unit,
+          ].join("\u0000");
+          const group = complex.get(key) ?? {
+            key,
+            label: `${analysisTitle(analysis.analysis)} · ${analysis.plotName}`,
+            traces: [],
+          };
+          const phases = unwrapPhaseDegrees(
+            output.values.map(
+              (real, index) =>
+                (Math.atan2(
+                  output.imaginary?.[index] ?? Number.NaN,
+                  real ?? Number.NaN,
+                ) *
+                  180) /
+                Math.PI,
+            ),
+          );
+          const trace: OutputTrace = {
+            id: `${run.id}:${analysis.plotName}:${output.id}`,
+            label,
+            colorIndex: colorIndex++,
+            unit: output.unit,
+            quantity: quantity(output.unit),
+            points: analysis.domain.values.map((frequency, index) => ({
+              ...complexAcPoint(
+                frequency,
+                output.values[index] ?? Number.NaN,
+                output.imaginary?.[index] ?? Number.NaN,
+              ),
+              phaseDeg: phases[index] ?? Number.NaN,
+            })),
+          };
+          complex.set(key, { ...group, traces: [...group.traces, trace] });
+          continue;
+        }
+
+        const key = [
+          analysis.analysis,
+          analysis.plotName,
+          domainIdentity(analysis.domain),
+          output.unit,
+        ].join("\u0000");
+        const group = scalar.get(key) ?? {
+          key,
+          label: `${analysisTitle(analysis.analysis)} · ${analysis.plotName}`,
+          analysis: analysis.analysis,
+          domain: analysis.domain,
+          unit: output.unit,
+          traces: [],
+        };
+        const trace: ScalarTrace = {
+          id: `${run.id}:${analysis.plotName}:${output.id}`,
+          label,
+          colorIndex: colorIndex++,
+          quantity: quantity(output.unit),
+          unit: output.unit === "1" ? null : output.unit,
+          values: output.values.map((value) => value ?? Number.NaN),
+        };
+        scalar.set(key, { ...group, traces: [...group.traces, trace] });
+      }
+    }
+  }
+
+  return {
+    scalar: [...scalar.values()].filter((group) => group.traces.length > 1),
+    complex: [...complex.values()].filter((group) => group.traces.length > 1),
+  };
+}
+
+export function SimulationWaveformComparison({
+  runs,
+}: {
+  runs: readonly SimulationComparisonRun[];
+}) {
+  const waveforms = buildComparisonWaveforms(runs);
+  if (!waveforms.scalar.length && !waveforms.complex.length) return null;
+  return (
+    <section
+      className="simulation-waveform-comparison"
+      aria-label="Waveform overlays"
+    >
+      <header>
+        <strong>Waveform overlays</strong>
+        <small>Only compatible analyses and units share an axis.</small>
+      </header>
+      {waveforms.complex.map((group) => (
+        <ComplexResultsExplorer
+          key={group.key}
+          resultKey={`comparison:${group.key}`}
+          plotName={group.label}
+          traces={group.traces}
+        />
+      ))}
+      {waveforms.scalar.map((group) => (
+        <ScalarResultsExplorer
+          key={group.key}
+          resultKey={`comparison:${group.key}`}
+          plotName={group.label}
+          domain={group.domain.values}
+          domainLabel={group.domain.name}
+          domainUnit={group.domain.unit}
+          logarithmicX={group.analysis === "ac" || group.analysis === "noise"}
+          analysisLabel={`${analysisTitle(group.analysis)} comparison`}
+          traces={group.traces}
+        />
+      ))}
+    </section>
+  );
+}

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -51,6 +51,7 @@ import {
   SimulationRunComparison,
   type SimulationComparisonRun,
 } from "./simulation-run-comparison";
+import { SimulationWaveformComparison } from "./simulation-waveform-comparison";
 import { createBrowserSimulationArchiveStore } from "./browser-simulation-archive-store";
 import {
   SimulationSweepDialog,
@@ -811,22 +812,54 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
         )
       : undefined;
   const currentComparisonRun: SimulationComparisonRun | undefined =
-    run?.outputData?.measurements?.length && runPresentation
+    run?.outputData && runPresentation
       ? {
           id: run.id,
           label: runPresentation.setupName,
           inputRevision: run.inputRevision,
           environment: runPresentation.prepared.environment,
-          measurements: run.outputData.measurements,
+          outputData: run.outputData,
+          measurements: run.outputData.measurements ?? [],
           current: true,
         }
       : undefined;
+  const batchComparisonRuns: readonly SimulationComparisonRun[] =
+    batch?.items
+      .flatMap((item) => {
+        if (!item.runId) return [];
+        const resolved = batchRuns.current.get(item.runId);
+        const presentation = preparedPresentations.current.get(
+          item.prepared.id,
+        );
+        if (!resolved?.run.outputData || !presentation) return [];
+        return [
+          {
+            id: resolved.run.id,
+            label: presentation.setupName,
+            inputRevision: resolved.run.inputRevision,
+            environment: presentation.prepared.environment,
+            outputData: resolved.run.outputData,
+            measurements: resolved.run.outputData.measurements ?? [],
+            current: resolved.run.id === run?.id,
+          },
+        ];
+      })
+      .slice(-MAX_COMPARISON_RUNS) ?? [];
+  const automaticComparisonIds = new Set(
+    batchComparisonRuns.map((candidate) => candidate.id),
+  );
   const comparisonRuns = [
     ...retainedComparisonRuns.filter(
-      (candidate) => candidate.id !== currentComparisonRun?.id,
+      (candidate) =>
+        candidate.id !== currentComparisonRun?.id &&
+        !automaticComparisonIds.has(candidate.id),
     ),
-    ...(currentComparisonRun ? [currentComparisonRun] : []),
-  ];
+    ...batchComparisonRuns,
+    ...(currentComparisonRun &&
+    !automaticComparisonIds.has(currentComparisonRun.id)
+      ? [currentComparisonRun]
+      : []),
+  ].slice(-MAX_COMPARISON_RUNS);
   const retainCurrentComparison = (): void => {
     if (!currentComparisonRun) return;
     setRetainedComparisonRuns((current) => {
@@ -1605,6 +1638,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
                     again to compare.
                   </p>
                 ) : null}
+                <SimulationWaveformComparison runs={comparisonRuns} />
                 <SimulationRunComparison
                   runs={comparisonRuns}
                   onRemove={(runId) =>

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -1252,6 +1252,21 @@
 .simulation-comparison-hint {
   margin: 0 0 10px;
 }
+.simulation-waveform-comparison {
+  display: grid;
+  gap: 12px;
+  margin-bottom: 14px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--icm-border);
+}
+.simulation-waveform-comparison > header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+.simulation-waveform-comparison > header small {
+  color: var(--icm-text-muted);
+}
 .simulation-archive-list {
   margin-top: 14px;
   border-top: 1px solid var(--icm-border);

--- a/docs/roadmap/simulation-remaining-work.md
+++ b/docs/roadmap/simulation-remaining-work.md
@@ -125,7 +125,7 @@ After promotion, verify actual Production identity and health separately.
 These are not implicit promises of the current UI or executor:
 
 - Live cross-Project library synchronization and automatic version following.
-- Persistent Project result archives and overlaid multi-run waveform comparison.
+- Persistent Project result archives.
 - Monte Carlo, batch optimization, and automated circuit modification.
 - A second simulator, general simulator plugins, or uploaded Verilog-A compilation.
 - Model marketplaces, automatic PDK/binned-model fallback, or parameter rewriting.

--- a/docs/user/analog-simulation.md
+++ b/docs/user/analog-simulation.md
@@ -131,7 +131,10 @@ the same rules, or replace the complete typed Setup through
 Simulation session and align saved rules by measurement ID and automatic
 summaries by output identity, analysis, metric and unit. Keep a result, edit
 the circuit or conditions, run again, and inspect the current and retained
-columns. These comparison copies are transient.
+columns. Compatible DC, AC, TRAN and Noise outputs are also overlaid on shared
+waveform axes; incompatible domains or units remain separate rather than being
+silently resampled. Completed batch items populate the same comparison view.
+These comparison copies are transient.
 
 Choose **Archive** on a completed result to keep its verified run files and
 view locally in this browser. **Compare → Browser archives** can reopen or
@@ -156,9 +159,8 @@ independent Cell-closure imports from authorized Cloud Projects. The GUI uses
 The [simulation roadmap](../roadmap/simulation-remaining-work.md) retains the
 integrated cross-Project acceptance boundary rather than treating that
 implemented flow as future functionality.
-Persistent Project result archives and overlaid multi-run waveforms are not
-provided by the session comparison view. Raw/Agent workflows retain their
-advertised capabilities.
+Persistent Project result archives are not provided by the session comparison
+view. Raw/Agent workflows retain their advertised capabilities.
 Browser regressions use a controlled executor
 to verify interaction/protocol behavior; they do **not** certify OTA numbers,
 model qualification or the separate real Preview acceptance journey.


### PR DESCRIPTION
## Summary
- retain structured output data for session comparisons
- automatically include completed batch items, capped by the existing five-run comparison limit
- overlay compatible DC, AC, TRAN, and Noise traces while separating mismatched domains and units
- keep scalar measurement tables and document the transient comparison boundary

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main (2881 passed)
- pnpm build
- git diff --check