### PR TITLE
fix(editor): remove underscore from polarity default

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -606,10 +606,22 @@ test("groups drafting tools and editable polarity labels under Annotations", asy
   await canvas.click({ position: { x: 460, y: 260 } });
   const editor = page.getByRole("textbox", { name: "Canvas text editor" });
   await expect(editor).toBeVisible();
-  await editor.fill("VGS");
+  await expect(editor).toHaveText("Vx");
+  await expect(editor.locator("sub")).toHaveText("x");
+  await expect(editor).not.toContainText("_");
   await page.getByRole("button", { name: "Apply text changes" }).click();
 
   const polarity = canvas.locator('[data-polarity="both"]');
+  await expect(polarity).toBeVisible();
+  await expect(polarity.locator("text")).toHaveText("Vx");
+  await expect(polarity.locator('[data-text-run="subscript"]')).toHaveText("x");
+  await expect(polarity.locator("text")).not.toContainText("_");
+
+  await page.getByTestId("drafting-hit-polarity-1").dblclick();
+  await expect(editor).toBeVisible();
+  await editor.fill("VGS");
+  await page.getByRole("button", { name: "Apply text changes" }).click();
+
   await expect(polarity).toBeVisible();
   await expect(polarity).toHaveAttribute("transform", /rotate\(90 /u);
   await expect(

--- a/apps/editor/src/features/component-insert/use-component-placement.ts
+++ b/apps/editor/src/features/component-insert/use-component-placement.ts
@@ -670,6 +670,8 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
     ) {
       id = options.nextId("polarity");
     }
+    // The semantic-text helper turns the suffix into a true subscript. The
+    // authored value is therefore "Vx"; a literal underscore would be drawn.
     const object: Extract<DraftingObject, { kind: "text" }> = {
       id,
       kind: "text",
@@ -680,7 +682,7 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
         ? { runs: [{ kind: "line-break" as const }] }
         : preset
           ? { runs: [{ kind: "text" as const, value: preset }] }
-          : defaultDraftTextDocument("V_x"),
+          : defaultDraftTextDocument("Vx"),
       alignment: "middle",
       rotation: options.componentPlacementRotation,
       typographyToken: "label",


### PR DESCRIPTION
## Summary
- author the default polarity label as `Vx` so `x` is a true RichText subscript
- avoid painting a literal underscore above the polarity minus mark
- preserve underscores in all user-authored text

## Validation
- reproduced the regression before the fix (`V_x` in the canvas editor)
- focused polarity placement browser test passed after the fix
- verified committed SVG text is `Vx`, its subscript is `x`, and it contains no underscore
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
- 2924 unit tests passed
- 33 component-insert browser tests passed
- visual inspection of the rendered polarity annotation
- git diff --check

Test-Impact: tests-updated