### PR TITLE
Enable isolated Preview project workspaces

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -83,6 +83,30 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      # Preview accounts and Projects are isolated Durable Object namespaces.
+      # A dedicated OAuth client activates human login when both credentials
+      # are configured; the private CI acceptance identity remains independent.
+      - name: Sync preview authentication secrets
+        run: |
+          set -euo pipefail
+          if [ -z "$PREVIEW_GOOGLE_CLIENT_ID" ] && [ -z "$PREVIEW_GOOGLE_CLIENT_SECRET" ]; then
+            echo "Preview Google OAuth is not configured; keeping human login dark"
+            exit 0
+          fi
+          if [ -z "$PREVIEW_GOOGLE_CLIENT_ID" ] || [ -z "$PREVIEW_GOOGLE_CLIENT_SECRET" ]; then
+            echo "Preview Google OAuth credentials must be configured together"
+            exit 1
+          fi
+          jq -n \
+            --arg clientId "$PREVIEW_GOOGLE_CLIENT_ID" \
+            --arg clientSecret "$PREVIEW_GOOGLE_CLIENT_SECRET" \
+            '{GOOGLE_CLIENT_ID:$clientId, GOOGLE_CLIENT_SECRET:$clientSecret}' \
+            | pnpm dlx wrangler@4.120.1 secret bulk --config wrangler.preview.jsonc
+        env:
+          PREVIEW_GOOGLE_CLIENT_ID: ${{ secrets.PREVIEW_GOOGLE_CLIENT_ID }}
+          PREVIEW_GOOGLE_CLIENT_SECRET: ${{ secrets.PREVIEW_GOOGLE_CLIENT_SECRET }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       # The token the operator-run simulator host requires (worker/simulation.ts,
       # SIMULATION_UPSTREAM_TOKEN). A Worker secret outlives deploys, so setting
       # it every time is idempotent; with no repository secret the step is
@@ -106,7 +130,8 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       # What a preview is for: the page renders, the gallery reads and never
-      # writes, nothing is indexed, and the simulator answers.
+      # writes, isolated accounts/Projects are available, nothing is indexed,
+      # and the simulator answers.
       - name: Verify preview
         run: |
           set -euo pipefail
@@ -178,6 +203,18 @@ jobs:
             --write-out '%{http_code}' "${PREVIEW_URL}/api/gallery/preview-smoke/like")"
           if [ "$write" != "403" ]; then
             echo "A gallery write on the preview must be refused, got: $write"
+            exit 1
+          fi
+          providers="$(curl --fail --silent --show-error --max-time 20 \
+            "${PREVIEW_URL}/api/auth/providers")"
+          case "$providers" in
+            *'"google":true'*|*'"google":false'*) ;;
+            *) echo "Preview auth providers returned an invalid contract: $providers"; exit 1 ;;
+          esac
+          projects="$(curl --silent --output /dev/null --max-time 20 \
+            --write-out '%{http_code}' "${PREVIEW_URL}/api/projects")"
+          if [ "$projects" != "401" ]; then
+            echo "Anonymous Preview Projects must require sign-in, got: $projects"
             exit 1
           fi
       # A divider checks the transport and the persisted OTA Project checks the

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -80,6 +80,7 @@ import { startCanvasDragVisual } from "../canvas/canvas-drag-visual";
 import { instanceVisibleHitBox } from "../canvas/instance-geometry";
 import {
   loadReleaseChannel,
+  projectStoreCopy,
   type ReleaseChannel,
 } from "../document/release-channel";
 import { createCanvasHitController } from "../canvas/canvas-hit-controller";
