### PR TITLE
fix(simulation): move waveform units to axis end titles

### DIFF
--- a/apps/editor/src/features/simulation/ac-response-plot.ts
+++ b/apps/editor/src/features/simulation/ac-response-plot.ts
@@ -1,4 +1,4 @@
-import { waveformTicks } from "./waveform-interaction";
+import { waveformTicks, waveformAxisLabels } from "./waveform-interaction";
 /**
  * A projected waveform plot for complex AC analysis results.
  *
@@ -290,16 +290,23 @@ export function acResponseSvg(
   const axis = layout.value;
   const axisY = project.valueY;
   const unit = options.valueUnit ?? (options.kind === "phase" ? "°" : "");
+  const xLabels = waveformAxisLabels(
+    layout.frequency.min,
+    layout.frequency.max,
+    "Hz",
+    true,
+  );
+  const yLabels = waveformAxisLabels(axis.min, axis.max, unit);
 
   const gridLines = [
     ...layout.frequency.ticks.map((hz) => {
       const projectedX = project.x(hz);
       const x = projectedX.toFixed(2);
-      return `<line class="ac-grid" x1="${x}" y1="${frame.y}" x2="${x}" y2="${frame.y + frame.height}"/><text class="ac-axis-label ac-x-axis-label" x="${x}" y="${frame.y + frame.height + 18}" text-anchor="${horizontalTickAnchor(projectedX, frame)}">${escapeXml(formatFrequency(hz))}</text>`;
+      return `<line class="ac-grid" x1="${x}" y1="${frame.y}" x2="${x}" y2="${frame.y + frame.height}"/><text class="ac-axis-label ac-x-axis-label" x="${x}" y="${frame.y + frame.height + 18}" text-anchor="${horizontalTickAnchor(projectedX, frame)}">${xLabels.tick(hz, hz / 1000)}</text>`;
     }),
     ...axis.ticks.map((value) => {
       const y = axisY(value).toFixed(2);
-      return `<line class="ac-grid" x1="${frame.x}" y1="${y}" x2="${frame.x + frame.width}" y2="${y}"/><text class="ac-axis-label" x="${frame.x - 8}" y="${y}" text-anchor="end" dominant-baseline="middle">${Number(value.toPrecision(6))}${unit}</text>`;
+      return `<line class="ac-grid" x1="${frame.x}" y1="${y}" x2="${frame.x + frame.width}" y2="${y}"/><text class="ac-axis-label" x="${frame.x - 8}" y="${y}" text-anchor="end" dominant-baseline="middle">${yLabels.tick(value, (axis.max - axis.min) / 10)}</text>`;
     }),
   ].join("");
 
@@ -369,7 +376,8 @@ export function acResponseSvg(
     `<defs><clipPath id="${clipId}"><rect x="${frame.x}" y="${frame.y}" width="${frame.width}" height="${frame.height}"/></clipPath></defs>` +
     `<rect class="ac-frame" x="${frame.x}" y="${frame.y}" width="${frame.width}" height="${frame.height}"/>` +
     gridLines +
-    `<text class="ac-axis-title" x="${frame.x + frame.width}" y="${size.height - 7}" text-anchor="end">Frequency</text>` +
+    `<text class="ac-axis-title" x="${frame.x + frame.width}" y="${size.height - 7}" text-anchor="end">freq/Hz</text>` +
+    `<text class="ac-axis-title" x="${frame.x}" y="${frame.y - 5}">${escapeXml(options.kind + (yLabels.unit ? `/${yLabels.unit}` : ""))}</text>` +
     `<g clip-path="url(#${clipId})">${curves}</g>` +
     cursor +
     legend +

--- a/apps/editor/src/features/simulation/ac-results-explorer.test.tsx
+++ b/apps/editor/src/features/simulation/ac-results-explorer.test.tsx
@@ -60,7 +60,7 @@ describe("AC Results Explorer", () => {
     expect(markup.match(/data-trace-index="0"/gu)).toHaveLength(1);
     expect(markup).toContain('aria-label="Voltage display"');
     expect(markup).toContain('aria-pressed="true">Magnitude');
-    expect(markup).toContain("0.7V");
+    expect(markup).toContain("magnitude/V");
     expect(markup).toContain('aria-label="Plot tools"');
     expect(markup).toContain('class="waveform-tools-hint"');
     expect(markup).toContain('class="waveform-tool-actions"');
@@ -69,7 +69,7 @@ describe("AC Results Explorer", () => {
     expect(markup).not.toContain("<strong>Voltage</strong>");
     expect(markup).toContain('aria-label="Open plot"');
     expect(markup).toContain('class="ac-axis-title"');
-    expect(markup).toContain(">Frequency</text>");
+    expect(markup).toContain(">freq/Hz</text>");
     expect(markup).not.toContain("Wheel to zoom");
   });
 

--- a/apps/editor/src/features/simulation/dc-results-explorer.test.tsx
+++ b/apps/editor/src/features/simulation/dc-results-explorer.test.tsx
@@ -45,9 +45,10 @@ describe("DcResultsExplorer", () => {
     expect(markup).toContain("3 points");
     expect(markup).toContain("Output");
     expect(markup).toContain('class="ac-axis-title"');
-    expect(markup).toContain(">v-sweep</text>");
+    expect(markup).toContain(">v-sweep/V</text>");
     expect(markup).toContain("<polyline");
-    expect(markup).toContain("-50mV");
-    expect(markup).toContain("1.050V");
+    expect(markup).toContain(">-0.05</text>");
+    expect(markup).toContain(">1.05</text>");
+    expect(markup).toContain(">voltage/mV</text>");
   });
 });

--- a/apps/editor/src/features/simulation/dc-results-explorer.tsx
+++ b/apps/editor/src/features/simulation/dc-results-explorer.tsx
@@ -1,6 +1,7 @@
 import type { SimulationFocusTarget } from "./simulation-focus-target";
 import type { DcSweepResult } from "@icm/spice-run";
 import type { Prepared } from "@icm/simulation-service/contract";
+import { waveformAxisLabels } from "./waveform-interaction";
 
 export interface DcResultsExplorerProps {
   analysis: DcSweepResult;
@@ -30,23 +31,6 @@ function extent(values: readonly number[]): readonly [number, number] {
   }
   const margin = Math.max(Math.abs(low) * 0.05, 1e-12);
   return [low - margin, high + margin];
-}
-
-function compact(value: number): string {
-  if (value === 0) return "0";
-  const magnitude = Math.abs(value);
-  const scales = [
-    [1e9, "G"],
-    [1e6, "M"],
-    [1e3, "k"],
-    [1, ""],
-    [1e-3, "m"],
-    [1e-6, "µ"],
-    [1e-9, "n"],
-    [1e-12, "p"],
-  ] as const;
-  const scale = scales.find(([factor]) => magnitude >= factor) ?? [1e-15, "f"];
-  return `${(value / scale[0]).toPrecision(4).replace(/\.0+$/u, "")}${scale[1]}`;
 }
 
 function points(
@@ -91,6 +75,7 @@ export function DcResultsExplorer({
     };
   });
   const xExtent = extent(analysis.sweep.values);
+  const xLabels = waveformAxisLabels(...xExtent, analysis.sweep.unit ?? "");
 
   return (
     <section
@@ -109,6 +94,7 @@ export function DcResultsExplorer({
         if (!group.length) return null;
         const yExtent = extent(group.flatMap((trace) => [...trace.values]));
         const unit = group.find((trace) => trace.unit)?.unit ?? "";
+        const yLabels = waveformAxisLabels(...yExtent, unit);
         return (
           <div className="ac-plot-row" key={quantity}>
             <strong>
@@ -140,8 +126,7 @@ export function DcResultsExplorer({
                     x={PLOT.left}
                     y={PLOT.height - PLOT.bottom + 18}
                   >
-                    {compact(xExtent[0])}
-                    {analysis.sweep.unit ?? ""}
+                    {xLabels.tick(xExtent[0], (xExtent[1] - xExtent[0]) / 100)}
                   </text>
                   <text
                     className="ac-axis-label ac-x-axis-label"
@@ -149,8 +134,7 @@ export function DcResultsExplorer({
                     x={PLOT.width - PLOT.right}
                     y={PLOT.height - PLOT.bottom + 18}
                   >
-                    {compact(xExtent[1])}
-                    {analysis.sweep.unit ?? ""}
+                    {xLabels.tick(xExtent[1], (xExtent[1] - xExtent[0]) / 100)}
                   </text>
                   <text
                     className="ac-axis-title"
@@ -159,14 +143,21 @@ export function DcResultsExplorer({
                     y={PLOT.height - 7}
                   >
                     {analysis.sweep.name}
+                    {xLabels.unit ? `/${xLabels.unit}` : ""}
+                  </text>
+                  <text
+                    className="ac-axis-title"
+                    x={PLOT.left}
+                    y={PLOT.top - 5}
+                  >
+                    {quantity}
+                    {yLabels.unit ? `/${yLabels.unit}` : ""}
                   </text>
                   <text x={4} y={PLOT.top + 5}>
-                    {compact(yExtent[1])}
-                    {unit}
+                    {yLabels.tick(yExtent[1], (yExtent[1] - yExtent[0]) / 100)}
                   </text>
                   <text x={4} y={PLOT.height - PLOT.bottom}>
-                    {compact(yExtent[0])}
-                    {unit}
+                    {yLabels.tick(yExtent[0], (yExtent[1] - yExtent[0]) / 100)}
                   </text>
                   {group.map((trace) => (
                     <polyline

--- a/apps/editor/src/features/simulation/transient-results-explorer.test.tsx
+++ b/apps/editor/src/features/simulation/transient-results-explorer.test.tsx
@@ -102,8 +102,9 @@ describe("Transient Results Explorer", () => {
     expect(markup.match(/drag to zoom, click to measure/gu)).toHaveLength(2);
     expect(markup).not.toContain('aria-label="Inspect plot"');
     expect(markup.match(/aria-label="Open plot"/gu)).toHaveLength(2);
-    expect(markup.match(/class="ac-axis-title"/gu)).toHaveLength(2);
-    expect(markup.match(/>Time<\/text>/gu)).toHaveLength(2);
+    expect(markup.match(/class="ac-axis-title"/gu)).toHaveLength(4);
+    expect(markup).toContain("time/");
+    expect(markup).toContain("voltage/");
     expect(markup).toContain(
       'class="ac-trace-hit" fill="none" stroke="transparent" stroke-width="12" pointer-events="stroke"',
     );

--- a/apps/editor/src/features/simulation/transient-results-explorer.tsx
+++ b/apps/editor/src/features/simulation/transient-results-explorer.tsx
@@ -3,7 +3,7 @@ import {
   WaveformInteraction,
   responsiveWaveformHeight,
   waveformTicks,
-  waveformTickLabel,
+  waveformAxisLabels,
   useWaveformWidth,
 } from "./waveform-interaction";
 import { useWaveformView } from "./waveform-view";
@@ -310,6 +310,13 @@ export function ScalarResultsExplorer({
     const automaticExtent = transientValueExtent(visibleValues);
     const extent = valueRanges[quantity] ?? automaticExtent;
     const unit = quantityTraces.find((trace) => trace.unit)?.unit ?? "";
+    const xLabels = waveformAxisLabels(
+      range[0],
+      range[1],
+      domainUnit,
+      logarithmicX,
+    );
+    const yLabels = waveformAxisLabels(extent[0], extent[1], unit);
     return (
       <div className={`ac-plot-shell${expanded ? " expanded" : ""}`}>
         <WaveformInteraction
@@ -444,11 +451,12 @@ export function ScalarResultsExplorer({
                     x={x}
                     y={geometry.height - geometry.bottom + 18}
                   >
-                    {waveformTickLabel(
+                    {xLabels.tick(
                       value,
-                      (range[1] - range[0]) /
-                        Math.max(2, Math.floor(geometry.width / 110)),
-                      domainUnit,
+                      logarithmicX
+                        ? value / 1000
+                        : (range[1] - range[0]) /
+                            Math.max(2, Math.floor(geometry.width / 110)),
                     )}
                   </text>
                 </g>
@@ -460,7 +468,18 @@ export function ScalarResultsExplorer({
               x={geometry.width - geometry.right}
               y={geometry.height - 7}
             >
-              {domainLabel}
+              {domainLabel.toLowerCase() === "frequency"
+                ? "freq"
+                : domainLabel.toLowerCase()}
+              {xLabels.unit ? `/${xLabels.unit}` : ""}
+            </text>
+            <text
+              className="ac-axis-title"
+              x={geometry.left}
+              y={geometry.top - 5}
+            >
+              {quantity}
+              {yLabels.unit ? `/${yLabels.unit}` : ""}
             </text>
             {waveformTicks(
               extent[0],
@@ -487,11 +506,10 @@ export function ScalarResultsExplorer({
                     y={y}
                     dominantBaseline="middle"
                   >
-                    {waveformTickLabel(
+                    {yLabels.tick(
                       value,
                       (extent[1] - extent[0]) /
                         Math.max(2, Math.floor(geometry.height / 55)),
-                      unit,
                     )}
                   </text>
                 </g>

--- a/apps/editor/src/features/simulation/waveform-interaction.test.ts
+++ b/apps/editor/src/features/simulation/waveform-interaction.test.ts
@@ -3,6 +3,7 @@ import {
   responsiveWaveformHeight,
   waveformTicks,
   waveformTickLabel,
+  waveformAxisLabels,
 } from "./waveform-interaction";
 import { layoutAcPlot } from "./ac-response-plot";
 
@@ -18,8 +19,8 @@ describe("waveform axes", () => {
   });
 
   it("adapts tick spacing to nanoseconds and a zoomed small signal", () => {
-    expect(waveformTickLabel(1.8000005, 5e-7, "V")).not.toBe(
-      waveformTickLabel(1.800001, 5e-7, "V"),
+    expect(waveformTickLabel(1.8000005, 5e-7)).not.toBe(
+      waveformTickLabel(1.800001, 5e-7),
     );
     expect(waveformTicks(0, 1e-9, 5)).toEqual([
       0, 2e-10, 4e-10, 6e-10, 8e-10, 1e-9,
@@ -28,6 +29,20 @@ describe("waveform axes", () => {
     expect(ticks.length).toBeGreaterThan(2);
     expect(new Set(ticks).size).toBe(ticks.length);
     expect(waveformTicks(2, 2)).toEqual([]);
+  });
+  it("uses a shared axis unit and numeric-only ticks including zero and log decades", () => {
+    const time = waveformAxisLabels(0, 8e-9, "s");
+    expect(time.unit).toBe("ns");
+    expect([0, 2e-9, 4e-9].map((value) => time.tick(value, 2e-9))).toEqual([
+      "0",
+      "2",
+      "4",
+    ]);
+    const frequency = waveformAxisLabels(1, 1e9, "Hz", true);
+    expect(frequency.unit).toBe("Hz");
+    expect(frequency.tick(1e9, 1e6)).toBe("1e+9");
+    expect(frequency.tick(0.01, 0.00001)).toBe("0.01");
+    expect(waveformAxisLabels(-180, 180, "°").unit).toBe("°");
   });
   it("keeps frequency ticks inside a sub-decade zoom and respects explicit Y zoom", () => {
     const result = layoutAcPlot(

--- a/apps/editor/src/features/simulation/waveform-interaction.tsx
+++ b/apps/editor/src/features/simulation/waveform-interaction.tsx
@@ -266,19 +266,33 @@ export function waveformTicks(min: number, max: number, count = 6): number[] {
   );
 }
 
-export function waveformTickLabel(
-  value: number,
-  step: number,
+export function waveformTickLabel(value: number, step: number): string {
+  const decimals = Math.min(
+    15,
+    Math.max(0, -Math.floor(Math.log10(Math.abs(step) || 1))),
+  );
+  if (value !== 0 && (Math.abs(value) >= 1e5 || Math.abs(value) < 1e-3))
+    return Number(value.toFixed(decimals)).toExponential();
+  return Number(value.toFixed(decimals)).toString();
+}
+
+/** One scale for the whole visible axis; ticks contain numbers only. */
+export function waveformAxisLabels(
+  min: number,
+  max: number,
   unit: string,
-): string {
+  logarithmic = false,
+) {
   const exponent = Math.max(
     -15,
     Math.min(
       9,
-      Math.floor(Math.log10(Math.abs(value) || Math.abs(step) || 1) / 3) * 3,
+      Math.floor(Math.log10(Math.max(Math.abs(min), Math.abs(max)) || 1) / 3) *
+        3,
     ),
   );
-  const scale = 10 ** exponent;
+  const scale =
+    unit && !logarithmic && unit !== "°" && unit !== "dB" ? 10 ** exponent : 1;
   const prefix =
     new Map([
       [-15, "f"],
@@ -290,10 +304,10 @@ export function waveformTickLabel(
       [3, "k"],
       [6, "M"],
       [9, "G"],
-    ]).get(exponent) ?? "";
-  const decimals = Math.min(
-    15,
-    Math.max(0, -Math.floor(Math.log10(Math.abs(step) / scale || 1))),
-  );
-  return `${(value / scale).toFixed(decimals)} ${prefix}${unit}`;
+    ]).get(scale === 1 ? 0 : exponent) ?? "";
+  return {
+    unit: `${prefix}${unit}`,
+    tick: (value: number, step: number) =>
+      waveformTickLabel(value / scale, step / scale),
+  };
 }


### PR DESCRIPTION
Plot ticks repeated units and engineering prefixes, crowding the axes. AC, transient, noise and DC plots now show numeric-only ticks and quantity/unit titles at the axis ends. Linear axes share a visible-range engineering scale; logarithmic frequency keeps Hz with scientific numeric labels. Exported plots use the same labels.

Validation: static preflight, editor build, 24 focused tests and the human simulation browser/export flow passed; maximized screenshots inspected. Workspace tests: 2884 passed, one unrelated formula-render test hit its 5-second timeout; all 32 tests in that file passed on focused rerun.

Test-Impact: tests-updated
