### PR TITLE
Refine simulation batch controls

### DIFF
--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -548,16 +548,17 @@ test("a saved-setup batch prepares first and exposes each ordinary run", async (
   await panel.getByLabel("Include TT in batch").check();
   await panel.getByLabel("Include FF in batch").check();
   await panel.getByRole("button", { name: "Run selected (2)" }).click();
-  const batch = panel.locator(".simulation-batch-strip");
+  await panel.getByTitle("Batch queue", { exact: true }).click();
+  const batch = panel.locator(".simulation-batch-menu-popover");
   await expect(batch).toContainText("Batch · finished");
   await expect(
-    batch.getByRole("button", { name: /TT · finished/ }),
+    batch.getByRole("button", { name: /TT finished/ }),
   ).toBeEnabled();
   await expect(
-    batch.getByRole("button", { name: /FF · finished/ }),
+    batch.getByRole("button", { name: /FF finished/ }),
   ).toBeEnabled();
   expect(executions).toBe(2);
-  await batch.getByRole("button", { name: /FF · finished/ }).click();
+  await batch.getByRole("button", { name: /FF finished/ }).click();
   await expect(
     panel.getByTitle("Simulation setup", { exact: true }),
   ).toContainText("FF");
@@ -671,13 +672,14 @@ test("a saved Run Plan prepares without executing and Run starts its ordinary ba
     .click();
   const panel = page.getByRole("region", { name: "Analog simulation" });
   await panel.getByRole("button", { name: "Prepare deck" }).click();
-  await expect(panel.locator(".simulation-batch-strip")).toContainText(
+  await panel.getByTitle("Batch queue", { exact: true }).click();
+  await expect(panel.locator(".simulation-batch-menu-popover")).toContainText(
     "Batch · prepared",
   );
   await expect(panel.getByLabel("Prepare files")).toBeVisible();
   expect(executions).toBe(0);
   await panel.getByRole("button", { name: "Run", exact: true }).click();
-  await expect(panel.locator(".simulation-batch-strip")).toContainText(
+  await expect(panel.locator(".simulation-batch-menu-popover")).toContainText(
     "Batch · finished",
   );
   expect(executions).toBe(2);

--- a/apps/editor/src/features/simulation/simulation-design-run-plan-editor.tsx
+++ b/apps/editor/src/features/simulation/simulation-design-run-plan-editor.tsx
@@ -488,26 +488,23 @@ export function RunPlanEditor({
             >
               Variable
             </button>
-            <details>
-              <summary>Advanced</summary>
-              <button
-                type="button"
-                disabled={axes.length >= 4 || choices.length === 0}
-                onClick={() => {
-                  const choice = choices[0];
-                  if (choice)
-                    addAxis({
-                      kind: "parameter",
-                      documentId: choice.documentId,
-                      instanceId: choice.instanceId,
-                      parameter: choice.parameter,
-                      values: ["1"],
-                    });
-                }}
-              >
-                Instance parameter
-              </button>
-            </details>
+            <button
+              type="button"
+              disabled={axes.length >= 4 || choices.length === 0}
+              onClick={() => {
+                const choice = choices[0];
+                if (choice)
+                  addAxis({
+                    kind: "parameter",
+                    documentId: choice.documentId,
+                    instanceId: choice.instanceId,
+                    parameter: choice.parameter,
+                    values: ["1"],
+                  });
+              }}
+            >
+              Instance parameter
+            </button>
           </div>
           <div className="simulation-run-plan-summary">
             <strong>{pointCount} points</strong>

--- a/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
@@ -235,6 +235,8 @@ describe("SpiceSimulationSurface workspace", () => {
     expect(markup).toContain("R1 · resistance");
     expect(markup).toContain("2 points");
     expect(markup).toContain("Design Variable");
+    expect(markup).toContain(">Instance parameter</button>");
+    expect(markup).not.toContain("<summary>Advanced</summary>");
   });
 
   it("keeps a saved raw setup distinct from the structured editor", () => {

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -154,14 +154,19 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
     readonly SimulationRunArchiveSummary[]
   >([]);
   const setupMenuRef = useRef<HTMLDetailsElement>(null);
+  const batchMenuRef = useRef<HTMLDetailsElement>(null);
   useEffect(() => {
-    const closeSetupMenu = (event: PointerEvent): void => {
-      if (setupMenuRef.current?.contains(event.target as Node)) return;
-      setupMenuRef.current?.removeAttribute("open");
-      setDeleteSetupId(undefined);
+    const closeTaskbarMenus = (event: PointerEvent): void => {
+      const target = event.target as Node;
+      if (!setupMenuRef.current?.contains(target)) {
+        setupMenuRef.current?.removeAttribute("open");
+        setDeleteSetupId(undefined);
+      }
+      if (!batchMenuRef.current?.contains(target))
+        batchMenuRef.current?.removeAttribute("open");
     };
-    document.addEventListener("pointerdown", closeSetupMenu);
-    return () => document.removeEventListener("pointerdown", closeSetupMenu);
+    document.addEventListener("pointerdown", closeTaskbarMenus);
+    return () => document.removeEventListener("pointerdown", closeTaskbarMenus);
   }, []);
   const operatingPointProjectionRef = useRef(props.onOperatingPointProjection);
   operatingPointProjectionRef.current = props.onOperatingPointProjection;
@@ -990,6 +995,8 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
         if (setupMenuRef.current?.open) {
           setupMenuRef.current.removeAttribute("open");
           setDeleteSetupId(undefined);
+        } else if (batchMenuRef.current?.open) {
+          batchMenuRef.current.removeAttribute("open");
         } else props.onMinimize();
       }}
     >
@@ -1173,6 +1180,55 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
               Set up
             </button>
           )}
+          {batch ? (
+            <details
+              ref={batchMenuRef}
+              className="simulation-batch-menu"
+              onToggle={(event) => {
+                if (event.currentTarget.open)
+                  setupMenuRef.current?.removeAttribute("open");
+              }}
+            >
+              <summary
+                aria-label={`Batch queue: ${batch.state}, ${finishedBatchItems} of ${batch.items.length} finished`}
+                title="Batch queue"
+              >
+                <span aria-hidden="true">≡</span>
+              </summary>
+              <div className="simulation-batch-menu-popover">
+                <header>
+                  <strong>Batch · {batch.state}</strong>
+                  <span>
+                    {finishedBatchItems}/{batch.items.length}
+                  </span>
+                </header>
+                <div className="simulation-batch-menu-items">
+                  {batch.items.map((item) => {
+                    const setup = project.simulationSetups.find(
+                      (candidate) => candidate.id === item.setupId,
+                    );
+                    return (
+                      <button
+                        type="button"
+                        key={item.id}
+                        data-state={item.state}
+                        disabled={item.state === "queued"}
+                        onClick={() => void showBatchItem(item)}
+                      >
+                        <span>{item.label ?? setup?.name ?? item.setupId}</span>
+                        <small>{item.state}</small>
+                      </button>
+                    );
+                  })}
+                </div>
+                {!batchRunning ? (
+                  <button type="button" onClick={() => setBatch(undefined)}>
+                    Dismiss
+                  </button>
+                ) : null}
+              </div>
+            </details>
+          ) : null}
         </div>
         <div className="simulation-window-actions">
           <button
@@ -1208,35 +1264,6 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
           </button>
         </div>
       </header>
-
-      {batch ? (
-        <div className="simulation-batch-strip" role="status">
-          <strong>Batch · {batch.state}</strong>
-          <div>
-            {batch.items.map((item) => {
-              const setup = project.simulationSetups.find(
-                (candidate) => candidate.id === item.setupId,
-              );
-              return (
-                <button
-                  type="button"
-                  key={item.id}
-                  data-state={item.state}
-                  disabled={item.state === "queued"}
-                  onClick={() => void showBatchItem(item)}
-                >
-                  {item.label ?? setup?.name ?? item.setupId} · {item.state}
-                </button>
-              );
-            })}
-          </div>
-          {!batchRunning ? (
-            <button type="button" onClick={() => setBatch(undefined)}>
-              Dismiss
-            </button>
-          ) : null}
-        </div>
-      ) : null}
 
       {!selectedSetup && !hasDutInstance ? (
         <p className="simulation-context-hint">

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -211,38 +211,86 @@
   border-color: #75e0a7;
   background: #ecfdf3;
 }
-.simulation-batch-strip {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  min-height: 34px;
-  padding: 3px 7px;
-  overflow-x: auto;
-  border-bottom: 1px solid var(--icm-border);
+.simulation-batch-menu {
+  position: relative;
+  flex: 0 0 28px;
+}
+.simulation-batch-menu > summary {
+  display: grid;
+  width: 28px;
+  min-height: 28px;
+  padding: 0;
+  place-items: center;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  background: var(--icm-surface);
+  cursor: pointer;
+  font-size: 17px;
+  line-height: 1;
+  list-style: none;
+}
+.simulation-batch-menu > summary::-webkit-details-marker {
+  display: none;
+}
+.simulation-batch-menu[open] > summary {
+  border-color: var(--icm-accent);
+  color: var(--icm-accent);
   background: var(--icm-surface-muted);
+}
+.simulation-batch-menu-popover {
+  position: absolute;
+  z-index: 12;
+  top: calc(100% + 4px);
+  right: 0;
+  display: grid;
+  gap: 4px;
+  width: 230px;
+  max-height: min(360px, 60vh);
+  padding: 5px;
+  overflow-y: auto;
+  border: 1px solid var(--icm-border-strong);
+  border-radius: var(--icm-radius-sm);
+  background: var(--icm-surface);
+  box-shadow: var(--icm-shadow-md);
   font-size: var(--icm-font-xs);
 }
-.simulation-batch-strip > strong,
-.simulation-batch-strip > button {
-  flex: 0 0 auto;
-}
-.simulation-batch-strip > div {
+.simulation-batch-menu-popover > header {
   display: flex;
-  gap: 4px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 3px 4px 5px;
+  border-bottom: 1px solid var(--icm-border);
+}
+.simulation-batch-menu-items {
+  display: grid;
+  gap: 3px;
+}
+.simulation-batch-menu-items button {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-height: 27px;
+  padding: 3px 6px;
+  border-color: transparent;
+  text-align: left;
+}
+.simulation-batch-menu-items button > span {
   min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
-.simulation-batch-strip button {
-  min-height: 24px;
-  padding: 2px 6px;
+.simulation-batch-menu-items button > small {
+  flex: 0 0 auto;
+  color: var(--icm-text-muted);
 }
-.simulation-batch-strip button[data-state="finished"] {
+.simulation-batch-menu-items button[data-state="finished"] {
   color: #067647;
-  border-color: #75e0a7;
 }
-.simulation-batch-strip button[data-state="failed"],
-.simulation-batch-strip button[data-state="lost"] {
+.simulation-batch-menu-items button[data-state="failed"],
+.simulation-batch-menu-items button[data-state="lost"] {
   color: #b42318;
-  border-color: #fda29b;
 }
 .simulation-primary-button {
   border-color: var(--icm-accent) !important;
@@ -731,17 +779,6 @@
 }
 .simulation-run-plan-add {
   flex-wrap: wrap;
-}
-.simulation-run-plan-add > details {
-  position: relative;
-}
-.simulation-run-plan-add > details > summary {
-  cursor: pointer;
-  color: var(--icm-text-muted);
-  font-size: var(--icm-font-xs);
-}
-.simulation-run-plan-add > details > button {
-  margin-top: 4px;
 }
 .simulation-run-plan-summary > span {
   color: var(--icm-text-muted);


### PR DESCRIPTION
## Summary
- replace the always-visible batch strip with a compact queue dropdown beside Run/Cancel
- keep per-run status and result selection in the on-demand queue
- expose Instance parameter alongside the other Run Plan sweep axes instead of nesting it under Advanced

## Validation
- pnpm test:local apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
- focused batch/Run Plan Playwright regression (2 passed)
- pnpm ci:static
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main (2,894 unit tests + 9 browser tests passed)

Test-Impact: tests-updated