### PR TITLE
Clarify Analog Simulation test ownership

### DIFF
--- a/config/validation-gates.json
+++ b/config/validation-gates.json
@@ -155,6 +155,16 @@
       "packages/agent-client/**",
       "packages/agent-routing/**"
     ],
+    "analogSimulation": [
+      "apps/editor/src/features/simulation/**",
+      "apps/editor/e2e/agent-simulation.spec.ts",
+      "packages/simulation-service/**",
+      "packages/spice-run/**",
+      "packages/netlist/src/simulation-compile*",
+      "packages/netlist/src/source-waveform*",
+      "scripts/preview-simulation-smoke.mjs",
+      "scripts/simulation-acceptance.mjs"
+    ],
     "release": [
       "apps/local-host/**",
       "config/agent-mcp-distribution.json",
@@ -294,6 +304,18 @@
           "apps/editor/e2e/agent-simulation.spec.ts"
         ]
       }
+    },
+    {
+      "id": "analog-simulation-browser",
+      "stage": "affected",
+      "groups": ["analogSimulation"],
+      "description": "Validate the existing browser-authoritative Analog Simulation workflow.",
+      "command": [
+        "pnpm",
+        "test:e2e:local",
+        "apps/editor/e2e/agent-simulation.spec.ts"
+      ],
+      "ci": { "e2eArgs": ["apps/editor/e2e/agent-simulation.spec.ts"] }
     },
     {
       "id": "editor-browser",
@@ -488,6 +510,7 @@
         "project-file-browser",
         "gallery-browser",
         "agent-browser",
+        "analog-simulation-browser",
         "editor-browser",
         "editor-commands-browser",
         "editor-diagnostics-browser",

--- a/docs/testing/contract-matrix.md
+++ b/docs/testing/contract-matrix.md
@@ -12,6 +12,10 @@ an index for change impact, not a claim that the listed suites are exhaustive.
 | Connectivity, diagnostics, and hierarchy interpretation          | `packages/derived/src/{derived,current-contract,diagnostics/*.test.ts}`                                            | Editor net highlighting and Agent snapshots                     |
 | Formal SVG and export artifacts                                  | `packages/render-svg/src/*.test.ts`, `packages/exporters/src/exporters.test.ts`                                    | visual golden and release checks                                |
 | Design-netlist extraction and printing                           | `packages/netlist/src/{current-contract,printers}.test.ts`                                                         | editor netlist authoring workflow                               |
+| Analog Simulation deck compilation and source/probe mapping      | `packages/netlist/src/{simulation-compile,source-waveform}.test.ts`                                                | existing Agent Simulation browser workflow                      |
+| Analog Simulation execution, lifecycle, and artifact contracts   | `packages/simulation-service/src/*.test.ts`                                                                        | existing Agent/MCP and browser wiring checks                    |
+| ngspice process, environment, rawfile, and result interpretation | `packages/spice-run/src/*.test.ts`                                                                                 | qualified fixture and Preview smoke checks                      |
+| Digital Timing Simulation logic and waveform projection          | `packages/timing-simulation/src/*.test.ts` and focused Editor timing tests                                         | development-only timing window workflow                         |
 | Agent authentication, permissions, and session lifetime          | `packages/agent-adapter/src/{session-state,service,request-contract}.test.ts`                                      | browser Agent session workflow                                  |
 | Browser recovery and persistence hardening                       | editor document unit contracts                                                                                     | recovery dialog and hardening Playwright specs                  |
 | User-visible editing workflows                                   | focused editor unit contracts                                                                                      | `apps/editor/e2e/` scenarios                                    |
@@ -19,3 +23,18 @@ an index for change impact, not a claim that the listed suites are exhaustive.
 
 When a change touches more than one row, add or update a cross-module test only
 for the shared fact. Do not duplicate all lower-level cases in Playwright.
+
+## Simulation vocabulary
+
+`Timing Simulation` means the deterministic digital timing engine in
+`packages/timing-simulation`. `Analog Simulation` means the structured Canvas
+to ngspice path owned by `packages/netlist`, `packages/simulation-service`, and
+`packages/spice-run`. Tests and documentation must use those names instead of
+the unqualified word "simulation" when the distinction matters.
+
+Recorded ngspice rawfiles are parser and numerical-reference fixtures. Package
+builders are unit or module-contract fixtures. A browser Project is a workflow
+fixture. Reusing one authoritative, human-importable Project across layers is
+allowed, but each layer asserts only the contract it owns. This matrix does not
+add or freeze a new full-chain Project; that fixture and its acceptance scope
+remain a separate product decision.

--- a/fixtures/ngspice-rawfile/README.md
+++ b/fixtures/ngspice-rawfile/README.md
@@ -1,20 +1,20 @@
 # ngspice ASCII rawfile fixtures
 
-Six rawfiles written by ngspice 46, each beside the deck that produced it.
+Seven rawfiles written by ngspice 46, each beside the deck that produced it.
 They exist so a parser is tested against output a simulator actually wrote,
 not against output someone believed it writes.
 
 Regenerate any of them with `ngspice -b <name>.deck.spi` from this directory.
 
-| file                    | plot               | flags       | vars           | points |
-| ----------------------- | ------------------ | ----------- | -------------- | ------ |
-| `divider-op.raw`        | Operating Point    | real        | 3              | 1      |
-| `divider-op-listed.raw` | Operating Point    | real        | 4 (one echoed) | 1      |
-| `divider-dc.raw`        | DC transfer        | real        | 4              | 4      |
-| `rc-ac.raw`             | AC Analysis        | **complex** | 4              | 17     |
-| `rc-tran.raw`           | Transient Analysis | real        | 4              | 79     |
-| `resistor-noise-ngspice46.raw` | Noise spectrum + integrated | real | 3 + 2 | 7 + 1 |
-| `resistor-current-noise-ngspice46.raw` | Noise spectrum + integrated | real | 3 + 2 | 7 + 1 |
+| file                                   | plot                        | flags       | vars           | points |
+| -------------------------------------- | --------------------------- | ----------- | -------------- | ------ |
+| `divider-op.raw`                       | Operating Point             | real        | 3              | 1      |
+| `divider-op-listed.raw`                | Operating Point             | real        | 4 (one echoed) | 1      |
+| `divider-dc.raw`                       | DC transfer                 | real        | 4              | 4      |
+| `rc-ac.raw`                            | AC Analysis                 | **complex** | 4              | 17     |
+| `rc-tran.raw`                          | Transient Analysis          | real        | 4              | 79     |
+| `resistor-noise-ngspice46.raw`         | Noise spectrum + integrated | real        | 3 + 2          | 7 + 1  |
+| `resistor-current-noise-ngspice46.raw` | Noise spectrum + integrated | real        | 3 + 2          | 7 + 1  |
 
 ## What each one is for
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "mcp:release:package": "pnpm build && node scripts/package-mcp.mjs --verify-declared-release-sha",
     "mcp:distribution:check": "node scripts/check-mcp-distribution.mjs",
     "mcp:smoke": "node scripts/mcp-release-smoke.mjs",
-    "sim:accept": "pnpm build && node scripts/simulation-acceptance.mjs",
+    "sim:accept:roundtrip": "pnpm build && node scripts/simulation-acceptance.mjs",
     "dev": "pnpm --filter @icm/editor dev",
     "gate:plan": "node scripts/gate-plan.mjs",
     "gate:preflight": "node scripts/gate-run.mjs --stage preflight",

--- a/scripts/lib/ci-validation-plan.test.mjs
+++ b/scripts/lib/ci-validation-plan.test.mjs
@@ -31,6 +31,16 @@ describe("CI validation planning", () => {
     });
   });
 
