### PR TITLE
fix(simulation): keep cross-project baseline on formal output

### DIFF
--- a/scripts/preview-cross-project-simulation-journey.mjs
+++ b/scripts/preview-cross-project-simulation-journey.mjs
@@ -335,15 +335,22 @@ try {
   opSetup.input.rootDocumentId = importedTestbenchId;
   opSetup.input.analyses = [{ kind: "op" }];
   delete opSetup.input.deviceOperatingPoints;
-  opSetup.input.outputs = opSetup.input.outputs.map((output) => {
-    const mapped = structuredClone(output);
-    if (mapped.expression.documentId === testbench.id) {
-      mapped.expression.documentId = importedTestbenchId;
-    } else if (mapped.expression.documentId === dut.id) {
-      mapped.expression.documentId = imported.rootDocumentId;
-    }
-    return mapped;
-  });
+  opSetup.input.outputs = opSetup.input.outputs
+    .filter((output) => output.id === "probe-vout")
+    .map((output) => {
+      const mapped = structuredClone(output);
+      if (mapped.expression.documentId === testbench.id) {
+        mapped.expression.documentId = importedTestbenchId;
+      } else if (mapped.expression.documentId === dut.id) {
+        mapped.expression.documentId = imported.rootDocumentId;
+      }
+      return mapped;
+    });
+  assert.deepEqual(
+    opSetup.input.outputs.map((output) => output.id),
+    ["probe-vout"],
+    "The cross-Project baseline must probe only the DUT formal output",
+  );
 
   const authored = await tool("advanced_transact", {
     structureEdits: [

--- a/scripts/preview-workflow.test.mjs
+++ b/scripts/preview-workflow.test.mjs
@@ -108,6 +108,9 @@ describe("the preview deploy", () => {
     expect(crossProjectJourney).toContain('action: "import-cell"');
     expect(crossProjectJourney).toContain('kind: "add_document"');
     expect(crossProjectJourney).toContain('kind: "upsert_simulation_setup"');
+    expect(crossProjectJourney).toContain(
+      '.filter((output) => output.id === "probe-vout")',
+    );
     expect(crossProjectJourney).toContain('operation: "prepare"');
     expect(crossProjectJourney).toContain('operation: "start"');
     expect(crossProjectJourney).toContain('operation: "read"');


### PR DESCRIPTION
## Summary
- keep the one-run cross-Project Preview baseline on the DUT formal out port
- do not inherit internal terminal probes whose instance IDs are intentionally remapped during Cell import
- lock the journey's scope with a workflow contract test

## Failure evidence
Preview deployment for #720 reached the new journey but prepare correctly returned SIMULATION_PROBE_ANCHOR_UNAVAILABLE for imported internal M5/M3 terminal anchors. The formal XDUT.vout anchor remained portable and is the intended acceptance boundary.

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
- 2884 unit tests passed, 23 skipped
- 
ode --check scripts/preview-cross-project-simulation-journey.mjs

Test-Impact: tests-updated