@@ -541,7 +542,7 @@ export function App({
   useEffect(() => () => cameraRuntime.dispose(), [cameraRuntime]);
   const [gridDotsVisible, setGridDotsVisible] = useState(true);
   // Which channel serves this build (ADR 0057). Asked once; anything but a
-  // clear "preview" is production, so the public site never wears the banner.
+  // clear "preview" is production, so the public site never wears its badge.
   const [releaseChannel, setReleaseChannel] =
     useState<ReleaseChannel>("production");
   useEffect(() => {
@@ -553,6 +554,7 @@ export function App({
       cancelled = true;
     };
   }, []);
+  const projectStore = projectStoreCopy(releaseChannel);
   // Annotations and drafting place on their own pitch; the Document grid
   // stays the electrical contract for devices, wires, and junctions.
   const [annotationGrid, setAnnotationGridState] = useState<1 | 5 | 10>(() => {
@@ -861,6 +863,7 @@ export function App({
     viewBox,
     defaultViewBox: DEFAULT_VIEWBOX,
     setStatus,
+    projectStoreCopy: projectStore,
     onCloudProjectSaved: (saved) => {
       cloudListMutationRef.current += 1;
       setCloudProjects((current) => [
@@ -4343,6 +4346,8 @@ export function App({
           });
         }}
         fileCommands={{
+          projectStoreLabel: projectStore.plural,
+          projectStoreItemLabel: projectStore.singular,
           cloudProjects,
           activeCloudProjectId: cloudBinding?.id ?? null,
           canRevert: savedProjectBaseline !== null && isDirtyWork(),
@@ -4358,17 +4363,23 @@ export function App({
           onOpenCloudProject: (summary) =>
             void openCloudProjectById(summary.id),
           onDeleteCloudProject: (summary) => {
-            if (!window.confirm(`Delete Cloud Project "${summary.name}"?`)) {
+            if (
+              !window.confirm(
+                `Delete ${projectStore.singular} "${summary.name}"?`,
+              )
+            ) {
               return;
             }
             void deleteCloudProject(summary.id).then((outcome) => {
               if (outcome.status === "deleted") {
                 cloudListMutationRef.current += 1;
                 setCloudProjects(outcome.projects);
-                setStatus(`Deleted Cloud Project ${summary.name}`);
+                setStatus(`Deleted ${projectStore.singular} ${summary.name}`);
                 return;
               }
-              setStatus(`Could not delete Cloud Project (${outcome.message})`);
+              setStatus(
+                `Could not delete ${projectStore.singular} (${outcome.message})`,
+              );
             });
           },
           onRefresh: () => {

--- a/apps/editor/src/app/editor-app-chrome.test.tsx
+++ b/apps/editor/src/app/editor-app-chrome.test.tsx
@@ -1,0 +1,23 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { ReleaseChannelBadge } from "./editor-app-chrome";
+
+describe("editor release channel identity", () => {
+  it("uses a compact Preview identity instead of the retired warning banner", () => {
+    const markup = renderToStaticMarkup(
+      <ReleaseChannelBadge releaseChannel="preview" />,
+    );
+
+    expect(markup).toContain('data-testid="release-channel-badge"');
+    expect(markup).toContain("Preview");
+    expect(markup).not.toContain("unreleased features");
+    expect(markup).not.toContain("gallery is read-only");
+  });
+
+  it("adds no channel chrome on production", () => {
+    expect(
+      renderToStaticMarkup(<ReleaseChannelBadge releaseChannel="production" />),
+    ).toBe("");
+  });
+});

--- a/apps/editor/src/app/editor-app-chrome.tsx
+++ b/apps/editor/src/app/editor-app-chrome.tsx
@@ -1,5 +1,6 @@
 import type { ComponentProps, RefObject } from "react";
 
+import { AccountMenu } from "../components/account";
 import { BugReportLink } from "../components/bug-report-link";
 import { DrawingToolbar } from "../features/editor-shell/drawing-toolbar";
 import { EditorTestTelemetry } from "../features/editor-shell/editor-test-telemetry";
@@ -68,8 +69,20 @@ export interface EditorAppChromeProps {
   drawingToolbar: ComponentProps<typeof DrawingToolbar>;
   hierarchyToolbar: ComponentProps<typeof HierarchyToolbar>;
   telemetry: ComponentProps<typeof EditorTestTelemetry>;
-  /** Which channel serves this build; the preview wears a banner. */
+  /** Which channel serves this build; Preview is identified without a warning. */
   releaseChannel: ReleaseChannel;
+}
+
+export function ReleaseChannelBadge({
+  releaseChannel,
+}: {
+  releaseChannel: ReleaseChannel;
+}) {
+  return releaseChannel === "preview" ? (
+    <span className="app-channel-badge" data-testid="release-channel-badge">
+      Preview
+    </span>
+  ) : null;
 }
 
 /** Persistent command chrome above the document workspace. */
@@ -120,16 +133,6 @@ export function EditorAppChrome({
   const displayedProjectName = projectNameDraft ?? projectName;
   return (
     <header className="app-chrome">
-      {releaseChannel === "preview" ? (
-        <p
-          className="app-channel-banner"
-          role="status"
-          data-testid="release-channel-banner"
-        >
-          Preview build: unreleased features, simulation included. The gallery
-          is read-only here; publish on the production site.
-        </p>
-      ) : null}
       <div className="app-chrome-main">
         <div className="app-brand">
           <a
@@ -361,7 +364,7 @@ export function EditorAppChrome({
               data-testid="check-and-save"
               disabled={!checkAndSave.enabled}
               onClick={checkAndSave.execute}
-              title="Check ERC and visual issues, and save this Cloud Project"
+              title={`Check ERC and visual issues, and save this ${fileCommands.projectStoreItemLabel}`}
             >
               <span className="toolbar-check-glyph" aria-hidden="true" />
               Check and Save
@@ -379,6 +382,10 @@ export function EditorAppChrome({
           </div>
         </nav>
         <div className="app-chrome-actions">
+          <ReleaseChannelBadge releaseChannel={releaseChannel} />
+          {releaseChannel === "preview" ? (
+            <AccountMenu showGalleryLinks={false} />
+          ) : null}
           <BugReportLink
             testId="editor-report-bug"
             surface="Editor"

--- a/apps/editor/src/components/account.test.tsx
+++ b/apps/editor/src/components/account.test.tsx
@@ -8,11 +8,16 @@ import {
   type AccountState,
 } from "./account";
 
-function markupFor(state: AccountState, notice: string | null = null): string {
+function markupFor(
+  state: AccountState,
+  notice: string | null = null,
+  showGalleryLinks = true,
+): string {
   return renderToStaticMarkup(
     createElement(AccountMenuView, {
       state,
       notice,
+      showGalleryLinks,
       onEmailStart: () => undefined,
       onRename: () => undefined,
       onSignOut: () => undefined,
@@ -62,6 +67,28 @@ describe("AccountMenuView", () => {
     expect(markup).toContain('data-testid="account-owner"');
     expect(markup).toContain('data-testid="account-signout"');
     expect(markup).not.toContain("account-signin");
+  });
+
+  it("can reuse the account control without exposing Gallery-only links", () => {
+    const markup = markupFor(
+      {
+        providers: { github: false, google: true, email: false },
+        user: {
+          id: "preview-user",
+          displayName: "Preview Tester",
+          email: "tester@example.com",
+          provider: "google",
+          role: "moderator",
+          isAdmin: false,
+        },
+      },
+      null,
+      false,
+    );
+
+    expect(markup).toContain('data-testid="account-signout"');
+    expect(markup).not.toContain('data-testid="account-mine"');
+    expect(markup).not.toContain('data-testid="account-moderation-link"');
   });
 });
 

--- a/apps/editor/src/components/account.tsx
+++ b/apps/editor/src/components/account.tsx
@@ -148,6 +148,7 @@ async function signOut(fetchLike: typeof fetch = fetch): Promise<void> {
 export interface AccountMenuViewProps {
   state: AccountState;
   notice: string | null;
+  showGalleryLinks?: boolean;
   onEmailStart: (email: string) => void;
   onRename: (displayName: string) => void;
   onSignOut: () => void;
@@ -157,6 +158,7 @@ export interface AccountMenuViewProps {
 export function AccountMenuView({
   state,
   notice,
+  showGalleryLinks = true,
   onEmailStart,
   onRename,
   onSignOut,
@@ -218,7 +220,7 @@ export function AccountMenuView({
             <span aria-hidden="true">⋯</span>
           </summary>
           <div className="account-popover">
-            {user.isAdmin || user.role === "moderator" ? (
+            {showGalleryLinks && (user.isAdmin || user.role === "moderator") ? (
               <a
                 className="account-link"
                 href="/moderation"
@@ -227,9 +229,15 @@ export function AccountMenuView({
                 Moderation
               </a>
             ) : null}
-            <a className="account-link" href="/mine" data-testid="account-mine">
-              My submissions
-            </a>
+            {showGalleryLinks ? (
+              <a
+                className="account-link"
+                href="/mine"
+                data-testid="account-mine"
+              >
+                My submissions
+              </a>
+            ) : null}
             <button
               type="button"
               className="account-signout"
@@ -294,8 +302,12 @@ export function AccountMenuView({
   );
 }
 
-/** Self-loading account area for the gallery chrome. */
-export function AccountMenu() {
+/** Self-loading account area shared by Gallery and Editor chrome. */
+export function AccountMenu({
+  showGalleryLinks = true,
+}: {
+  showGalleryLinks?: boolean;
+}) {
   const [state, setState] = useState<AccountState | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
 
@@ -318,6 +330,7 @@ export function AccountMenu() {
     <AccountMenuView
       state={state}
       notice={notice}
+      showGalleryLinks={showGalleryLinks}
       onEmailStart={(email) => {
         void requestEmailLink(email).then(setNotice);
       }}

--- a/apps/editor/src/document/release-channel.test.ts
+++ b/apps/editor/src/document/release-channel.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { loadReleaseChannel } from "./release-channel";
+import { loadReleaseChannel, projectStoreCopy } from "./release-channel";
 
 const answering = (status: number, body: unknown): typeof fetch =>
   (async () =>
@@ -10,6 +10,19 @@ const answering = (status: number, body: unknown): typeof fetch =>
     })) as unknown as typeof fetch;
 
 describe("release channel discovery", () => {
+  it("names each channel's private Project store without changing its API", () => {
+    expect(projectStoreCopy("production")).toEqual({
+      singular: "Cloud Project",
+      plural: "Cloud Projects",
+      destination: "Cloud",
+    });
+    expect(projectStoreCopy("preview")).toEqual({
+      singular: "Preview Project",
+      plural: "Preview Projects",
+      destination: "Preview Projects",
+    });
+  });
+
   it("reads a preview answer", async () => {
     expect(
       await loadReleaseChannel(answering(200, { channel: "preview" })),

--- a/apps/editor/src/document/release-channel.ts
+++ b/apps/editor/src/document/release-channel.ts
@@ -9,6 +9,27 @@
  */
 export type ReleaseChannel = "production" | "preview";
 
+export interface ProjectStoreCopy {
+  singular: "Cloud Project" | "Preview Project";
+  plural: "Cloud Projects" | "Preview Projects";
+  destination: "Cloud" | "Preview Projects";
+}
+
+/** Human-facing storage identity; the underlying Project API is shared. */
+export function projectStoreCopy(channel: ReleaseChannel): ProjectStoreCopy {
+  return channel === "preview"
+    ? {
+        singular: "Preview Project",
+        plural: "Preview Projects",
+        destination: "Preview Projects",
+      }
+    : {
+        singular: "Cloud Project",
+        plural: "Cloud Projects",
+        destination: "Cloud",
+      };
+}
+
 export async function loadReleaseChannel(
   fetchLike: typeof fetch | null = typeof fetch === "function" ? fetch : null,
 ): Promise<ReleaseChannel> {

--- a/apps/editor/src/document/use-project-file-lifecycle.ts
+++ b/apps/editor/src/document/use-project-file-lifecycle.ts
@@ -39,6 +39,7 @@ import {
   readRecentCloudProjectId,
   rememberRecentCloudProject,
 } from "./cloud-project-session";
+import type { ProjectStoreCopy } from "./release-channel";
 
 export const REFRESH_RESTORE_STORAGE_KEY = "icm.restore-after-refresh.v1";
 
@@ -91,6 +92,7 @@ export interface UseProjectFileLifecycleOptions {
   installProject(project: CircuitProject, viewBox: GridRect): SchematicDocument;
   setStatus(message: string): void;
   onCloudProjectSaved(project: CloudProjectSummary): void;
+  projectStoreCopy: ProjectStoreCopy;
 }
 
 export function useProjectFileLifecycle({
@@ -102,6 +104,7 @@ export function useProjectFileLifecycle({
   installProject,
   setStatus,
   onCloudProjectSaved,
+  projectStoreCopy,
 }: UseProjectFileLifecycleOptions) {
   // Read-only initializer: consuming the one-shot flag here would be a render
   // side effect, and a discarded render (StrictMode's double pass, a Suspense
@@ -224,7 +227,9 @@ export function useProjectFileLifecycle({
     const savedCandidate = structuredClone(candidate);
     const savedCandidateToken = projectChangeToken(savedCandidate);
     setPersistenceState("saving");
-    setStatus(`Saving ${savedCandidate.name} to Cloud`);
+    setStatus(
+      `Saving ${savedCandidate.name} to ${projectStoreCopy.destination}`,
+    );
     recovery.stage(savedCandidate, { unsavedAtSnapshot: true, cloudBinding });
     await recovery.flushNow();
     const outcome = await saveCloudProject(savedCandidate, cloudBinding);
@@ -255,33 +260,35 @@ export function useProjectFileLifecycle({
       onCloudProjectSaved(outcome.project);
       setStatus(
         stillMatchesSavedCandidate
-          ? `Saved ${savedCandidate.name} to Cloud`
-          : `Saved ${savedCandidate.name} to Cloud; newer edits remain unsaved`,
+          ? `Saved ${savedCandidate.name} to ${projectStoreCopy.destination}`
+          : `Saved ${savedCandidate.name} to ${projectStoreCopy.destination}; newer edits remain unsaved`,
       );
       return outcome;
     }
     if (outcome.status === "unreachable") {
       setPersistenceState("offline");
-      setStatus(`Cloud unavailable; work remains local (${outcome.message})`);
+      setStatus(
+        `${projectStoreCopy.plural} unavailable; work remains local (${outcome.message})`,
+      );
       return outcome;
     }
     if (outcome.status === "conflict") {
       setPersistenceState("conflict");
       setStatus(
-        `Cloud Project changed elsewhere at revision ${outcome.project.revision}; current work was not overwritten`,
+        `${projectStoreCopy.singular} changed elsewhere at revision ${outcome.project.revision}; current work was not overwritten`,
       );
       return outcome;
     }
     setPersistenceState("failed");
     setStatus(
       outcome.status === "signed-out"
-        ? "Sign in to save this Cloud Project"
+        ? `Sign in to save this ${projectStoreCopy.singular}`
         : outcome.status === "too-large"
-          ? "Project is too large for Cloud storage; download a backup"
+          ? `Project is too large for ${projectStoreCopy.plural}; download a backup`
           : outcome.status === "limit"
-            ? `Cloud Project limit reached (${outcome.projects.length}/${CLOUD_PROJECT_LIMIT})`
+            ? `${projectStoreCopy.singular} limit reached (${outcome.projects.length}/${CLOUD_PROJECT_LIMIT})`
             : outcome.status === "not-found"
-              ? "Cloud Project no longer exists; current work remains local"
+              ? `${projectStoreCopy.singular} no longer exists; current work remains local`
               : outcome.message,
     );
     return outcome;

--- a/apps/editor/src/features/editor-shell/file-command-menu.test.tsx
+++ b/apps/editor/src/features/editor-shell/file-command-menu.test.tsx
@@ -9,6 +9,8 @@ describe("FileCommandMenu", () => {
   it("presents one Cloud Save protocol and explicit local interchange", () => {
     const markup = renderToStaticMarkup(
       <FileCommandMenu
+        projectStoreLabel="Cloud Projects"
+        projectStoreItemLabel="Cloud Project"
         cloudProjects={[
           {
             id: "cloud-1",
@@ -52,5 +54,35 @@ describe("FileCommandMenu", () => {
     expect(markup).not.toContain("Download Backup");
     expect(markup).not.toContain("Previous Project");
     expect(markup).not.toContain("cloud snapshot");
+  });
+
+  it("identifies the isolated Preview Project store", () => {
+    const markup = renderToStaticMarkup(
+      <FileCommandMenu
+        projectStoreLabel="Preview Projects"
+        projectStoreItemLabel="Preview Project"
+        cloudProjects={[]}
+        activeCloudProjectId={null}
+        canRevert={false}
+        hasRecoverySessions={false}
+        projectInputRef={createRef<HTMLInputElement>()}
+        onNewProject={vi.fn()}
+        onSave={vi.fn()}
+        onRefreshCloudProjects={vi.fn()}
+        onOpenCloudProject={vi.fn()}
+        onDeleteCloudProject={vi.fn()}
+        onRefresh={vi.fn()}
+        onImportProject={vi.fn()}
+        onImportSpice={vi.fn()}
+        onExportProject={vi.fn()}
+        onExportSvg={vi.fn()}
+        onExportRaster={vi.fn()}
+        onExportNetlist={vi.fn()}
+        onRevert={vi.fn()}
+        onOpenRecovery={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain(`Preview Projects (0/${CLOUD_PROJECT_LIMIT})`);
   });
 });

--- a/apps/editor/src/features/editor-shell/file-command-menu.tsx
+++ b/apps/editor/src/features/editor-shell/file-command-menu.tsx
@@ -6,6 +6,8 @@ import {
 } from "./cloud-projects";
 
 export interface FileCommandMenuProps {
+  projectStoreLabel: "Cloud Projects" | "Preview Projects";
+  projectStoreItemLabel: "Cloud Project" | "Preview Project";
   cloudProjects: readonly CloudProjectSummary[];
   activeCloudProjectId: string | null;
   canRevert: boolean;
@@ -104,6 +106,8 @@ function ExportSubmenu({
 }
 
 export function FileCommandMenu({
+  projectStoreLabel,
+  projectStoreItemLabel,
   cloudProjects,
   activeCloudProjectId,
   onOpenCloudProject,
@@ -145,7 +149,7 @@ export function FileCommandMenu({
           Save
         </button>
         <span className="command-group-label">
-          Cloud Projects ({cloudProjects.length}/{CLOUD_PROJECT_LIMIT})
+          {projectStoreLabel} ({cloudProjects.length}/{CLOUD_PROJECT_LIMIT})
         </span>
         {cloudProjects.map((project) => (
           <div className="cloud-project-command" key={project.id}>
@@ -167,8 +171,8 @@ export function FileCommandMenu({
             </button>
             <button
               type="button"
-              aria-label={`Delete Cloud Project ${project.name}`}
-              title="Delete this Cloud Project"
+              aria-label={`Delete ${projectStoreItemLabel} ${project.name}`}
+              title={`Delete this ${projectStoreItemLabel}`}
               disabled={project.id === activeCloudProjectId}
               onClick={() => onDeleteCloudProject(project)}
             >

--- a/apps/editor/src/styles/editor-chrome.css
+++ b/apps/editor/src/styles/editor-chrome.css
@@ -968,14 +968,133 @@
   }
 }
 
-/* The preview channel's banner (ADR 0057): always visible, never dismissable,
-   so a screenshot or a shared tab cannot be mistaken for the public site. */
-.app-channel-banner {
-  margin: 0;
-  padding: 2px var(--icm-space-3);
-  background: #8a4b00;
-  color: #fff;
-  font-size: 0.8rem;
-  line-height: 1.4;
+/* Preview is an environment identity, not a warning repeated above every
+   editing action. Keep it visible but subordinate to the Project name. */
+.app-channel-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.5rem;
+  padding: 0 0.45rem;
+  border: 1px solid #c47a1b;
+  border-radius: 999px;
+  color: #8a4b00;
+  font-size: 0.72rem;
+  font-weight: 650;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+
+/* The editor reuses the account contract from Gallery without importing the
+   Gallery page stylesheet. Only its compact header treatment lives here. */
+.app-chrome-actions .account-menu {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--icm-space-1);
+}
+
+.app-chrome-actions .account-name,
+.app-chrome-actions .account-signout,
+.app-chrome-actions .account-signin > summary,
+.app-chrome-actions .account-link {
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  min-height: var(--icm-control-h);
+  padding: 0 var(--icm-space-2);
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  color: var(--icm-text);
+  background: var(--icm-surface);
+  font: inherit;
+  font-size: var(--icm-font-sm);
+  text-decoration: none;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.app-chrome-actions .account-name:hover,
+.app-chrome-actions .account-signout:hover,
+.app-chrome-actions .account-signin > summary:hover,
+.app-chrome-actions .account-link:hover {
+  background: var(--icm-surface-hover);
+}
+
+.app-chrome-actions .account-name {
+  max-width: 10rem;
+  overflow: hidden;
+  font-weight: 600;
+  text-overflow: ellipsis;
+}
+
+.app-chrome-actions .account-signin,
+.app-chrome-actions .account-more {
+  position: relative;
+}
+
+.app-chrome-actions .account-signin > summary,
+.app-chrome-actions .account-more > summary {
+  list-style: none;
+}
+
+.app-chrome-actions .account-signin > summary::-webkit-details-marker,
+.app-chrome-actions .account-more > summary::-webkit-details-marker {
+  display: none;
+}
+
+.app-chrome-actions .account-more > summary {
+  display: inline-flex;
+  align-items: center;
+  min-height: var(--icm-control-h);
+  padding: 0 var(--icm-space-2);
+  border-radius: var(--icm-radius-sm);
+  cursor: pointer;
+}
+
+.app-chrome-actions .account-signin-panel,
+.app-chrome-actions .account-popover {
+  position: absolute;
+  z-index: 60;
+  top: calc(100% + 6px);
+  right: 0;
+  display: grid;
+  min-width: 11rem;
+  gap: var(--icm-space-1);
+  padding: var(--icm-space-2);
+  border: 1px solid var(--icm-border);
+  border-radius: 10px;
+  background: var(--icm-surface);
+  box-shadow: 0 12px 32px rgb(15 15 15 / 12%);
+}
+
+.app-chrome-actions .account-signin-panel {
+  width: 17rem;
+}
+
+.app-chrome-actions .account-signin-panel a {
+  display: block;
+  padding: var(--icm-space-2);
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  color: var(--icm-text);
+  font-weight: 600;
   text-align: center;
+  text-decoration: none;
+}
+
+.app-chrome-actions .account-signin-panel a:hover {
+  background: var(--icm-surface-hover);
+}
+
+.app-chrome-actions .account-owner-badge {
+  color: var(--icm-accent);
+  font-size: var(--icm-font-xs);
+  font-weight: 700;
+}
+
+.app-chrome-actions .account-rename-input {
+  width: 10rem;
+  min-height: var(--icm-control-h);
+  border: 1px solid var(--icm-accent);
+  border-radius: var(--icm-radius-sm);
+  font: inherit;
 }

--- a/docs/adr/0057-release-channels-preview-and-production.md
+++ b/docs/adr/0057-release-channels-preview-and-production.md
@@ -20,8 +20,10 @@ Wrangler environments and not a claim of one promoted binary artifact.
 - **Preview:** `wrangler.preview.jsonc`, its own hostname and namespaces.
   Every merge to main deploys and verifies this channel. The public shell is
   unindexed and visibly labelled. Public Gallery reads go through Production's
-  anonymous HTTP API; Gallery and Cloud Project writes are refused. Preview has
-  no binding to Production's Durable Objects.
+  anonymous HTTP API and Gallery writes are refused. When a Preview-only Google
+  OAuth client is configured, human testers sign in and save private Projects
+  in Preview's own namespace; CI uses a separate acceptance identity against
+  that same Project API. Preview has no binding to Production's Durable Objects.
 - **Production:** `wrangler.jsonc`. A release tag or explicit commit dispatch
   selects the candidate. The workflow checks for a successful Preview deployment
   of that exact commit before deploying, verifying, and recovering on failure.
@@ -32,8 +34,10 @@ Wrangler environments and not a claim of one promoted binary artifact.
   the configured gateway/Tunnel. It is not a Worker-native process or a spare
   Cloudflare Container. An unavailable named executor does not silently fall back.
 - **Data and identity:** cookies and credentials remain host/session scoped.
-  Preview's production-Gallery view cannot validate private Production storage
-  migrations; those require their own tests and release care.
+  Preview accounts, sessions, and Projects are independent from Production and
+  its test data is not promoted or synchronized. Preview's production-Gallery
+  view cannot validate private Production storage migrations; those require
+  their own tests and release care.
 
 The exact deployment commands, evidence predicate, capabilities, and recovery
 limitations are owned by [deployment](../deployment.md). This ADR does not add a

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,16 +2,17 @@
 
 ## Channels and data isolation
 
-| Channel    | Trigger and configuration                                                         | Data boundary                                                                                                                                  |
-| ---------- | --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| Preview    | main push; `.github/workflows/deploy-preview.yml`; `wrangler.preview.jsonc`       | Own namespaces; anonymous HTTP read-through to public Gallery; public writes refused; private CI acceptance may use the isolated Project shelf |
-| Production | `v*` tag or commit dispatch; `.github/workflows/cloudflare.yml`; `wrangler.jsonc` | Public product and its private storage                                                                                                         |
+| Channel    | Trigger and configuration                                                         | Data boundary                                                                                                                                              |
+| ---------- | --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Preview    | main push; `.github/workflows/deploy-preview.yml`; `wrangler.preview.jsonc`       | Own accounts and Projects; anonymous HTTP read-through to public Gallery; Gallery writes refused; private CI acceptance uses the same isolated Project API |
+| Production | `v*` tag or commit dispatch; `.github/workflows/cloudflare.yml`; `wrangler.jsonc` | Public product and its private storage                                                                                                                     |
 
 Preview is served at `analog-canvas-preview.tokenzhang.com`, labelled and
 unindexed. Production is `analog-canvas.tokenzhang.com`. The separate
 configuration files do not inherit routes or bindings. Preview has no
-Production Durable Object binding, no Production cookies, and no configured
-OAuth provider. Its simulation capability can be issued without OAuth; public
+Production Durable Object binding or Production cookies. Human testers use a
+Preview-only Google OAuth client; its consent-screen test-user roster controls
+who can sign in. Its simulation capability can be issued without OAuth; public
 site access is not unrestricted compute authority.
 
 The channels share source and contracts, not a guarantee of a single promoted
@@ -27,6 +28,21 @@ GalleryDO, imports it through the public `project_cells` resource, runs the
 resulting Testbench, preserves its receipt, and removes the seed. Missing or
 incorrect credentials fail closed as the same 401/403 seen by an ordinary
 visitor.
+
+Human Preview login uses this callback:
+
+```text
+https://analog-canvas-preview.tokenzhang.com/api/auth/google/callback
+```
+
+The `cloudflare-preview` GitHub environment supplies
+`PREVIEW_GOOGLE_CLIENT_ID` and `PREVIEW_GOOGLE_CLIENT_SECRET`. Deployment maps
+them to the Preview Worker's standard OAuth secret names when both are present.
+Human login remains dark when neither is configured; a partial pair fails the
+deployment. Preview's `AUTH` and `GALLERY` bindings are independent namespaces;
+the same Google account may therefore use Preview and Production without
+sharing sessions, internal user IDs, limits, or Projects. Preview Projects are
+disposable test data and never synchronize or promote to Production.
 
 ## Releasing to Production
 

--- a/scripts/preview-workflow.test.mjs
+++ b/scripts/preview-workflow.test.mjs
@@ -65,6 +65,13 @@ describe("the preview deploy", () => {
     expect(preview).toContain("noindex");
     expect(preview).toContain("must read the production gallery");
     expect(preview).toContain("must be refused");
+    expect(preview).toContain("PREVIEW_GOOGLE_CLIENT_ID");
+    expect(preview).toContain("PREVIEW_GOOGLE_CLIENT_SECRET");
+    expect(preview).toContain("/api/auth/providers");
+    expect(preview).toContain("keeping human login dark");
+    expect(preview).toContain(
+      "Anonymous Preview Projects must require sign-in",
+    );
     expect(preview).toContain(
       'node scripts/preview-simulation-smoke.mjs "$PREVIEW_URL"',
     );

--- a/worker/channel.test.ts
+++ b/worker/channel.test.ts
@@ -3,9 +3,9 @@ import { describe, expect, it } from "vitest";
 import {
   channelResponse,
   markPreviewResponse,
+  previewGalleryWriteRefusal,
   previewGalleryReadThrough,
   previewRobotsResponse,
-  previewWriteRefusal,
   releaseChannel,
 } from "./channel";
 
@@ -37,16 +37,14 @@ describe("release channel", () => {
     ).toBe("production");
   });
 
-  it("refuses every write to the shared gallery and projects on the preview", async () => {
+  it("refuses every write to the production gallery on the preview", async () => {
     const env = { ICM_CHANNEL: "preview" };
     for (const [path, method] of [
       ["/api/gallery/submissions", "POST"],
       ["/api/gallery/abc/like", "POST"],
       ["/api/gallery/abc", "DELETE"],
-      ["/api/projects", "POST"],
-      ["/api/projects/p1", "PUT"],
     ] as const) {
-      const refusal = previewWriteRefusal(req(path, method), env);
+      const refusal = previewGalleryWriteRefusal(req(path, method), env);
       expect(refusal?.status, `${method} ${path}`).toBe(403);
       const body = (await refusal!.json()) as { error: string };
       expect(body.error).toBe("preview-read-only");
@@ -55,36 +53,40 @@ describe("release channel", () => {
 
   it("lets the preview read, and leaves other routes alone", () => {
     const env = { ICM_CHANNEL: "preview" };
-    expect(previewWriteRefusal(req("/api/gallery"), env)).toBeNull();
-    expect(previewWriteRefusal(req("/api/projects/p1"), env)).toBeNull();
+    expect(previewGalleryWriteRefusal(req("/api/gallery"), env)).toBeNull();
+    expect(previewGalleryWriteRefusal(req("/api/projects/p1"), env)).toBeNull();
+    expect(
+      previewGalleryWriteRefusal(req("/api/projects", "POST"), env),
+    ).toBeNull();
+    expect(
+      previewGalleryWriteRefusal(req("/api/projects/p1", "PUT"), env),
+    ).toBeNull();
+    expect(
+      previewGalleryWriteRefusal(req("/api/projects/p1", "DELETE"), env),
+    ).toBeNull();
     // Simulation runs are the preview's whole purpose; agent sessions and
     // analytics are its own namespaces. None of these reach shared data.
-    expect(previewWriteRefusal(req("/api/simulate", "POST"), env)).toBeNull();
     expect(
-      previewWriteRefusal(req("/api/simulation/runs", "POST"), env),
+      previewGalleryWriteRefusal(req("/api/simulate", "POST"), env),
     ).toBeNull();
-    expect(previewWriteRefusal(req("/api/track", "POST"), env)).toBeNull();
     expect(
-      previewWriteRefusal(req("/api/agent/sessions", "POST"), env),
+      previewGalleryWriteRefusal(req("/api/simulation/runs", "POST"), env),
+    ).toBeNull();
+    expect(
+      previewGalleryWriteRefusal(req("/api/track", "POST"), env),
+    ).toBeNull();
+    expect(
+      previewGalleryWriteRefusal(req("/api/agent/sessions", "POST"), env),
     ).toBeNull();
   });
 
-  it("opens only the isolated Project store to the private Preview journey", () => {
+  it("does not let the private Preview journey bypass the Gallery boundary", () => {
     const env = {
       ICM_CHANNEL: "preview",
       PREVIEW_ACCEPTANCE_TOKEN: "test-token",
     };
     expect(
-      previewWriteRefusal(acceptanceReq("/api/projects", "POST"), env),
-    ).toBeNull();
-    expect(
-      previewWriteRefusal(
-        acceptanceReq("/api/projects/p1", "DELETE", "wrong-token"),
-        env,
-      )?.status,
-    ).toBe(403);
-    expect(
-      previewWriteRefusal(
+      previewGalleryWriteRefusal(
         acceptanceReq("/api/gallery/submissions", "POST"),
         env,
       )?.status,
@@ -93,7 +95,7 @@ describe("release channel", () => {
 
   it("never refuses anything on production", () => {
     expect(
-      previewWriteRefusal(req("/api/gallery/submissions", "POST"), {}),
+      previewGalleryWriteRefusal(req("/api/gallery/submissions", "POST"), {}),
     ).toBeNull();
   });
 

--- a/worker/channel.ts
+++ b/worker/channel.ts
@@ -1,7 +1,4 @@
-import {
-  isPreviewAcceptanceRequest,
-  type PreviewAcceptanceEnv,
-} from "./preview-acceptance";
+import type { PreviewAcceptanceEnv } from "./preview-acceptance";
 
 /**
  * Which release channel this deployment is, and what that changes.
@@ -28,7 +25,7 @@ export function releaseChannel(env: ChannelEnv): ReleaseChannel {
   return env.ICM_CHANNEL === "preview" ? "preview" : "production";
 }
 
-/** What the editor asks at boot so it can show the preview banner. */
+/** What the editor asks at boot so it can identify the preview channel. */
 export function channelResponse(env: ChannelEnv): Response {
   return Response.json(
     { channel: releaseChannel(env) },
@@ -40,30 +37,23 @@ const READ_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
 
 /**
  * The preview reads the production gallery live and must never write to it.
- * Every path whose writes would reach the shared store is refused here,
- * before any route handler runs, so no handler can forget.
+ * Gallery writes are refused before any route handler runs, so no handler can
+ * forget. Private Project requests continue to the preview's own isolated
+ * GalleryDO namespace and never reach production.
  */
-export function previewWriteRefusal(
+export function previewGalleryWriteRefusal(
   request: Request,
   env: ChannelEnv,
 ): Response | null {
   if (releaseChannel(env) !== "preview") return null;
   if (READ_METHODS.has(request.method)) return null;
   const path = new URL(request.url).pathname;
-  if (
-    path.startsWith("/api/projects") &&
-    isPreviewAcceptanceRequest(request, env)
-  ) {
-    return null;
-  }
-  if (!path.startsWith("/api/gallery") && !path.startsWith("/api/projects")) {
-    return null;
-  }
+  if (!path.startsWith("/api/gallery")) return null;
   return Response.json(
     {
       error: "preview-read-only",
       message:
-        "The preview build reads the gallery but never writes to it. Publish, like, moderate, and save Cloud Projects on the production site.",
+        "The preview reads the production gallery but never writes to it. Publish, like, and moderate on the production site.",
     },
     { status: 403, headers: { "cache-control": "no-store" } },
   );
@@ -76,7 +66,7 @@ export function previewWriteRefusal(
  * and would have handed unreleased code a namespace with no read-only mode.
  * Fetching the public API instead is read-only by construction: the request
  * carries no cookie, so it is an anonymous visitor's view, and every write
- * has already been refused by `previewWriteRefusal` before this runs.
+ * has already been refused by `previewGalleryWriteRefusal` before this runs.
  */
 export async function previewGalleryReadThrough(
   request: Request,

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -25,8 +25,8 @@ import {
   channelResponse,
   markPreviewResponse,
   previewGalleryReadThrough,
+  previewGalleryWriteRefusal,
   previewRobotsResponse,
-  previewWriteRefusal,
   releaseChannel,
   type ChannelEnv,
 } from "./channel";
@@ -136,7 +136,7 @@ async function route(request: Request, env: Env): Promise<Response> {
   if (url.pathname === "/robots.txt" && releaseChannel(env) === "preview") {
     return previewRobotsResponse();
   }
-  const readOnlyRefusal = previewWriteRefusal(request, env);
+  const readOnlyRefusal = previewGalleryWriteRefusal(request, env);
   if (readOnlyRefusal) return readOnlyRefusal;
   const galleryReadThrough = await previewGalleryReadThrough(request, env);
   if (galleryReadThrough) return galleryReadThrough;

--- a/wrangler.preview.jsonc
+++ b/wrangler.preview.jsonc
@@ -24,7 +24,7 @@
     // API, over HTTP, exactly as any anonymous visitor would. No Durable
     // Object of the production script is bound here, because a binding has
     // no read-only mode and this Worker runs code production has not
-    // accepted yet. Writes never leave this Worker (see channel.ts).
+    // accepted yet. Gallery writes never leave this Worker (see channel.ts).
     "ICM_GALLERY_UPSTREAM": "https://analog-canvas.tokenzhang.com",
     // Where simulations run: the operator-run host behind its Cloudflare
     // Tunnel (docs/deployment.md, "Where the simulator runs"). The Worker
@@ -55,13 +55,13 @@
     "bindings": [
       { "name": "ANALYTICS", "class_name": "AnalyticsDO" },
       { "name": "AGENT_SESSION", "class_name": "AgentSessionDO" },
-      // The preview's own, empty gallery store. Gallery reads are served from
-      // the public site through ICM_GALLERY_UPSTREAM instead; this binding
-      // exists so the route module has something to hand a write to, and the
-      // channel rules refuse every write before it gets that far.
+      // The preview's own private Project store. Public Gallery reads are
+      // served from the production site through ICM_GALLERY_UPSTREAM and all
+      // Gallery writes are refused before routing. Authenticated /api/projects
+      // requests use only this isolated namespace.
       { "name": "GALLERY", "class_name": "GalleryDO" },
-      // The preview's own accounts: nobody signs in here, and no login
-      // provider is configured, so this namespace stays empty by design.
+      // Preview accounts are isolated from production accounts. The deploy
+      // workflow installs a preview-only Google OAuth client.
       { "name": "AUTH", "class_name": "AuthDO" },
       // Server-side authority for queued runs. Large immutable bytes live in
       // R2; this object stores only lifecycle, ownership and artifact refs.


### PR DESCRIPTION
## Summary

- give Preview its own authenticated Project workspace on the existing Project API while keeping Gallery publication read-only
- retain the CI Preview acceptance identity and route both human and automated journeys through the same isolated Preview Durable Objects
- support optional Preview-only Google OAuth credentials with fail-closed partial configuration
- replace the large Preview warning banner with a compact channel badge and expose the existing account/Project controls in Preview
- document the Preview/Production account, data, and deployment boundaries

## Activation

Human Preview login remains intentionally unavailable until both `PREVIEW_GOOGLE_CLIENT_ID` and `PREVIEW_GOOGLE_CLIENT_SECRET` are configured in the `cloudflare-preview` GitHub environment. Their absence does not block deployment; configuring only one does.

## Validation

- `pnpm gate:preflight -- --base origin/main`
- `pnpm gate:full` — 2899 unit tests and 365 browser tests passed, plus static, build, performance, golden, and release checks
- post-rebase `pnpm typecheck`
- post-rebase focused Vitest — 29 tests passed
- `git diff --check origin/main...HEAD`
