### PR TITLE
test(simulation): exercise cross-project Preview journey

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -96,6 +96,15 @@ jobs:
           SIMULATION_UPSTREAM_TOKEN: ${{ secrets.SIMULATION_UPSTREAM_TOKEN }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      - name: Give the Preview its private acceptance identity
+        run: |
+          test -n "$PREVIEW_ACCEPTANCE_TOKEN"
+          printf '%s' "$PREVIEW_ACCEPTANCE_TOKEN" \
+            | pnpm dlx wrangler@4.120.1 secret put PREVIEW_ACCEPTANCE_TOKEN --config wrangler.preview.jsonc
+        env:
+          PREVIEW_ACCEPTANCE_TOKEN: ${{ secrets.PREVIEW_ACCEPTANCE_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       # What a preview is for: the page renders, the gallery reads and never
       # writes, nothing is indexed, and the simulator answers.
       - name: Verify preview
@@ -178,11 +187,23 @@ jobs:
         run: node scripts/preview-simulation-smoke.mjs "$PREVIEW_URL"
       - name: Run the public Agent/MCP simulation journey
         run: node scripts/preview-agent-simulation-journey.mjs "$PREVIEW_URL"
+      - name: Run the cross-Project Agent/MCP simulation journey
+        run: node scripts/preview-cross-project-simulation-journey.mjs "$PREVIEW_URL"
+        env:
+          ICM_PREVIEW_ACCEPTANCE_TOKEN: ${{ secrets.PREVIEW_ACCEPTANCE_TOKEN }}
       - name: Preserve the Agent/MCP simulation receipt
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: preview-agent-simulation-${{ github.sha }}
           path: test-results/preview-agent-simulation/
+          if-no-files-found: error
+          retention-days: 14
+      - name: Preserve the cross-Project simulation receipt
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-cross-project-simulation-${{ github.sha }}
+          path: test-results/preview-cross-project-simulation/
           if-no-files-found: error
           retention-days: 14

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,10 +2,10 @@
 
 ## Channels and data isolation
 
-| Channel    | Trigger and configuration                                                         | Data boundary                                                                                           |
-| ---------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| Preview    | main push; `.github/workflows/deploy-preview.yml`; `wrangler.preview.jsonc`       | Own namespaces; anonymous HTTP read-through to public Gallery; refuses Gallery and Cloud Project writes |
-| Production | `v*` tag or commit dispatch; `.github/workflows/cloudflare.yml`; `wrangler.jsonc` | Public product and its private storage                                                                  |
+| Channel    | Trigger and configuration                                                         | Data boundary                                                                                                                                  |
+| ---------- | --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| Preview    | main push; `.github/workflows/deploy-preview.yml`; `wrangler.preview.jsonc`       | Own namespaces; anonymous HTTP read-through to public Gallery; public writes refused; private CI acceptance may use the isolated Project shelf |
+| Production | `v*` tag or commit dispatch; `.github/workflows/cloudflare.yml`; `wrangler.jsonc` | Public product and its private storage                                                                                                         |
 
 Preview is served at `analog-canvas-preview.tokenzhang.com`, labelled and
 unindexed. Production is `analog-canvas.tokenzhang.com`. The separate
@@ -18,6 +18,15 @@ The channels share source and contracts, not a guarantee of a single promoted
 build artifact: the workflows build their selected checkout. Channel-controlled
 features and runtime bindings may differ.
 [ADR 0057](adr/0057-release-channels-preview-and-production.md) explains the choice.
+
+The deployed cross-Project journey receives a repository secret as a
+host-scoped HttpOnly cookie. Only `/api/projects` recognizes that identity, and
+only when `ICM_CHANNEL=preview`; Gallery, account, moderation and Production
+routes do not. The journey seeds one DUT Project in the Preview Worker’s own
+GalleryDO, imports it through the public `project_cells` resource, runs the
+resulting Testbench, preserves its receipt, and removes the seed. Missing or
+incorrect credentials fail closed as the same 401/403 seen by an ordinary
+visitor.
 
 ## Releasing to Production
 

--- a/scripts/preview-cross-project-simulation-journey.mjs
+++ b/scripts/preview-cross-project-simulation-journey.mjs
@@ -1,0 +1,467 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { createInterface } from "node:readline";
+
+import { chromium } from "@playwright/test";
+import { createEmptyProject } from "../packages/model/dist/index.js";
+import {
+  parseProject,
+  serializeProject,
+} from "../packages/project-protocol/dist/index.js";
+import { SimulationOutputDataSchema } from "../packages/simulation-service/dist/contract.js";
+import { SimulationResultSchema } from "../packages/spice-run/dist/index.js";
+import { materializeSimulationRunEvidence } from "./lib/simulation-run-evidence.mjs";
+
+const baseUrl = new URL(
+  process.argv[2] ?? "https://analog-canvas-preview.tokenzhang.com",
+);
+const acceptanceToken = process.env.ICM_PREVIEW_ACCEPTANCE_TOKEN;
+assert(acceptanceToken, "ICM_PREVIEW_ACCEPTANCE_TOKEN is required");
+const outputDirectory = resolve(
+  process.env.ICM_ACCEPTANCE_OUTPUT_DIR ??
+    "test-results/preview-cross-project-simulation",
+);
+const referenceText = await readFile(
+  new URL(
+    "../apps/editor/src/examples/five-transistor-ota-sky130.icproj.json",
+    import.meta.url,
+  ),
+  "utf8",
+);
+const referenceProject = parseProject(referenceText);
+const dut = referenceProject.documents.find(
+  (document) => document.id === "document-ota-5t",
+);
+const testbench = referenceProject.documents.find(
+  (document) => document.id === "document-ota-5t-testbench",
+);
+const referenceSetup = referenceProject.simulationSetups.find(
+  (setup) => setup.id === "simulation-setup-ota-op-ac",
+);
+assert(
+  dut && testbench && referenceSetup,
+  "OTA acceptance fixture is incomplete",
+);
+
+const sourceProject = structuredClone(referenceProject);
+sourceProject.id = "preview-cross-project-dut-source";
+sourceProject.name = "Preview Cross-Project OTA DUT";
+sourceProject.topDocumentId = dut.id;
+sourceProject.documents = [structuredClone(dut)];
+sourceProject.simulationSetups = [];
+const sourceProjectText = serializeProject(sourceProject);
+
+const destinationProject = createEmptyProject(
+  "preview-cross-project-destination",
+  "Preview Cross-Project Simulation",
+  "acceptance-main",
+);
+const destinationProjectText = serializeProject(destinationProject);
+const importedTestbenchId = "acceptance-cross-project-tb";
+const importedSetupId = "acceptance-cross-project-op";
+const privateDirectory = await mkdtemp(
+  join(tmpdir(), "analog-canvas-cross-project-"),
+);
+await mkdir(outputDirectory, { recursive: true });
+
+let browser;
+let context;
+let mcp;
+let sourceCloudProjectId;
+let paired = false;
+let sequence = 0;
+const pending = new Map();
+const report = {
+  schemaVersion: 1,
+  target: baseUrl.origin,
+  fixture: "cross-project-sky130-ota-op",
+  commitSha: process.env.GITHUB_SHA ?? null,
+  startedAt: new Date().toISOString(),
+};
+
+function rpc(method, params) {
+  return new Promise((resolveReply, reject) => {
+    const id = ++sequence;
+    const timeout = setTimeout(() => {
+      pending.delete(id);
+      reject(new Error(`MCP request timed out: ${method}`));
+    }, 150_000);
+    pending.set(id, {
+      resolve(value) {
+        clearTimeout(timeout);
+        resolveReply(value);
+      },
+      reject(error) {
+        clearTimeout(timeout);
+        reject(error);
+      },
+    });
+    mcp.stdin.write(
+      `${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`,
+    );
+  });
+}
+
+async function tool(name, args = {}, allowProblem = false) {
+  for (let attempt = 0; ; attempt += 1) {
+    const reply = await rpc("tools/call", { name, arguments: args });
+    const text = reply.content?.find((item) => item.type === "text")?.text;
+    assert.equal(typeof text, "string", `${name} returned no text result`);
+    const value = JSON.parse(text);
+    if (reply.isError && value.error?.code === "RATE_LIMITED" && attempt < 12) {
+      await new Promise((resolveWait) =>
+        setTimeout(
+          resolveWait,
+          Math.max(value.error.retryAfterMs ?? 5_000, 1_000),
+        ),
+      );
+      continue;
+    }
+    if (reply.isError && !allowProblem) {
+      throw new Error(`${name} failed: ${text}`);
+    }
+    return value;
+  }
+}
+
+async function startMcp() {
+  mcp = spawn(process.execPath, [resolve("apps/mcp-server/dist/main.js")], {
+    cwd: resolve("."),
+    env: {
+      ...process.env,
+      ANALOG_CANVAS_API_URL: baseUrl.origin,
+      ANALOG_CANVAS_MCP_CONNECTOR: join(privateDirectory, "connector.json"),
+    },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  const stderr = [];
+  mcp.stderr.on("data", (chunk) => stderr.push(String(chunk).slice(-2_000)));
+  mcp.once("exit", (code, signal) => {
+    const error = new Error(
+      `MCP exited ${code ?? signal ?? "unknown"}: ${stderr.join("").slice(-4_000)}`,
+    );
+    for (const request of pending.values()) request.reject(error);
+    pending.clear();
+  });
+  createInterface({ input: mcp.stdout }).on("line", (line) => {
+    let reply;
+    try {
+      reply = JSON.parse(line);
+    } catch {
+      return;
+    }
+    const request = pending.get(reply.id);
+    if (!request) return;
+    pending.delete(reply.id);
+    reply.error
+      ? request.reject(new Error(JSON.stringify(reply.error)))
+      : request.resolve(reply.result);
+  });
+  await rpc("initialize", {
+    protocolVersion: "2025-06-18",
+    capabilities: {},
+    clientInfo: { name: "preview-cross-project-acceptance", version: "1" },
+  });
+  mcp.stdin.write(
+    `${JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" })}\n`,
+  );
+}
+
+async function startAndRead(prepared) {
+  const started = await tool("simulation", {
+    request: {
+      operation: "start",
+      preparedId: prepared.id,
+      digest: prepared.digest,
+    },
+  });
+  assert.equal(started.ok, true);
+  for (let attempt = 0; attempt < 180; attempt += 1) {
+    const reading = await tool("simulation", {
+      request: { operation: "read", runId: started.run.id },
+    });
+    assert.equal(reading.ok, true);
+    if (!["running", "cancelling"].includes(reading.run.state))
+      return reading.run;
+    await new Promise((resolveWait) => setTimeout(resolveWait, 1_500));
+  }
+  throw new Error(`Run ${started.run.id} did not reach a terminal state`);
+}
+
+async function exportArtifact(artifact) {
+  assert(artifact, "Expected simulation artifact is missing");
+  const saved = await tool("simulation_files", {
+    request: { action: "artifact", artifactId: artifact.id },
+    outputPath: join(outputDirectory, artifact.name),
+  });
+  assert.notEqual(saved.ok, false, `Could not export ${artifact.name}`);
+  return {
+    name: artifact.name,
+    byteLength: artifact.byteLength,
+    sha256: artifact.sha256,
+  };
+}
+
+async function cloudRequest(path, options = {}) {
+  const response = await context.request.fetch(
+    new URL(path, baseUrl).toString(),
+    {
+      ...options,
+      headers: {
+        Origin: baseUrl.origin,
+        ...(options.headers ?? {}),
+      },
+    },
+  );
+  return response;
+}
+
+try {
+  browser = await chromium.launch({ headless: true });
+  context = await browser.newContext({
+    viewport: { width: 1_440, height: 1_000 },
+  });
+  await context.addCookies([
+    {
+      name: "icm_preview_acceptance",
+      value: acceptanceToken,
+      url: baseUrl.origin,
+      httpOnly: true,
+      secure: true,
+      sameSite: "Strict",
+    },
+  ]);
+
+  const prior = await cloudRequest("/api/projects");
+  assert.equal(
+    prior.status(),
+    200,
+    "Preview acceptance Project shelf is unavailable",
+  );
+  for (const project of (await prior.json()).projects ?? []) {
+    if (project.name !== sourceProject.name) continue;
+    const removed = await cloudRequest(
+      `/api/projects/${encodeURIComponent(project.id)}`,
+      {
+        method: "DELETE",
+      },
+    );
+    assert.equal(
+      removed.ok(),
+      true,
+      "Could not clear an earlier acceptance source",
+    );
+  }
+  const seeded = await cloudRequest("/api/projects", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    data: { name: sourceProject.name, projectText: sourceProjectText },
+  });
+  assert.equal(
+    seeded.status(),
+    201,
+    `Could not seed source Project (${seeded.status()})`,
+  );
+  sourceCloudProjectId = (await seeded.json()).project.id;
+
+  const page = await context.newPage();
+  await page.goto(new URL("/editor", baseUrl).toString());
+  await page.getByTestId("project-file").setInputFiles({
+    name: "cross-project-destination.icproj.json",
+    mimeType: "application/json",
+    buffer: Buffer.from(destinationProjectText),
+  });
+  await page
+    .locator("summary")
+    .filter({ hasText: /^Agent$/ })
+    .click();
+  await page
+    .getByRole("button", { name: "Connect Agent", exact: true })
+    .click();
+  await page.getByTestId("agent-preset-full").click();
+  const claimElement = page.getByTestId("agent-claim-code");
+  await claimElement.waitFor({ state: "attached", timeout: 30_000 });
+  const claimCode = await claimElement.textContent();
+  assert(claimCode, "Preview returned no Agent claim code");
+
+  await startMcp();
+  const connection = await tool("connect", { claimCode });
+  assert.equal(connection.ok, true);
+  paired = true;
+  await page
+    .getByTestId("agent-status")
+    .filter({ hasText: "Connected" })
+    .waitFor({ state: "visible", timeout: 30_000 });
+
+  const projects = await tool("project_cells", { action: "list-projects" });
+  assert.equal(projects.ok, true);
+  assert(
+    projects.projects.some((project) => project.id === sourceCloudProjectId),
+    "Agent could not discover the seeded source Project",
+  );
+  const cells = await tool("project_cells", {
+    action: "list-cells",
+    cloudProjectId: sourceCloudProjectId,
+  });
+  assert.equal(cells.ok, true);
+  assert.deepEqual(
+    cells.cells[0].formalPorts.map((port) => port.name),
+    ["vss", "ibias", "vdd", "vinn", "vinp", "vout"],
+  );
+  const imported = await tool("project_cells", {
+    action: "import-cell",
+    cloudProjectId: sourceCloudProjectId,
+    sourceDocumentId: dut.id,
+  });
+  assert.equal(imported.ok, true);
+  assert.equal(imported.status, "imported");
+
+  const importedTestbench = structuredClone(testbench);
+  importedTestbench.id = importedTestbenchId;
+  importedTestbench.name = "Cross-Project OTA Testbench";
+  importedTestbench.netlist.name = "cross_project_ota_tb";
+  const dutInstance = importedTestbench.instances.find(
+    (instance) => instance.id === "XDUT",
+  );
+  assert.equal(dutInstance?.netlist?.binding?.kind, "subcircuit");
+  dutInstance.netlist.binding.childDocumentId = imported.rootDocumentId;
+
+  const opSetup = structuredClone(referenceSetup);
+  opSetup.id = importedSetupId;
+  opSetup.name = "Cross-Project OTA OP";
+  opSetup.input.rootDocumentId = importedTestbenchId;
+  opSetup.input.analyses = [{ kind: "op" }];
+  delete opSetup.input.deviceOperatingPoints;
+  opSetup.input.outputs = opSetup.input.outputs.map((output) => {
+    const mapped = structuredClone(output);
+    if (mapped.expression.documentId === testbench.id) {
+      mapped.expression.documentId = importedTestbenchId;
+    } else if (mapped.expression.documentId === dut.id) {
+      mapped.expression.documentId = imported.rootDocumentId;
+    }
+    return mapped;
+  });
+
+  const authored = await tool("advanced_transact", {
+    structureEdits: [
+      { kind: "add_document", document: importedTestbench },
+      { kind: "upsert_simulation_setup", setup: opSetup },
+    ],
+  });
+  assert.equal(authored.ok, true);
+  const preparedReply = await tool("simulation", {
+    request: {
+      operation: "prepare",
+      source: {
+        kind: "project-setup",
+        setupId: importedSetupId,
+        expectedStructureRevision: authored.projectStructure.toRevision,
+      },
+    },
+  });
+  assert.equal(preparedReply.ok, true);
+  const finished = await startAndRead(preparedReply.prepared);
+  assert.equal(finished.state, "finished");
+
+  const exports = [];
+  const fullRun = await materializeSimulationRunEvidence(
+    finished,
+    async (artifact) => {
+      exports.push(await exportArtifact(artifact));
+      const value = JSON.parse(
+        await readFile(join(outputDirectory, artifact.name), "utf8"),
+      );
+      return artifact.name === "result.json"
+        ? SimulationResultSchema.parse(value)
+        : SimulationOutputDataSchema.parse(value);
+    },
+  );
+  assert.equal(fullRun.result?.outcome.status, "completed");
+  const op = fullRun.outputData?.analyses.find(
+    (analysis) => analysis.analysis === "op",
+  );
+  const vout = op?.outputs.find((output) => output.id === "probe-vout")
+    ?.values[0];
+  assert(Number.isFinite(vout), "Imported OTA returned no finite OP output");
+  assert(
+    vout > 0.5 && vout < 1.2,
+    `Imported OTA OP output is implausible: ${vout}`,
+  );
+
+  for (const artifact of [
+    preparedReply.prepared.artifacts.find(
+      (item) => item.name === "prepared.cir",
+    ),
+    ...finished.artifacts.filter((item) =>
+      [
+        "out.raw",
+        "result.json",
+        "outputs.json",
+        "op.csv",
+        "outputs-op.csv",
+      ].includes(item.name),
+    ),
+  ]) {
+    if (!artifact || exports.some((item) => item.name === artifact.name))
+      continue;
+    exports.push(await exportArtifact(artifact));
+  }
+
+  report.status = "passed";
+  report.completedAt = new Date().toISOString();
+  report.sourceProject = {
+    cloudProjectId: sourceCloudProjectId,
+    sourceDocumentId: dut.id,
+  };
+  report.import = {
+    status: imported.status,
+    rootDocumentId: imported.rootDocumentId,
+    importedDocumentIds: imported.importedDocumentIds,
+    testbenchDocumentId: importedTestbenchId,
+  };
+  report.simulation = {
+    setupId: importedSetupId,
+    preparedId: preparedReply.prepared.id,
+    runId: finished.id,
+    inputRevision: preparedReply.prepared.inputRevision,
+    environment: fullRun.result.metadata.environment,
+    vout,
+  };
+  report.exports = exports;
+  await writeFile(
+    join(outputDirectory, "acceptance-report.json"),
+    `${JSON.stringify(report, null, 2)}\n`,
+  );
+  await tool("disconnect");
+  paired = false;
+  console.log(`Preview cross-Project OTA OP passed: vout=${vout}`);
+} catch (error) {
+  report.status = "failed";
+  report.completedAt = new Date().toISOString();
+  report.error =
+    error instanceof Error ? (error.stack ?? error.message) : String(error);
+  await writeFile(
+    join(outputDirectory, "acceptance-report.json"),
+    `${JSON.stringify(report, null, 2)}\n`,
+  );
+  throw error;
+} finally {
+  if (paired) await tool("disconnect", {}, true).catch(() => {});
+  if (mcp) {
+    mcp.stdin.end();
+    mcp.kill();
+  }
+  if (sourceCloudProjectId && context) {
+    await cloudRequest(
+      `/api/projects/${encodeURIComponent(sourceCloudProjectId)}`,
+      {
+        method: "DELETE",
+      },
+    ).catch(() => {});
+  }
+  await browser?.close();
+  await rm(privateDirectory, { recursive: true, force: true });
+}

--- a/scripts/preview-workflow.test.mjs
+++ b/scripts/preview-workflow.test.mjs
@@ -13,6 +13,10 @@ const agentJourney = readFileSync(
   "scripts/preview-agent-simulation-journey.mjs",
   "utf8",
 );
+const crossProjectJourney = readFileSync(
+  "scripts/preview-cross-project-simulation-journey.mjs",
+  "utf8",
+);
 
 describe("the preview deploy", () => {
   it("deploys the preview configuration file and nothing else", () => {
@@ -70,7 +74,14 @@ describe("the preview deploy", () => {
     expect(preview).toContain(
       'node scripts/preview-agent-simulation-journey.mjs "$PREVIEW_URL"',
     );
+    expect(preview).toContain(
+      'node scripts/preview-cross-project-simulation-journey.mjs "$PREVIEW_URL"',
+    );
+    expect(preview).toContain("PREVIEW_ACCEPTANCE_TOKEN");
     expect(preview).toContain("preview-agent-simulation-${{ github.sha }}");
+    expect(preview).toContain(
+      "preview-cross-project-simulation-${{ github.sha }}",
+    );
     // The reusable smoke is responsible for explicit transport selection,
     // numeric validation, and environment parity; the workflow must not
     // quietly restore an inline, default-executor-only probe.
@@ -89,5 +100,17 @@ describe("the preview deploy", () => {
     expect(agentJourney).toContain("invalidSetup.input.outputs[0]");
     expect(agentJourney).toContain("firstOutput.expression.anchor");
     expect(agentJourney).not.toContain("invalidSetup.input.probes");
+  });
+
+  it("imports a Cloud Project Cell before compiling the cross-Project Testbench", () => {
+    expect(crossProjectJourney).toContain('action: "list-projects"');
+    expect(crossProjectJourney).toContain('action: "list-cells"');
+    expect(crossProjectJourney).toContain('action: "import-cell"');
+    expect(crossProjectJourney).toContain('kind: "add_document"');
+    expect(crossProjectJourney).toContain('kind: "upsert_simulation_setup"');
+    expect(crossProjectJourney).toContain('operation: "prepare"');
+    expect(crossProjectJourney).toContain('operation: "start"');
+    expect(crossProjectJourney).toContain('operation: "read"');
+    expect(crossProjectJourney).toContain("acceptance-report.json");
   });
 });

--- a/worker/channel.test.ts
+++ b/worker/channel.test.ts
@@ -12,6 +12,12 @@ import {
 const req = (path: string, method = "GET") =>
   new Request(`https://preview.test${path}`, { method });
 
+const acceptanceReq = (path: string, method = "GET", token = "test-token") =>
+  new Request(`https://preview.test${path}`, {
+    method,
+    headers: { cookie: `icm_preview_acceptance=${token}` },
+  });
+
 describe("release channel", () => {
   it("is production unless the deployment says preview", () => {
     // Production never sets the variable. Anything but the exact word is
@@ -61,6 +67,28 @@ describe("release channel", () => {
     expect(
       previewWriteRefusal(req("/api/agent/sessions", "POST"), env),
     ).toBeNull();
+  });
+
+  it("opens only the isolated Project store to the private Preview journey", () => {
+    const env = {
+      ICM_CHANNEL: "preview",
+      PREVIEW_ACCEPTANCE_TOKEN: "test-token",
+    };
+    expect(
+      previewWriteRefusal(acceptanceReq("/api/projects", "POST"), env),
+    ).toBeNull();
+    expect(
+      previewWriteRefusal(
+        acceptanceReq("/api/projects/p1", "DELETE", "wrong-token"),
+        env,
+      )?.status,
+    ).toBe(403);
+    expect(
+      previewWriteRefusal(
+        acceptanceReq("/api/gallery/submissions", "POST"),
+        env,
+      )?.status,
+    ).toBe(403);
   });
 
   it("never refuses anything on production", () => {

--- a/worker/channel.ts
+++ b/worker/channel.ts
@@ -1,3 +1,8 @@
+import {
+  isPreviewAcceptanceRequest,
+  type PreviewAcceptanceEnv,
+} from "./preview-acceptance";
+
 /**
  * Which release channel this deployment is, and what that changes.
  *
@@ -8,7 +13,7 @@
  */
 export type ReleaseChannel = "production" | "preview";
 
-export interface ChannelEnv {
+export interface ChannelEnv extends PreviewAcceptanceEnv {
   /** "preview" on the preview Worker; production leaves it unset. */
   ICM_CHANNEL?: string;
   /**
@@ -45,6 +50,12 @@ export function previewWriteRefusal(
   if (releaseChannel(env) !== "preview") return null;
   if (READ_METHODS.has(request.method)) return null;
   const path = new URL(request.url).pathname;
+  if (
+    path.startsWith("/api/projects") &&
+    isPreviewAcceptanceRequest(request, env)
+  ) {
+    return null;
+  }
   if (!path.startsWith("/api/gallery") && !path.startsWith("/api/projects")) {
     return null;
   }

--- a/worker/gallery.test.ts
+++ b/worker/gallery.test.ts
@@ -738,6 +738,28 @@ describe("private Cloud Projects", () => {
     });
   }
 
+  it("uses a private Preview acceptance identity only in the isolated shelf", async () => {
+    const env = Object.assign(environment(), {
+      ICM_CHANNEL: "preview",
+      PREVIEW_ACCEPTANCE_TOKEN: "acceptance-secret",
+    });
+    const cookie = "icm_preview_acceptance=acceptance-secret";
+    const saved = await route(env, saveRequest(cookie, "Cross-Project DUT"));
+    expect(saved.status).toBe(201);
+    const listed = await route(
+      env,
+      new Request(`${ORIGIN}/api/projects`, {
+        headers: { Cookie: cookie },
+      }),
+    );
+    expect(listed.status).toBe(200);
+    expect((await listed.json()).projects).toEqual([
+      expect.objectContaining({ name: "Cross-Project DUT" }),
+    ]);
+    const anonymous = await route(env, new Request(`${ORIGIN}/api/projects`));
+    expect(anonymous.status).toBe(401);
+  });
+
   it("limits distinct Projects without evicting an existing Project", async () => {
     const env = environment();
     const cookie = await makerOf(env);

--- a/worker/gallery.ts
+++ b/worker/gallery.ts
@@ -13,6 +13,10 @@ import { type CircuitProject } from "@icm/model";
 
 import { sessionUserOf } from "./auth";
 import {
+  previewAcceptanceUserOf,
+  type PreviewAcceptanceEnv,
+} from "./preview-acceptance";
+import {
   GALLERY_MAX_AUTHOR_LENGTH,
   GALLERY_MAX_DESCRIPTION_LENGTH,
   GALLERY_MAX_NAME_LENGTH,
@@ -176,13 +180,15 @@ function renderPreview(
 /** Private, stable Cloud Projects. Save updates a bound Project in place. */
 async function handleCloudProjects(
   request: Request,
-  env: GalleryEnv,
+  env: GalleryEnv & PreviewAcceptanceEnv,
   projectId: string | null,
 ): Promise<Response> {
   if (request.method !== "GET" && !sameOrigin(request)) {
     return Response.json({ error: "forbidden" }, { status: 403 });
   }
-  const user = await sessionUserOf(request, env);
+  const user =
+    previewAcceptanceUserOf(request, env) ??
+    (await sessionUserOf(request, env));
   if (!user) return Response.json({ error: "unauthorized" }, { status: 401 });
 
   if (request.method === "GET") {
@@ -271,10 +277,12 @@ async function handleCloudProjects(
  */
 async function handleCloudProjectPreview(
   request: Request,
-  env: GalleryEnv,
+  env: GalleryEnv & PreviewAcceptanceEnv,
   projectId: string,
 ): Promise<Response> {
-  const user = await sessionUserOf(request, env);
+  const user =
+    previewAcceptanceUserOf(request, env) ??
+    (await sessionUserOf(request, env));
   if (!user) {
     return Response.json(
       { error: "unauthorized" },
@@ -529,7 +537,7 @@ async function handleEntryUpdate(
  */
 export async function routeGalleryRequest(
   request: Request,
-  env: GalleryEnv,
+  env: GalleryEnv & PreviewAcceptanceEnv,
   runtime: GalleryRouteRuntime = {},
 ): Promise<Response | null> {
   const url = new URL(request.url);

--- a/worker/preview-acceptance.ts
+++ b/worker/preview-acceptance.ts
@@ -1,0 +1,61 @@
+import type { SessionUser } from "./auth-do";
+
+export const PREVIEW_ACCEPTANCE_COOKIE = "icm_preview_acceptance";
+
+export interface PreviewAcceptanceEnv {
+  ICM_CHANNEL?: string;
+  PREVIEW_ACCEPTANCE_TOKEN?: string;
+}
+
+function cookieValue(request: Request, name: string): string | null {
+  const prefix = `${name}=`;
+  for (const part of (request.headers.get("Cookie") ?? "").split(";")) {
+    const cookie = part.trim();
+    if (cookie.startsWith(prefix)) return cookie.slice(prefix.length);
+  }
+  return null;
+}
+
+function constantTimeEqual(left: string, right: string): boolean {
+  if (left.length !== right.length) return false;
+  let difference = 0;
+  for (let index = 0; index < left.length; index += 1) {
+    difference |= left.charCodeAt(index) ^ right.charCodeAt(index);
+  }
+  return difference === 0;
+}
+
+/**
+ * Private identity for the deployed Preview journey. It can reach only the
+ * Preview Worker and its isolated Project store; Production never sets either
+ * half of this contract. Ordinary Preview visitors remain signed out.
+ */
+export function isPreviewAcceptanceRequest(
+  request: Request,
+  env: PreviewAcceptanceEnv,
+): boolean {
+  if (env.ICM_CHANNEL !== "preview" || !env.PREVIEW_ACCEPTANCE_TOKEN) {
+    return false;
+  }
+  const supplied = cookieValue(request, PREVIEW_ACCEPTANCE_COOKIE);
+  return (
+    supplied !== null &&
+    constantTimeEqual(supplied, env.PREVIEW_ACCEPTANCE_TOKEN)
+  );
+}
+
+export function previewAcceptanceUserOf(
+  request: Request,
+  env: PreviewAcceptanceEnv,
+): SessionUser | null {
+  return isPreviewAcceptanceRequest(request, env)
+    ? {
+        id: "preview-cross-project-acceptance",
+        displayName: "Preview acceptance",
+        email: null,
+        provider: "preview-acceptance",
+        role: "user",
+        isAdmin: false,
+      }
+    : null;
+}

--- a/wrangler.preview.jsonc
+++ b/wrangler.preview.jsonc
@@ -37,6 +37,8 @@
     // a release deliberately promotes it.
     "SIMULATION_UPSTREAM_URL": "https://sim-fra.analog-canvas.tokenzhang.com",
     "SIMULATION_DEFAULT_EXECUTOR": "operator-host",
+    // PREVIEW_ACCEPTANCE_TOKEN is a Worker secret, set by the Preview deploy.
+    // It authorizes only the CI journey's isolated Cloud Project shelf.
   },
   "assets": {
     "binding": "ASSETS",


### PR DESCRIPTION
## Summary
- add a secret-scoped, non-admin identity limited to Preview's isolated Cloud Project shelf
- seed one OTA DUT Project, import its Cell into a separate Project through MCP, construct a Testbench, and run OP
- preserve an auditable receipt and exported simulation artifacts in the Preview deployment workflow

## Why
Preview refused every Cloud Project write, so the documented same-candidate cross-Project acceptance could not execute. This keeps public Preview and all Gallery writes read-only while giving CI the narrow authority needed for the real journey.

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm gate:full
  - 2884 unit tests passed, 23 skipped
  - production build/release/performance/golden checks passed
  - 362 browser tests passed

Test-Impact: tests-updated