### PR TITLE
fix(devices): restore SKY130 PNP three-terminal contract

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -5008,49 +5008,69 @@ test("selects a reviewed SKY130 MOS through the existing Model field", async ({
   });
 });
 
-for (const fixture of [
-  {
-    symbolId: "pnp",
-    model: "sky130_fd_pr__pnp_05v5_W0p68L0p68",
-  },
-  {
-    symbolId: "npn",
-    model: "sky130_fd_pr__npn_05v5_W1p00L1p00",
-  },
-] as const) {
-  test(`derives ${fixture.symbolId.toUpperCase()} substrate from its exact Model`, async ({
-    page,
-  }) => {
-    await page.goto("/editor");
-    await placeComponent(page, fixture.symbolId, { x: 360, y: 220 });
-    await openSelectionShelf(page);
-    const properties = page.getByRole("complementary", {
-      name: "Properties",
-    });
-    const model = properties.getByLabel("Component model target", {
-      exact: true,
-    });
-
-    await expect(properties.getByLabel("Substrate Net")).toHaveCount(0);
-    await model.selectOption(fixture.model);
-    await expect(properties.getByLabel("Substrate Net")).toBeVisible();
-    await expect(properties.getByLabel("Netlist Reference")).toHaveValue("XQ1");
-
-    const saved = JSON.parse(
-      (await downloadBytes(page, "File", "Export Project File…")).toString(
-        "utf8",
-      ),
-    );
-    expect(saved.externalSubcircuitDefinitions[0]).toMatchObject({
-      name: fixture.model,
-      terminals: [{ name: "C" }, { name: "B" }, { name: "E" }, { name: "S" }],
-    });
-
-    await model.selectOption("");
-    await expect(properties.getByLabel("Substrate Net")).toHaveCount(0);
-    await expect(properties.getByLabel("Netlist Reference")).toHaveValue("Q1");
+test("keeps the exact SKY130 PNP on its three-terminal model interface", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await placeComponent(page, "pnp", { x: 360, y: 220 });
+  await openSelectionShelf(page);
+  const properties = page.getByRole("complementary", {
+    name: "Properties",
   });
-}
+  const model = properties.getByLabel("Component model target", {
+    exact: true,
+  });
+
+  await expect(properties.getByLabel("Substrate Net")).toHaveCount(0);
+  await model.selectOption("sky130_fd_pr__pnp_05v5_W0p68L0p68");
+  await expect(properties.getByLabel("Substrate Net")).toHaveCount(0);
+  await expect(properties.getByLabel("Netlist Reference")).toHaveValue("XQ1");
+
+  const saved = JSON.parse(
+    (await downloadBytes(page, "File", "Export Project File…")).toString(
+      "utf8",
+    ),
+  );
+  expect(saved.externalSubcircuitDefinitions[0]).toMatchObject({
+    name: "sky130_fd_pr__pnp_05v5_W0p68L0p68",
+    terminals: [{ name: "C" }, { name: "B" }, { name: "E" }],
+  });
+
+  await model.selectOption("");
+  await expect(properties.getByLabel("Substrate Net")).toHaveCount(0);
+  await expect(properties.getByLabel("Netlist Reference")).toHaveValue("Q1");
+});
+
+test("derives NPN substrate from its exact Model", async ({ page }) => {
+  await page.goto("/editor");
+  await placeComponent(page, "npn", { x: 360, y: 220 });
+  await openSelectionShelf(page);
+  const properties = page.getByRole("complementary", {
+    name: "Properties",
+  });
+  const model = properties.getByLabel("Component model target", {
+    exact: true,
+  });
+
+  await expect(properties.getByLabel("Substrate Net")).toHaveCount(0);
+  await model.selectOption("sky130_fd_pr__npn_05v5_W1p00L1p00");
+  await expect(properties.getByLabel("Substrate Net")).toBeVisible();
+  await expect(properties.getByLabel("Netlist Reference")).toHaveValue("XQ1");
+
+  const saved = JSON.parse(
+    (await downloadBytes(page, "File", "Export Project File…")).toString(
+      "utf8",
+    ),
+  );
+  expect(saved.externalSubcircuitDefinitions[0]).toMatchObject({
+    name: "sky130_fd_pr__npn_05v5_W1p00L1p00",
+    terminals: [{ name: "C" }, { name: "B" }, { name: "E" }, { name: "S" }],
+  });
+
+  await model.selectOption("");
+  await expect(properties.getByLabel("Substrate Net")).toHaveCount(0);
+  await expect(properties.getByLabel("Netlist Reference")).toHaveValue("Q1");
+});
 
 for (const fixture of [
   {

--- a/docs/agent/knowledge/pdk-and-symbols.md
+++ b/docs/agent/knowledge/pdk-and-symbols.md
@@ -25,10 +25,11 @@ The mapped instance keeps its external binding while borrowing native artwork.
 Its authored reference remains in the native M/R/C/Q domain; SPICE derives the
 X card. MOS exposes D/G/S/B electrically, resistor R0/R1 map to frozen pins
 1/2 and B is property-only, and MIM C0/C1 map to frozen pins 1/2. The exact PNP
-and NPN interfaces map C/B/E to their existing visible symbols and expose S
-only as a Substrate Net property. Their ordinary model-bound Q cards remain
-three-node. An explicit external block presentation overrides automatic
-artwork choice.
+maps its three public C/B/E terminals directly to the existing symbol; its
+model wrapper ties the internal substrate node to C. The exact NPN maps C/B/E
+to its visible symbol and exposes its fourth S terminal only as a Substrate Net
+property. Their ordinary model-bound Q cards remain three-node. An explicit
+external block presentation overrides automatic artwork choice.
 
 The hosted Profile qualifies seven of those interfaces and excludes the exact
 NPN. The continuous library does not expose

--- a/docs/specs/simulation-execution.md
+++ b/docs/specs/simulation-execution.md
@@ -100,7 +100,7 @@ downgraded to an observed hosted run. Local deployment is an optional adapter,
 not an implicit fallback to a program found on the user's machine.
 
 The qualified scope is deliberately exact and factual: core and LVT 1.8 V
-NFET/PFET wrappers, `res_high_po`, `cap_mim_m3_1`, and the fixed four-terminal
+NFET/PFET wrappers, `res_high_po`, `cap_mim_m3_1`, and the fixed three-terminal
 `pnp_05v5_W0p68L0p68` wrapper, over the Profile's qualified sections
 (`tt/ff/ss/fs/sf`). OP/DC/AC/TRAN/Noise remain covered by the hosted core-model
 acceptance fixture; a second OP/AC fixture verifies every added device at every

--- a/docs/user/spice-compatibility.md
+++ b/docs/user/spice-compatibility.md
@@ -29,13 +29,14 @@ the editor never derives it from an ideal scalar value.
 
 The ordinary PNP symbol similarly offers the exact fixed
 `sky130_fd_pr__pnp_05v5_W0p68L0p68` wrapper. It keeps the visible C/B/E pins,
-adds its real S terminal as a `Substrate Net` property, and prints a four-node
-external X call. The exact `sky130_fd_pr__npn_05v5_W1p00L1p00` interface has
-the same model-bound four-terminal behavior, but is structural only in the
-hosted Profile. Clearing Model, or choosing an ordinary model name, restores
-the ordinary three-node Q card and removes the model-only substrate membership.
-The generic Diode remains model-bearing structural only; this hosted
-environment does not claim a qualified SKY130 diode or NPN target.
+prints a three-node external X call, and relies on that wrapper's internal
+substrate-to-collector connection. The exact
+`sky130_fd_pr__npn_05v5_W1p00L1p00` interface instead exposes its real fourth S
+terminal as a `Substrate Net` property and is structural only in the hosted
+Profile. Clearing its Model, or choosing an ordinary model name, restores the
+ordinary three-node Q card and removes the model-only substrate membership. The
+generic Diode remains model-bearing structural only; this hosted environment
+does not claim a qualified SKY130 diode or NPN target.
 
 This convenience is structural only. It does not install SKY130, resolve a
 local `.include`, supply foundry models or corners, or make the exported

--- a/packages/devices/src/reviewed-external.test.ts
+++ b/packages/devices/src/reviewed-external.test.ts
@@ -39,7 +39,6 @@ describe("reviewed external device bindings", () => {
         "C",
         "B",
         "E",
-        "S",
       ]),
     ).toMatchObject({
       id: "sky130-pnp-05v5-w0p68l0p68",
@@ -49,7 +48,6 @@ describe("reviewed external device bindings", () => {
         { pinName: "C", interaction: "canvas" },
         { pinName: "B", interaction: "canvas" },
         { pinName: "E", interaction: "canvas" },
-        { pinName: "S", interaction: "property", role: "substrate" },
       ],
     });
     expect(
@@ -69,6 +67,7 @@ describe("reviewed external device bindings", () => {
         "C",
         "B",
         "E",
+        "S",
       ]),
     ).toBeUndefined();
   });

--- a/packages/devices/src/reviewed-external.ts
+++ b/packages/devices/src/reviewed-external.ts
@@ -76,19 +76,23 @@ const count = (
   spiceOrder,
 });
 
-const bjtTerminals = (): readonly ReviewedExternalTerminalBinding[] => [
-  ...["C", "B", "E"].map((name) => ({
+const bjtCanvasTerminals = (): readonly ReviewedExternalTerminalBinding[] =>
+  ["C", "B", "E"].map((name) => ({
     targetName: name,
     pinName: name,
     interaction: "canvas" as const,
-  })),
-  {
-    targetName: "S",
-    pinName: "S",
-    interaction: "property",
-    role: "substrate",
-  },
-];
+  }));
+
+const bjtTerminalsWithSubstrate =
+  (): readonly ReviewedExternalTerminalBinding[] => [
+    ...bjtCanvasTerminals(),
+    {
+      targetName: "S",
+      pinName: "S",
+      interaction: "property",
+      role: "substrate",
+    },
+  ];
 
 export const reviewedExternalDeviceBindings: readonly ReviewedExternalDeviceBinding[] =
   [
@@ -215,7 +219,8 @@ export const reviewedExternalDeviceBindings: readonly ReviewedExternalDeviceBind
       invocationKind: "external-subcircuit",
       symbolId: "pnp",
       deviceClass: "bjt",
-      terminals: bjtTerminals(),
+      // This wrapper exposes C/B/E only; its internal Q card ties substrate to C.
+      terminals: bjtCanvasTerminals(),
       parameters: [],
     },
     {
@@ -225,7 +230,7 @@ export const reviewedExternalDeviceBindings: readonly ReviewedExternalDeviceBind
       invocationKind: "external-subcircuit",
       symbolId: "npn",
       deviceClass: "bjt",
-      terminals: bjtTerminals(),
+      terminals: bjtTerminalsWithSubstrate(),
       parameters: [],
     },
   ];

