### PR TITLE
feat(devices): derive BJT substrate from exact models

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -5010,6 +5010,50 @@ test("selects a reviewed SKY130 MOS through the existing Model field", async ({
 
 for (const fixture of [
   {
+    symbolId: "pnp",
+    model: "sky130_fd_pr__pnp_05v5_W0p68L0p68",
+  },
+  {
+    symbolId: "npn",
+    model: "sky130_fd_pr__npn_05v5_W1p00L1p00",
+  },
+] as const) {
+  test(`derives ${fixture.symbolId.toUpperCase()} substrate from its exact Model`, async ({
+    page,
+  }) => {
+    await page.goto("/editor");
+    await placeComponent(page, fixture.symbolId, { x: 360, y: 220 });
+    await openSelectionShelf(page);
+    const properties = page.getByRole("complementary", {
+      name: "Properties",
+    });
+    const model = properties.getByLabel("Component model target", {
+      exact: true,
+    });
+
+    await expect(properties.getByLabel("Substrate Net")).toHaveCount(0);
+    await model.selectOption(fixture.model);
+    await expect(properties.getByLabel("Substrate Net")).toBeVisible();
+    await expect(properties.getByLabel("Netlist Reference")).toHaveValue("XQ1");
+
+    const saved = JSON.parse(
+      (await downloadBytes(page, "File", "Export Project File…")).toString(
+        "utf8",
+      ),
+    );
+    expect(saved.externalSubcircuitDefinitions[0]).toMatchObject({
+      name: fixture.model,
+      terminals: [{ name: "C" }, { name: "B" }, { name: "E" }, { name: "S" }],
+    });
+
+    await model.selectOption("");
+    await expect(properties.getByLabel("Substrate Net")).toHaveCount(0);
+    await expect(properties.getByLabel("Netlist Reference")).toHaveValue("Q1");
+  });
+}
+
+for (const fixture of [
+  {
     symbolId: "resistor",
     model: "sky130_fd_pr__res_high_po",
     externalParameter: "Component mult",

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -5377,7 +5377,7 @@ export function App({
                         ? {
                             label:
                               selectedPropertyOnlyTerminal.role === "substrate"
-                                ? "Body/Substrate Net"
+                                ? "Substrate Net"
                                 : `${selectedPropertyOnlyTerminal.targetName} Net`,
                             pinName: selectedPropertyOnlyTerminal.pinName,
                             netId: selectedPropertyOnlyTerminalNet?.id ?? null,

--- a/docs/agent/knowledge/pdk-and-symbols.md
+++ b/docs/agent/knowledge/pdk-and-symbols.md
@@ -15,23 +15,26 @@ existing Net membership. Prefer mappings in this order:
 3. primitive mapping supported by the parsed model type;
 4. unresolved generic symbol.
 
-Only the seven released exact SKY130 masters are mapped: the core and LVT
+Eight exact SKY130 interfaces are mapped structurally: the core and LVT
 1.8 V NFET/PFET pairs, `res_high_po`, `cap_mim_m3_1`, and the fixed
-`pnp_05v5_W0p68L0p68`. Both exact master name and ordered public interface must
-match. No SKY130 family regular expression is an electrical authority.
+`pnp_05v5_W0p68L0p68` and `npn_05v5_W1p00L1p00`. Both exact master name and
+ordered public interface must match. No SKY130 family regular expression is an
+electrical authority.
 
 The mapped instance keeps its external binding while borrowing native artwork.
 Its authored reference remains in the native M/R/C/Q domain; SPICE derives the
 X card. MOS exposes D/G/S/B electrically, resistor R0/R1 map to frozen pins
-1/2 and B is property-only, MIM C0/C1 map to frozen pins 1/2, and the fixed PNP
-maps C/B/E directly to the existing PNP symbol. An explicit external block
-presentation overrides automatic artwork choice.
+1/2 and B is property-only, and MIM C0/C1 map to frozen pins 1/2. The exact PNP
+and NPN interfaces map C/B/E to their existing visible symbols and expose S
+only as a Substrate Net property. Their ordinary model-bound Q cards remain
+three-node. An explicit external block presentation overrides automatic
+artwork choice.
 
-The hosted Profile qualifies those same seven exact names. The continuous
-library does not expose `sky130_fd_pr__diode_pw2nd_05v5`, while the available
-four-terminal `sky130_fd_pr__npn_05v5_W1p00L1p00` makes ngspice 46 discard
-model parameters. Neither is advertised as qualified merely because a generic
-Diode or NPN symbol can print a model-bearing SPICE card.
+The hosted Profile qualifies seven of those interfaces and excludes the exact
+NPN. The continuous library does not expose
+`sky130_fd_pr__diode_pw2nd_05v5`, while the available four-terminal NPN makes
+ngspice 46 discard model parameters. Structural mapping is therefore not a
+qualification claim.
 
 ## Safe symbol replacement
 

--- a/docs/specs/simulation-execution.md
+++ b/docs/specs/simulation-execution.md
@@ -100,7 +100,7 @@ downgraded to an observed hosted run. Local deployment is an optional adapter,
 not an implicit fallback to a program found on the user's machine.
 
 The qualified scope is deliberately exact and factual: core and LVT 1.8 V
-NFET/PFET wrappers, `res_high_po`, `cap_mim_m3_1`, and the fixed
+NFET/PFET wrappers, `res_high_po`, `cap_mim_m3_1`, and the fixed four-terminal
 `pnp_05v5_W0p68L0p68` wrapper, over the Profile's qualified sections
 (`tt/ff/ss/fs/sf`). OP/DC/AC/TRAN/Noise remain covered by the hosted core-model
 acceptance fixture; a second OP/AC fixture verifies every added device at every

--- a/docs/user/spice-compatibility.md
+++ b/docs/user/spice-compatibility.md
@@ -23,16 +23,19 @@ into `nf`.
 The same Model field on the ordinary resistor and capacitor offers
 `sky130_fd_pr__res_high_po` and `sky130_fd_pr__cap_mim_m3_1`. Their existing
 icons and visible pins do not change. The resistor's real B substrate terminal
-is selected from existing Nets through `Body/Substrate Net` in Properties and
+is selected from existing Nets through `Substrate Net` in Properties and
 has no canvas pin or wire. Physical R/C geometry is `w/l/mult` or `w/l/mf`;
 the editor never derives it from an ideal scalar value.
 
 The ordinary PNP symbol similarly offers the exact fixed
-`sky130_fd_pr__pnp_05v5_W0p68L0p68` wrapper. It keeps the visible C/B/E pins
-and prints an external X call; arbitrary model names continue to use the
-ordinary three-terminal Q card. The generic Diode and NPN symbols remain
-model-bearing structural devices, but this hosted environment does not claim
-a qualified SKY130 diode or NPN target.
+`sky130_fd_pr__pnp_05v5_W0p68L0p68` wrapper. It keeps the visible C/B/E pins,
+adds its real S terminal as a `Substrate Net` property, and prints a four-node
+external X call. The exact `sky130_fd_pr__npn_05v5_W1p00L1p00` interface has
+the same model-bound four-terminal behavior, but is structural only in the
+hosted Profile. Clearing Model, or choosing an ordinary model name, restores
+the ordinary three-node Q card and removes the model-only substrate membership.
+The generic Diode remains model-bearing structural only; this hosted
+environment does not claim a qualified SKY130 diode or NPN target.
 
 This convenience is structural only. It does not install SKY130, resolve a
 local `.include`, supply foundry models or corners, or make the exported

--- a/packages/devices/src/reviewed-external.test.ts
+++ b/packages/devices/src/reviewed-external.test.ts
@@ -39,12 +39,38 @@ describe("reviewed external device bindings", () => {
         "C",
         "B",
         "E",
+        "S",
       ]),
     ).toMatchObject({
       id: "sky130-pnp-05v5-w0p68l0p68",
       symbolId: "pnp",
       deviceClass: "bjt",
+      terminals: [
+        { pinName: "C", interaction: "canvas" },
+        { pinName: "B", interaction: "canvas" },
+        { pinName: "E", interaction: "canvas" },
+        { pinName: "S", interaction: "property", role: "substrate" },
+      ],
     });
+    expect(
+      resolveReviewedExternalBinding("sky130_fd_pr__npn_05v5_W1p00L1p00", [
+        "C",
+        "B",
+        "E",
+        "S",
+      ]),
+    ).toMatchObject({
+      id: "sky130-npn-05v5-w1p00l1p00",
+      symbolId: "npn",
+      deviceClass: "bjt",
+    });
+    expect(
+      resolveReviewedExternalBinding("sky130_fd_pr__pnp_05v5_W0p68L0p68", [
+        "C",
+        "B",
+        "E",
+      ]),
+    ).toBeUndefined();
   });
 
   it("converts reviewed geometry in both directions without aliasing counts", () => {

--- a/packages/devices/src/reviewed-external.ts
+++ b/packages/devices/src/reviewed-external.ts
@@ -7,7 +7,8 @@ export type ReviewedExternalBindingId =
   | "sky130-pfet-01v8-lvt"
   | "sky130-res-high-po"
   | "sky130-cap-mim-m3-1"
-  | "sky130-pnp-05v5-w0p68l0p68";
+  | "sky130-pnp-05v5-w0p68l0p68"
+  | "sky130-npn-05v5-w1p00l1p00";
 
 export interface ReviewedExternalTerminalBinding {
   /** Public target terminal spelling and order from the external wrapper. */
@@ -30,7 +31,7 @@ export interface ReviewedExternalDeviceBinding {
   readonly libraryId: "sky130_fd_pr";
   readonly masterName: string;
   readonly invocationKind: "external-subcircuit";
-  readonly symbolId: "nmos" | "pmos" | "resistor" | "capacitor" | "pnp";
+  readonly symbolId: "nmos" | "pmos" | "resistor" | "capacitor" | "npn" | "pnp";
   readonly deviceClass: "mos" | "resistor" | "capacitor" | "bjt";
   readonly terminals: readonly ReviewedExternalTerminalBinding[];
   readonly parameters: readonly ReviewedExternalParameterBinding[];
@@ -74,6 +75,20 @@ const count = (
   targetDefaultValue: "1",
   spiceOrder,
 });
+
+const bjtTerminals = (): readonly ReviewedExternalTerminalBinding[] => [
+  ...["C", "B", "E"].map((name) => ({
+    targetName: name,
+    pinName: name,
+    interaction: "canvas" as const,
+  })),
+  {
+    targetName: "S",
+    pinName: "S",
+    interaction: "property",
+    role: "substrate",
+  },
+];
 
 export const reviewedExternalDeviceBindings: readonly ReviewedExternalDeviceBinding[] =
   [
@@ -200,11 +215,17 @@ export const reviewedExternalDeviceBindings: readonly ReviewedExternalDeviceBind
       invocationKind: "external-subcircuit",
       symbolId: "pnp",
       deviceClass: "bjt",
-      terminals: ["C", "B", "E"].map((name) => ({
-        targetName: name,
-        pinName: name,
-        interaction: "canvas" as const,
-      })),
+      terminals: bjtTerminals(),
+      parameters: [],
+    },
+    {
+      id: "sky130-npn-05v5-w1p00l1p00",
+      libraryId: "sky130_fd_pr",
+      masterName: "sky130_fd_pr__npn_05v5_W1p00L1p00",
+      invocationKind: "external-subcircuit",
+      symbolId: "npn",
+      deviceClass: "bjt",
+      terminals: bjtTerminals(),
       parameters: [],
     },
   ];

--- a/packages/edit-engine/src/hierarchy-planner.test.ts
+++ b/packages/edit-engine/src/hierarchy-planner.test.ts
@@ -663,6 +663,7 @@ describe("reviewed external MOS model targets", () => {
 
   it("switches the ordinary PNP between a primitive model and its exact SKY130 wrapper", () => {
     const project = createEmptyProject("project", "Project");
+    project.documents[0]!.nets.push({ id: "net-substrate", terminals: [] });
     project.documents[0]!.instances.push({
       id: "Q1",
       symbolId: "pnp",
@@ -697,17 +698,44 @@ describe("reviewed external MOS model targets", () => {
     });
     expect(external.project.externalSubcircuitDefinitions[0]).toMatchObject({
       name: "sky130_fd_pr__pnp_05v5_W0p68L0p68",
-      terminals: [{ name: "C" }, { name: "B" }, { name: "E" }],
+      terminals: [{ name: "C" }, { name: "B" }, { name: "E" }, { name: "S" }],
     });
 
-    const ordinary = executeProjectTransaction(external.project, {
-      transactionId: "set-generic-pnp",
+    const withSubstrate = executeProjectTransaction(external.project, {
+      transactionId: "set-sky130-pnp-substrate",
       projectId: external.project.id,
       expectedStructureRevision: external.project.structureRevision,
       actor: { kind: "human", id: "test" },
+      edits: [
+        {
+          kind: "transact_document",
+          documentId: external.project.topDocumentId,
+          expectedRevision: external.project.documents[0]!.revision,
+          edits: [
+            {
+              kind: "set_property_terminal_net",
+              instanceId: "Q1",
+              pinName: "S",
+              netId: "net-substrate",
+            },
+          ],
+        },
+      ],
+    });
+    expect(withSubstrate.ok).toBe(true);
+    if (!withSubstrate.ok) return;
+    expect(withSubstrate.project.documents[0]!.nets[0]!.terminals).toEqual([
+      { instanceId: "Q1", pinName: "S" },
+    ]);
+
+    const ordinary = executeProjectTransaction(withSubstrate.project, {
+      transactionId: "set-generic-pnp",
+      projectId: withSubstrate.project.id,
+      expectedStructureRevision: withSubstrate.project.structureRevision,
+      actor: { kind: "human", id: "test" },
       edits: planSetDeviceModelTarget(
-        external.project,
-        external.project.topDocumentId,
+        withSubstrate.project,
+        withSubstrate.project.topDocumentId,
         "Q1",
         "generic_pnp",
       ),
@@ -722,6 +750,9 @@ describe("reviewed external MOS model targets", () => {
         parameters: {},
       },
     });
+    expect(
+      ordinary.project.documents[0]!.nets.flatMap((net) => net.terminals),
+    ).not.toContainEqual({ instanceId: "Q1", pinName: "S" });
   });
 
   it("refuses a Model transition when its canonical X reference is occupied", () => {

--- a/packages/edit-engine/src/hierarchy-planner.ts
+++ b/packages/edit-engine/src/hierarchy-planner.ts
@@ -318,6 +318,40 @@ function matchingReviewedExternalDefinition(
   return { definition, binding };
 }
 
+function removedPropertyTerminalEdits(
+  document: SchematicDocument,
+  instanceId: string,
+  currentBinding: ReturnType<typeof matchingReviewedExternalDefinition>,
+  nextBinding?: ReturnType<typeof reviewedExternalBindingForMaster>,
+): DocumentEdits {
+  if (!currentBinding) return [];
+  const retainedPins = new Set(
+    nextBinding?.terminals
+      .filter((terminal) => terminal.interaction === "property")
+      .map((terminal) => terminal.pinName.toLowerCase()) ?? [],
+  );
+  return currentBinding.binding.terminals.flatMap((terminal) =>
+    terminal.interaction === "property" &&
+    !retainedPins.has(terminal.pinName.toLowerCase()) &&
+    document.nets.some((net) =>
+      net.terminals.some(
+        (member) =>
+          member.instanceId === instanceId &&
+          member.pinName.toLowerCase() === terminal.pinName.toLowerCase(),
+      ),
+    )
+      ? [
+          {
+            kind: "set_property_terminal_net" as const,
+            instanceId,
+            pinName: terminal.pinName,
+            netId: null,
+          },
+        ]
+      : [],
+  );
+}
+
 /**
  * Switches a native device between its ordinary binding and one exact reviewed
  * external target. The ngspice card designator is the persisted Reference, so
@@ -415,7 +449,12 @@ export function planSetDeviceModelTarget(
         `Cannot set external target because Reference ${reference} is already used`,
       );
     }
-    const documentEdits: DocumentEdits = [];
+    const documentEdits: DocumentEdits = removedPropertyTerminalEdits(
+      document,
+      instanceId,
+      currentExternal,
+      verified,
+    );
     if (instance.symbolId !== symbolId) {
       documentEdits.push({
         kind: "set_instance_symbol",
@@ -522,7 +561,11 @@ export function planSetDeviceModelTarget(
   const unset = Object.keys(instance.netlist.parameters).filter(
     (name) => !ordinaryParameterNames.has(name.toLowerCase()),
   );
-  const documentEdits: DocumentEdits = [];
+  const documentEdits: DocumentEdits = removedPropertyTerminalEdits(
+    document,
+    instanceId,
+    currentExternal,
+  );
   if (instance.symbolId !== symbolId) {
     documentEdits.push({ kind: "set_instance_symbol", instanceId, symbolId });
   }

--- a/packages/netlist/src/current-contract.test.ts
+++ b/packages/netlist/src/current-contract.test.ts
@@ -1243,8 +1243,17 @@ describe("voltage-controlled switch", () => {
         name: "sky130_fd_pr__pnp_05v5_W0p68L0p68",
         symbolId: "pnp",
         reference: "XQ1",
-        terminalNames: ["C", "B", "E"],
-        pinNames: ["C", "B", "E"],
+        terminalNames: ["C", "B", "E", "S"],
+        pinNames: ["C", "B", "E", "S"],
+        parameters: {},
+      },
+      {
+        id: "sky-npn",
+        name: "sky130_fd_pr__npn_05v5_W1p00L1p00",
+        symbolId: "npn",
+        reference: "XQ2",
+        terminalNames: ["C", "B", "E", "S"],
+        pinNames: ["C", "B", "E", "S"],
         parameters: {},
       },
     ] as const;
@@ -1293,10 +1302,13 @@ describe("voltage-controlled switch", () => {
       "XC1 XC1_0 XC1_1 sky130_fd_pr__cap_mim_m3_1 w=5 l=5 mf=4",
     );
     expect(text).toContain(
-      "XQ1 XQ1_0 XQ1_1 XQ1_2 sky130_fd_pr__pnp_05v5_W0p68L0p68",
+      "XQ1 XQ1_0 XQ1_1 XQ1_2 XQ1_3 sky130_fd_pr__pnp_05v5_W0p68L0p68",
+    );
+    expect(text).toContain(
+      "XQ2 XQ2_0 XQ2_1 XQ2_2 XQ2_3 sky130_fd_pr__npn_05v5_W1p00L1p00",
     );
     expect(
       analysis.ir?.cells[0]?.instances.map((instance) => instance.reference),
-    ).toEqual(["XC1", "XM1", "XQ1", "XR1"]);
+    ).toEqual(["XC1", "XM1", "XQ1", "XQ2", "XR1"]);
   });
 });

--- a/packages/symbols/src/pdk-registry.test.ts
+++ b/packages/symbols/src/pdk-registry.test.ts
@@ -33,8 +33,11 @@ describe("PDK symbol mapping registry", () => {
       resolvePdkSymbolMapping("sky130_fd_pr__res_high_po", 3),
     ).toMatchObject({ symbolId: "resistor", pinNames: ["1", "2", "B"] });
     expect(
-      resolvePdkSymbolMapping("sky130_fd_pr__pnp_05v5_W0p68L0p68", 3),
-    ).toMatchObject({ symbolId: "pnp", pinNames: ["C", "B", "E"] });
+      resolvePdkSymbolMapping("sky130_fd_pr__pnp_05v5_W0p68L0p68", 4),
+    ).toMatchObject({ symbolId: "pnp", pinNames: ["C", "B", "E", "S"] });
+    expect(
+      resolvePdkSymbolMapping("sky130_fd_pr__npn_05v5_W1p00L1p00", 4),
+    ).toMatchObject({ symbolId: "npn", pinNames: ["C", "B", "E", "S"] });
   });
 
   it("does not guess an unknown namespace or conflicting terminal count", () => {

--- a/scripts/preview-simulation-smoke.mjs
+++ b/scripts/preview-simulation-smoke.mjs
@@ -235,7 +235,7 @@ export function hostedSky130ExtendedDeviceRequest(corner) {
       "XMPL dpl gpl spl spl sky130_fd_pr__pfet_01v8_lvt L=0.5 W=3 nf=2",
       "XR1 rin rout 0 sky130_fd_pr__res_high_po w=1 l=5.5 mult=1",
       "XC1 capout 0 sky130_fd_pr__cap_mim_m3_1 w=5 l=5 mf=1",
-      "XQP pc pb pe sky130_fd_pr__pnp_05v5_W0p68L0p68",
+      "XQP pc pb pe 0 sky130_fd_pr__pnp_05v5_W0p68L0p68",
       ".ends extended_models",
     ].join("\n"),
     testbench: [


### PR DESCRIPTION
## Summary
- keep ordinary NPN/PNP models on the existing three-terminal Q contract
- derive a property-only S/Substrate Net terminal from exact four-terminal SKY130 bindings
- clear model-only substrate membership when returning to a three-terminal model
- align netlist output, import mapping, hosted PNP smoke coverage, and user/agent documentation

## Validation
- pnpm ci:check (2885 unit tests, 362 browser tests, build/release/golden/performance gates)
- focused BJT substrate browser tests (2 passed)
- pnpm gate:preflight -- --base origin/main

Test-Impact: tests-updated