### PR TITLE
Rebalance simulation result presentation

### DIFF
--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -895,7 +895,12 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   await expect(panel.locator('svg[aria-label="AC db20"]')).toBeVisible();
   await expect(panel.locator('svg[aria-label="AC phase"]')).toBeVisible();
   await expect(panel.getByLabel("Voltage reference")).toHaveValue("");
-  await expect(panel.getByText("ref 1 V", { exact: false })).toHaveCount(2);
+  await expect(panel.getByText("ref 1 V", { exact: false })).toHaveCount(0);
+  await expect(
+    panel
+      .locator('svg[aria-label="AC db20"] .ac-axis-title')
+      .filter({ hasText: "db20/dBV" }),
+  ).toBeVisible();
   await expect
     .poll(
       async () =>
@@ -1371,6 +1376,11 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
       name: "Remove E2E setup from comparison",
     }),
   ).toBeVisible();
+  await expect(
+    panel.locator(
+      ".simulation-waveform-comparison > header > .simulation-comparison-actions",
+    ),
+  ).toContainText("Keep current");
   await panel.getByRole("button", { name: "Maximize simulation" }).click();
   const previousViewport = page.viewportSize()!;
   for (const [width, height] of [
@@ -1397,6 +1407,12 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
       surfaceBox.x + surfaceBox.width / 2,
       0,
     );
+    const firstComparisonRunBox = (await comparisonRuns.nth(0).boundingBox())!;
+    const secondComparisonRunBox = (await comparisonRuns.nth(1).boundingBox())!;
+    expect(secondComparisonRunBox.y).toBeCloseTo(firstComparisonRunBox.y, 0);
+    expect(secondComparisonRunBox.x).toBeGreaterThan(
+      firstComparisonRunBox.x + firstComparisonRunBox.width,
+    );
     await panel.getByRole("tab", { name: "Plot" }).click();
     const plotCards = panel.locator(
       ".simulation-plot-view .simulation-output-results > .simulation-analysis-card",
@@ -1404,9 +1420,10 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
     await expect(plotCards).toHaveCount(3);
     const firstPlotCardBox = (await plotCards.nth(0).boundingBox())!;
     const secondPlotCardBox = (await plotCards.nth(1).boundingBox())!;
-    expect(secondPlotCardBox.y).toBeCloseTo(firstPlotCardBox.y, 0);
-    expect(secondPlotCardBox.x).toBeGreaterThan(
-      firstPlotCardBox.x + firstPlotCardBox.width,
+    expect(secondPlotCardBox.x).toBeCloseTo(firstPlotCardBox.x, 0);
+    expect(secondPlotCardBox.width).toBeCloseTo(firstPlotCardBox.width, 0);
+    expect(secondPlotCardBox.y).toBeGreaterThan(
+      firstPlotCardBox.y + firstPlotCardBox.height,
     );
     const card = panel
       .locator(".simulation-analysis-card")
@@ -1414,6 +1431,16 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
         has: page.locator(".ac-view-toolbar"),
       })
       .first();
+    await expect
+      .poll(() =>
+        card
+          .locator(".simulation-analysis-card-body")
+          .evaluate(
+            (element) =>
+              getComputedStyle(element).gridTemplateColumns.split(" ").length,
+          ),
+      )
+      .toBe(2);
     const shell = card.locator(".ac-plot-shell").first();
     await expect
       .poll(async () => (await shell.locator("svg").boundingBox())!.height)

--- a/apps/editor/src/features/simulation/ac-results-explorer.test.tsx
+++ b/apps/editor/src/features/simulation/ac-results-explorer.test.tsx
@@ -52,7 +52,7 @@ describe("AC Results Explorer", () => {
     );
 
     expect(markup).toContain("VOUT");
-    expect(markup).toContain("Voltage Magnitude");
+    expect(markup).not.toContain("Voltage Magnitude");
     expect(markup).not.toContain("Voltage Phase");
     expect(markup).not.toContain("<h4>Voltage</h4>");
     expect(markup).toContain('aria-label="AC magnitude"');

--- a/apps/editor/src/features/simulation/ac-results-explorer.tsx
+++ b/apps/editor/src/features/simulation/ac-results-explorer.tsx
@@ -564,20 +564,6 @@ export function ComplexResultsExplorer({
                 {visibleQuantityTraces.length ? (
                   kinds.map((kind) => (
                     <div key={kind} className="ac-plot-row">
-                      <strong>
-                        {groupLabel(quantity)} {plotKindLabel(kind)}
-                        {(kind === "db20" || mode === "bode") && (
-                          <small>
-                            {" "}
-                            · ref{" "}
-                            {referenceId
-                              ? quantityTraces.find(
-                                  (trace) => trace.id === referenceId,
-                                )?.label
-                              : unityReferenceLabel(sourceUnit)}
-                          </small>
-                        )}
-                      </strong>
                       {renderPlot(
                         { quantity, kind, referenced: referenceActive },
                         visibleQuantityTraces,

--- a/apps/editor/src/features/simulation/dc-results-explorer.test.tsx
+++ b/apps/editor/src/features/simulation/dc-results-explorer.test.tsx
@@ -42,6 +42,7 @@ describe("DcResultsExplorer", () => {
     );
     expect(markup).toContain('aria-label="DC sweep results"');
     expect(markup).toContain('aria-label="DC voltage"');
+    expect(markup).not.toContain("Voltage DC sweep");
     expect(markup).toContain("3 points");
     expect(markup).toContain("Output");
     expect(markup).toContain('class="ac-axis-title"');

--- a/apps/editor/src/features/simulation/dc-results-explorer.tsx
+++ b/apps/editor/src/features/simulation/dc-results-explorer.tsx
@@ -97,9 +97,6 @@ export function DcResultsExplorer({
         const yLabels = waveformAxisLabels(...yExtent, unit);
         return (
           <div className="ac-plot-row" key={quantity}>
-            <strong>
-              {quantity === "voltage" ? "Voltage" : "Current"} DC sweep
-            </strong>
             <div className="ac-plot-shell">
               <div className="spice-ac-plot">
                 <svg

--- a/apps/editor/src/features/simulation/simulation-output-results.test.tsx
+++ b/apps/editor/src/features/simulation/simulation-output-results.test.tsx
@@ -109,4 +109,98 @@ describe("Simulation Output Results", () => {
     expect(markup).toContain("Integrated input-referred noise");
     expect(markup).toContain("1.80000e-7 V");
   });
+
+  it("presents AC expression variants as one switchable signal family", () => {
+    const gain = {
+      kind: "divide" as const,
+      left: {
+        kind: "voltage" as const,
+        documentId: "tb",
+        anchor: { kind: "base-net" as const, netId: "out" },
+        occurrence: [],
+      },
+      right: {
+        kind: "voltage" as const,
+        documentId: "tb",
+        anchor: { kind: "base-net" as const, netId: "in" },
+        occurrence: [],
+      },
+    };
+    const markup = renderToStaticMarkup(
+      <SimulationOutputResults
+        resultKey="run-gain"
+        outputs={[
+          { id: "gain", label: "A_v", expression: gain },
+          {
+            id: "gain-db",
+            label: "dB(A_v)",
+            expression: { kind: "db20", operand: gain },
+          },
+        ]}
+        data={{
+          schemaVersion: 1,
+          diagnostics: [],
+          analyses: [
+            {
+              analysis: "ac",
+              plotName: "AC Analysis",
+              domain: { name: "Frequency", unit: "Hz", values: [10, 100] },
+              outputs: [
+                {
+                  id: "gain",
+                  label: "A_v",
+                  unit: "1",
+                  values: [2, 1],
+                  imaginary: [0, -1],
+                },
+                {
+                  id: "gain-db",
+                  label: "dB(A_v)",
+                  unit: "dB",
+                  values: [6.0206, 3.0103],
+                },
+              ],
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(markup).toContain("A_v");
+    expect(markup).not.toContain("dB(A_v)");
+    expect(markup).toContain('aria-label="Ratio display"');
+    expect(markup).toContain(">dB</button>");
+    expect(markup.match(/class="simulation-plot-layout"/gu)).toHaveLength(1);
+  });
+
+  it("keeps non-AC scalar outputs visible", () => {
+    const markup = renderToStaticMarkup(
+      <SimulationOutputResults
+        resultKey="run-tran"
+        outputs={[]}
+        data={{
+          schemaVersion: 1,
+          diagnostics: [],
+          analyses: [
+            {
+              analysis: "tran",
+              plotName: "Transient Analysis",
+              domain: { name: "Time", unit: "s", values: [0, 1e-6] },
+              outputs: [
+                {
+                  id: "out-v",
+                  label: "VOUT",
+                  unit: "V",
+                  values: [0, 1.2],
+                },
+              ],
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(markup).toContain("VOUT");
+    expect(markup).toContain('aria-label="Transient voltage"');
+  });
 });

--- a/apps/editor/src/features/simulation/simulation-output-results.tsx
+++ b/apps/editor/src/features/simulation/simulation-output-results.tsx
@@ -2,6 +2,7 @@ import type { SimulationFocusTarget } from "./simulation-focus-target";
 import type { ReactNode } from "react";
 import {
   simulationExpressionDependencies,
+  type SimulationExpression,
   type SimulationOutputSpec,
 } from "@icm/model";
 import type { SimulationOutputData } from "@icm/simulation-service/contract";
@@ -16,6 +17,22 @@ import { SimulationMeasurementResults } from "./simulation-measurement-results";
 import { NoiseResultsExplorer } from "./noise-results-explorer";
 
 export type SimulationAnalysisKind = "op" | "dc" | "ac" | "tran" | "noise";
+
+const AC_PRESENTATION_KINDS = new Set<SimulationExpression["kind"]>([
+  "magnitude",
+  "db20",
+  "phase",
+  "real",
+  "imaginary",
+  "absolute",
+]);
+
+function acPresentationBase(expression: SimulationExpression) {
+  let base = expression;
+  while ("operand" in base && AC_PRESENTATION_KINDS.has(base.kind))
+    base = base.operand;
+  return JSON.stringify(base);
+}
 
 function simulationAnalysisTitle(kind: SimulationAnalysisKind): string {
   switch (kind) {
@@ -118,7 +135,22 @@ export function SimulationOutputResults({
           );
         if (!analysis.domain) return null;
         const complex = analysis.outputs.filter((output) => output.imaginary);
-        const scalar = analysis.outputs.filter((output) => !output.imaginary);
+        const complexFamilies = new Set(
+          complex.flatMap((output) => {
+            const expression = authored.get(output.id)?.expression;
+            return expression ? [acPresentationBase(expression)] : [];
+          }),
+        );
+        const scalar = analysis.outputs.filter((output) => {
+          if (output.imaginary) return false;
+          if (analysis.analysis !== "ac") return true;
+          const expression = authored.get(output.id)?.expression;
+          return !(
+            expression &&
+            AC_PRESENTATION_KINDS.has(expression.kind) &&
+            complexFamilies.has(acPresentationBase(expression))
+          );
+        });
         const scalarByUnit = new Map<string, typeof scalar>();
         for (const output of scalar)
           scalarByUnit.set(output.unit, [

--- a/apps/editor/src/features/simulation/simulation-waveform-comparison.tsx
+++ b/apps/editor/src/features/simulation/simulation-waveform-comparison.tsx
@@ -1,4 +1,5 @@
 import type { SimulationOutputData } from "@icm/simulation-service/contract";
+import type { ReactNode } from "react";
 
 import {
   ComplexResultsExplorer,
@@ -159,19 +160,20 @@ export function buildComparisonWaveforms(
 
 export function SimulationWaveformComparison({
   runs,
+  actions,
 }: {
   runs: readonly SimulationComparisonRun[];
+  actions?: ReactNode;
 }) {
   const waveforms = buildComparisonWaveforms(runs);
-  if (!waveforms.scalar.length && !waveforms.complex.length) return null;
   return (
     <section
       className="simulation-waveform-comparison"
       aria-label="Waveform overlays"
     >
       <header>
-        <strong>Waveform overlays</strong>
-        <small>Only compatible analyses and units share an axis.</small>
+        <strong>Waveforms</strong>
+        {actions}
       </header>
       {waveforms.complex.map((group) => (
         <ComplexResultsExplorer

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -1504,7 +1504,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
             ) : null}
 
             {resultTab === "operating-point" ? (
-              <div className="simulation-analysis-view">
+              <div className="simulation-analysis-view simulation-operating-point-view">
                 <div className="simulation-op-canvas-controls">
                   <button
                     type="button"
@@ -1605,40 +1605,47 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
 
             {resultTab === "compare" ? (
               <div className="simulation-comparison-view">
-                <div className="simulation-comparison-actions">
-                  <button
-                    type="button"
-                    disabled={
-                      !currentComparisonRun ||
-                      retainedComparisonRuns.some(
-                        (candidate) => candidate.id === currentComparisonRun.id,
-                      ) ||
-                      retainedComparisonRuns.length >= MAX_COMPARISON_RUNS - 1
-                    }
-                    onClick={retainCurrentComparison}
-                  >
-                    {retainedComparisonRuns.some(
-                      (candidate) => candidate.id === currentComparisonRun?.id,
-                    )
-                      ? "Current kept"
-                      : "Keep current"}
-                  </button>
-                  {retainedComparisonRuns.length ? (
-                    <button
-                      type="button"
-                      onClick={() => setRetainedComparisonRuns([])}
-                    >
-                      Clear kept
-                    </button>
-                  ) : null}
-                </div>
+                <SimulationWaveformComparison
+                  runs={comparisonRuns}
+                  actions={
+                    <div className="simulation-comparison-actions">
+                      <button
+                        type="button"
+                        disabled={
+                          !currentComparisonRun ||
+                          retainedComparisonRuns.some(
+                            (candidate) =>
+                              candidate.id === currentComparisonRun.id,
+                          ) ||
+                          retainedComparisonRuns.length >=
+                            MAX_COMPARISON_RUNS - 1
+                        }
+                        onClick={retainCurrentComparison}
+                      >
+                        {retainedComparisonRuns.some(
+                          (candidate) =>
+                            candidate.id === currentComparisonRun?.id,
+                        )
+                          ? "Current kept"
+                          : "Keep current"}
+                      </button>
+                      {retainedComparisonRuns.length ? (
+                        <button
+                          type="button"
+                          onClick={() => setRetainedComparisonRuns([])}
+                        >
+                          Clear kept
+                        </button>
+                      ) : null}
+                    </div>
+                  }
+                />
                 {comparisonRuns.length < 2 && currentComparisonRun ? (
                   <p className="simulation-comparison-hint">
                     Keep this result, change the circuit or conditions, then run
                     again to compare.
                   </p>
                 ) : null}
-                <SimulationWaveformComparison runs={comparisonRuns} />
                 <SimulationRunComparison
                   runs={comparisonRuns}
                   onRemove={(runId) =>

--- a/apps/editor/src/features/simulation/transient-results-explorer.test.tsx
+++ b/apps/editor/src/features/simulation/transient-results-explorer.test.tsx
@@ -85,8 +85,8 @@ describe("Transient Results Explorer", () => {
 
     expect(markup).toContain("VOUT");
     expect(markup).toContain("IIN");
-    expect(markup).toContain("Voltage transient");
-    expect(markup).toContain("Current transient");
+    expect(markup).not.toContain("Voltage transient");
+    expect(markup).not.toContain("Current transient");
     expect(markup).toContain('aria-label="Hide VOUT"');
     expect(markup).toContain('aria-label="Hide IIN"');
     expect(markup).toContain('aria-pressed="true"');

--- a/apps/editor/src/features/simulation/transient-results-explorer.tsx
+++ b/apps/editor/src/features/simulation/transient-results-explorer.tsx
@@ -728,14 +728,6 @@ export function ScalarResultsExplorer({
               <div className="simulation-plot-stack">
                 {visibleQuantityTraces.length ? (
                   <div className="ac-plot-row">
-                    <strong>
-                      {quantity === "voltage"
-                        ? "Voltage"
-                        : quantity === "current"
-                          ? "Current"
-                          : quantity}{" "}
-                      {analysisLabel.toLowerCase()}
-                    </strong>
                     {plot(quantity, visibleQuantityTraces)}
                   </div>
                 ) : (

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -408,16 +408,22 @@
   .spice-simulation-surface.maximized
     .simulation-plot-view
     > .simulation-output-results {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: minmax(0, 1fr);
     align-items: start;
   }
 
   .spice-simulation-surface.maximized
     .simulation-plot-view
-    > .simulation-output-results,
+    .simulation-analysis-card-body,
   .spice-simulation-surface.maximized
-    .simulation-plot-view
-    > .simulation-empty-result,
+    .simulation-operating-point-view
+    > .simulation-output-results,
+  .spice-simulation-surface.maximized .simulation-device-operating-points > div,
+  .spice-simulation-surface.maximized .simulation-comparison-runs {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: start;
+  }
+
   .spice-simulation-surface.maximized
     .simulation-plot-view
     > .simulation-output-results
@@ -426,6 +432,69 @@
     .simulation-plot-view
     > .simulation-output-results
     > .simulation-measurement-results {
+    grid-column: 1 / -1;
+  }
+
+  .spice-simulation-surface.maximized
+    .simulation-plot-view
+    .simulation-analysis-card-body
+    > :only-child,
+  .spice-simulation-surface.maximized
+    .simulation-operating-point-view
+    > .simulation-op-canvas-controls,
+  .spice-simulation-surface.maximized
+    .simulation-operating-point-view
+    > .simulation-device-operating-points {
+    grid-column: 1 / -1;
+  }
+
+  .spice-simulation-surface.maximized
+    .simulation-plot-view
+    .simulation-analysis-card-body
+    > .ac-results-explorer:only-child,
+  .spice-simulation-surface.maximized
+    .simulation-plot-view
+    .noise-results-explorer {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: start;
+  }
+
+  .spice-simulation-surface.maximized
+    .simulation-plot-view
+    .ac-results-explorer:only-child
+    > header,
+  .spice-simulation-surface.maximized
+    .simulation-plot-view
+    .ac-results-explorer:only-child
+    > .ac-quantity-group:only-of-type,
+  .spice-simulation-surface.maximized
+    .simulation-plot-view
+    .noise-results-explorer
+    > .simulation-integrated-results:only-child {
+    grid-column: 1 / -1;
+  }
+
+  .spice-simulation-surface.maximized
+    .simulation-plot-view
+    .ac-results-explorer:only-child
+    > .ac-quantity-group:only-of-type
+    .simulation-plot-stack {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .spice-simulation-surface.maximized
+    .simulation-plot-view
+    .simulation-plot-stack
+    > :only-child {
+    grid-column: 1 / -1;
+  }
+
+  .spice-simulation-surface.maximized
+    .simulation-plot-view
+    > .simulation-empty-result,
+  .spice-simulation-surface.maximized
+    .simulation-operating-point-view
+    > .simulation-empty-result {
     grid-column: 1 / -1;
   }
 
@@ -1242,7 +1311,7 @@
   align-items: center;
   justify-content: flex-end;
   gap: 6px;
-  margin-bottom: 10px;
+  margin-left: auto;
 }
 .simulation-comparison-view small,
 .simulation-comparison-hint {
@@ -1261,11 +1330,8 @@
 }
 .simulation-waveform-comparison > header {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: 8px;
-}
-.simulation-waveform-comparison > header small {
-  color: var(--icm-text-muted);
 }
 .simulation-archive-list {
   margin-top: 14px;
@@ -1751,10 +1817,6 @@
   min-height: 28px;
   max-width: 180px;
 }
-.ac-plot-row > strong small {
-  color: var(--icm-text-muted);
-  font-weight: 500;
-}
 .simulation-plot-layout {
   display: grid;
   grid-template-columns: minmax(88px, 108px) minmax(0, 1fr);
@@ -1771,7 +1833,6 @@
   display: grid;
   gap: 4px;
   min-width: 0;
-  padding-top: 23px;
 }
 .waveform-trace-toggle {
   width: 100%;
@@ -1827,10 +1888,6 @@
   display: grid;
   gap: 6px;
   min-width: 0;
-}
-.ac-plot-row > strong {
-  padding-left: 2px;
-  font-size: var(--icm-font-xs);
 }
 .spice-ac-plot.interactive {
   position: relative;


### PR DESCRIPTION
## Summary
- remove redundant per-plot captions and move comparison retention actions into the Waveforms header
- present AC expression variants such as A_v and dB(A_v) as one signal with the existing view switcher
- make maximized plots, operating-point tables, and comparison runs use adaptive two-column leaf layouts without cross-analysis grid gaps

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main (2887 unit tests passed; 8 browser tests passed)
- pnpm build
- focused simulation result unit tests and isolated agent-simulation browser flow