### PR TITLE
Fix sweep value-list editing

### DIFF
--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -670,6 +670,25 @@ test("a saved Run Plan prepares without executing and Run starts its ordinary ba
     .getByRole("button", { name: "Analog simulation", exact: true })
     .click();
   const panel = page.getByRole("region", { name: "Analog simulation" });
+  const runPlan = panel.getByLabel("Run Plan settings");
+  await runPlan.locator(":scope > summary").click();
+  await runPlan
+    .getByRole("button", { name: "Temperature", exact: true })
+    .click();
+  const temperatures = runPlan.getByLabel("Run Plan temperatures");
+  await expect(temperatures).toHaveValue("-40, 27, 125");
+  await temperatures.press("Control+A");
+  await temperatures.press("Backspace");
+  await expect(temperatures).toHaveValue("");
+  await temperatures.type("-20, nope");
+  await temperatures.press("Enter");
+  await expect(temperatures).toHaveValue("-20, nope");
+  await expect(runPlan.getByRole("alert")).toContainText("finite number");
+  await temperatures.press("Control+A");
+  await temperatures.type("-20, 0, 25.5");
+  await temperatures.press("Enter");
+  await expect(temperatures).toHaveValue("-20, 0, 25.5");
+  await panel.getByRole("button", { name: "Apply setup" }).click();
   await panel.getByRole("button", { name: "Prepare deck" }).click();
   await expect(panel.locator(".simulation-batch-strip")).toContainText(
     "Batch · prepared",
@@ -680,7 +699,7 @@ test("a saved Run Plan prepares without executing and Run starts its ordinary ba
   await expect(panel.locator(".simulation-batch-strip")).toContainText(
     "Batch · finished",
   );
-  expect(executions).toBe(2);
+  expect(executions).toBe(6);
 });
 
 test("human simulation uses saved setup, survives minimizing, recovers a bad input and exports results", async ({

--- a/apps/editor/src/features/simulation/simulation-design-run-plan-editor.tsx
+++ b/apps/editor/src/features/simulation/simulation-design-run-plan-editor.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 import type {
   CircuitProject,
   SimulationDesignVariable,
@@ -49,11 +49,106 @@ export function simulationRunPlanPointCount(plan: SimulationRunPlan): number {
     : plan.axes.reduce((count, axis) => count * axis.values.length, 1);
 }
 
-function commaStrings(value: string): readonly string[] {
-  return value
-    .split(",")
-    .map((part) => part.trim())
-    .filter(Boolean);
+type DraftValuesResult<T extends string | number> =
+  | { readonly ok: true; readonly values: readonly T[] }
+  | { readonly ok: false; readonly message: string };
+
+function parseTextValues(value: string): DraftValuesResult<string> {
+  const values = value.split(",").map((part) => part.trim());
+  if (!value.trim() || values.some((part) => !part))
+    return {
+      ok: false,
+      message: "Enter one or more comma-separated values.",
+    };
+  return { ok: true, values };
+}
+
+function parseTemperatureValues(value: string): DraftValuesResult<number> {
+  const parsed = parseTextValues(value);
+  if (!parsed.ok)
+    return {
+      ok: false,
+      message: "Enter one or more comma-separated temperatures.",
+    };
+  const values = parsed.values.map(Number);
+  if (values.some((candidate) => !Number.isFinite(candidate)))
+    return {
+      ok: false,
+      message: "Every temperature must be a finite number in °C.",
+    };
+  return { ok: true, values };
+}
+
+function DraftValuesInput<T extends string | number>({
+  label,
+  values,
+  parse,
+  onCommit,
+}: {
+  readonly label: string;
+  readonly values: readonly T[];
+  readonly parse: (value: string) => DraftValuesResult<T>;
+  readonly onCommit: (values: readonly T[]) => void;
+}) {
+  const canonical = values.join(", ");
+  const [draft, setDraft] = useState(canonical);
+  const [problem, setProblem] = useState<string | null>(null);
+  const input = useRef<HTMLInputElement>(null);
+  const problemId = useId();
+
+  useEffect(() => {
+    setDraft(canonical);
+    setProblem(null);
+    input.current?.setCustomValidity("");
+  }, [canonical]);
+
+  const commit = () => {
+    const result = parse(draft);
+    if (!result.ok) {
+      setProblem(result.message);
+      input.current?.setCustomValidity(result.message);
+      return;
+    }
+    setProblem(null);
+    input.current?.setCustomValidity("");
+    setDraft(result.values.join(", "));
+    onCommit(result.values);
+  };
+
+  return (
+    <span className="simulation-run-plan-draft-values">
+      <input
+        ref={input}
+        aria-label={label}
+        aria-invalid={problem ? true : undefined}
+        aria-describedby={problem ? problemId : undefined}
+        value={draft}
+        onChange={(event) => {
+          setDraft(event.currentTarget.value);
+          setProblem(null);
+          event.currentTarget.setCustomValidity("");
+        }}
+        onBlur={commit}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") {
+            event.preventDefault();
+            event.currentTarget.blur();
+          } else if (event.key === "Escape") {
+            event.preventDefault();
+            setDraft(canonical);
+            setProblem(null);
+            event.currentTarget.setCustomValidity("");
+            event.currentTarget.blur();
+          }
+        }}
+      />
+      {problem ? (
+        <small id={problemId} role="alert">
+          {problem}
+        </small>
+      ) : null}
+    </span>
+  );
 }
 
 function nextVariableName(variables: readonly SimulationDesignVariable[]) {
@@ -352,16 +447,13 @@ export function RunPlanEditor({
                   ))}
                 </span>
               ) : axis.kind === "temperature" ? (
-                <input
-                  aria-label="Run Plan temperatures"
-                  value={axis.values.join(", ")}
-                  onChange={(event) => {
-                    const values = commaStrings(event.currentTarget.value).map(
-                      Number,
-                    );
-                    if (values.length && values.every(Number.isFinite))
-                      replaceAxis(index, { ...axis, values });
-                  }}
+                <DraftValuesInput
+                  label="Run Plan temperatures"
+                  values={axis.values}
+                  parse={parseTemperatureValues}
+                  onCommit={(values) =>
+                    replaceAxis(index, { ...axis, values: [...values] })
+                  }
                 />
               ) : axis.kind === "variable" ? (
                 <span className="simulation-run-plan-target-values">
@@ -381,14 +473,13 @@ export function RunPlanEditor({
                       </option>
                     ))}
                   </select>
-                  <input
-                    aria-label="Run Plan Design Variable values"
-                    value={axis.values.join(", ")}
-                    onChange={(event) => {
-                      const values = commaStrings(event.currentTarget.value);
-                      if (values.length)
-                        replaceAxis(index, { ...axis, values: [...values] });
-                    }}
+                  <DraftValuesInput
+                    label="Run Plan Design Variable values"
+                    values={axis.values}
+                    parse={parseTextValues}
+                    onCommit={(values) =>
+                      replaceAxis(index, { ...axis, values: [...values] })
+                    }
                   />
                 </span>
               ) : (
@@ -415,14 +506,13 @@ export function RunPlanEditor({
                       </option>
                     ))}
                   </select>
-                  <input
-                    aria-label="Run Plan Instance parameter values"
-                    value={axis.values.join(", ")}
-                    onChange={(event) => {
-                      const values = commaStrings(event.currentTarget.value);
-                      if (values.length)
-                        replaceAxis(index, { ...axis, values: [...values] });
-                    }}
+                  <DraftValuesInput
+                    label="Run Plan Instance parameter values"
+                    values={axis.values}
+                    parse={parseTextValues}
+                    onCommit={(values) =>
+                      replaceAxis(index, { ...axis, values: [...values] })
+                    }
                   />
                 </span>
               )}


### PR DESCRIPTION
## Summary\n- keep temperature and other comma-separated Run Plan axes editable while input is incomplete\n- validate and commit values on blur or Enter, with Escape restoring the saved list\n- retain invalid drafts with an inline error instead of silently snapping back\n\n## Validation\n- pnpm typecheck\n- focused Run Plan browser regression\n- pnpm gate:preflight -- --base origin/main\n- pnpm gate:affected -- --base origin/main (2894 unit tests passed, 23 skipped; 9 browser tests passed)