### PR TITLE
Unify the canvas text editor layout

### DIFF
--- a/apps/editor/e2e/drafting.spec.ts
+++ b/apps/editor/e2e/drafting.spec.ts
@@ -188,6 +188,12 @@ async function expectForeignObjectContentsContained(
   expect(containment).toEqual({ contentFits: true, contained: true });
 }
 
+async function controlTop(locator: Locator): Promise<number> {
+  const bounds = await locator.boundingBox();
+  if (!bounds) throw new Error("Toolbar control is not measurable");
+  return bounds.y;
+}
+
 // The canvas-local toolbar creates RichText AST without exposing raw markup.
 test("adds formatted drafting text and undo/redo restores it", async ({
   page,
@@ -229,20 +235,42 @@ test("adds formatted drafting text and undo/redo restores it", async ({
   expect(editorBounds.x + editorBounds.width).toBeLessThanOrEqual(
     canvasBounds.x + canvasBounds.width + 1,
   );
-  const toolbarCenters = await page
-    .getByRole("toolbar", { name: "Text formatting" })
-    .locator(":scope > *")
-    .evaluateAll((elements) =>
-      elements.map((element) => {
-        const bounds = element.getBoundingClientRect();
-        return bounds.top + bounds.height / 2;
-      }),
-    );
-  const toolbarRows = toolbarCenters.reduce<number[]>((rows, center) => {
-    if (!rows.some((row) => Math.abs(row - center) < 2)) rows.push(center);
-    return rows;
-  }, []);
-  expect(toolbarRows).toHaveLength(2);
+  expect(editorBounds.width).toBeCloseTo(440, 0);
+  const [boldTop, increaseTop, applyTop, cancelTop, deleteTop] =
+    await Promise.all([
+      controlTop(page.getByRole("button", { name: "Bold" })),
+      controlTop(page.getByRole("button", { name: "Increase text size" })),
+      controlTop(page.getByRole("button", { name: "Apply text changes" })),
+      controlTop(page.getByRole("button", { name: "Cancel text changes" })),
+      controlTop(page.getByRole("button", { name: "Delete text" })),
+    ]);
+  expect(Math.abs(increaseTop - boldTop)).toBeLessThan(1);
+  expect(Math.abs(cancelTop - applyTop)).toBeLessThan(1);
+  expect(Math.abs(deleteTop - applyTop)).toBeLessThan(1);
+  expect(applyTop).toBeGreaterThan(boldTop);
+
+  const fullViewport = page.viewportSize();
+  await page.setViewportSize({ width: 720, height: 720 });
+  await expect
+    .poll(async () =>
+      page
+        .getByTestId("canvas-text-editor")
+        .boundingBox()
+        .then((bounds) => bounds?.width),
+    )
+    .toBeCloseTo(440, 0);
+  const [narrowBoldTop, narrowIncreaseTop, narrowApplyTop, narrowCancelTop] =
+    await Promise.all([
+      controlTop(page.getByRole("button", { name: "Bold" })),
+      controlTop(page.getByRole("button", { name: "Increase text size" })),
+      controlTop(page.getByRole("button", { name: "Apply text changes" })),
+      controlTop(page.getByRole("button", { name: "Cancel text changes" })),
+    ]);
+  expect(Math.abs(narrowIncreaseTop - narrowBoldTop)).toBeLessThan(1);
+  expect(Math.abs(narrowCancelTop - narrowApplyTop)).toBeLessThan(1);
+  expect(narrowApplyTop).toBeGreaterThan(narrowBoldTop);
+  if (fullViewport) await page.setViewportSize(fullViewport);
+
   await draftInput.fill(
     "A deliberately long annotation that wraps inside the compact canvas text editor instead of extending beyond it",
   );

--- a/apps/editor/e2e/reference-label.spec.ts
+++ b/apps/editor/e2e/reference-label.spec.ts
@@ -42,6 +42,23 @@ test("canvas edits one visual annotation without changing the Netlist Reference"
   await expect(
     page.getByRole("button", { name: "Subscript", exact: true }),
   ).toBeVisible();
+  const [sizeControl, ...actionControls] = await Promise.all(
+    [
+      page.getByRole("button", { name: "Increase text size" }),
+      page.getByRole("button", { name: "Apply text changes" }),
+      page.getByRole("button", { name: "Cancel text changes" }),
+      page.getByRole("button", { name: "Delete text" }),
+      page.getByRole("button", { name: "Use netlist name", exact: true }),
+    ].map(async (control) => {
+      const bounds = await control.boundingBox();
+      if (!bounds) throw new Error("Text editor control is not measurable");
+      return bounds;
+    }),
+  );
+  expect(
+    actionControls.every(({ y }) => Math.abs(y - actionControls[0]!.y) < 1),
+  ).toBe(true);
+  expect(actionControls[0]!.y).toBeGreaterThan(sizeControl!.y);
   await editor.fill("R2");
   await editor.press("End");
   await editor.press("Shift+Enter");

--- a/apps/editor/src/features/text-editing/canvas-text-editor-overlay.test.ts
+++ b/apps/editor/src/features/text-editing/canvas-text-editor-overlay.test.ts
@@ -26,9 +26,10 @@ describe("canvas text editor frame", () => {
     expect(frame.layoutWidth).toBeCloseTo(frame.width * pixelsPerUnit, 10);
   });
 
-  it("uses at most half of the canvas and caps its screen width", () => {
+  it("uses one screen width at full- and half-window sizes", () => {
     for (const [view, pixelsPerUnit] of [
       [camera(960, 640), 0.95],
+      [camera(960, 640), 0.7],
       [camera(240, 160), 3.8],
       [camera(3840, 2560), 0.2375],
     ] as const) {
@@ -38,13 +39,17 @@ describe("canvas text editor frame", () => {
         1,
         pixelsPerUnit,
       );
-      expect(frame.width / view.width).toBeLessThanOrEqual(1 / 2);
-      // The same physical canvas width and cap produce one layout width at
-      // every camera zoom.
-      const canvasPx = view.width * pixelsPerUnit;
-      expect(canvasPx).toBeCloseTo(912, 10);
+      expect(view.width * pixelsPerUnit).toBeGreaterThan(440);
+      expect(frame.width * pixelsPerUnit).toBeCloseTo(440, 10);
       expect(frame.layoutWidth).toBeCloseTo(440, 10);
     }
+  });
+
+  it("shrinks only when the canvas cannot fit the standard editor", () => {
+    const frame = resolveCanvasTextEditorFrame(target, camera(400, 640), 1, 1);
+    expect(frame.layoutWidth).toBe(384);
+    expect(frame.x).toBeGreaterThanOrEqual(8);
+    expect(frame.x + frame.width).toBeLessThanOrEqual(392);
   });
 
   it("holds one apparent size however far the camera is zoomed", () => {

--- a/apps/editor/src/features/text-editing/canvas-text-editor-overlay.tsx
+++ b/apps/editor/src/features/text-editing/canvas-text-editor-overlay.tsx
@@ -34,20 +34,17 @@ export interface CanvasTextEditorOverlayProps {
  * text — are laid out at this size and then scaled as one, so the panel keeps
  * its proportions instead of reflowing as the camera moves.
  */
-const EDITOR_FALLBACK_LAYOUT_WIDTH = 420;
-const EDITOR_LAYOUT_MAX_WIDTH = 440;
+const EDITOR_LAYOUT_WIDTH = 440;
 const EDITOR_LAYOUT_MIN_HEIGHT = 150;
 
 /**
- * How much of the camera the panel occupies.
+ * How much of the camera the panel occupies before its screen scale is known.
  *
- * Sizing the panel in Document units made it a part of the drawing: it grew
- * on zoom in and shrank to illegibility on zoom out. A fraction of the camera
- * is the same fraction of the canvas at every zoom, so the panel holds one
- * apparent size — and because its contents are laid out at a fixed pixel size
- * and scaled with it, they hold their size too.
+ * The measured editor has one fixed screen width at both full- and half-window
+ * sizes. This fraction only supplies a stable first-paint scale before the SVG
+ * has reported its screen dimensions.
  */
-const EDITOR_VIEW_FRACTION = 1 / 2;
+const EDITOR_FALLBACK_VIEW_FRACTION = 1 / 2;
 
 export interface CanvasTextEditorFrame {
   /** Where the panel sits, in Document units. */
@@ -69,7 +66,8 @@ export function resolveCanvasTextEditorFrame(
   pixelsPerUnit?: number | null,
   preferredLayoutHeight?: number | null,
 ): CanvasTextEditorFrame {
-  const availableWidth = viewBox.width * EDITOR_VIEW_FRACTION;
+  const viewportInset = 8;
+  const availableWidth = Math.max(0, viewBox.width - viewportInset * 2);
   // Laying the panel out at true screen pixels is what lets its type be set
   // against the rest of the chrome rather than against the drawing. Without a
   // measurement — the first render, before the canvas is on screen — fall back
@@ -77,11 +75,10 @@ export function resolveCanvasTextEditorFrame(
   const scale =
     pixelsPerUnit && pixelsPerUnit > 0
       ? 1 / pixelsPerUnit
-      : availableWidth / EDITOR_FALLBACK_LAYOUT_WIDTH;
-  // Half of a wide canvas is still needlessly long. Cap the editor in actual
-  // screen pixels so ordinary desktop and half-screen windows use the same
-  // compact, wrapping control surface regardless of camera zoom.
-  const width = Math.min(availableWidth, EDITOR_LAYOUT_MAX_WIDTH * scale);
+      : (viewBox.width * EDITOR_FALLBACK_VIEW_FRACTION) / EDITOR_LAYOUT_WIDTH;
+  // Full- and half-window workspaces use the same control surface. Only a
+  // canvas physically narrower than the editor makes it shrink.
+  const width = Math.min(availableWidth, EDITOR_LAYOUT_WIDTH * scale);
   const layoutWidth = width / scale;
   // A name longer than the box wraps, and the frame is sized before any of it
   // is typed, so budget for a few wrapped lines instead of the one the
@@ -94,7 +91,6 @@ export function resolveCanvasTextEditorFrame(
     preferredLayoutHeight ?? 0,
   );
   const height = layoutHeight * scale;
-  const viewportInset = 8;
   const targetGap = 8;
   const minX = viewBox.x + viewportInset;
   const maxX = viewBox.x + viewBox.width - width - viewportInset;

--- a/apps/editor/src/features/text-editing/rich-text-editor.tsx
+++ b/apps/editor/src/features/text-editing/rich-text-editor.tsx
@@ -827,6 +827,9 @@ export function RichTextEditor({
             </button>
           </>
         ) : null}
+        {!compact ? (
+          <span className="rich-text-toolbar-action-break" aria-hidden="true" />
+        ) : null}
         <button
           type="button"
           aria-label="Apply text changes"

--- a/apps/editor/src/styles/editor-canvas.css
+++ b/apps/editor/src/styles/editor-canvas.css
@@ -613,6 +613,15 @@
   background: var(--icm-border-strong);
 }
 
+/* Keep commit controls on a deliberate second row. The canvas editor has one
+   440px layout at both full- and half-window sizes, so this break is stable
+   instead of changing with incidental flex wrapping. */
+.rich-text-toolbar-action-break {
+  flex: 0 0 100%;
+  width: 0;
+  height: 0;
+}
+
 .rich-text-overbar-button {
   text-decoration: overline;
   text-decoration-thickness: 1px;


### PR DESCRIPTION
## Summary
- keep the canvas text editor at the same 440px layout width in full- and half-window workspaces
- place Apply, Cancel, Delete, and netlist-name actions on a deliberate second row
- keep compact specialized text editors on their existing layout
- cover full/split viewport geometry and editing regressions

## Validation
- `pnpm gate:preflight -- --base origin/main`
- `pnpm gate:affected -- --base origin/main`
- focused drafting and reference-label Chromium regressions

All 2,962 unit tests, 139 editor browser tests, and 12 symbol-body text browser tests passed locally.
