### PR TITLE
fix(simulation): prevent corner sweep render crash

### DIFF
--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -172,6 +172,11 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
         maxTimeoutMs: 120000,
         maxInputBytes: 1048576,
         cancel: true,
+        batch: {
+          maxItems: 16,
+          execution: "sequential",
+          sweepAxes: ["corner", "temperature", "parameter"],
+        },
       },
     });
   });
@@ -185,6 +190,18 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
     .getByRole("button", { name: "Analog simulation", exact: true })
     .click();
   const panel = page.getByRole("region", { name: "Analog simulation" });
+  await panel.getByTitle("Simulation setup").click();
+  await panel.getByRole("button", { name: "Sweep…" }).click();
+  const sweepDialog = page.getByRole("dialog", {
+    name: "Run parameter sweep",
+  });
+  await sweepDialog.getByLabel("Sweep corner ff").check();
+  await sweepDialog.getByLabel("Sweep corner ss").check();
+  await expect(sweepDialog).toContainText("3 sequential runs");
+  await expect(
+    page.getByText("The editor hit an unexpected problem"),
+  ).toHaveCount(0);
+  await sweepDialog.getByRole("button", { name: "Cancel" }).click();
   await panel.getByRole("button", { name: "Settings" }).click();
   await panel
     .locator('details[aria-label="Analyses settings"] > summary')

--- a/apps/editor/src/features/simulation/simulation-sweep-dialog.tsx
+++ b/apps/editor/src/features/simulation/simulation-sweep-dialog.tsx
@@ -151,13 +151,14 @@ export function SimulationSweepDialog(props: SimulationSweepDialogProps) {
                   aria-label={`Sweep corner ${corner}`}
                   checked={corners.includes(corner)}
                   disabled={!cornerEnabled}
-                  onChange={(event) =>
+                  onChange={(event) => {
+                    const checked = event.currentTarget.checked;
                     setCorners((current) =>
-                      event.currentTarget.checked
+                      checked
                         ? [...current, corner]
                         : current.filter((value) => value !== corner),
-                    )
-                  }
+                    );
+                  }}
                 />
                 {corner}
               </label>


### PR DESCRIPTION
## Summary
- capture the corner checkbox value before React releases the event target
- cover OTA multi-corner selection in the browser regression suite

## Root cause
The functional state updater read event.currentTarget after the checkbox callback returned. React had already cleared currentTarget, so selecting a second process corner crashed the editor.

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
- 436 unit files passed (2885 tests; expected skips unchanged)
- 8 selected Agent/simulation browser tests passed

Test-Impact: tests-updated