### PR TITLE
fix(gallery): update a new publication in place

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -1235,7 +1235,8 @@ test("a signed-in member publishes directly, bylined by the account", async ({
           displayName: "Token Zhang",
           email: "owner@example.com",
           provider: "github",
-          isAdmin: true,
+          role: "user",
+          isAdmin: false,
         },
       },
     }),
@@ -1247,6 +1248,7 @@ test("a signed-in member publishes directly, bylined by the account", async ({
     tags: string[];
     schemaVersion: number;
   }[] = [];
+  const updated: { name: string; instanceCount: number }[] = [];
   // The real submissions endpoint is /api/gallery/submissions — the mock
   // matches it exactly so a client posting anywhere else fails this test.
   await page.route("**/api/gallery/submissions", (route) => {
@@ -1266,6 +1268,21 @@ test("a signed-in member publishes directly, bylined by the account", async ({
         .schemaVersion,
     });
     return route.fulfill({ status: 201, json: { id: "entry-77" } });
+  });
+  await page.route("**/api/gallery/entry-77", (route) => {
+    if (route.request().method() !== "PUT") return route.fallback();
+    const body = route.request().postDataJSON() as {
+      name: string;
+      projectText: string;
+    };
+    const project = JSON.parse(body.projectText) as {
+      documents: { instances: unknown[] }[];
+    };
+    updated.push({
+      name: body.name,
+      instanceCount: project.documents[0]?.instances.length ?? 0,
+    });
+    return route.fulfill({ status: 200, json: { id: "entry-77" } });
   });
 
   await page.goto("/editor");
@@ -1295,6 +1312,28 @@ test("a signed-in member publishes directly, bylined by the account", async ({
       schemaVersion: CURRENT_PROJECT_SCHEMA_VERSION,
     },
   ]);
+
+  // The live Project remains the source of this publication. After another
+  // edit, Publish must update the item it just created rather than creating a
+  // duplicate Gallery entry.
+  await chooseComponent(page, "resistor");
+  await page
+    .getByTestId("schematic-canvas")
+    .click({ position: { x: 340, y: 230 } });
+  await page.keyboard.press("Escape");
+  await page.getByTestId("publish-gallery-button").click();
+  await expect(page.getByTestId("publish-mode")).toContainText(
+    "Session Publish",
+  );
+  await page
+    .getByTestId("publish-gallery-dialog")
+    .getByRole("button", { name: "Update entry" })
+    .click();
+  await expect(page.getByTestId("status")).toHaveText(
+    'Updated "Session Publish" in the gallery',
+  );
+  expect(posted).toHaveLength(1);
+  expect(updated).toEqual([{ name: "Session Publish", instanceCount: 1 }]);
 });
 
 test("a mistaken click beside the publish form keeps what was written", async ({

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -4865,7 +4865,7 @@ export function App({
             ? {
                 draft: publishDraft,
                 onDraftChange: setPublishDraft,
-                defaultName: project.name,
+                defaultName: galleryEntryContext?.name ?? project.name,
                 session: publishSession,
                 gateReport: publishGates,
                 updateTarget:
@@ -4897,10 +4897,37 @@ export function App({
                         ),
                     }
                   : {}),
-                onPublished: ({ id, name, updated, previewRevision }) => {
+                onPublished: ({
+                  id,
+                  name,
+                  description,
+                  tags,
+                  updated,
+                  previewRevision,
+                }) => {
                   // The gallery now holds these exact bytes: leaving or
                   // refreshing loses nothing until the next edit.
                   noteProjectSnapshotSafe();
+                  // Publishing establishes the same update-in-place binding
+                  // as opening an existing Gallery entry. Keep it attached to
+                  // this Project only; replacing the Project clears it above.
+                  setGalleryEntryContext({
+                    id,
+                    name,
+                    projectId: project.id,
+                    ownerUserId: updated
+                      ? (galleryEntryContext?.ownerUserId ??
+                        publishSession?.id ??
+                        null)
+                      : (publishSession?.id ?? null),
+                    author: updated
+                      ? (galleryEntryContext?.author ??
+                        publishSession?.displayName ??
+                        "")
+                      : (publishSession?.displayName ?? ""),
+                    description,
+                    tags,
+                  });
                   void primeGalleryPreview(id, previewRevision);
                   announceGalleryChange({
                     entryId: id,

--- a/apps/editor/src/features/editor-shell/publish-gallery-dialog.tsx
+++ b/apps/editor/src/features/editor-shell/publish-gallery-dialog.tsx
@@ -15,8 +15,8 @@ export interface PublishGalleryDialogProps {
   session?: PublishSessionUser | null;
   /** Quality-gate evaluation of the live Project. */
   gateReport?: SubmissionGateReport | null;
-  /** Present when the open circuit came from a gallery entry the signed-in
-   * user may update (owner, admin, or moderator). */
+  /** Present when the current Project is associated with a gallery entry the
+   * signed-in user may update (owner, admin, or moderator). */
   updateTarget?: { id: string; name: string } | null;
   /** The opened entry's stored fields, prefilled once in update mode. */
   updateDefaults?: {
@@ -30,6 +30,8 @@ export interface PublishGalleryDialogProps {
   onPublished: (outcome: {
     id: string;
     name: string;
+    description: string;
+    tags: readonly string[];
     updated: boolean;
     previewRevision?: string;
   }) => void;
@@ -139,6 +141,8 @@ export function PublishGalleryDialog({
       onPublished({
         id: outcome.id,
         name: name.trim(),
+        description: description.trim(),
+        tags,
         updated: updating,
         ...(outcome.previewRevision === undefined
           ? {}

--- a/docs/specs/community-gallery.md
+++ b/docs/specs/community-gallery.md
@@ -70,6 +70,12 @@ The byline is not a request field: the Worker takes `author` from the
 session's display name, so one account cannot publish under another's
 name, and an update never re-attributes an entry.
 
+After a successful first publication, the editor associates the live Project
+with the returned entry id. Further edits followed by Publish default to
+`PUT /api/gallery/<id>` for that same item rather than creating duplicates.
+Replacing the active Project clears the association; deliberately choosing
+"Publish as a new entry" replaces it with the newly returned entry id.
+
 Every entry records the submitting account: `owner_user_id` plus the
 `submitter_email` and `submitter_provider` read from the session at
 submission time, so an entry stays traceable to the identity that


### PR DESCRIPTION
## Summary
- associate a successful first Gallery publication with the still-open Project
- default the next Publish to updating that returned item instead of creating a duplicate
- preserve the published name, description, and tags for the update form
- keep explicit “Publish as a new entry” behavior and clear the association when the active Project is replaced

## Root cause
The editor already supported `PUT /api/gallery/<id>` for circuits opened from Gallery, but a successful initial `POST /api/gallery/submissions` never created the same `galleryEntryContext`. A second Publish therefore had no update target and posted a new item.

## Validation
- focused regression reproduced the missing update mode before the fix and passed afterward
- `pnpm gate:preflight -- --base origin/main`
- `pnpm gate:affected -- --base origin/main`
  - 2927 unit tests passed
  - 40 Gallery browser tests passed
  - 139 editor browser tests passed
- `git diff --check`

The gate plan classified this as bounded; no local full gate was run.

Test-Impact: tests-updated
