### PR TITLE
feat(gallery): add contributor leaderboard

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -801,6 +801,92 @@ test("the wall states how many circuits the gallery holds", async ({
   await expect(page.getByTestId("gallery-count-panel")).toHaveCount(0);
 });
 
+test("the wall count opens a contributor ranking and each author gallery", async ({
+  page,
+}) => {
+  const aliceEntries = [
+    {
+      ...ENTRY,
+      id: "alice-2",
+      name: "Alice OTA",
+      author: "Alice",
+      createdAt: "2026-08-22T10:00:00.000Z",
+    },
+    {
+      ...ENTRY,
+      id: "alice-1",
+      name: "Alice Bandgap",
+      author: "Alice",
+    },
+  ];
+  const bobEntry = {
+    ...ENTRY,
+    id: "bob-1",
+    name: "Bob Comparator",
+    author: "Bob",
+  };
+  await page.route(galleryListUrl, (route) => {
+    const url = new URL(route.request().url());
+    const entries =
+      url.searchParams.get("author") === "Alice"
+        ? aliceEntries
+        : [...aliceEntries, bobEntry];
+    return route.fulfill({
+      json: { entries, nextCursor: null, total: entries.length },
+    });
+  });
+  await page.route("**/api/gallery/authors", (route) =>
+    route.fulfill({
+      json: {
+        authors: [
+          { author: "Alice", count: 2 },
+          { author: "Bob", count: 1 },
+        ],
+      },
+    }),
+  );
+  await page.route("**/api/gallery/tags", (route) =>
+    route.fulfill({ json: { tags: [] } }),
+  );
+  await page.route("**/api/gallery/*/preview.svg*", (route) =>
+    route.fulfill({
+      contentType: "image/svg+xml",
+      body: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><rect width="10" height="10" fill="#fff"/></svg>',
+    }),
+  );
+
+  await page.goto("/");
+  await page.getByTestId("gallery-count-panel").click();
+  await expect(page.getByTestId("gallery-contributor-popover")).toContainText(
+    "2 authors",
+  );
+  await expect(page.getByTestId("gallery-contributor-row-1")).toContainText(
+    "Alice",
+  );
+  await expect(page.getByTestId("gallery-contributor-row-1")).toContainText(
+    "2 circuits",
+  );
+  await expect(page.getByTestId("gallery-contributor-row-2")).toContainText(
+    "Bob",
+  );
+
+  await page
+    .getByTestId("gallery-contributor-row-1")
+    .locator("summary")
+    .click();
+  await expect(
+    page.getByTestId("gallery-contributor-circuit-alice-2"),
+  ).toHaveText("Alice OTA");
+  await page.getByTestId("gallery-contributor-view-1").click();
+
+  await expect(page).toHaveURL(/\?author=Alice$/u);
+  await expect(page.getByTestId("gallery-filter")).toContainText(
+    "Circuits by Alice",
+  );
+  await expect(page.getByTestId("gallery-tile-alice-2")).toBeVisible();
+  await expect(page.getByTestId("gallery-tile-bob-1")).toHaveCount(0);
+});
+
 test("an API without totals hides the count rather than guessing", async ({
   page,
 }) => {

--- a/apps/editor/src/components/gallery-feed.test.tsx
+++ b/apps/editor/src/components/gallery-feed.test.tsx
@@ -6,6 +6,7 @@ import {
   galleryEntryMatchesQuery,
   GalleryCountPanel,
   GalleryFeed,
+  loadGalleryAuthors,
   loadGalleryFeed,
 } from "./gallery-feed";
 
@@ -47,10 +48,12 @@ describe("loadGalleryFeed", () => {
     await loadGalleryFeed(capturing);
     await loadGalleryFeed(capturing, { author: "alice" });
     await loadGalleryFeed(capturing, { author: "alice", cursor: "c|1" });
+    await loadGalleryFeed(capturing, { author: "alice", limit: 4 });
     expect(urls).toEqual([
       "/api/gallery",
       "/api/gallery?author=alice",
       "/api/gallery?author=alice&cursor=c%7C1",
+      "/api/gallery?author=alice&limit=4",
     ]);
   });
 
@@ -70,6 +73,37 @@ describe("loadGalleryFeed", () => {
       throw new Error("offline");
     }) as unknown as typeof fetch;
     expect(await loadGalleryFeed(throwing)).toBeNull();
+  });
+});
+
+describe("loadGalleryAuthors", () => {
+  it("loads the full public contributor ranking", async () => {
+    const urls: string[] = [];
+    const capturing = (async (input: RequestInfo | URL) => {
+      urls.push(String(input));
+      return new Response(
+        JSON.stringify({
+          authors: [
+            { author: "Alice", count: 12 },
+            { author: "Bob", count: 3 },
+          ],
+        }),
+        { status: 200 },
+      );
+    }) as typeof fetch;
+
+    expect(await loadGalleryAuthors(capturing)).toEqual([
+      { author: "Alice", count: 12 },
+      { author: "Bob", count: 3 },
+    ]);
+    expect(urls).toEqual(["/api/gallery/authors"]);
+  });
+
+  it("distinguishes an empty ranking from an unavailable one", async () => {
+    expect(await loadGalleryAuthors(fetchReturning({ authors: [] }))).toEqual(
+      [],
+    );
+    expect(await loadGalleryAuthors(fetchReturning({}, false))).toBeNull();
   });
 });
 