--- a/packages/edit-engine/src/hierarchy-planner.test.ts
+++ b/packages/edit-engine/src/hierarchy-planner.test.ts
@@ -663,7 +663,6 @@ describe("reviewed external MOS model targets", () => {
 
   it("switches the ordinary PNP between a primitive model and its exact SKY130 wrapper", () => {
     const project = createEmptyProject("project", "Project");
-    project.documents[0]!.nets.push({ id: "net-substrate", terminals: [] });
     project.documents[0]!.instances.push({
       id: "Q1",
       symbolId: "pnp",
@@ -698,44 +697,17 @@ describe("reviewed external MOS model targets", () => {
     });
     expect(external.project.externalSubcircuitDefinitions[0]).toMatchObject({
       name: "sky130_fd_pr__pnp_05v5_W0p68L0p68",
-      terminals: [{ name: "C" }, { name: "B" }, { name: "E" }, { name: "S" }],
+      terminals: [{ name: "C" }, { name: "B" }, { name: "E" }],
     });
 
-    const withSubstrate = executeProjectTransaction(external.project, {
-      transactionId: "set-sky130-pnp-substrate",
+    const ordinary = executeProjectTransaction(external.project, {
+      transactionId: "set-generic-pnp",
       projectId: external.project.id,
       expectedStructureRevision: external.project.structureRevision,
       actor: { kind: "human", id: "test" },
-      edits: [
-        {
-          kind: "transact_document",
-          documentId: external.project.topDocumentId,
-          expectedRevision: external.project.documents[0]!.revision,
-          edits: [
-            {
-              kind: "set_property_terminal_net",
-              instanceId: "Q1",
-              pinName: "S",
-              netId: "net-substrate",
-            },
-          ],
-        },
-      ],
-    });
-    expect(withSubstrate.ok).toBe(true);
-    if (!withSubstrate.ok) return;
-    expect(withSubstrate.project.documents[0]!.nets[0]!.terminals).toEqual([
-      { instanceId: "Q1", pinName: "S" },
-    ]);
-
-    const ordinary = executeProjectTransaction(withSubstrate.project, {
-      transactionId: "set-generic-pnp",
-      projectId: withSubstrate.project.id,
-      expectedStructureRevision: withSubstrate.project.structureRevision,
-      actor: { kind: "human", id: "test" },
       edits: planSetDeviceModelTarget(
-        withSubstrate.project,
-        withSubstrate.project.topDocumentId,
+        external.project,
+        external.project.topDocumentId,
         "Q1",
         "generic_pnp",
       ),
@@ -750,9 +722,6 @@ describe("reviewed external MOS model targets", () => {
         parameters: {},
       },
     });
-    expect(
-      ordinary.project.documents[0]!.nets.flatMap((net) => net.terminals),
-    ).not.toContainEqual({ instanceId: "Q1", pinName: "S" });
   });
 
   it("refuses a Model transition when its canonical X reference is occupied", () => {

--- a/packages/netlist/src/current-contract.test.ts
+++ b/packages/netlist/src/current-contract.test.ts
@@ -1243,8 +1243,8 @@ describe("voltage-controlled switch", () => {
         name: "sky130_fd_pr__pnp_05v5_W0p68L0p68",
         symbolId: "pnp",
         reference: "XQ1",
-        terminalNames: ["C", "B", "E", "S"],
-        pinNames: ["C", "B", "E", "S"],
+        terminalNames: ["C", "B", "E"],
+        pinNames: ["C", "B", "E"],
         parameters: {},
       },
       {
@@ -1302,7 +1302,7 @@ describe("voltage-controlled switch", () => {
       "XC1 XC1_0 XC1_1 sky130_fd_pr__cap_mim_m3_1 w=5 l=5 mf=4",
     );
     expect(text).toContain(
-      "XQ1 XQ1_0 XQ1_1 XQ1_2 XQ1_3 sky130_fd_pr__pnp_05v5_W0p68L0p68",
+      "XQ1 XQ1_0 XQ1_1 XQ1_2 sky130_fd_pr__pnp_05v5_W0p68L0p68",
     );
     expect(text).toContain(
       "XQ2 XQ2_0 XQ2_1 XQ2_2 XQ2_3 sky130_fd_pr__npn_05v5_W1p00L1p00",

--- a/packages/symbols/src/pdk-registry.test.ts
+++ b/packages/symbols/src/pdk-registry.test.ts
@@ -33,8 +33,8 @@ describe("PDK symbol mapping registry", () => {
       resolvePdkSymbolMapping("sky130_fd_pr__res_high_po", 3),
     ).toMatchObject({ symbolId: "resistor", pinNames: ["1", "2", "B"] });
     expect(
-      resolvePdkSymbolMapping("sky130_fd_pr__pnp_05v5_W0p68L0p68", 4),
-    ).toMatchObject({ symbolId: "pnp", pinNames: ["C", "B", "E", "S"] });
+      resolvePdkSymbolMapping("sky130_fd_pr__pnp_05v5_W0p68L0p68", 3),
+    ).toMatchObject({ symbolId: "pnp", pinNames: ["C", "B", "E"] });
     expect(
       resolvePdkSymbolMapping("sky130_fd_pr__npn_05v5_W1p00L1p00", 4),
     ).toMatchObject({ symbolId: "npn", pinNames: ["C", "B", "E", "S"] });

--- a/scripts/preview-simulation-smoke.mjs
+++ b/scripts/preview-simulation-smoke.mjs
@@ -235,7 +235,7 @@ export function hostedSky130ExtendedDeviceRequest(corner) {
       "XMPL dpl gpl spl spl sky130_fd_pr__pfet_01v8_lvt L=0.5 W=3 nf=2",
       "XR1 rin rout 0 sky130_fd_pr__res_high_po w=1 l=5.5 mult=1",
       "XC1 capout 0 sky130_fd_pr__cap_mim_m3_1 w=5 l=5 mf=1",
-      "XQP pc pb pe 0 sky130_fd_pr__pnp_05v5_W0p68L0p68",
+      "XQP pc pb pe sky130_fd_pr__pnp_05v5_W0p68L0p68",
       ".ends extended_models",
     ].join("\n"),
     testbench: [

--- a/scripts/preview-simulation-smoke.test.mjs
+++ b/scripts/preview-simulation-smoke.test.mjs
@@ -536,7 +536,12 @@ describe("the hosted SKY130 qualification", () => {
     expect(request.netlist).toContain("sky130_fd_pr__pfet_01v8_lvt");
     expect(request.netlist).toContain("sky130_fd_pr__res_high_po");
     expect(request.netlist).toContain("sky130_fd_pr__cap_mim_m3_1");
-    expect(request.netlist).toContain("sky130_fd_pr__pnp_05v5_W0p68L0p68");
+    expect(request.netlist).toContain(
+      "XQP pc pb pe sky130_fd_pr__pnp_05v5_W0p68L0p68",
+    );
+    expect(request.netlist).not.toContain(
+      "XQP pc pb pe 0 sky130_fd_pr__pnp_05v5_W0p68L0p68",
+    );
     expect(
       validateHostedSky130ExtendedDeviceResult(
         extendedDeviceResult("operator-host"),


### PR DESCRIPTION
## Summary
- restore the exact SKY130 PNP wrapper to its upstream C/B/E interface
- keep the exact SKY130 NPN on C/B/E/S and remove the PNP Substrate Net control
- assert the complete three-node PNP qualification card so PR tests catch future arity regressions
- align device, netlist, editor, qualification, and documentation contracts

## Root cause
The PNP and NPN bindings shared one four-terminal helper. SKY130's fixed PNP wrapper exposes only C/B/E and internally ties substrate to collector, so the added fourth 