+  it("selects the existing Analog Simulation browser contract", () => {
+    expect(
+      ciPlan(["packages/simulation-service/src/service.ts"]),
+    ).toMatchObject({
+      heavy: true,
+      mode: "focused",
+      e2eArgs: ["apps/editor/e2e/agent-simulation.spec.ts"],
+    });
+  });
+
   it("combines fixed browser contracts for a bounded cross-feature change", () => {
     expect(
       ciPlan([

--- a/scripts/lib/validation-gates.test.mjs
+++ b/scripts/lib/validation-gates.test.mjs
@@ -85,6 +85,18 @@ describe("validation gate planning", () => {
     expect(selected).not.toContain("full-delivery");
   });
 
+  it("maps Analog Simulation changes to the existing simulation workflow", () => {
+    for (const path of [
+      "packages/simulation-service/src/service.ts",
+      "packages/spice-run/src/rawfile.ts",
+      "apps/editor/src/features/simulation/spice-simulation-surface.tsx",
+    ]) {
+      const selected = ids([path]);
+      expect(selected, path).toContain("analog-simulation-browser");
+      expect(selected, path).not.toContain("editor-browser");
+    }
+  });
+
   it("selects release verification for package scripts", () => {
     expect(ids(["scripts/package-mcp.mjs"])).toContain("release-verification");
   });


### PR DESCRIPTION
## Summary
- distinguish Analog Simulation from digital Timing Simulation in the test contract matrix
- route analog compiler, service, runner, Editor, and smoke-script paths to the existing Agent Simulation browser workflow
- rename sim:accept to the precise sim:accept:roundtrip
- correct the ngspice rawfile catalog count

This change adds no full-chain project, scenario, or assertion. The authoritative human-importable workflow fixture remains a separate product decision.

## Validation
- validation planner contracts: 26 passed
- pnpm gate:preflight -- --base origin/main
- pnpm gate:full -- --base origin/main: 2,901 unit/module tests and 365 browser tests passed; build, performance, goldens, release smoke, and MCP smoke passed
- git diff --check

Test-Impact: tests-updated