@@ -109,6 +143,7 @@ describe("GalleryCountPanel", () => {
     expect(render(1280)).toContain(`${(1280).toLocaleString()} circuits`);
     expect(render(1)).toContain("1 circuit");
     expect(render(1)).not.toContain("circuits");
+    expect(render(1)).toContain("Show contributor leaderboard");
     // "Filtered" names the state; "match" belongs to the text query alone.
     expect(render(3, true)).toContain("3 filtered circuits");
     expect(render(1, true)).toContain("1 filtered circuit");

--- a/apps/editor/src/components/gallery-feed.tsx
+++ b/apps/editor/src/components/gallery-feed.tsx
@@ -7,9 +7,11 @@ import {
   galleryCountLabel,
   galleryEntryMatchesQuery,
   galleryPreviewUrl,
+  loadGalleryAuthors,
   loadGalleryFeed,
   loadGalleryTags,
   subscribeGalleryRefresh,
+  type GalleryAuthorOption,
   type GalleryFeedEntry,
   type GalleryFeedPage,
   type GalleryFeedState,
@@ -22,8 +24,10 @@ import type { BundledGalleryTile } from "./gallery-bundled-fallback";
 // existing importer of this module working unchanged.
 export {
   galleryEntryMatchesQuery,
+  loadGalleryAuthors,
   loadGalleryFeed,
   loadGalleryTags,
+  type GalleryAuthorOption,
   type GalleryFeedEntry,
   type GalleryFeedPage,
   type GalleryFeedState,
@@ -40,6 +44,7 @@ import { ShelfWall } from "./shelf-wall";
  * header rather than becoming the page.
  */
 const COLLAPSED_TAG_COUNT = 10;
+const CONTRIBUTOR_PREVIEW_COUNT = 4;
 const OWNER_REJECT_REASONS = [
   "too ugly",
   "circuit incorrect",
@@ -252,21 +257,191 @@ function HeartIcon({ filled }: { filled: boolean }) {
  * clause counts VISIBLE tiles (true at every instant by construction) and
  * says "so far" until the feed is exhausted.
  */
+function contributionLabel(count: number): string {
+  return `${count.toLocaleString()} ${count === 1 ? "circuit" : "circuits"}`;
+}
+
+function GalleryContributorRow({
+  option,
+  rank,
+  onSelectAuthor,
+}: {
+  option: GalleryAuthorOption;
+  rank: number;
+  onSelectAuthor: (author: string) => void;
+}) {
+  const [preview, setPreview] = useState<{
+    status: "idle" | "loading" | "ready" | "unavailable";
+    entries: GalleryFeedEntry[];
+  }>({ status: "idle", entries: [] });
+  const requestGenerationRef = useRef(0);
+
+  function loadPreview(): void {
+    if (preview.status === "loading" || preview.status === "ready") return;
+    const generation = ++requestGenerationRef.current;
+    setPreview({ status: "loading", entries: [] });
+    void loadGalleryFeed(fetch, {
+      author: option.author,
+      limit: CONTRIBUTOR_PREVIEW_COUNT,
+    }).then((page) => {
+      if (generation !== requestGenerationRef.current) return;
+      setPreview(
+        page
+          ? { status: "ready", entries: page.entries }
+          : { status: "unavailable", entries: [] },
+      );
+    });
+  }
+
+  return (
+    <li>
+      <details
+        className="gallery-contributor-row"
+        data-testid={`gallery-contributor-row-${rank}`}
+        onToggle={(event) => {
+          if (event.currentTarget.open) loadPreview();
+        }}
+      >
+        <summary>
+          <span className="gallery-contributor-rank">{rank}</span>
+          <span className="gallery-contributor-author">{option.author}</span>
+          <span className="gallery-contributor-count">
+            {contributionLabel(option.count)}
+          </span>
+        </summary>
+        <div className="gallery-contributor-detail">
+          {preview.status === "loading" ? (
+            <p>Loading circuits…</p>
+          ) : preview.status === "unavailable" ? (
+            <p>Could not load the circuit preview.</p>
+          ) : preview.status === "ready" && preview.entries.length > 0 ? (
+            <ul className="gallery-contributor-circuits">
+              {preview.entries.map((entry) => (
+                <li key={entry.id}>
+                  <a
+                    href={`/g/${entry.id}`}
+                    data-testid={`gallery-contributor-circuit-${entry.id}`}
+                  >
+                    {entry.name}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+          <button
+            type="button"
+            data-testid={`gallery-contributor-view-${rank}`}
+            onClick={() => onSelectAuthor(option.author)}
+          >
+            View {option.author}&apos;s gallery
+          </button>
+        </div>
+      </details>
+    </li>
+  );
+}
+
 export function GalleryCountPanel({
   total,
   filtered = false,
   search = null,
+  refreshSignal = 0,
+  onSelectAuthor = () => undefined,
 }: {
   total: number | null;
   filtered?: boolean;
   search?: { visible: number; settled: boolean } | null;
+  refreshSignal?: number;
+  onSelectAuthor?: (author: string) => void;
 }) {
   const label = galleryCountLabel(total, { filtered, search });
+  const rootRef = useRef<HTMLDetailsElement | null>(null);
+  const requestGenerationRef = useRef(0);
+  const revision = `${refreshSignal}:${total ?? "unknown"}`;
+  const [contributors, setContributors] = useState<{
+    status: "idle" | "loading" | "ready" | "unavailable";
+    authors: GalleryAuthorOption[];
+    revision: string;
+  }>({ status: "idle", authors: [], revision });
+  const contributorStatus =
+    contributors.revision === revision ? contributors.status : "idle";
+  const contributorAuthors =
+    contributors.revision === revision ? contributors.authors : [];
+
+  function loadContributors(): void {
+    if (contributorStatus === "loading" || contributorStatus === "ready") {
+      return;
+    }
+    const generation = ++requestGenerationRef.current;
+    setContributors({ status: "loading", authors: [], revision });
+    void loadGalleryAuthors(fetch).then((authors) => {
+      if (generation !== requestGenerationRef.current) return;
+      setContributors(
+        authors === null
+          ? { status: "unavailable", authors: [], revision }
+          : { status: "ready", authors, revision },
+      );
+    });
+  }
+
   if (label === null) return null;
   return (
-    <span className="gallery-count-panel" data-testid="gallery-count-panel">
-      {label}
-    </span>
+    <details
+      ref={rootRef}
+      className="gallery-contributor-menu"
+      data-testid="gallery-contributor-menu"
+      onToggle={(event) => {
+        if (event.currentTarget.open) loadContributors();
+      }}
+    >
+      <summary
+        className="gallery-count-panel"
+        data-testid="gallery-count-panel"
+        aria-label={`${label}. Show contributor leaderboard`}
+      >
+        {label}
+      </summary>
+      <div
+        className="gallery-contributor-popover"
+        data-testid="gallery-contributor-popover"
+      >
+        <div className="gallery-contributor-heading">
+          <strong>Contributors</strong>
+          {contributorStatus === "ready" ? (
+            <span>
+              {contributorAuthors.length.toLocaleString()}{" "}
+              {contributorAuthors.length === 1 ? "author" : "authors"}
+            </span>
+          ) : null}
+        </div>
+        {contributorStatus === "loading" || contributorStatus === "idle" ? (
+          <p className="gallery-contributor-status">Loading contributors…</p>
+        ) : contributorStatus === "unavailable" ? (
+          <div className="gallery-contributor-status">
+            <p>Could not load contributors.</p>
+            <button type="button" onClick={loadContributors}>
+              Try again
+            </button>
+          </div>
+        ) : contributorAuthors.length === 0 ? (
+          <p className="gallery-contributor-status">No contributors yet.</p>
+        ) : (
+          <ol className="gallery-contributor-list">
+            {contributorAuthors.map((option, index) => (
+              <GalleryContributorRow
+                key={`${refreshSignal}:${total}:${option.author}`}
+                option={option}
+                rank={index + 1}
+                onSelectAuthor={(author) => {
+                  rootRef.current?.removeAttribute("open");
+                  onSelectAuthor(author);
+                }}
+              />
+            ))}
+          </ol>
+        )}
+      </div>
+    </details>
   );
 }
 
@@ -524,6 +699,13 @@ export function GalleryFeed({
     syncQuery(next, selectedTags);
   }
 
+  function selectContributor(nextAuthor: string): void {
+    setSearchQuery("");
+    setSelectedTags([]);
+    setAuthor(nextAuthor);
+    syncQuery(nextAuthor, []);
+  }
+
   function toggleTag(tag: string): void {
     setSelectedTags((previous) => {
       const next = previous.includes(tag)
@@ -693,6 +875,8 @@ export function GalleryFeed({
           <GalleryCountPanel
             total={state.total}
             filtered={author !== null || selectedTags.length > 0}
+            refreshSignal={refreshSignal}
+            onSelectAuthor={selectContributor}
             search={
               normalizedSearchQuery
                 ? {

--- a/apps/editor/src/gallery-client.ts
+++ b/apps/editor/src/gallery-client.ts
@@ -216,12 +216,19 @@ export interface GalleryTagOption {
   count: number;
 }
 
+/** One public byline and its contribution to the whole Gallery wall. */
+export interface GalleryAuthorOption {
+  author: string;
+  count: number;
+}
+
 export async function loadGalleryFeed(
   fetchLike: typeof fetch = fetch,
   options: {
     cursor?: string | null;
     author?: string | null;
     tags?: readonly string[];
+    limit?: number;
   } = {},
 ): Promise<GalleryFeedPage | null> {
   const params = new URLSearchParams();
@@ -230,6 +237,7 @@ export async function loadGalleryFeed(
     params.set("tags", options.tags.join(","));
   }
   if (options.cursor) params.set("cursor", options.cursor);
+  if (options.limit !== undefined) params.set("limit", String(options.limit));
   const query = params.toString();
   try {
     const response = await fetchLike(
@@ -248,6 +256,24 @@ export async function loadGalleryFeed(
         typeof payload.nextCursor === "string" ? payload.nextCursor : null,
       total: typeof payload.total === "number" ? payload.total : null,
     };
+  } catch {
+    return null;
+  }
+}
+
+/** The public contributors ranked by how many circuits they have shared. */
+export async function loadGalleryAuthors(
+  fetchLike: typeof fetch = fetch,
+): Promise<GalleryAuthorOption[] | null> {
+  try {
+    const response = await fetchLike("/api/gallery/authors", {
+      credentials: "same-origin",
+    });
+    if (!response.ok) return null;
+    const payload = (await response.json()) as {
+      authors?: GalleryAuthorOption[];
+    };
+    return payload.authors ?? [];
   } catch {
     return null;
   }

--- a/apps/editor/src/gallery.css
+++ b/apps/editor/src/gallery.css
@@ -1059,15 +1059,214 @@
   gap: 6px;
 }
 
-/* The band's spare right side carries the wall's one number. Muted like
-   .shelf-count: a fact about the wall, not a control. */
-.gallery-count-panel {
+/* The wall count is also the door to a compact contributor leaderboard. */
+.gallery-contributor-menu {
+  position: relative;
   margin-left: auto;
   align-self: center;
   padding-bottom: 6px;
+}
+
+.gallery-count-panel {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 10px;
+  border: 1px solid var(--icm-border);
+  border-radius: 999px;
+  background: var(--icm-surface);
   color: var(--icm-text-muted);
+  font: inherit;
   font-size: 0.85rem;
+  list-style: none;
   white-space: nowrap;
+  cursor: pointer;
+}
+
+.gallery-count-panel::-webkit-details-marker,
+.gallery-contributor-row > summary::-webkit-details-marker {
+  display: none;
+}
+
+.gallery-count-panel::after,
+.gallery-contributor-row > summary::after {
+  width: 6px;
+  height: 6px;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  content: "";
+  transform: translateY(-2px) rotate(45deg);
+  transition: transform 120ms ease;
+}
+
+.gallery-contributor-menu[open] > .gallery-count-panel,
+.gallery-count-panel:hover {
+  border-color: var(--icm-accent);
+  color: var(--icm-text);
+  background: var(--icm-surface-hover);
+}
+
+.gallery-contributor-menu[open] > .gallery-count-panel::after,
+.gallery-contributor-row[open] > summary::after {
+  transform: translateY(2px) rotate(225deg);
+}
+
+.gallery-count-panel:focus-visible,
+.gallery-contributor-row > summary:focus-visible,
+.gallery-contributor-detail button:focus-visible,
+.gallery-contributor-circuits a:focus-visible {
+  outline: 2px solid var(--icm-accent);
+  outline-offset: 2px;
+}
+
+.gallery-contributor-popover {
+  position: absolute;
+  z-index: 70;
+  top: calc(100% + 1px);
+  right: 0;
+  box-sizing: border-box;
+  width: min(23rem, calc(100vw - 44px));
+  padding: 10px;
+  border: 1px solid var(--icm-border);
+  border-radius: 12px;
+  background: var(--icm-surface);
+  box-shadow: 0 16px 36px rgb(15 15 15 / 16%);
+}
+
+.gallery-contributor-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 4px 6px 10px;
+}
+
+.gallery-contributor-heading strong {
+  color: var(--icm-text);
+  font-size: 14px;
+}
+
+.gallery-contributor-heading span,
+.gallery-contributor-status {
+  color: var(--icm-text-muted);
+  font-size: 12px;
+}
+
+.gallery-contributor-status {
+  margin: 0;
+  padding: 10px 6px;
+}
+
+div.gallery-contributor-status {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.gallery-contributor-status p {
+  margin: 0;
+}
+
+.gallery-contributor-status button,
+.gallery-contributor-detail button {
+  padding: 5px 9px;
+  border: 1px solid var(--icm-border);
+  border-radius: 999px;
+  color: var(--icm-text);
+  background: var(--icm-surface);
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.gallery-contributor-status button:hover,
+.gallery-contributor-detail button:hover {
+  border-color: var(--icm-accent);
+  background: var(--icm-accent-soft);
+}
+
+.gallery-contributor-list {
+  max-height: min(32rem, 65vh);
+  margin: 0;
+  padding: 0;
+  overflow-y: auto;
+  list-style: none;
+}
+
+.gallery-contributor-list > li + li {
+  border-top: 1px solid var(--icm-border);
+}
+
+.gallery-contributor-row > summary {
+  display: grid;
+  grid-template-columns: 1.7rem minmax(0, 1fr) auto 0.6rem;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 6px;
+  border-radius: 7px;
+  color: var(--icm-text);
+  list-style: none;
+  cursor: pointer;
+}
+
+.gallery-contributor-row > summary:hover {
+  background: var(--icm-surface-hover);
+}
+
+.gallery-contributor-rank,
+.gallery-contributor-count {
+  color: var(--icm-text-muted);
+  font-size: 12px;
+}
+
+.gallery-contributor-rank {
+  text-align: center;
+}
+
+.gallery-contributor-author {
+  overflow: hidden;
+  font-size: 13px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.gallery-contributor-detail {
+  display: grid;
+  justify-items: start;
+  gap: 9px;
+  padding: 0 6px 10px 2.5rem;
+}
+
+.gallery-contributor-detail > p {
+  margin: 0;
+  color: var(--icm-text-muted);
+  font-size: 12px;
+}
+
+.gallery-contributor-circuits {
+  display: grid;
+  gap: 5px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.gallery-contributor-circuits a {
+  display: block;
+  max-width: 17rem;
+  overflow: hidden;
+  color: var(--icm-text-muted);
+  font-size: 12px;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.gallery-contributor-circuits a:hover {
+  color: var(--icm-accent);
+  text-decoration: underline;
 }
 
 .gallery-view-tab {

--- a/docs/specs/community-gallery.md
+++ b/docs/specs/community-gallery.md
@@ -28,6 +28,11 @@ restrictive content-security-policy.
   fallback.
 - `GET /api/gallery/tags` — distinct public tags with counts, most
   frequent first (feeds the multi-select menu).
+- `GET /api/gallery/authors` — non-empty public bylines with their currently
+  visible circuit counts, ranked by count and then author name. The clickable
+  wall count uses this roll-up for its contributor leaderboard; expanding one
+  author lazily reads that author's newest circuits from the ordinary feed and
+  can switch the wall to the existing exact-author filter.
 - `GET /api/gallery/<id>` — one public entry with its canonical
   `projectText`.
 - `GET /api/gallery/<id>/preview.svg?v=<previewRevision>` — the

--- a/worker/gallery-do.ts
+++ b/worker/gallery-do.ts
@@ -418,6 +418,11 @@ export class GalleryDO {
       CREATE INDEX IF NOT EXISTS idx_gallery_entries_status_created
       ON gallery_entries(status, created_at)
     `);
+    // Covers both the public contributor roll-up and exact-author feeds.
+    this.sql.exec(`
+      CREATE INDEX IF NOT EXISTS idx_gallery_entries_status_author
+      ON gallery_entries(status, author)
+    `);
     // One thumb per account per circuit, so the primary key is the rule.
     this.sql.exec(`
       CREATE TABLE IF NOT EXISTS gallery_likes (
@@ -636,6 +641,8 @@ export class GalleryDO {
         return this.allIds();
       case "tags":
         return this.tagCounts();
+      case "authors":
+        return this.authorCounts();
       case "update-entry":
         return this.updateEntry(body);
       case "replace-entry":
@@ -1965,6 +1972,25 @@ export class GalleryDO {
       .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0], "en"))
       .map(([tag, count]) => ({ tag, count }));
     return Response.json({ tags });
+  }
+
+  /** Public bylines ranked by their number of currently visible circuits. */
+  private authorCounts(): Response {
+    const rows = this.sql
+      .exec<{ author: string; count: number }>(
+        `SELECT author, COUNT(*) AS count
+         FROM gallery_entries
+         WHERE status = 'public' AND TRIM(author) <> ''
+         GROUP BY author
+         ORDER BY count DESC, author COLLATE NOCASE ASC, author ASC`,
+      )
+      .toArray();
+    return Response.json({
+      authors: rows.map((row) => ({
+        author: row.author,
+        count: Number(row.count),
+      })),
+    });
   }
 
   private allIds(): Response {

--- a/worker/gallery.test.ts
+++ b/worker/gallery.test.ts
@@ -559,6 +559,49 @@ describe("newest-first gallery feed", () => {
     expect(filtered.total).toBe(3);
   });
 
+  it("ranks public contributors by circuit count and excludes hidden or blank bylines", async () => {
+    const env = environment();
+    const ids = await wallOf(env, 6);
+    env.gallerySql.exec(
+      "UPDATE gallery_entries SET author = ? WHERE id IN (?, ?)",
+      "Alice",
+      ids[0]!,
+      ids[1]!,
+    );
+    env.gallerySql.exec(
+      "UPDATE gallery_entries SET author = ? WHERE id = ?",
+      "Chen",
+      ids[2]!,
+    );
+    env.gallerySql.exec(
+      "UPDATE gallery_entries SET author = ? WHERE id = ?",
+      "Bob",
+      ids[3]!,
+    );
+    env.gallerySql.exec(
+      "UPDATE gallery_entries SET author = '' WHERE id = ?",
+      ids[4]!,
+    );
+    env.gallerySql.exec(
+      "UPDATE gallery_entries SET author = ?, status = 'rejected' WHERE id = ?",
+      "Hidden",
+      ids[5]!,
+    );
+
+    const response = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/authors`),
+    );
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(await response.json()).toEqual({
+      authors: [
+        { author: "Alice", count: 2 },
+        { author: "Bob", count: 1 },
+        { author: "Chen", count: 1 },
+      ],
+    });
+  });
+
   it("returns the same newest-first order on every read", async () => {
     const env = environment();
     await wallOf(env, 3);

--- a/worker/gallery.ts
+++ b/worker/gallery.ts
@@ -705,6 +705,14 @@ export async function routeGalleryRequest(
   }
   if (
     segments.length === 1 &&
+    segments[0] === "authors" &&
+    request.method === "GET"
+  ) {
+    const { payload } = await callGallery(env, "authors", {});
+    return Response.json(payload, { headers: { "cache-control": "no-store" } });
+  }
+  if (
+    segments.length === 1 &&
     segments[0] === "mine" &&
     request.method === "GET"
   ) {


### PR DESCRIPTION
## Summary
- make the Gallery circuit count open a contributor leaderboard
- rank public authors by shared-circuit count and exclude hidden entries
- lazily preview recent circuits for each author and open the complete filtered Gallery
- add a covering author index without changing the initial Gallery feed request

## Validation
- `pnpm gate:preflight -- --base origin/main`
- focused Gallery unit tests: 78 passed
- focused contributor Playwright regression: passed
- affected workspace unit suite: 439 files / 2930 tests passed
- affected Gallery browser suite: 39 passed initially; the 2 stale-local-dist failures passed after rebuilding the project-protocol dependency chain, together with the new regression

Test-Impact: tests-updated