### PR TITLE
Widen the responsive Insert Component panel

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -1339,6 +1339,52 @@ test("tiles the whole catalog into one flat quick-pick grid", async ({
   await page.keyboard.press("Escape");
 });
 
+test("widens the Insert picker and adds columns with the editor viewport", async ({
+  page,
+}) => {
+  const measurePicker = async () => {
+    const dialog = page.getByRole("dialog", { name: "Insert Component" });
+    await expect(dialog).toBeVisible();
+    const box = await dialog.boundingBox();
+    if (!box) throw new Error("Insert Component dialog is not measurable");
+    const firstTop = await dialog
+      .getByRole("option")
+      .first()
+      .evaluate((element) => (element as HTMLElement).offsetTop);
+    const columns = await dialog
+      .locator(".insert-tile-grid")
+      .evaluate(
+        (element, top) =>
+          Array.from(
+            element.querySelectorAll<HTMLElement>('[role="option"]'),
+          ).filter((option) => option.offsetTop === top).length,
+        firstTop,
+      );
+    return { width: box.width, columns };
+  };
+
+  // A window snapped to half of a common desktop uses its complete available
+  // width apart from the 20px modal gutter on each side.
+  await page.setViewportSize({ width: 960, height: 800 });
+  await page.goto("/editor");
+  await awaitEditorReady(page);
+  await page.keyboard.press("i");
+  const halfScreen = await measurePicker();
+  const rootFontSize = await page.evaluate(() =>
+    Number.parseFloat(getComputedStyle(document.documentElement).fontSize),
+  );
+  expect(halfScreen.width).toBe(960 - rootFontSize * 2.5);
+
+  await page.keyboard.press("Escape");
+  await page.setViewportSize({ width: 1920, height: 1080 });
+  await page.keyboard.press("i");
+  const fullScreen = await measurePicker();
+
+  expect(fullScreen.width).toBe(rootFontSize * 96);
+  expect(fullScreen.width).toBeGreaterThan(halfScreen.width + 250);
+  expect(fullScreen.columns).toBeGreaterThan(halfScreen.columns);
+});
+
 test("sets MOS parameters and orientation through the ghost and Properties", async ({
   page,
 }) => {

--- a/apps/editor/src/styles/editor-dialogs.css
+++ b/apps/editor/src/styles/editor-dialogs.css
@@ -117,7 +117,11 @@
   display: flex;
   flex-direction: column;
   gap: 0.8rem;
-  width: min(46rem, calc(100vw - 2.5rem));
+  /* The viewport is the available workspace: a half-screen editor fills its
+     half (minus the modal gutter), while a full-screen editor earns enough
+     width for substantially more component columns. The cap keeps ultrawide
+     displays from turning the picker into an unreadably long scan line. */
+  width: min(96rem, calc(100vw - 2.5rem));
   max-height: calc(100dvh - 2.5rem);
   padding: 1rem;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- let the Insert Component panel use the available editor viewport width
- cap the panel on large displays while allowing more component columns
- cover half-screen and full-screen viewport behavior in Playwright

## Validation
- `pnpm gate:preflight -- --base origin/main`
- `pnpm gate:affected -- --base origin/main`
- 439 unit files / 2930 tests passed
- 34 component-insert browser tests passed