### PR TITLE
Compact Analog Blocks connection leads

### DIFF
--- a/apps/editor/src/features/component-insert/symbol-artwork.test.tsx
+++ b/apps/editor/src/features/component-insert/symbol-artwork.test.tsx
@@ -78,10 +78,10 @@ describe("SymbolArtwork pin-name previews", () => {
     );
 
     expect(symbol.pins.map((pin) => pin.name)).toEqual(["IN+", "IN-", "OUT"]);
-    expect(markup).toContain('x1="-40" y1="20" x2="-20" y2="20"');
-    expect(markup).toContain('x1="-40" y1="-20" x2="-20" y2="-20"');
-    expect(markup).toContain('x1="-14" y1="17" x2="-14" y2="23"');
-    expect(markup).toContain('x1="-17" y1="-20" x2="-11" y2="-20"');
+    expect(markup).toContain('x1="-30" y1="10" x2="-20" y2="10"');
+    expect(markup).toContain('x1="-30" y1="-10" x2="-20" y2="-10"');
+    expect(markup).toContain('x1="-10" y1="7" x2="-10" y2="13"');
+    expect(markup).toContain('x1="-13" y1="-10" x2="-7" y2="-10"');
     expect(markup).toContain('data-role="formula-subscript"');
   });
 

--- a/packages/symbols/assets/razavi-v1/catalog.json
+++ b/packages/symbols/assets/razavi-v1/catalog.json
@@ -116,7 +116,7 @@
       "automaticMappings": [],
       "manualOnlyReason": "Textbook comparator block; SPICE subcircuit pin and supply contracts require an explicit PDK mapping.",
       "assetPath": "comparator.symbol.json",
-      "assetHash": "078862e5572a2d43e6d5ad36b71a68fbc9cd6f62813c3642f0f233c9c7cbe731",
+      "assetHash": "183d61c3af6b3e9e52bcf42dca74f05db737fa73942abb8e1e066121064c501e",
       "visualAuthority": {
         "kind": "razavi-reference-v1",
         "referenceManifestPath": "fixtures/visual-reference/razavi-reference-v1/manifest.json",
@@ -137,7 +137,7 @@
       "automaticMappings": [],
       "manualOnlyReason": "Textbook comparator block; SPICE subcircuit pin and supply contracts require an explicit PDK mapping.",
       "assetPath": "comparator-inputs-swapped.symbol.json",
-      "assetHash": "01f193443072617925cd6dc52dc534f30a66b9fb7c51cc05742136f301db9d70",
+      "assetHash": "36f81058bf7084902ad8deef1bdb3f96a0af272ef08c26fd47eae9e1f7dc5f88",
       "visualAuthority": {
         "kind": "razavi-reference-v1",
         "referenceManifestPath": "fixtures/visual-reference/razavi-reference-v1/manifest.json",
@@ -164,7 +164,7 @@
       "automaticMappings": [],
       "manualOnlyReason": "Unmarked comparator block; SPICE subcircuit pin polarity and supply contracts require an explicit PDK mapping.",
       "assetPath": "comparator-unmarked.symbol.json",
-      "assetHash": "201c9f0739ac58b637e93364bf1f1235432dbed0b3eb864f279634d7e099f80c",
+      "assetHash": "e85c804fabdc0c61a911f4cd0bbedb693d93263f8f896fc405707a870cd15d9b",
       "visualAuthority": {
         "kind": "razavi-reference-v1",
         "referenceManifestPath": "fixtures/visual-reference/razavi-reference-v1/manifest.json",
@@ -356,7 +356,7 @@
       "automaticMappings": [],
       "manualOnlyReason": "Behavioral differential transconductance block; structural netlists need an explicit implementation mapping.",
       "assetPath": "differential-transconductance.symbol.json",
-      "assetHash": "62a15b844cb1a0c61fa3af4b60a404986ab5877d477118fe69fc43cb90905a37"
+      "assetHash": "a788faa770d370b7869fc1a8a4d3fa1a03c5209bd078030971c3cdf0b0ef1a74"
     },
     {
       "symbolId": "differential-transconductance-inputs-swapped",
@@ -370,7 +370,7 @@
       "automaticMappings": [],
       "manualOnlyReason": "Behavioral differential transconductance block; structural netlists need an explicit implementation mapping.",
       "assetPath": "differential-transconductance-inputs-swapped.symbol.json",
-      "assetHash": "5c9ef3b71215dc9006e7b38efebeeb434cfba2664477b58ea979b4bcfce4b15b",
+      "assetHash": "7aff3a7490b6de7fcf0b95e819c7f06771b719423e97c659e5247ffca27d8251",
       "generation": {
         "kind": "derived-input-swap",
         "sourceSymbolId": "differential-transconductance",
@@ -789,7 +789,7 @@
       "automaticMappings": [],
       "manualOnlyReason": "Three-terminal textbook op-amp; SPICE subcircuit pin and supply contracts require an explicit PDK mapping.",
       "assetPath": "opamp.symbol.json",
-      "assetHash": "4d605de29d5ccbc5b1207d1225cc55bb0baa4521f57208b270e4ed1cdf9b56eb",
+      "assetHash": "fb6b8605feb8c296edd6bf43500a02690ec4fb17c849745a67e0290ef95890d6",
       "visualAuthority": {
         "kind": "razavi-reference-v1",
         "referenceManifestPath": "fixtures/visual-reference/razavi-reference-v1/manifest.json",
@@ -817,7 +817,7 @@
       "automaticMappings": [],
       "manualOnlyReason": "Three-terminal textbook op-amp; SPICE subcircuit pin and supply contracts require an explicit PDK mapping.",
       "assetPath": "opamp-lettered.symbol.json",
-      "assetHash": "fb1ee16e2a32d575939ff2f05030c15d05c81898907dc4c677b5fe1e89c4fe70",
+      "assetHash": "53a12caba1d472fc036044031ef0faaad92554defe84c2f541539f2b164556ff",
       "visualAuthority": {
         "kind": "razavi-reference-v1",
         "referenceManifestPath": "fixtures/visual-reference/razavi-reference-v1/manifest.json",
@@ -844,7 +844,7 @@
       "automaticMappings": [],
       "manualOnlyReason": "Three-terminal textbook op-amp; SPICE subcircuit pin and supply contracts require an explicit PDK mapping.",
       "assetPath": "opamp-lettered-inputs-swapped.symbol.json",
-      "assetHash": "43226808e78e6eb1a2248b4894101eee2ac97154001041c3fbf38d1c3e1ec6bd",
+      "assetHash": "58c63d290daf3e5d72228dd371a7b36042c67d6f2693210fe2402175d4945411",
       "visualAuthority": {
         "kind": "razavi-reference-v1",
         "referenceManifestPath": "fixtures/visual-reference/razavi-reference-v1/manifest.json",
@@ -871,7 +871,7 @@
       "automaticMappings": [],
       "manualOnlyReason": "Three-terminal textbook op-amp; SPICE subcircuit pin and supply contracts require an explicit PDK mapping.",
       "assetPath": "opamp-inputs-swapped.symbol.json",
-      "assetHash": "84ab7f3458235a9281f269dfefb03d27352827af26c40214179bf364c5a55676",
+      "assetHash": "a81158cd150c72ba3b69a441dd50bc3790d779f18489116ef4d3d5d19919d165",
       "visualAuthority": {
         "kind": "razavi-reference-v1",
         "referenceManifestPath": "fixtures/visual-reference/razavi-reference-v1/manifest.json",
@@ -898,7 +898,7 @@
       "automaticMappings": [],
       "manualOnlyReason": "Fully differential textbook body; SPICE subcircuit pin and supply contracts require an explicit PDK mapping.",
       "assetPath": "opamp-differential.symbol.json",
-      "assetHash": "c9bd18c0b9e70fb69fc65d8a8367ceaab7b8213b0f65db8e06db7c72b2c0a87d",
+      "assetHash": "fa4917dfe1c6f3b183006a104428d38bb05a51872778b00235a37d0386ef84d3",
       "visualAuthority": {
         "kind": "razavi-reference-v1",
         "referenceManifestPath": "fixtures/visual-reference/razavi-reference-v1/manifest.json",
@@ -927,7 +927,7 @@
       "automaticMappings": [],
       "manualOnlyReason": "Fully differential textbook body; SPICE subcircuit pin and supply contracts require an explicit PDK mapping.",
       "assetPath": "opamp-differential-lettered.symbol.json",
-      "assetHash": "1a7be7e6110b196ef2c680e878ebc7ac79c69175aaa030a4441970756994d574",
+      "assetHash": "46495affececc8c90b6be3116f9333d7b1e74f99f1cfd9968e8cfdf9db5f717f",
       "visualAuthority": {
         "kind": "razavi-reference-v1",
         "referenceManifestPath": "fixtures/visual-reference/razavi-reference-v1/manifest.json",
@@ -955,7 +955,7 @@
       "automaticMappings": [],
       "manualOnlyReason": "Fully differential textbook body; SPICE subcircuit pin and supply contracts require an explicit PDK mapping.",
       "assetPath": "opamp-differential-lettered-inputs-swapped.symbol.json",
-      "assetHash": "489d9c15b1cd0cf1d39982c38f4314b9bcc0c3cdc3b0921be7d7315ceb14dd02",
+      "assetHash": "a65767af7c4ea9e755e0f8f71452fb53008f776267c96ca1c0fb1413dc777f5a",
       "visualAuthority": {
         "kind": "razavi-reference-v1",
         "referenceManifestPath": "fixtures/visual-reference/razavi-reference-v1/manifest.json",
@@ -983,7 +983,7 @@
       "automaticMappings": [],
       "manualOnlyReason": "Fully differential textbook body; SPICE subcircuit pin and supply contracts require an explicit PDK mapping.",
       "assetPath": "opamp-differential-inputs-swapped.symbol.json",
-      "assetHash": "8875987d3073511fd80e1a09c8bdd52dfb2ac461c98f6d95ab0daa21955b6b8d",
+      "assetHash": "6d362069c9874d18f371cfae6d2ba6c435321cfa90fe8c03fd8636afae9e4dbc",
       "visualAuthority": {
         "kind": "razavi-reference-v1",
         "referenceManifestPath": "fixtures/visual-reference/razavi-reference-v1/manifest.json",
@@ -1011,7 +1011,7 @@
       "automaticMappings": [],
       "manualOnlyReason": "Output-polarity sibling of opamp-differential; SPICE subcircuit pin and supply contracts require an explicit PDK mapping.",
       "assetPath": "opamp-differential-crossed.symbol.json",
-      "assetHash": "3792399ef9044eb6a6ce77126b1c911b07b6ff94d86603afc49fdf23454d81ab",
+      "assetHash": "2ac3fc5c11fb99903170eff3eb41b240fad47fa1d8e59b2f0ac00865d73f45de",
       "visualAuthority": {
         "kind": "razavi-reference-v1",
         "referenceManifestPath": "fixtures/visual-reference/razavi-reference-v1/manifest.json",
@@ -1040,7 +1040,7 @@
       "automaticMappings": [],
       "manualOnlyReason": "Output-polarity sibling of opamp-differential; SPICE subcircuit pin and supply contracts require an explicit PDK mapping.",
       "assetPath": "opamp-differential-crossed-lettered.symbol.json",
-      "assetHash": "7761a62e4622b70a2022f1410365054e777c94adad9e9026ad7e705e41a87166",
+      "assetHash": "9ec07bdefa2cd349a613b59dedab23cb31bf3edec1102ee44fcca1596edf3f32",
       "visualAuthority": {
         "kind": "razavi-reference-v1",
         "referenceManifestPath": "fixtures/visual-reference/razavi-reference-v1/manifest.json",
@@ -1068,7 +1068,7 @@
       "automaticMappings": [],
       "manualOnlyReason": "Output-polarity sibling of opamp-differential; SPICE subcircuit pin and supply contracts require an explicit PDK mapping.",
       "assetPath": "opamp-differential-crossed-lettered-inputs-swapped.symbol.json",
-      "assetHash": "d2f7069dc052fc7bc3a3b31c76dd3e9969823abb0d2224b681c7c54d2e4f22c6",
+      "assetHash": "541b9b86827927457028ec04dba83ae50af40eebaa2ffde5d135329c2f8d9aca",
       "visualAuthority": {
         "kind": "razavi-reference-v1",
         "referenceManifestPath": "fixtures/visual-reference/razavi-reference-v1/manifest.json",
@@ -1096,7 +1096,7 @@
       "automaticMappings": [],
       "manualOnlyReason": "Output-polarity sibling of opamp-differential; SPICE subcircuit pin and supply contracts require an explicit PDK mapping.",
       "assetPath": "opamp-differential-crossed-inputs-swapped.symbol.json",
-      "assetHash": "4cf4c0894d170c87e34d078c58cc0b27fd72ab641bf4debea3f517e46b235e73",
+      "assetHash": "771c4ca11370b343eb9bccba2d06623df26e90bf9ad0297d19cd6148f20f08e1",
       "visualAuthority": {
         "kind": "razavi-reference-v1",
         "referenceManifestPath": "fixtures/visual-reference/razavi-reference-v1/manifest.json",
@@ -1377,7 +1377,7 @@
       "automaticMappings": [],
       "manualOnlyReason": "Textbook gain block has implicit reference nodes and no exact primitive SPICE terminal contract.",
       "assetPath": "voltage-amplifier.symbol.json",
-      "assetHash": "538411b2fc3df120f910c47c92502b1b4bdefef52f1296170167180c61109816",
+      "assetHash": "54a484ad99c36ef67f6774551d96d212fb17855570e545b457ea3b102da6d385",
       "visualAuthority": {
         "kind": "razavi-reference-v1",
         "referenceManifestPath": "fixtures/visual-reference/razavi-reference-v1/manifest.json",
@@ -1405,7 +1405,7 @@
       "automaticMappings": [],
       "manualOnlyReason": "Textbook gain block has implicit reference nodes and no exact primitive SPICE terminal contract.",
       "assetPath": "voltage-amplifier-lettered.symbol.json",
-      "assetHash": "b243d887263879131fc7c6eefefc8d5f1ecadeb3f11b51541ec7aa133b0e0db9",
+      "assetHash": "5d07c56e7df42bf779cf172ba471477333ee042d70db4f9e86a4ebf5684fe173",
       "visualAuthority": {
         "kind": "razavi-reference-v1",
         "referenceManifestPath": "fixtures/visual-reference/razavi-reference-v1/manifest.json",

--- a/packages/symbols/assets/razavi-v1/comparator-inputs-swapped.symbol.json
+++ b/packages/symbols/assets/razavi-v1/comparator-inputs-swapped.symbol.json
@@ -3,9 +3,9 @@
   "id": "comparator-inputs-swapped",
   "name": "Comparator (swapped inputs)",
   "viewBox": {
-    "x": -54,
+    "x": -34,
     "y": -28,
-    "width": 98,
+    "width": 68,
     "height": 56
   },
   "pins": [
@@ -13,39 +13,39 @@
       "name": "IN+",
       "role": "non-inverting-input",
       "at": {
-        "x": -50,
+        "x": -30,
         "y": -10
       },
       "direction": "west",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "IN-",
       "role": "inverting-input",
       "at": {
-        "x": -50,
+        "x": -30,
         "y": 10
       },
       "direction": "west",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "OUT",
       "role": "output",
       "at": {
-        "x": 40,
+        "x": 30,
         "y": 0
       },
       "direction": "east",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     }
   ],
@@ -53,7 +53,7 @@
     {
       "kind": "line",
       "from": {
-        "x": -50,
+        "x": -30,
         "y": -10
       },
       "to": {
@@ -69,7 +69,7 @@
     {
       "kind": "line",
       "from": {
-        "x": -50,
+        "x": -30,
         "y": 10
       },
       "to": {
@@ -89,7 +89,7 @@
         "y": 0
       },
       "to": {
-        "x": 40,
+        "x": 30,
         "y": 0
       },
       "style": {

--- a/packages/symbols/assets/razavi-v1/comparator-unmarked.symbol.json
+++ b/packages/symbols/assets/razavi-v1/comparator-unmarked.symbol.json
@@ -3,9 +3,9 @@
   "id": "comparator-unmarked",
   "name": "Comparator (unmarked)",
   "viewBox": {
-    "x": -54,
+    "x": -34,
     "y": -28,
-    "width": 98,
+    "width": 68,
     "height": 56
   },
   "pins": [
@@ -13,39 +13,39 @@
       "name": "IN+",
       "role": "non-inverting-input",
       "at": {
-        "x": -50,
+        "x": -30,
         "y": 10
       },
       "direction": "west",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "IN-",
       "role": "inverting-input",
       "at": {
-        "x": -50,
+        "x": -30,
         "y": -10
       },
       "direction": "west",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "OUT",
       "role": "output",
       "at": {
-        "x": 40,
+        "x": 30,
         "y": 0
       },
       "direction": "east",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     }
   ],
@@ -53,7 +53,7 @@
     {
       "kind": "line",
       "from": {
-        "x": -50,
+        "x": -30,
         "y": -10
       },
       "to": {
@@ -69,7 +69,7 @@
     {
       "kind": "line",
       "from": {
-        "x": -50,
+        "x": -30,
         "y": 10
       },
       "to": {
@@ -89,7 +89,7 @@
         "y": 0
       },
       "to": {
-        "x": 40,
+        "x": 30,
         "y": 0
       },
       "style": {

--- a/packages/symbols/assets/razavi-v1/comparator.symbol.json
+++ b/packages/symbols/assets/razavi-v1/comparator.symbol.json
@@ -3,9 +3,9 @@
   "id": "comparator",
   "name": "Comparator",
   "viewBox": {
-    "x": -54,
+    "x": -34,
     "y": -28,
-    "width": 98,
+    "width": 68,
     "height": 56
   },
   "pins": [
@@ -13,39 +13,39 @@
       "name": "IN+",
       "role": "non-inverting-input",
       "at": {
-        "x": -50,
+        "x": -30,
         "y": 10
       },
       "direction": "west",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "IN-",
       "role": "inverting-input",
       "at": {
-        "x": -50,
+        "x": -30,
         "y": -10
       },
       "direction": "west",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "OUT",
       "role": "output",
       "at": {
-        "x": 40,
+        "x": 30,
         "y": 0
       },
       "direction": "east",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     }
   ],
@@ -53,7 +53,7 @@
     {
       "kind": "line",
       "from": {
-        "x": -50,
+        "x": -30,
         "y": -10
       },
       "to": {
@@ -69,7 +69,7 @@
     {
       "kind": "line",
       "from": {
-        "x": -50,
+        "x": -30,
         "y": 10
       },
       "to": {
@@ -89,7 +89,7 @@
         "y": 0
       },
       "to": {
-        "x": 40,
+        "x": 30,
         "y": 0
       },
       "style": {

--- a/packages/symbols/assets/razavi-v1/differential-transconductance-inputs-swapped.symbol.json
+++ b/packages/symbols/assets/razavi-v1/differential-transconductance-inputs-swapped.symbol.json
@@ -3,9 +3,9 @@
   "id": "differential-transconductance-inputs-swapped",
   "name": "Differential Transconductance (gₘ) (swapped inputs)",
   "viewBox": {
-    "x": -44,
+    "x": -34,
     "y": -39,
-    "width": 88,
+    "width": 68,
     "height": 78
   },
   "pins": [
@@ -13,39 +13,39 @@
       "name": "IN+",
       "role": "non-inverting-input",
       "at": {
-        "x": -40,
-        "y": -20
+        "x": -30,
+        "y": -10
       },
       "direction": "west",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "IN-",
       "role": "inverting-input",
       "at": {
-        "x": -40,
-        "y": 20
+        "x": -30,
+        "y": 10
       },
       "direction": "west",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "OUT",
       "role": "output",
       "at": {
-        "x": 40,
+        "x": 30,
         "y": 0
       },
       "direction": "east",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     }
   ],
@@ -54,12 +54,12 @@
       "kind": "line",
       "part": "input-positive-lead",
       "from": {
-        "x": -40,
-        "y": 20
+        "x": -30,
+        "y": 10
       },
       "to": {
         "x": -20,
-        "y": 20
+        "y": 10
       },
       "style": {
         "strokeRole": "normal",
@@ -71,12 +71,12 @@
       "kind": "line",
       "part": "input-negative-lead",
       "from": {
-        "x": -40,
-        "y": -20
+        "x": -30,
+        "y": -10
       },
       "to": {
         "x": -20,
-        "y": -20
+        "y": -10
       },
       "style": {
         "strokeRole": "normal",
@@ -99,12 +99,12 @@
       "kind": "line",
       "part": "input-polarity",
       "from": {
-        "x": -17,
-        "y": -20
+        "x": -13,
+        "y": -10
       },
       "to": {
-        "x": -11,
-        "y": -20
+        "x": -7,
+        "y": -10
       },
       "style": {
         "strokeRole": "normal",
@@ -116,12 +116,12 @@
       "kind": "line",
       "part": "input-polarity",
       "from": {
-        "x": -14,
-        "y": -17
+        "x": -10,
+        "y": -7
       },
       "to": {
-        "x": -14,
-        "y": -23
+        "x": -10,
+        "y": -13
       },
       "style": {
         "strokeRole": "normal",
@@ -133,12 +133,12 @@
       "kind": "line",
       "part": "upright-input-polarity-negative",
       "from": {
-        "x": -17,
-        "y": 20
+        "x": -13,
+        "y": 10
       },
       "to": {
-        "x": -11,
-        "y": 20
+        "x": -7,
+        "y": 10
       },
       "style": {
         "strokeRole": "normal",
@@ -154,7 +154,7 @@
         "y": 0
       },
       "to": {
-        "x": 40,
+        "x": 30,
         "y": 0
       },
       "style": {

--- a/packages/symbols/assets/razavi-v1/differential-transconductance.symbol.json
+++ b/packages/symbols/assets/razavi-v1/differential-transconductance.symbol.json
@@ -3,40 +3,40 @@
   "id": "differential-transconductance",
   "name": "Differential Transconductance (gₘ)",
   "viewBox": {
-    "x": -44,
+    "x": -34,
     "y": -39,
-    "width": 88,
+    "width": 68,
     "height": 78
   },
   "pins": [
     {
       "name": "IN+",
       "role": "non-inverting-input",
-      "at": { "x": -40, "y": 20 },
+      "at": { "x": -30, "y": 10 },
       "direction": "west",
-      "presentation": { "visibility": "visible", "leadLength": 20 }
+      "presentation": { "visibility": "visible", "leadLength": 10 }
     },
     {
       "name": "IN-",
       "role": "inverting-input",
-      "at": { "x": -40, "y": -20 },
+      "at": { "x": -30, "y": -10 },
       "direction": "west",
-      "presentation": { "visibility": "visible", "leadLength": 20 }
+      "presentation": { "visibility": "visible", "leadLength": 10 }
     },
     {
       "name": "OUT",
       "role": "output",
-      "at": { "x": 40, "y": 0 },
+      "at": { "x": 30, "y": 0 },
       "direction": "east",
-      "presentation": { "visibility": "visible", "leadLength": 20 }
+      "presentation": { "visibility": "visible", "leadLength": 10 }
     }
   ],
   "primitives": [
     {
       "kind": "line",
       "part": "input-positive-lead",
-      "from": { "x": -40, "y": 20 },
-      "to": { "x": -20, "y": 20 },
+      "from": { "x": -30, "y": 10 },
+      "to": { "x": -20, "y": 10 },
       "style": {
         "strokeRole": "normal",
         "lineCap": "butt",
@@ -46,8 +46,8 @@
     {
       "kind": "line",
       "part": "input-negative-lead",
-      "from": { "x": -40, "y": -20 },
-      "to": { "x": -20, "y": -20 },
+      "from": { "x": -30, "y": -10 },
+      "to": { "x": -20, "y": -10 },
       "style": {
         "strokeRole": "normal",
         "lineCap": "butt",
@@ -68,8 +68,8 @@
     {
       "kind": "line",
       "part": "input-polarity",
-      "from": { "x": -17, "y": 20 },
-      "to": { "x": -11, "y": 20 },
+      "from": { "x": -13, "y": 10 },
+      "to": { "x": -7, "y": 10 },
       "style": {
         "strokeRole": "normal",
         "lineCap": "round",
@@ -79,8 +79,8 @@
     {
       "kind": "line",
       "part": "input-polarity",
-      "from": { "x": -14, "y": 17 },
-      "to": { "x": -14, "y": 23 },
+      "from": { "x": -10, "y": 7 },
+      "to": { "x": -10, "y": 13 },
       "style": {
         "strokeRole": "normal",
         "lineCap": "round",
@@ -90,8 +90,8 @@
     {
       "kind": "line",
       "part": "upright-input-polarity-negative",
-      "from": { "x": -17, "y": -20 },
-      "to": { "x": -11, "y": -20 },
+      "from": { "x": -13, "y": -10 },
+      "to": { "x": -7, "y": -10 },
       "style": {
         "strokeRole": "normal",
         "lineCap": "round",
@@ -102,7 +102,7 @@
       "kind": "line",
       "part": "output-lead",
       "from": { "x": 20, "y": 0 },
-      "to": { "x": 40, "y": 0 },
+      "to": { "x": 30, "y": 0 },
       "style": {
         "strokeRole": "normal",
         "lineCap": "butt",

--- a/packages/symbols/assets/razavi-v1/opamp-differential-crossed-inputs-swapped.symbol.json
+++ b/packages/symbols/assets/razavi-v1/opamp-differential-crossed-inputs-swapped.symbol.json
@@ -3,62 +3,62 @@
   "id": "opamp-differential-crossed-inputs-swapped",
   "name": "Differential Op Amp (crossed outputs) (swapped inputs)",
   "viewBox": {
-    "x": -54,
-    "y": -28,
-    "width": 98,
-    "height": 56
+    "x": -44,
+    "y": -34,
+    "width": 82,
+    "height": 68
   },
   "pins": [
     {
       "name": "IN+",
       "role": "non-inverting-input",
       "at": {
-        "x": -50,
+        "x": -40,
         "y": -20
       },
       "direction": "west",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "IN-",
       "role": "inverting-input",
       "at": {
-        "x": -50,
+        "x": -40,
         "y": 20
       },
       "direction": "west",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "OUT+",
       "role": "output",
       "at": {
-        "x": 10,
+        "x": -10,
         "y": -20
       },
       "direction": "east",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "OUT-",
       "role": "output",
       "at": {
-        "x": 10,
+        "x": -10,
         "y": 20
       },
       "direction": "east",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     }
   ],
@@ -67,7 +67,7 @@
       "kind": "line",
       "part": "input-lead",
       "from": {
-        "x": -50,
+        "x": -40,
         "y": -20
       },
       "to": {
@@ -84,7 +84,7 @@
       "kind": "line",
       "part": "input-lead",
       "from": {
-        "x": -50,
+        "x": -40,
         "y": 20
       },
       "to": {
@@ -105,7 +105,7 @@
         "y": -20
       },
       "to": {
-        "x": 10,
+        "x": -10,
         "y": -20
       },
       "style": {
@@ -122,7 +122,7 @@
         "y": 20
       },
       "to": {
-        "x": 10,
+        "x": -10,
         "y": 20
       },
       "style": {

--- a/packages/symbols/assets/razavi-v1/opamp-differential-crossed-lettered-inputs-swapped.symbol.json
+++ b/packages/symbols/assets/razavi-v1/opamp-differential-crossed-lettered-inputs-swapped.symbol.json
@@ -3,62 +3,62 @@
   "id": "opamp-differential-crossed-lettered-inputs-swapped",
   "name": "Differential Op Amp (crossed outputs, lettered) (swapped inputs)",
   "viewBox": {
-    "x": -54,
-    "y": -28,
-    "width": 98,
-    "height": 56
+    "x": -44,
+    "y": -34,
+    "width": 82,
+    "height": 68
   },
   "pins": [
     {
       "name": "IN+",
       "role": "non-inverting-input",
       "at": {
-        "x": -50,
+        "x": -40,
         "y": -20
       },
       "direction": "west",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "IN-",
       "role": "inverting-input",
       "at": {
-        "x": -50,
+        "x": -40,
         "y": 20
       },
       "direction": "west",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "OUT+",
       "role": "output",
       "at": {
-        "x": 10,
+        "x": -10,
         "y": -20
       },
       "direction": "east",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "OUT-",
       "role": "output",
       "at": {
-        "x": 10,
+        "x": -10,
         "y": 20
       },
       "direction": "east",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     }
   ],
@@ -67,7 +67,7 @@
       "kind": "line",
       "part": "input-lead",
       "from": {
-        "x": -50,
+        "x": -40,
         "y": -20
       },
       "to": {
@@ -84,7 +84,7 @@
       "kind": "line",
       "part": "input-lead",
       "from": {
-        "x": -50,
+        "x": -40,
         "y": 20
       },
       "to": {
@@ -105,7 +105,7 @@
         "y": -20
       },
       "to": {
-        "x": 10,
+        "x": -10,
         "y": -20
       },
       "style": {
@@ -122,7 +122,7 @@
         "y": 20
       },
       "to": {
-        "x": 10,
+        "x": -10,
         "y": 20
       },
       "style": {

--- a/packages/symbols/assets/razavi-v1/opamp-differential-crossed-lettered.symbol.json
+++ b/packages/symbols/assets/razavi-v1/opamp-differential-crossed-lettered.symbol.json
@@ -3,62 +3,62 @@
   "id": "opamp-differential-crossed-lettered",
   "name": "Differential Op Amp (crossed outputs, lettered)",
   "viewBox": {
-    "x": -54,
-    "y": -28,
-    "width": 98,
-    "height": 56
+    "x": -44,
+    "y": -34,
+    "width": 82,
+    "height": 68
   },
   "pins": [
     {
       "name": "IN+",
       "role": "non-inverting-input",
       "at": {
-        "x": -50,
+        "x": -40,
         "y": 20
       },
       "direction": "west",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "IN-",
       "role": "inverting-input",
       "at": {
-        "x": -50,
+        "x": -40,
         "y": -20
       },
       "direction": "west",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "OUT+",
       "role": "output",
       "at": {
-        "x": 10,
+        "x": -10,
         "y": -20
       },
       "direction": "east",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "OUT-",
       "role": "output",
       "at": {
-        "x": 10,
+        "x": -10,
         "y": 20
       },
       "direction": "east",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     }
   ],
@@ -67,7 +67,7 @@
       "kind": "line",
       "part": "input-lead",
       "from": {
-        "x": -50,
+        "x": -40,
         "y": -20
       },
       "to": {
@@ -84,7 +84,7 @@
       "kind": "line",
       "part": "input-lead",
       "from": {
-        "x": -50,
+        "x": -40,
         "y": 20
       },
       "to": {
@@ -105,7 +105,7 @@
         "y": -20
       },
       "to": {
-        "x": 10,
+        "x": -10,
         "y": -20
       },
       "style": {
@@ -122,7 +122,7 @@
         "y": 20
       },
       "to": {
-        "x": 10,
+        "x": -10,
         "y": 20
       },
       "style": {

--- a/packages/symbols/assets/razavi-v1/opamp-differential-crossed.symbol.json
+++ b/packages/symbols/assets/razavi-v1/opamp-differential-crossed.symbol.json
@@ -3,62 +3,62 @@
   "id": "opamp-differential-crossed",
   "name": "Differential Op Amp (crossed outputs)",
   "viewBox": {
-    "x": -54,
-    "y": -28,
-    "width": 98,
-    "height": 56
+    "x": -44,
+    "y": -34,
+    "width": 82,
+    "height": 68
   },
   "pins": [
     {
       "name": "IN+",
       "role": "non-inverting-input",
       "at": {
-        "x": -50,
+        "x": -40,
         "y": 20
       },
       "direction": "west",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "IN-",
       "role": "inverting-input",
       "at": {
-        "x": -50,
+        "x": -40,
         "y": -20
       },
       "direction": "west",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "OUT+",
       "role": "output",
       "at": {
-        "x": 10,
+        "x": -10,
         "y": -20
       },
       "direction": "east",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "OUT-",
       "role": "output",
       "at": {
-        "x": 10,
+        "x": -10,
         "y": 20
       },
       "direction": "east",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     }
   ],
@@ -67,7 +67,7 @@
       "kind": "line",
       "part": "input-lead",
       "from": {
-        "x": -50,
+        "x": -40,
         "y": -20
       },
       "to": {
@@ -84,7 +84,7 @@
       "kind": "line",
       "part": "input-lead",
       "from": {
-        "x": -50,
+        "x": -40,
         "y": 20
       },
       "to": {
@@ -105,7 +105,7 @@
         "y": -20
       },
       "to": {
-        "x": 10,
+        "x": -10,
         "y": -20
       },
       "style": {
@@ -122,7 +122,7 @@
         "y": 20
       },
       "to": {
-        "x": 10,
+        "x": -10,
         "y": 20
       },
       "style": {

--- a/packages/symbols/assets/razavi-v1/opamp-differential-inputs-swapped.symbol.json
+++ b/packages/symbols/assets/razavi-v1/opamp-differential-inputs-swapped.symbol.json
@@ -3,62 +3,62 @@
   "id": "opamp-differential-inputs-swapped",
   "name": "Differential Op Amp (swapped inputs)",
   "viewBox": {
-    "x": -54,
-    "y": -28,
-    "width": 98,
-    "height": 56
+    "x": -44,
+    "y": -34,
+    "width": 82,
+    "height": 68
   },
   "pins": [
     {
       "name": "IN+",
       "role": "non-inverting-input",
       "at": {
-        "x": -50,
+        "x": -40,
         "y": -20
       },
       "direction": "west",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "IN-",
       "role": "inverting-input",
       "at": {
-        "x": -50,
+        "x": -40,
         "y": 20
       },
       "direction": "west",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "OUT+",
       "role": "output",
       "at": {
-        "x": 10,
+        "x": -10,
         "y": 20
       },
       "direction": "east",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "OUT-",
       "role": "output",
       "at": {
-        "x": 10,
+        "x": -10,
         "y": -20
       },
       "direction": "east",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     }
   ],
@@ -67,7 +67,7 @@
       "kind": "line",
       "part": "input-lead",
       "from": {
-        "x": -50,
+        "x": -40,
         "y": -20
       },
       "to": {
@@ -84,7 +84,7 @@
       "kind": "line",
       "part": "input-lead",
       "from": {
-        "x": -50,
+        "x": -40,
         "y": 20
       },
       "to": {
@@ -105,7 +105,7 @@
         "y": -20
       },
       "to": {
-        "x": 10,
+        "x": -10,
         "y": -20
       },
       "style": {
@@ -122,7 +122,7 @@
         "y": 20
       },
       "to": {
-        "x": 10,
+        "x": -10,
         "y": 20
       },
       "style": {

--- a/packages/symbols/assets/razavi-v1/opamp-differential-lettered-inputs-swapped.symbol.json
+++ b/packages/symbols/assets/razavi-v1/opamp-differential-lettered-inputs-swapped.symbol.json
@@ -3,62 +3,62 @@
   "id": "opamp-differential-lettered-inputs-swapped",
   "name": "Differential Op Amp (lettered) (swapped inputs)",
   "viewBox": {
-    "x": -54,
-    "y": -28,
-    "width": 98,
-    "height": 56
+    "x": -44,
+    "y": -34,
+    "width": 82,
+    "height": 68
   },
   "pins": [
     {
       "name": "IN+",
       "role": "non-inverting-input",
       "at": {
-        "x": -50,
+        "x": -40,
         "y": -20
       },
       "direction": "west",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "IN-",
       "role": "inverting-input",
       "at": {
-        "x": -50,
+        "x": -40,
         "y": 20
       },
       "direction": "west",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "OUT+",
       "role": "output",
       "at": {
-        "x": 10,
+        "x": -10,
         "y": 20
       },
       "direction": "east",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "OUT-",
       "role": "output",
       "at": {
-        "x": 10,
+        "x": -10,
         "y": -20
       },
       "direction": "east",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     }
   ],
@@ -67,7 +67,7 @@
       "kind": "line",
       "part": "input-lead",
       "from": {
-        "x": -50,
+        "x": -40,
         "y": -20
       },
       "to": {
@@ -84,7 +84,7 @@
       "kind": "line",
       "part": "input-lead",
       "from": {
-        "x": -50,
+        "x": -40,
         "y": 20
       },
       "to": {
@@ -105,7 +105,7 @@
         "y": -20
       },
       "to": {
-        "x": 10,
+        "x": -10,
         "y": -20
       },
       "style": {
@@ -122,7 +122,7 @@
         "y": 20
       },
       "to": {
-        "x": 10,
+        "x": -10,
         "y": 20
       },
       "style": {

--- a/packages/symbols/assets/razavi-v1/opamp-differential-lettered.symbol.json
+++ b/packages/symbols/assets/razavi-v1/opamp-differential-lettered.symbol.json
@@ -3,62 +3,62 @@
   "id": "opamp-differential-lettered",
   "name": "Differential Op Amp (lettered)",
   "viewBox": {
-    "x": -54,
-    "y": -28,
-    "width": 98,
-    "height": 56
+    "x": -44,
+    "y": -34,
+    "width": 82,
+    "height": 68
   },
   "pins": [
     {
       "name": "IN+",
       "role": "non-inverting-input",
       "at": {
-        "x": -50,
+        "x": -40,
         "y": 20
       },
       "direction": "west",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "IN-",
       "role": "inverting-input",
       "at": {
-        "x": -50,
+        "x": -40,
         "y": -20
       },
       "direction": "west",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "OUT+",
       "role": "output",
       "at": {
-        "x": 10,
+        "x": -10,
         "y": 20
       },
       "direction": "east",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "OUT-",
       "role": "output",
       "at": {
-        "x": 10,
+        "x": -10,
         "y": -20
       },
       "direction": "east",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     }
   ],
@@ -67,7 +67,7 @@
       "kind": "line",
       "part": "input-lead",
       "from": {
-        "x": -50,
+        "x": -40,
         "y": -20
       },
       "to": {
@@ -84,7 +84,7 @@
       "kind": "line",
       "part": "input-lead",
       "from": {
-        "x": -50,
+        "x": -40,
         "y": 20
       },
       "to": {
@@ -105,7 +105,7 @@
         "y": -20
       },
       "to": {
-        "x": 10,
+        "x": -10,
         "y": -20
       },
       "style": {
@@ -122,7 +122,7 @@
         "y": 20
       },
       "to": {
-        "x": 10,
+        "x": -10,
         "y": 20
       },
       "style": {

--- a/packages/symbols/assets/razavi-v1/opamp-differential.symbol.json
+++ b/packages/symbols/assets/razavi-v1/opamp-differential.symbol.json
@@ -3,62 +3,62 @@
   "id": "opamp-differential",
   "name": "Differential Op Amp",
   "viewBox": {
-    "x": -54,
-    "y": -28,
-    "width": 98,
-    "height": 56
+    "x": -44,
+    "y": -34,
+    "width": 82,
+    "height": 68
   },
   "pins": [
     {
       "name": "IN+",
       "role": "non-inverting-input",
       "at": {
-        "x": -50,
+        "x": -40,
         "y": 20
       },
       "direction": "west",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "IN-",
       "role": "inverting-input",
       "at": {
-        "x": -50,
+        "x": -40,
         "y": -20
       },
       "direction": "west",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "OUT+",
       "role": "output",
       "at": {
-        "x": 10,
+        "x": -10,
         "y": 20
       },
       "direction": "east",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "OUT-",
       "role": "output",
       "at": {
-        "x": 10,
+        "x": -10,
         "y": -20
       },
       "direction": "east",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     }
   ],
@@ -67,7 +67,7 @@
       "kind": "line",
       "part": "input-lead",
       "from": {
-        "x": -50,
+        "x": -40,
         "y": -20
       },
       "to": {
@@ -84,7 +84,7 @@
       "kind": "line",
       "part": "input-lead",
       "from": {
-        "x": -50,
+        "x": -40,
         "y": 20
       },
       "to": {
@@ -105,7 +105,7 @@
         "y": -20
       },
       "to": {
-        "x": 10,
+        "x": -10,
         "y": -20
       },
       "style": {
@@ -122,7 +122,7 @@
         "y": 20
       },
       "to": {
-        "x": 10,
+        "x": -10,
         "y": 20
       },
       "style": {

--- a/packages/symbols/assets/razavi-v1/opamp-inputs-swapped.symbol.json
+++ b/packages/symbols/assets/razavi-v1/opamp-inputs-swapped.symbol.json
@@ -3,9 +3,9 @@
   "id": "opamp-inputs-swapped",
   "name": "Operational Amplifier (swapped inputs)",
   "viewBox": {
-    "x": -54,
+    "x": -34,
     "y": -28,
-    "width": 98,
+    "width": 68,
     "height": 56
   },
   "pins": [
@@ -13,39 +13,39 @@
       "name": "IN+",
       "role": "non-inverting-input",
       "at": {
-        "x": -50,
+        "x": -30,
         "y": -10
       },
       "direction": "west",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "IN-",
       "role": "inverting-input",
       "at": {
-        "x": -50,
+        "x": -30,
         "y": 10
       },
       "direction": "west",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "OUT",
       "role": "output",
       "at": {
-        "x": 40,
+        "x": 30,
         "y": 0
       },
       "direction": "east",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     }
   ],
@@ -53,7 +53,7 @@
     {
       "kind": "line",
       "from": {
-        "x": -50,
+        "x": -30,
         "y": -10
       },
       "to": {
@@ -69,7 +69,7 @@
     {
       "kind": "line",
       "from": {
-        "x": -50,
+        "x": -30,
         "y": 10
       },
       "to": {
@@ -89,7 +89,7 @@
         "y": 0
       },
       "to": {
-        "x": 40,
+        "x": 30,
         "y": 0
       },
       "style": {

--- a/packages/symbols/assets/razavi-v1/opamp-lettered-inputs-swapped.symbol.json
+++ b/packages/symbols/assets/razavi-v1/opamp-lettered-inputs-swapped.symbol.json
@@ -3,9 +3,9 @@
   "id": "opamp-lettered-inputs-swapped",
   "name": "Operational Amplifier (lettered) (swapped inputs)",
   "viewBox": {
-    "x": -54,
+    "x": -34,
     "y": -28,
-    "width": 98,
+    "width": 68,
     "height": 56
   },
   "pins": [
@@ -13,39 +13,39 @@
       "name": "IN+",
       "role": "non-inverting-input",
       "at": {
-        "x": -50,
+        "x": -30,
         "y": -10
       },
       "direction": "west",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "IN-",
       "role": "inverting-input",
       "at": {
-        "x": -50,
+        "x": -30,
         "y": 10
       },
       "direction": "west",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "OUT",
       "role": "output",
       "at": {
-        "x": 40,
+        "x": 30,
         "y": 0
       },
       "direction": "east",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     }
   ],
@@ -53,7 +53,7 @@
     {
       "kind": "line",
       "from": {
-        "x": -50,
+        "x": -30,
         "y": -10
       },
       "to": {
@@ -69,7 +69,7 @@
     {
       "kind": "line",
       "from": {
-        "x": -50,
+        "x": -30,
         "y": 10
       },
       "to": {
@@ -89,7 +89,7 @@
         "y": 0
       },
       "to": {
-        "x": 40,
+        "x": 30,
         "y": 0
       },
       "style": {

--- a/packages/symbols/assets/razavi-v1/opamp-lettered.symbol.json
+++ b/packages/symbols/assets/razavi-v1/opamp-lettered.symbol.json
@@ -3,9 +3,9 @@
   "id": "opamp-lettered",
   "name": "Operational Amplifier (lettered)",
   "viewBox": {
-    "x": -54,
+    "x": -34,
     "y": -28,
-    "width": 98,
+    "width": 68,
     "height": 56
   },
   "pins": [
@@ -13,39 +13,39 @@
       "name": "IN+",
       "role": "non-inverting-input",
       "at": {
-        "x": -50,
+        "x": -30,
         "y": 10
       },
       "direction": "west",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "IN-",
       "role": "inverting-input",
       "at": {
-        "x": -50,
+        "x": -30,
         "y": -10
       },
       "direction": "west",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "OUT",
       "role": "output",
       "at": {
-        "x": 40,
+        "x": 30,
         "y": 0
       },
       "direction": "east",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     }
   ],
@@ -53,7 +53,7 @@
     {
       "kind": "line",
       "from": {
-        "x": -50,
+        "x": -30,
         "y": -10
       },
       "to": {
@@ -69,7 +69,7 @@
     {
       "kind": "line",
       "from": {
-        "x": -50,
+        "x": -30,
         "y": 10
       },
       "to": {
@@ -89,7 +89,7 @@
         "y": 0
       },
       "to": {
-        "x": 40,
+        "x": 30,
         "y": 0
       },
       "style": {

--- a/packages/symbols/assets/razavi-v1/opamp.symbol.json
+++ b/packages/symbols/assets/razavi-v1/opamp.symbol.json
@@ -3,9 +3,9 @@
   "id": "opamp",
   "name": "Operational Amplifier",
   "viewBox": {
-    "x": -54,
+    "x": -34,
     "y": -28,
-    "width": 98,
+    "width": 68,
     "height": 56
   },
   "pins": [
@@ -13,39 +13,39 @@
       "name": "IN+",
       "role": "non-inverting-input",
       "at": {
-        "x": -50,
+        "x": -30,
         "y": 10
       },
       "direction": "west",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "IN-",
       "role": "inverting-input",
       "at": {
-        "x": -50,
+        "x": -30,
         "y": -10
       },
       "direction": "west",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "OUT",
       "role": "output",
       "at": {
-        "x": 40,
+        "x": 30,
         "y": 0
       },
       "direction": "east",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     }
   ],
@@ -53,7 +53,7 @@
     {
       "kind": "line",
       "from": {
-        "x": -50,
+        "x": -30,
         "y": -10
       },
       "to": {
@@ -69,7 +69,7 @@
     {
       "kind": "line",
       "from": {
-        "x": -50,
+        "x": -30,
         "y": 10
       },
       "to": {
@@ -89,7 +89,7 @@
         "y": 0
       },
       "to": {
-        "x": 40,
+        "x": 30,
         "y": 0
       },
       "style": {

--- a/packages/symbols/assets/razavi-v1/voltage-amplifier-lettered.symbol.json
+++ b/packages/symbols/assets/razavi-v1/voltage-amplifier-lettered.symbol.json
@@ -3,36 +3,36 @@
   "id": "voltage-amplifier-lettered",
   "name": "Voltage Amplifier (lettered)",
   "viewBox": {
-    "x": -44,
-    "y": -28,
-    "width": 88,
-    "height": 56
+    "x": -34,
+    "y": -32,
+    "width": 68,
+    "height": 64
   },
   "pins": [
     {
       "name": "IN",
       "role": "input",
       "at": {
-        "x": -40,
+        "x": -30,
         "y": 0
       },
       "direction": "west",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "OUT",
       "role": "output",
       "at": {
-        "x": 40,
+        "x": 30,
         "y": 0
       },
       "direction": "east",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     }
   ],
@@ -40,7 +40,7 @@
     {
       "kind": "line",
       "from": {
-        "x": -40,
+        "x": -30,
         "y": 0
       },
       "to": {
@@ -69,7 +69,7 @@
         "y": 0
       },
       "to": {
-        "x": 40,
+        "x": 30,
         "y": 0
       },
       "style": {

--- a/packages/symbols/assets/razavi-v1/voltage-amplifier.symbol.json
+++ b/packages/symbols/assets/razavi-v1/voltage-amplifier.symbol.json
@@ -3,36 +3,36 @@
   "id": "voltage-amplifier",
   "name": "Voltage Amplifier",
   "viewBox": {
-    "x": -44,
-    "y": -28,
-    "width": 88,
-    "height": 56
+    "x": -34,
+    "y": -32,
+    "width": 68,
+    "height": 64
   },
   "pins": [
     {
       "name": "IN",
       "role": "input",
       "at": {
-        "x": -40,
+        "x": -30,
         "y": 0
       },
       "direction": "west",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     },
     {
       "name": "OUT",
       "role": "output",
       "at": {
-        "x": 40,
+        "x": 30,
         "y": 0
       },
       "direction": "east",
       "presentation": {
         "visibility": "visible",
-        "leadLength": 20
+        "leadLength": 10
       }
     }
   ],
@@ -40,7 +40,7 @@
     {
       "kind": "line",
       "from": {
-        "x": -40,
+        "x": -30,
         "y": 0
       },
       "to": {
@@ -69,7 +69,7 @@
         "y": 0
       },
       "to": {
-        "x": 40,
+        "x": 30,
         "y": 0
       },
       "style": {

--- a/packages/symbols/src/razavi-catalog.generated.ts
+++ b/packages/symbols/src/razavi-catalog.generated.ts
@@ -148,7 +148,7 @@ export const razaviSymbolCatalogEntries: readonly RazaviSymbolCatalogEntry[] = [
       "Textbook comparator block; SPICE subcircuit pin and supply contracts require an explicit PDK mapping.",
     assetPath: "comparator.symbol.json",
     assetHash:
-      "078862e5572a2d43e6d5ad36b71a68fbc9cd6f62813c3642f0f233c9c7cbe731",
+      "183d61c3af6b3e9e52bcf42dca74f05db737fa73942abb8e1e066121064c501e",
     visualAuthority: {
       kind: "razavi-reference-v1",
       referenceManifestPath:
@@ -173,7 +173,7 @@ export const razaviSymbolCatalogEntries: readonly RazaviSymbolCatalogEntry[] = [
       "Textbook comparator block; SPICE subcircuit pin and supply contracts require an explicit PDK mapping.",
     assetPath: "comparator-inputs-swapped.symbol.json",
     assetHash:
-      "01f193443072617925cd6dc52dc534f30a66b9fb7c51cc05742136f301db9d70",
+      "36f81058bf7084902ad8deef1bdb3f96a0af272ef08c26fd47eae9e1f7dc5f88",
     visualAuthority: {
       kind: "razavi-reference-v1",
       referenceManifestPath:
@@ -204,7 +204,7 @@ export const razaviSymbolCatalogEntries: readonly RazaviSymbolCatalogEntry[] = [
       "Unmarked comparator block; SPICE subcircuit pin polarity and supply contracts require an explicit PDK mapping.",
     assetPath: "comparator-unmarked.symbol.json",
     assetHash:
-      "201c9f0739ac58b637e93364bf1f1235432dbed0b3eb864f279634d7e099f80c",
+      "e85c804fabdc0c61a911f4cd0bbedb693d93263f8f896fc405707a870cd15d9b",
     visualAuthority: {
       kind: "razavi-reference-v1",
       referenceManifestPath:
@@ -434,7 +434,7 @@ export const razaviSymbolCatalogEntries: readonly RazaviSymbolCatalogEntry[] = [
       "Behavioral differential transconductance block; structural netlists need an explicit implementation mapping.",
     assetPath: "differential-transconductance.symbol.json",
     assetHash:
-      "62a15b844cb1a0c61fa3af4b60a404986ab5877d477118fe69fc43cb90905a37",
+      "a788faa770d370b7869fc1a8a4d3fa1a03c5209bd078030971c3cdf0b0ef1a74",
   },
   {
     symbolId: "differential-transconductance-inputs-swapped",
@@ -451,7 +451,7 @@ export const razaviSymbolCatalogEntries: readonly RazaviSymbolCatalogEntry[] = [
       "Behavioral differential transconductance block; structural netlists need an explicit implementation mapping.",
     assetPath: "differential-transconductance-inputs-swapped.symbol.json",
     assetHash:
-      "5c9ef3b71215dc9006e7b38efebeeb434cfba2664477b58ea979b4bcfce4b15b",
+      "7aff3a7490b6de7fcf0b95e819c7f06771b719423e97c659e5247ffca27d8251",
     generation: {
       kind: "derived-input-swap",
       sourceSymbolId: "differential-transconductance",
@@ -951,7 +951,7 @@ export const razaviSymbolCatalogEntries: readonly RazaviSymbolCatalogEntry[] = [
       "Three-terminal textbook op-amp; SPICE subcircuit pin and supply contracts require an explicit PDK mapping.",
     assetPath: "opamp.symbol.json",
     assetHash:
-      "4d605de29d5ccbc5b1207d1225cc55bb0baa4521f57208b270e4ed1cdf9b56eb",
+      "fb6b8605feb8c296edd6bf43500a02690ec4fb17c849745a67e0290ef95890d6",
     visualAuthority: {
       kind: "razavi-reference-v1",
       referenceManifestPath:
@@ -985,7 +985,7 @@ export const razaviSymbolCatalogEntries: readonly RazaviSymbolCatalogEntry[] = [
       "Three-terminal textbook op-amp; SPICE subcircuit pin and supply contracts require an explicit PDK mapping.",
     assetPath: "opamp-lettered.symbol.json",
     assetHash:
-      "fb1ee16e2a32d575939ff2f05030c15d05c81898907dc4c677b5fe1e89c4fe70",
+      "53a12caba1d472fc036044031ef0faaad92554defe84c2f541539f2b164556ff",
     visualAuthority: {
       kind: "razavi-reference-v1",
       referenceManifestPath:
@@ -1016,7 +1016,7 @@ export const razaviSymbolCatalogEntries: readonly RazaviSymbolCatalogEntry[] = [
       "Three-terminal textbook op-amp; SPICE subcircuit pin and supply contracts require an explicit PDK mapping.",
     assetPath: "opamp-lettered-inputs-swapped.symbol.json",
     assetHash:
-      "43226808e78e6eb1a2248b4894101eee2ac97154001041c3fbf38d1c3e1ec6bd",
+      "58c63d290daf3e5d72228dd371a7b36042c67d6f2693210fe2402175d4945411",
     visualAuthority: {
       kind: "razavi-reference-v1",
       referenceManifestPath:
@@ -1047,7 +1047,7 @@ export const razaviSymbolCatalogEntries: readonly RazaviSymbolCatalogEntry[] = [
       "Three-terminal textbook op-amp; SPICE subcircuit pin and supply contracts require an explicit PDK mapping.",
     assetPath: "opamp-inputs-swapped.symbol.json",
     assetHash:
-      "84ab7f3458235a9281f269dfefb03d27352827af26c40214179bf364c5a55676",
+      "a81158cd150c72ba3b69a441dd50bc3790d779f18489116ef4d3d5d19919d165",
     visualAuthority: {
       kind: "razavi-reference-v1",
       referenceManifestPath:
@@ -1078,7 +1078,7 @@ export const razaviSymbolCatalogEntries: readonly RazaviSymbolCatalogEntry[] = [
       "Fully differential textbook body; SPICE subcircuit pin and supply contracts require an explicit PDK mapping.",
     assetPath: "opamp-differential.symbol.json",
     assetHash:
-      "c9bd18c0b9e70fb69fc65d8a8367ceaab7b8213b0f65db8e06db7c72b2c0a87d",
+      "fa4917dfe1c6f3b183006a104428d38bb05a51872778b00235a37d0386ef84d3",
     visualAuthority: {
       kind: "razavi-reference-v1",
       referenceManifestPath:
@@ -1113,7 +1113,7 @@ export const razaviSymbolCatalogEntries: readonly RazaviSymbolCatalogEntry[] = [
       "Fully differential textbook body; SPICE subcircuit pin and supply contracts require an explicit PDK mapping.",
     assetPath: "opamp-differential-lettered.symbol.json",
     assetHash:
-      "1a7be7e6110b196ef2c680e878ebc7ac79c69175aaa030a4441970756994d574",
+      "46495affececc8c90b6be3116f9333d7b1e74f99f1cfd9968e8cfdf9db5f717f",
     visualAuthority: {
       kind: "razavi-reference-v1",
       referenceManifestPath:
@@ -1145,7 +1145,7 @@ export const razaviSymbolCatalogEntries: readonly RazaviSymbolCatalogEntry[] = [
       "Fully differential textbook body; SPICE subcircuit pin and supply contracts require an explicit PDK mapping.",
     assetPath: "opamp-differential-lettered-inputs-swapped.symbol.json",
     assetHash:
-      "489d9c15b1cd0cf1d39982c38f4314b9bcc0c3cdc3b0921be7d7315ceb14dd02",
+      "a65767af7c4ea9e755e0f8f71452fb53008f776267c96ca1c0fb1413dc777f5a",
     visualAuthority: {
       kind: "razavi-reference-v1",
       referenceManifestPath:
@@ -1177,7 +1177,7 @@ export const razaviSymbolCatalogEntries: readonly RazaviSymbolCatalogEntry[] = [
       "Fully differential textbook body; SPICE subcircuit pin and supply contracts require an explicit PDK mapping.",
     assetPath: "opamp-differential-inputs-swapped.symbol.json",
     assetHash:
-      "8875987d3073511fd80e1a09c8bdd52dfb2ac461c98f6d95ab0daa21955b6b8d",
+      "6d362069c9874d18f371cfae6d2ba6c435321cfa90fe8c03fd8636afae9e4dbc",
     visualAuthority: {
       kind: "razavi-reference-v1",
       referenceManifestPath:
@@ -1209,7 +1209,7 @@ export const razaviSymbolCatalogEntries: readonly RazaviSymbolCatalogEntry[] = [
       "Output-polarity sibling of opamp-differential; SPICE subcircuit pin and supply contracts require an explicit PDK mapping.",
     assetPath: "opamp-differential-crossed.symbol.json",
     assetHash:
-      "3792399ef9044eb6a6ce77126b1c911b07b6ff94d86603afc49fdf23454d81ab",
+      "2ac3fc5c11fb99903170eff3eb41b240fad47fa1d8e59b2f0ac00865d73f45de",
     visualAuthority: {
       kind: "razavi-reference-v1",
       referenceManifestPath:
@@ -1244,7 +1244,7 @@ export const razaviSymbolCatalogEntries: readonly RazaviSymbolCatalogEntry[] = [
       "Output-polarity sibling of opamp-differential; SPICE subcircuit pin and supply contracts require an explicit PDK mapping.",
     assetPath: "opamp-differential-crossed-lettered.symbol.json",
     assetHash:
-      "7761a62e4622b70a2022f1410365054e777c94adad9e9026ad7e705e41a87166",
+      "9ec07bdefa2cd349a613b59dedab23cb31bf3edec1102ee44fcca1596edf3f32",
     visualAuthority: {
       kind: "razavi-reference-v1",
       referenceManifestPath:
@@ -1276,7 +1276,7 @@ export const razaviSymbolCatalogEntries: readonly RazaviSymbolCatalogEntry[] = [
       "Output-polarity sibling of opamp-differential; SPICE subcircuit pin and supply contracts require an explicit PDK mapping.",
     assetPath: "opamp-differential-crossed-lettered-inputs-swapped.symbol.json",
     assetHash:
-      "d2f7069dc052fc7bc3a3b31c76dd3e9969823abb0d2224b681c7c54d2e4f22c6",
+      "541b9b86827927457028ec04dba83ae50af40eebaa2ffde5d135329c2f8d9aca",
     visualAuthority: {
       kind: "razavi-reference-v1",
       referenceManifestPath:
@@ -1308,7 +1308,7 @@ export const razaviSymbolCatalogEntries: readonly RazaviSymbolCatalogEntry[] = [
       "Output-polarity sibling of opamp-differential; SPICE subcircuit pin and supply contracts require an explicit PDK mapping.",
     assetPath: "opamp-differential-crossed-inputs-swapped.symbol.json",
     assetHash:
-      "4cf4c0894d170c87e34d078c58cc0b27fd72ab641bf4debea3f517e46b235e73",
+      "771c4ca11370b343eb9bccba2d06623df26e90bf9ad0297d19cd6148f20f08e1",
     visualAuthority: {
       kind: "razavi-reference-v1",
       referenceManifestPath:
@@ -1641,7 +1641,7 @@ export const razaviSymbolCatalogEntries: readonly RazaviSymbolCatalogEntry[] = [
       "Textbook gain block has implicit reference nodes and no exact primitive SPICE terminal contract.",
     assetPath: "voltage-amplifier.symbol.json",
     assetHash:
-      "538411b2fc3df120f910c47c92502b1b4bdefef52f1296170167180c61109816",
+      "54a484ad99c36ef67f6774551d96d212fb17855570e545b457ea3b102da6d385",
     visualAuthority: {
       kind: "razavi-reference-v1",
       referenceManifestPath:
@@ -1675,7 +1675,7 @@ export const razaviSymbolCatalogEntries: readonly RazaviSymbolCatalogEntry[] = [
       "Textbook gain block has implicit reference nodes and no exact primitive SPICE terminal contract.",
     assetPath: "voltage-amplifier-lettered.symbol.json",
     assetHash:
-      "b243d887263879131fc7c6eefefc8d5f1ecadeb3f11b51541ec7aa133b0e0db9",
+      "5d07c56e7df42bf779cf172ba471477333ee042d70db4f9e86a4ebf5684fe173",
     visualAuthority: {
       kind: "razavi-reference-v1",
       referenceManifestPath:
@@ -2369,9 +2369,9 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
     id: "comparator",
     name: "Comparator",
     viewBox: {
-      x: -54,
+      x: -34,
       y: -28,
-      width: 98,
+      width: 68,
       height: 56,
     },
     pins: [
@@ -2379,39 +2379,39 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         name: "IN+",
         role: "non-inverting-input",
         at: {
-          x: -50,
+          x: -30,
           y: 10,
         },
         direction: "west",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "IN-",
         role: "inverting-input",
         at: {
-          x: -50,
+          x: -30,
           y: -10,
         },
         direction: "west",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "OUT",
         role: "output",
         at: {
-          x: 40,
+          x: 30,
           y: 0,
         },
         direction: "east",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
     ],
@@ -2419,7 +2419,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
       {
         kind: "line",
         from: {
-          x: -50,
+          x: -30,
           y: -10,
         },
         to: {
@@ -2435,7 +2435,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
       {
         kind: "line",
         from: {
-          x: -50,
+          x: -30,
           y: 10,
         },
         to: {
@@ -2455,7 +2455,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
           y: 0,
         },
         to: {
-          x: 40,
+          x: 30,
           y: 0,
         },
         style: {
@@ -2541,9 +2541,9 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
     id: "comparator-inputs-swapped",
     name: "Comparator (swapped inputs)",
     viewBox: {
-      x: -54,
+      x: -34,
       y: -28,
-      width: 98,
+      width: 68,
       height: 56,
     },
     pins: [
@@ -2551,39 +2551,39 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         name: "IN+",
         role: "non-inverting-input",
         at: {
-          x: -50,
+          x: -30,
           y: -10,
         },
         direction: "west",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "IN-",
         role: "inverting-input",
         at: {
-          x: -50,
+          x: -30,
           y: 10,
         },
         direction: "west",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "OUT",
         role: "output",
         at: {
-          x: 40,
+          x: 30,
           y: 0,
         },
         direction: "east",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
     ],
@@ -2591,7 +2591,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
       {
         kind: "line",
         from: {
-          x: -50,
+          x: -30,
           y: -10,
         },
         to: {
@@ -2607,7 +2607,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
       {
         kind: "line",
         from: {
-          x: -50,
+          x: -30,
           y: 10,
         },
         to: {
@@ -2627,7 +2627,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
           y: 0,
         },
         to: {
-          x: 40,
+          x: 30,
           y: 0,
         },
         style: {
@@ -2713,9 +2713,9 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
     id: "comparator-unmarked",
     name: "Comparator (unmarked)",
     viewBox: {
-      x: -54,
+      x: -34,
       y: -28,
-      width: 98,
+      width: 68,
       height: 56,
     },
     pins: [
@@ -2723,39 +2723,39 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         name: "IN+",
         role: "non-inverting-input",
         at: {
-          x: -50,
+          x: -30,
           y: 10,
         },
         direction: "west",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "IN-",
         role: "inverting-input",
         at: {
-          x: -50,
+          x: -30,
           y: -10,
         },
         direction: "west",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "OUT",
         role: "output",
         at: {
-          x: 40,
+          x: 30,
           y: 0,
         },
         direction: "east",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
     ],
@@ -2763,7 +2763,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
       {
         kind: "line",
         from: {
-          x: -50,
+          x: -30,
           y: -10,
         },
         to: {
@@ -2779,7 +2779,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
       {
         kind: "line",
         from: {
-          x: -50,
+          x: -30,
           y: 10,
         },
         to: {
@@ -2799,7 +2799,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
           y: 0,
         },
         to: {
-          x: 40,
+          x: 30,
           y: 0,
         },
         style: {
@@ -3842,9 +3842,9 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
     id: "differential-transconductance",
     name: "Differential Transconductance (gₘ)",
     viewBox: {
-      x: -44,
+      x: -34,
       y: -39,
-      width: 88,
+      width: 68,
       height: 78,
     },
     pins: [
@@ -3852,39 +3852,39 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         name: "IN+",
         role: "non-inverting-input",
         at: {
-          x: -40,
-          y: 20,
+          x: -30,
+          y: 10,
         },
         direction: "west",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "IN-",
         role: "inverting-input",
         at: {
-          x: -40,
-          y: -20,
+          x: -30,
+          y: -10,
         },
         direction: "west",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "OUT",
         role: "output",
         at: {
-          x: 40,
+          x: 30,
           y: 0,
         },
         direction: "east",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
     ],
@@ -3893,12 +3893,12 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         kind: "line",
         part: "input-positive-lead",
         from: {
-          x: -40,
-          y: 20,
+          x: -30,
+          y: 10,
         },
         to: {
           x: -20,
-          y: 20,
+          y: 10,
         },
         style: {
           strokeRole: "normal",
@@ -3910,12 +3910,12 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         kind: "line",
         part: "input-negative-lead",
         from: {
-          x: -40,
-          y: -20,
+          x: -30,
+          y: -10,
         },
         to: {
           x: -20,
-          y: -20,
+          y: -10,
         },
         style: {
           strokeRole: "normal",
@@ -3938,12 +3938,12 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         kind: "line",
         part: "input-polarity",
         from: {
-          x: -17,
-          y: 20,
+          x: -13,
+          y: 10,
         },
         to: {
-          x: -11,
-          y: 20,
+          x: -7,
+          y: 10,
         },
         style: {
           strokeRole: "normal",
@@ -3955,12 +3955,12 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         kind: "line",
         part: "input-polarity",
         from: {
-          x: -14,
-          y: 17,
+          x: -10,
+          y: 7,
         },
         to: {
-          x: -14,
-          y: 23,
+          x: -10,
+          y: 13,
         },
         style: {
           strokeRole: "normal",
@@ -3972,12 +3972,12 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         kind: "line",
         part: "upright-input-polarity-negative",
         from: {
-          x: -17,
-          y: -20,
+          x: -13,
+          y: -10,
         },
         to: {
-          x: -11,
-          y: -20,
+          x: -7,
+          y: -10,
         },
         style: {
           strokeRole: "normal",
@@ -3993,7 +3993,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
           y: 0,
         },
         to: {
-          x: 40,
+          x: 30,
           y: 0,
         },
         style: {
@@ -4020,9 +4020,9 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
     id: "differential-transconductance-inputs-swapped",
     name: "Differential Transconductance (gₘ) (swapped inputs)",
     viewBox: {
-      x: -44,
+      x: -34,
       y: -39,
-      width: 88,
+      width: 68,
       height: 78,
     },
     pins: [
@@ -4030,39 +4030,39 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         name: "IN+",
         role: "non-inverting-input",
         at: {
-          x: -40,
-          y: -20,
+          x: -30,
+          y: -10,
         },
         direction: "west",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "IN-",
         role: "inverting-input",
         at: {
-          x: -40,
-          y: 20,
+          x: -30,
+          y: 10,
         },
         direction: "west",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "OUT",
         role: "output",
         at: {
-          x: 40,
+          x: 30,
           y: 0,
         },
         direction: "east",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
     ],
@@ -4071,12 +4071,12 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         kind: "line",
         part: "input-positive-lead",
         from: {
-          x: -40,
-          y: 20,
+          x: -30,
+          y: 10,
         },
         to: {
           x: -20,
-          y: 20,
+          y: 10,
         },
         style: {
           strokeRole: "normal",
@@ -4088,12 +4088,12 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         kind: "line",
         part: "input-negative-lead",
         from: {
-          x: -40,
-          y: -20,
+          x: -30,
+          y: -10,
         },
         to: {
           x: -20,
-          y: -20,
+          y: -10,
         },
         style: {
           strokeRole: "normal",
@@ -4116,12 +4116,12 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         kind: "line",
         part: "input-polarity",
         from: {
-          x: -17,
-          y: -20,
+          x: -13,
+          y: -10,
         },
         to: {
-          x: -11,
-          y: -20,
+          x: -7,
+          y: -10,
         },
         style: {
           strokeRole: "normal",
@@ -4133,12 +4133,12 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         kind: "line",
         part: "input-polarity",
         from: {
-          x: -14,
-          y: -17,
+          x: -10,
+          y: -7,
         },
         to: {
-          x: -14,
-          y: -23,
+          x: -10,
+          y: -13,
         },
         style: {
           strokeRole: "normal",
@@ -4150,12 +4150,12 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         kind: "line",
         part: "upright-input-polarity-negative",
         from: {
-          x: -17,
-          y: 20,
+          x: -13,
+          y: 10,
         },
         to: {
-          x: -11,
-          y: 20,
+          x: -7,
+          y: 10,
         },
         style: {
           strokeRole: "normal",
@@ -4171,7 +4171,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
           y: 0,
         },
         to: {
-          x: 40,
+          x: 30,
           y: 0,
         },
         style: {
@@ -6392,9 +6392,9 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
     id: "opamp",
     name: "Operational Amplifier",
     viewBox: {
-      x: -54,
+      x: -34,
       y: -28,
-      width: 98,
+      width: 68,
       height: 56,
     },
     pins: [
@@ -6402,39 +6402,39 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         name: "IN+",
         role: "non-inverting-input",
         at: {
-          x: -50,
+          x: -30,
           y: 10,
         },
         direction: "west",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "IN-",
         role: "inverting-input",
         at: {
-          x: -50,
+          x: -30,
           y: -10,
         },
         direction: "west",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "OUT",
         role: "output",
         at: {
-          x: 40,
+          x: 30,
           y: 0,
         },
         direction: "east",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
     ],
@@ -6442,7 +6442,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
       {
         kind: "line",
         from: {
-          x: -50,
+          x: -30,
           y: -10,
         },
         to: {
@@ -6458,7 +6458,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
       {
         kind: "line",
         from: {
-          x: -50,
+          x: -30,
           y: 10,
         },
         to: {
@@ -6478,7 +6478,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
           y: 0,
         },
         to: {
-          x: 40,
+          x: 30,
           y: 0,
         },
         style: {
@@ -6554,9 +6554,9 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
     id: "opamp-lettered",
     name: "Operational Amplifier (lettered)",
     viewBox: {
-      x: -54,
+      x: -34,
       y: -28,
-      width: 98,
+      width: 68,
       height: 56,
     },
     pins: [
@@ -6564,39 +6564,39 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         name: "IN+",
         role: "non-inverting-input",
         at: {
-          x: -50,
+          x: -30,
           y: 10,
         },
         direction: "west",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "IN-",
         role: "inverting-input",
         at: {
-          x: -50,
+          x: -30,
           y: -10,
         },
         direction: "west",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "OUT",
         role: "output",
         at: {
-          x: 40,
+          x: 30,
           y: 0,
         },
         direction: "east",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
     ],
@@ -6604,7 +6604,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
       {
         kind: "line",
         from: {
-          x: -50,
+          x: -30,
           y: -10,
         },
         to: {
@@ -6620,7 +6620,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
       {
         kind: "line",
         from: {
-          x: -50,
+          x: -30,
           y: 10,
         },
         to: {
@@ -6640,7 +6640,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
           y: 0,
         },
         to: {
-          x: 40,
+          x: 30,
           y: 0,
         },
         style: {
@@ -6725,9 +6725,9 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
     id: "opamp-lettered-inputs-swapped",
     name: "Operational Amplifier (lettered) (swapped inputs)",
     viewBox: {
-      x: -54,
+      x: -34,
       y: -28,
-      width: 98,
+      width: 68,
       height: 56,
     },
     pins: [
@@ -6735,39 +6735,39 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         name: "IN+",
         role: "non-inverting-input",
         at: {
-          x: -50,
+          x: -30,
           y: -10,
         },
         direction: "west",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "IN-",
         role: "inverting-input",
         at: {
-          x: -50,
+          x: -30,
           y: 10,
         },
         direction: "west",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "OUT",
         role: "output",
         at: {
-          x: 40,
+          x: 30,
           y: 0,
         },
         direction: "east",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
     ],
@@ -6775,7 +6775,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
       {
         kind: "line",
         from: {
-          x: -50,
+          x: -30,
           y: -10,
         },
         to: {
@@ -6791,7 +6791,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
       {
         kind: "line",
         from: {
-          x: -50,
+          x: -30,
           y: 10,
         },
         to: {
@@ -6811,7 +6811,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
           y: 0,
         },
         to: {
-          x: 40,
+          x: 30,
           y: 0,
         },
         style: {
@@ -6896,9 +6896,9 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
     id: "opamp-inputs-swapped",
     name: "Operational Amplifier (swapped inputs)",
     viewBox: {
-      x: -54,
+      x: -34,
       y: -28,
-      width: 98,
+      width: 68,
       height: 56,
     },
     pins: [
@@ -6906,39 +6906,39 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         name: "IN+",
         role: "non-inverting-input",
         at: {
-          x: -50,
+          x: -30,
           y: -10,
         },
         direction: "west",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "IN-",
         role: "inverting-input",
         at: {
-          x: -50,
+          x: -30,
           y: 10,
         },
         direction: "west",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "OUT",
         role: "output",
         at: {
-          x: 40,
+          x: 30,
           y: 0,
         },
         direction: "east",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
     ],
@@ -6946,7 +6946,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
       {
         kind: "line",
         from: {
-          x: -50,
+          x: -30,
           y: -10,
         },
         to: {
@@ -6962,7 +6962,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
       {
         kind: "line",
         from: {
-          x: -50,
+          x: -30,
           y: 10,
         },
         to: {
@@ -6982,7 +6982,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
           y: 0,
         },
         to: {
-          x: 40,
+          x: 30,
           y: 0,
         },
         style: {
@@ -7058,62 +7058,62 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
     id: "opamp-differential",
     name: "Differential Op Amp",
     viewBox: {
-      x: -54,
-      y: -28,
-      width: 98,
-      height: 56,
+      x: -44,
+      y: -34,
+      width: 82,
+      height: 68,
     },
     pins: [
       {
         name: "IN+",
         role: "non-inverting-input",
         at: {
-          x: -50,
+          x: -40,
           y: 20,
         },
         direction: "west",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "IN-",
         role: "inverting-input",
         at: {
-          x: -50,
+          x: -40,
           y: -20,
         },
         direction: "west",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "OUT+",
         role: "output",
         at: {
-          x: 10,
+          x: -10,
           y: 20,
         },
         direction: "east",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "OUT-",
         role: "output",
         at: {
-          x: 10,
+          x: -10,
           y: -20,
         },
         direction: "east",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
     ],
@@ -7122,7 +7122,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         kind: "line",
         part: "input-lead",
         from: {
-          x: -50,
+          x: -40,
           y: -20,
         },
         to: {
@@ -7139,7 +7139,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         kind: "line",
         part: "input-lead",
         from: {
-          x: -50,
+          x: -40,
           y: 20,
         },
         to: {
@@ -7160,7 +7160,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
           y: -20,
         },
         to: {
-          x: 10,
+          x: -10,
           y: -20,
         },
         style: {
@@ -7177,7 +7177,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
           y: 20,
         },
         to: {
-          x: 10,
+          x: -10,
           y: 20,
         },
         style: {
@@ -7306,62 +7306,62 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
     id: "opamp-differential-lettered",
     name: "Differential Op Amp (lettered)",
     viewBox: {
-      x: -54,
-      y: -28,
-      width: 98,
-      height: 56,
+      x: -44,
+      y: -34,
+      width: 82,
+      height: 68,
     },
     pins: [
       {
         name: "IN+",
         role: "non-inverting-input",
         at: {
-          x: -50,
+          x: -40,
           y: 20,
         },
         direction: "west",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "IN-",
         role: "inverting-input",
         at: {
-          x: -50,
+          x: -40,
           y: -20,
         },
         direction: "west",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "OUT+",
         role: "output",
         at: {
-          x: 10,
+          x: -10,
           y: 20,
         },
         direction: "east",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "OUT-",
         role: "output",
         at: {
-          x: 10,
+          x: -10,
           y: -20,
         },
         direction: "east",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
     ],
@@ -7370,7 +7370,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         kind: "line",
         part: "input-lead",
         from: {
-          x: -50,
+          x: -40,
           y: -20,
         },
         to: {
@@ -7387,7 +7387,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         kind: "line",
         part: "input-lead",
         from: {
-          x: -50,
+          x: -40,
           y: 20,
         },
         to: {
@@ -7408,7 +7408,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
           y: -20,
         },
         to: {
-          x: 10,
+          x: -10,
           y: -20,
         },
         style: {
@@ -7425,7 +7425,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
           y: 20,
         },
         to: {
-          x: 10,
+          x: -10,
           y: 20,
         },
         style: {
@@ -7563,62 +7563,62 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
     id: "opamp-differential-lettered-inputs-swapped",
     name: "Differential Op Amp (lettered) (swapped inputs)",
     viewBox: {
-      x: -54,
-      y: -28,
-      width: 98,
-      height: 56,
+      x: -44,
+      y: -34,
+      width: 82,
+      height: 68,
     },
     pins: [
       {
         name: "IN+",
         role: "non-inverting-input",
         at: {
-          x: -50,
+          x: -40,
           y: -20,
         },
         direction: "west",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "IN-",
         role: "inverting-input",
         at: {
-          x: -50,
+          x: -40,
           y: 20,
         },
         direction: "west",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "OUT+",
         role: "output",
         at: {
-          x: 10,
+          x: -10,
           y: 20,
         },
         direction: "east",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "OUT-",
         role: "output",
         at: {
-          x: 10,
+          x: -10,
           y: -20,
         },
         direction: "east",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
     ],
@@ -7627,7 +7627,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         kind: "line",
         part: "input-lead",
         from: {
-          x: -50,
+          x: -40,
           y: -20,
         },
         to: {
@@ -7644,7 +7644,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         kind: "line",
         part: "input-lead",
         from: {
-          x: -50,
+          x: -40,
           y: 20,
         },
         to: {
@@ -7665,7 +7665,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
           y: -20,
         },
         to: {
-          x: 10,
+          x: -10,
           y: -20,
         },
         style: {
@@ -7682,7 +7682,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
           y: 20,
         },
         to: {
-          x: 10,
+          x: -10,
           y: 20,
         },
         style: {
@@ -7820,62 +7820,62 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
     id: "opamp-differential-inputs-swapped",
     name: "Differential Op Amp (swapped inputs)",
     viewBox: {
-      x: -54,
-      y: -28,
-      width: 98,
-      height: 56,
+      x: -44,
+      y: -34,
+      width: 82,
+      height: 68,
     },
     pins: [
       {
         name: "IN+",
         role: "non-inverting-input",
         at: {
-          x: -50,
+          x: -40,
           y: -20,
         },
         direction: "west",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "IN-",
         role: "inverting-input",
         at: {
-          x: -50,
+          x: -40,
           y: 20,
         },
         direction: "west",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "OUT+",
         role: "output",
         at: {
-          x: 10,
+          x: -10,
           y: 20,
         },
         direction: "east",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "OUT-",
         role: "output",
         at: {
-          x: 10,
+          x: -10,
           y: -20,
         },
         direction: "east",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
     ],
@@ -7884,7 +7884,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         kind: "line",
         part: "input-lead",
         from: {
-          x: -50,
+          x: -40,
           y: -20,
         },
         to: {
@@ -7901,7 +7901,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         kind: "line",
         part: "input-lead",
         from: {
-          x: -50,
+          x: -40,
           y: 20,
         },
         to: {
@@ -7922,7 +7922,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
           y: -20,
         },
         to: {
-          x: 10,
+          x: -10,
           y: -20,
         },
         style: {
@@ -7939,7 +7939,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
           y: 20,
         },
         to: {
-          x: 10,
+          x: -10,
           y: 20,
         },
         style: {
@@ -8068,62 +8068,62 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
     id: "opamp-differential-crossed",
     name: "Differential Op Amp (crossed outputs)",
     viewBox: {
-      x: -54,
-      y: -28,
-      width: 98,
-      height: 56,
+      x: -44,
+      y: -34,
+      width: 82,
+      height: 68,
     },
     pins: [
       {
         name: "IN+",
         role: "non-inverting-input",
         at: {
-          x: -50,
+          x: -40,
           y: 20,
         },
         direction: "west",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "IN-",
         role: "inverting-input",
         at: {
-          x: -50,
+          x: -40,
           y: -20,
         },
         direction: "west",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "OUT+",
         role: "output",
         at: {
-          x: 10,
+          x: -10,
           y: -20,
         },
         direction: "east",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "OUT-",
         role: "output",
         at: {
-          x: 10,
+          x: -10,
           y: 20,
         },
         direction: "east",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
     ],
@@ -8132,7 +8132,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         kind: "line",
         part: "input-lead",
         from: {
-          x: -50,
+          x: -40,
           y: -20,
         },
         to: {
@@ -8149,7 +8149,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         kind: "line",
         part: "input-lead",
         from: {
-          x: -50,
+          x: -40,
           y: 20,
         },
         to: {
@@ -8170,7 +8170,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
           y: -20,
         },
         to: {
-          x: 10,
+          x: -10,
           y: -20,
         },
         style: {
@@ -8187,7 +8187,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
           y: 20,
         },
         to: {
-          x: 10,
+          x: -10,
           y: 20,
         },
         style: {
@@ -8316,62 +8316,62 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
     id: "opamp-differential-crossed-lettered",
     name: "Differential Op Amp (crossed outputs, lettered)",
     viewBox: {
-      x: -54,
-      y: -28,
-      width: 98,
-      height: 56,
+      x: -44,
+      y: -34,
+      width: 82,
+      height: 68,
     },
     pins: [
       {
         name: "IN+",
         role: "non-inverting-input",
         at: {
-          x: -50,
+          x: -40,
           y: 20,
         },
         direction: "west",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "IN-",
         role: "inverting-input",
         at: {
-          x: -50,
+          x: -40,
           y: -20,
         },
         direction: "west",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "OUT+",
         role: "output",
         at: {
-          x: 10,
+          x: -10,
           y: -20,
         },
         direction: "east",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "OUT-",
         role: "output",
         at: {
-          x: 10,
+          x: -10,
           y: 20,
         },
         direction: "east",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
     ],
@@ -8380,7 +8380,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         kind: "line",
         part: "input-lead",
         from: {
-          x: -50,
+          x: -40,
           y: -20,
         },
         to: {
@@ -8397,7 +8397,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         kind: "line",
         part: "input-lead",
         from: {
-          x: -50,
+          x: -40,
           y: 20,
         },
         to: {
@@ -8418,7 +8418,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
           y: -20,
         },
         to: {
-          x: 10,
+          x: -10,
           y: -20,
         },
         style: {
@@ -8435,7 +8435,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
           y: 20,
         },
         to: {
-          x: 10,
+          x: -10,
           y: 20,
         },
         style: {
@@ -8573,62 +8573,62 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
     id: "opamp-differential-crossed-lettered-inputs-swapped",
     name: "Differential Op Amp (crossed outputs, lettered) (swapped inputs)",
     viewBox: {
-      x: -54,
-      y: -28,
-      width: 98,
-      height: 56,
+      x: -44,
+      y: -34,
+      width: 82,
+      height: 68,
     },
     pins: [
       {
         name: "IN+",
         role: "non-inverting-input",
         at: {
-          x: -50,
+          x: -40,
           y: -20,
         },
         direction: "west",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "IN-",
         role: "inverting-input",
         at: {
-          x: -50,
+          x: -40,
           y: 20,
         },
         direction: "west",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "OUT+",
         role: "output",
         at: {
-          x: 10,
+          x: -10,
           y: -20,
         },
         direction: "east",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "OUT-",
         role: "output",
         at: {
-          x: 10,
+          x: -10,
           y: 20,
         },
         direction: "east",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
     ],
@@ -8637,7 +8637,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         kind: "line",
         part: "input-lead",
         from: {
-          x: -50,
+          x: -40,
           y: -20,
         },
         to: {
@@ -8654,7 +8654,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         kind: "line",
         part: "input-lead",
         from: {
-          x: -50,
+          x: -40,
           y: 20,
         },
         to: {
@@ -8675,7 +8675,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
           y: -20,
         },
         to: {
-          x: 10,
+          x: -10,
           y: -20,
         },
         style: {
@@ -8692,7 +8692,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
           y: 20,
         },
         to: {
-          x: 10,
+          x: -10,
           y: 20,
         },
         style: {
@@ -8830,62 +8830,62 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
     id: "opamp-differential-crossed-inputs-swapped",
     name: "Differential Op Amp (crossed outputs) (swapped inputs)",
     viewBox: {
-      x: -54,
-      y: -28,
-      width: 98,
-      height: 56,
+      x: -44,
+      y: -34,
+      width: 82,
+      height: 68,
     },
     pins: [
       {
         name: "IN+",
         role: "non-inverting-input",
         at: {
-          x: -50,
+          x: -40,
           y: -20,
         },
         direction: "west",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "IN-",
         role: "inverting-input",
         at: {
-          x: -50,
+          x: -40,
           y: 20,
         },
         direction: "west",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "OUT+",
         role: "output",
         at: {
-          x: 10,
+          x: -10,
           y: -20,
         },
         direction: "east",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "OUT-",
         role: "output",
         at: {
-          x: 10,
+          x: -10,
           y: 20,
         },
         direction: "east",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
     ],
@@ -8894,7 +8894,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         kind: "line",
         part: "input-lead",
         from: {
-          x: -50,
+          x: -40,
           y: -20,
         },
         to: {
@@ -8911,7 +8911,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         kind: "line",
         part: "input-lead",
         from: {
-          x: -50,
+          x: -40,
           y: 20,
         },
         to: {
@@ -8932,7 +8932,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
           y: -20,
         },
         to: {
-          x: 10,
+          x: -10,
           y: -20,
         },
         style: {
@@ -8949,7 +8949,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
           y: 20,
         },
         to: {
-          x: 10,
+          x: -10,
           y: 20,
         },
         style: {
@@ -10564,36 +10564,36 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
     id: "voltage-amplifier",
     name: "Voltage Amplifier",
     viewBox: {
-      x: -44,
-      y: -28,
-      width: 88,
-      height: 56,
+      x: -34,
+      y: -32,
+      width: 68,
+      height: 64,
     },
     pins: [
       {
         name: "IN",
         role: "input",
         at: {
-          x: -40,
+          x: -30,
           y: 0,
         },
         direction: "west",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "OUT",
         role: "output",
         at: {
-          x: 40,
+          x: 30,
           y: 0,
         },
         direction: "east",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
     ],
@@ -10601,7 +10601,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
       {
         kind: "line",
         from: {
-          x: -40,
+          x: -30,
           y: 0,
         },
         to: {
@@ -10630,7 +10630,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
           y: 0,
         },
         to: {
-          x: 40,
+          x: 30,
           y: 0,
         },
         style: {
@@ -10647,36 +10647,36 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
     id: "voltage-amplifier-lettered",
     name: "Voltage Amplifier (lettered)",
     viewBox: {
-      x: -44,
-      y: -28,
-      width: 88,
-      height: 56,
+      x: -34,
+      y: -32,
+      width: 68,
+      height: 64,
     },
     pins: [
       {
         name: "IN",
         role: "input",
         at: {
-          x: -40,
+          x: -30,
           y: 0,
         },
         direction: "west",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
       {
         name: "OUT",
         role: "output",
         at: {
-          x: 40,
+          x: 30,
           y: 0,
         },
         direction: "east",
         presentation: {
           visibility: "visible",
-          leadLength: 20,
+          leadLength: 10,
         },
       },
     ],
@@ -10684,7 +10684,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
       {
         kind: "line",
         from: {
-          x: -40,
+          x: -30,
           y: 0,
         },
         to: {
@@ -10713,7 +10713,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
           y: 0,
         },
         to: {
-          x: 40,
+          x: 30,
           y: 0,
         },
         style: {

--- a/packages/symbols/src/razavi-catalog.test.ts
+++ b/packages/symbols/src/razavi-catalog.test.ts
@@ -469,17 +469,17 @@ describe("Razavi symbol catalog", () => {
         expect.arrayContaining([
           expect.objectContaining({
             name: "IN+",
-            at: { x: -50, y: 20 },
+            at: { x: -40, y: 20 },
           }),
           expect.objectContaining({
             name: "IN-",
-            at: { x: -50, y: -20 },
+            at: { x: -40, y: -20 },
           }),
           expect.objectContaining({
-            at: { x: 10, y: -20 },
+            at: { x: -10, y: -20 },
           }),
           expect.objectContaining({
-            at: { x: 10, y: 20 },
+            at: { x: -10, y: 20 },
           }),
         ]),
       );
@@ -556,8 +556,8 @@ describe("Razavi symbol catalog", () => {
         throw new Error("FD Amp leads must remain line primitives");
       }
       const triangleHalfStroke = 1.2;
-      expect(topInput.to.x - topInput.from.x).toBeCloseTo(12.0521, 6);
-      expect(bottomInput.to.x - bottomInput.from.x).toBeCloseTo(12.0521, 6);
+      expect(topInput.to.x - topInput.from.x).toBeCloseTo(2.0521, 6);
+      expect(bottomInput.to.x - bottomInput.from.x).toBeCloseTo(2.0521, 6);
       expect(topInput.to.x).toBeLessThan(points.leftTop.x);
       expect(bottomInput.to.x).toBeLessThan(points.leftBottom.x);
       expect(
@@ -788,6 +788,78 @@ describe("Razavi symbol catalog", () => {
           primitive.part === "upright-input-polarity-negative",
       ),
     ).toHaveLength(3);
+    expect(differential.pins.map((pin) => pin.at)).toEqual([
+      { x: -30, y: 10 },
+      { x: -30, y: -10 },
+      { x: 30, y: 0 },
+    ]);
+    expect(
+      differential.primitives.filter(
+        (primitive) =>
+          primitive.part === "input-polarity" ||
+          primitive.part === "upright-input-polarity-negative",
+      ),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "line",
+          from: { x: -13, y: 10 },
+          to: { x: -7, y: 10 },
+        }),
+        expect.objectContaining({
+          kind: "line",
+          from: { x: -10, y: 7 },
+          to: { x: -10, y: 13 },
+        }),
+        expect.objectContaining({
+          kind: "line",
+          from: { x: -13, y: -10 },
+          to: { x: -7, y: -10 },
+        }),
+      ]),
+    );
+  });
+
+  it("keeps every Analog Blocks lead within one connection-grid cell", () => {
+    const analogBlocks = [
+      "opamp",
+      "opamp-lettered",
+      "opamp-differential",
+      "opamp-differential-lettered",
+      "voltage-amplifier",
+      "voltage-amplifier-lettered",
+      "transconductance",
+      "differential-transconductance",
+      "comparator",
+      "comparator-unmarked",
+      "adc",
+      "dac",
+    ];
+
+    for (const symbolId of analogBlocks) {
+      const symbol = requireRazaviCatalogSymbol(symbolId);
+      for (const pin of symbol.pins) {
+        expect(Math.abs(pin.at.x % 10), `${symbolId}.${pin.name} x`).toBe(0);
+        expect(Math.abs(pin.at.y % 10), `${symbolId}.${pin.name} y`).toBe(0);
+        expect(
+          pin.presentation.leadLength,
+          `${symbolId}.${pin.name} declared lead`,
+        ).toBeLessThanOrEqual(10);
+        const attached = symbol.primitives.filter(
+          (primitive) =>
+            primitive.kind === "line" &&
+            ((primitive.from.x === pin.at.x && primitive.from.y === pin.at.y) ||
+              (primitive.to.x === pin.at.x && primitive.to.y === pin.at.y)),
+        );
+        expect(attached, `${symbolId}.${pin.name} lead count`).toHaveLength(1);
+        const line = attached[0];
+        if (!line || line.kind !== "line") continue;
+        expect(
+          Math.hypot(line.to.x - line.from.x, line.to.y - line.from.y),
+          `${symbolId}.${pin.name} drawn lead`,
+        ).toBeLessThanOrEqual(10);
+      }
+    }
   });
 
   it("keeps Signal Flow leads within one grid cell and closes circular seams", () => {
@@ -1295,9 +1367,9 @@ describe("Razavi symbol catalog", () => {
   it("uses the PDF-derived three-terminal op-amp geometry and polarity marks", () => {
     const opamp = requireRazaviCatalogSymbol("opamp");
     expect(opamp.pins).toMatchObject([
-      { name: "IN+", at: { x: -50, y: 10 }, direction: "west" },
-      { name: "IN-", at: { x: -50, y: -10 }, direction: "west" },
-      { name: "OUT", at: { x: 40, y: 0 }, direction: "east" },
+      { name: "IN+", at: { x: -30, y: 10 }, direction: "west" },
+      { name: "IN-", at: { x: -30, y: -10 }, direction: "west" },
+      { name: "OUT", at: { x: 30, y: 0 }, direction: "east" },
     ]);
     expect(opamp.primitives).toEqual(
       expect.arrayContaining([
@@ -1483,7 +1555,7 @@ describe("Razavi symbol catalog", () => {
         }),
       ]),
     );
-    expect(voltageAmplifier.pins.map((pin) => pin.at.x)).toEqual([-40, 40]);
+    expect(voltageAmplifier.pins.map((pin) => pin.at.x)).toEqual([-30, 30]);
     const idealSwitch = requireRazaviCatalogSymbol("ideal-switch");
     expect(idealSwitch.name).toBe("Open Switch");
     expect(idealSwitch.pins.map((pin) => pin.at.x)).toEqual([-20, 20]);

--- a/scripts/generate-razavi-common-assets.mjs
+++ b/scripts/generate-razavi-common-assets.mjs
@@ -20,6 +20,42 @@ import { normalizeSwitchLeads } from "./lib/normalize-switch-leads.mjs";
  * held by the catalog test rather than by this pass.
  */
 const ONE_CELL_LEAD_SYMBOLS = new Set(["closed-switch", "ideal-switch"]);
+const ANALOG_BLOCK_LEAD_LENGTH = 10;
+
+/**
+ * Keep gain-block connection anchors on the nearest outer grid points. The
+ * reference body is untouched; only the blank lead between it and the sheet
+ * connection is compacted to the one-cell Analog Blocks contract.
+ */
+function normalizeVoltageAmplifierLeads(symbol) {
+  const targetX = new Map([
+    ["IN", -30],
+    ["OUT", 30],
+  ]);
+  const originalPins = new Map(
+    symbol.pins.map((pin) => [pin.name, { ...pin.at }]),
+  );
+  symbol.pins = symbol.pins.map((pin) => ({
+    ...pin,
+    at: { ...pin.at, x: targetX.get(pin.name) },
+    presentation: {
+      ...pin.presentation,
+      leadLength: ANALOG_BLOCK_LEAD_LENGTH,
+    },
+  }));
+  symbol.primitives = symbol.primitives.map((primitive) => {
+    if (primitive.kind !== "line") return primitive;
+    let from = primitive.from;
+    let to = primitive.to;
+    for (const pin of symbol.pins) {
+      const original = originalPins.get(pin.name);
+      if (from.x === original.x && from.y === original.y) from = pin.at;
+      if (to.x === original.x && to.y === original.y) to = pin.at;
+    }
+    return { ...primitive, from, to };
+  });
+  symbol.viewBox = { x: -34, y: -32, width: 68, height: 64 };
+}
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const referenceRoot = resolve(
@@ -79,6 +115,9 @@ for (const [symbolId, name, category, pinOrder, automaticMappings] of entries) {
   }
   delete symbol.aliases;
   if (ONE_CELL_LEAD_SYMBOLS.has(symbolId)) normalizeSwitchLeads(symbol);
+  if (symbolId === "voltage-amplifier") {
+    normalizeVoltageAmplifierLeads(symbol);
+  }
   const assetPath = resolve(assetRoot, `${symbolId}.symbol.json`);
   const assetSource = normalize(
     await format(JSON.stringify(symbol, null, 2), { parser: "json" }),
@@ -133,9 +172,6 @@ for (const [symbolId, name, category, pinOrder, automaticMappings] of entries) {
     await writeFile(assetPath, assetSource, "utf8");
   }
 }
-catalog.entries.sort((left, right) =>
-  left.symbolId.localeCompare(right.symbolId),
-);
 const catalogSource = normalize(
   await format(JSON.stringify(catalog, null, 2), { parser: "json" }),
 );

--- a/scripts/generate-razavi-opamp-asset.mjs
+++ b/scripts/generate-razavi-opamp-asset.mjs
@@ -42,6 +42,9 @@ const check = process.argv.includes("--check");
 const normalize = (value) => `${value.replaceAll("\r\n", "\n").trimEnd()}\n`;
 const hash = (value) => createHash("sha256").update(value).digest("hex");
 const normal = { strokeRole: "normal", lineCap: "butt", lineJoin: "miter" };
+const ANALOG_BLOCK_LEAD_LENGTH = 10;
+const OPAMP_INPUT_PIN_X = -30;
+const OPAMP_OUTPUT_PIN_X = 30;
 
 function fail(message) {
   throw new Error(`Razavi op-amp generation: ${message}`);
@@ -80,34 +83,52 @@ const symbol = {
   schemaVersion: 1,
   id: "opamp",
   name: "Operational Amplifier",
-  viewBox: { x: -54, y: -28, width: 98, height: 56 },
+  viewBox: { x: -34, y: -28, width: 68, height: 56 },
   pins: [
     {
       name: "IN+",
       role: "non-inverting-input",
-      at: { x: -50, y: 10 },
+      at: { x: OPAMP_INPUT_PIN_X, y: 10 },
       direction: "west",
-      presentation: { visibility: "visible", leadLength: 20 },
+      presentation: {
+        visibility: "visible",
+        leadLength: ANALOG_BLOCK_LEAD_LENGTH,
+      },
     },
     {
       name: "IN-",
       role: "inverting-input",
-      at: { x: -50, y: -10 },
+      at: { x: OPAMP_INPUT_PIN_X, y: -10 },
       direction: "west",
-      presentation: { visibility: "visible", leadLength: 20 },
+      presentation: {
+        visibility: "visible",
+        leadLength: ANALOG_BLOCK_LEAD_LENGTH,
+      },
     },
     {
       name: "OUT",
       role: "output",
-      at: { x: 40, y: 0 },
+      at: { x: OPAMP_OUTPUT_PIN_X, y: 0 },
       direction: "east",
-      presentation: { visibility: "visible", leadLength: 20 },
+      presentation: {
+        visibility: "visible",
+        leadLength: ANALOG_BLOCK_LEAD_LENGTH,
+      },
     },
   ],
   primitives: [
-    line(geometry.inputMinus),
-    line(geometry.inputPlus),
-    line(geometry.output),
+    line({
+      ...geometry.inputMinus,
+      from: { ...geometry.inputMinus.from, x: OPAMP_INPUT_PIN_X },
+    }),
+    line({
+      ...geometry.inputPlus,
+      from: { ...geometry.inputPlus.from, x: OPAMP_INPUT_PIN_X },
+    }),
+    line({
+      ...geometry.output,
+      to: { ...geometry.output.to, x: OPAMP_OUTPUT_PIN_X },
+    }),
     {
       kind: "path",
       data: geometry.trianglePathData,
@@ -303,23 +324,20 @@ const acrossAxis = (primitive) => ({
   from: { ...primitive.from, y: -primitive.from.y },
   to: { ...primitive.to, y: -primitive.to.y },
 });
-/** Keep the user-facing FD Amp leads compact on the connection grid. */
-const FD_AMP_LEAD_SCALE = 0.5;
 const CONNECTION_GRID = 10;
-const snapToConnectionGrid = (value) =>
-  Math.round(value / CONNECTION_GRID) * CONNECTION_GRID;
-const halfwayAlongLead = (contact, pin) => ({
+const pinOnGridOutsideBody = (contact, pin, direction) => ({
   ...pin,
   at: {
-    x: snapToConnectionGrid(
-      contact.x + (pin.at.x - contact.x) * FD_AMP_LEAD_SCALE,
-    ),
+    x:
+      (direction === "west" ? Math.floor : Math.ceil)(
+        contact.x / CONNECTION_GRID,
+      ) * CONNECTION_GRID,
     y: contact.y,
   },
-});
-const fullInputLeadPin = (contact, pin) => ({
-  ...pin,
-  at: { x: pin.at.x, y: contact.y },
+  presentation: {
+    ...pin.presentation,
+    leadLength: ANALOG_BLOCK_LEAD_LENGTH,
+  },
 });
 const TRIANGLE_STROKE_WIDTH = 2.4;
 const TRIANGLE_HALF_STROKE = TRIANGLE_STROKE_WIDTH / 2;
@@ -398,28 +416,38 @@ const sourceOutputMarks = [
   ),
 ];
 const differentialSymbol = (id, name, plusOutputAtBottom) => {
-  const topInput = fullInputLeadPin(
+  const topInput = pinOnGridOutsideBody(
     inputLeadContact(-OUTPUT_PAIR_OFFSET),
     symbol.pins[1],
+    "west",
   );
-  const bottomInput = fullInputLeadPin(
+  const bottomInput = pinOnGridOutsideBody(
     inputLeadContact(OUTPUT_PAIR_OFFSET),
     symbol.pins[0],
+    "west",
   );
-  const topOutput = halfwayAlongLead(outputLeadContact(-OUTPUT_PAIR_OFFSET), {
-    name: "OUT-",
-    role: "output",
-    at: { x: geometry.output.to.x, y: -OUTPUT_PAIR_OFFSET },
-    direction: "east",
-    presentation: { visibility: "visible", leadLength: 20 },
-  });
-  const bottomOutput = halfwayAlongLead(outputLeadContact(OUTPUT_PAIR_OFFSET), {
-    name: "OUT+",
-    role: "output",
-    at: { x: geometry.output.to.x, y: OUTPUT_PAIR_OFFSET },
-    direction: "east",
-    presentation: { visibility: "visible", leadLength: 20 },
-  });
+  const topOutput = pinOnGridOutsideBody(
+    outputLeadContact(-OUTPUT_PAIR_OFFSET),
+    {
+      name: "OUT-",
+      role: "output",
+      at: { x: geometry.output.to.x, y: -OUTPUT_PAIR_OFFSET },
+      direction: "east",
+      presentation: { visibility: "visible", leadLength: 20 },
+    },
+    "east",
+  );
+  const bottomOutput = pinOnGridOutsideBody(
+    outputLeadContact(OUTPUT_PAIR_OFFSET),
+    {
+      name: "OUT+",
+      role: "output",
+      at: { x: geometry.output.to.x, y: OUTPUT_PAIR_OFFSET },
+      direction: "east",
+      presentation: { visibility: "visible", leadLength: 20 },
+    },
+    "east",
+  );
   const outputPins = plusOutputAtBottom
     ? [bottomOutput, topOutput]
     : [
@@ -430,7 +458,7 @@ const differentialSymbol = (id, name, plusOutputAtBottom) => {
     schemaVersion: 1,
     id,
     name,
-    viewBox: symbol.viewBox,
+    viewBox: { x: -44, y: -34, width: 82, height: 68 },
     pins: [bottomInput, topInput, ...outputPins],
     primitives: [
       inputLead(topInput, inputLeadContact(-OUTPUT_PAIR_OFFSET)),


### PR DESCRIPTION
## Summary

- move the differential transconductance input pair to the ±10 grid and shift its polarity marks inward
- keep all 12 Analog Blocks palette symbols on 10-unit connection-grid anchors with declared and drawn leads no longer than one grid cell
- update generators, derived assets, catalog hashes, and regression coverage

## Validation

- `pnpm gate:preflight -- --base origin/main`
- `pnpm ci:check`
- 2963 unit tests passed
- production build, performance/release contracts, goldens, and smoke checks passed
- 367 Playwright browser tests completed: 366 direct passes and 1 automatic retry pass
- local Chromium visual inspection of the GM symbol and the full Analog Blocks palette

## Known unrelated baseline issue

The Razavi authority manifest on `main` contains stale extract hashes for `xfmr-vector-source.json` and `tcoil-vector-source.json`. Targeted generator checks for this change passed using the current extract hashes without committing any manifest change. The repository delivery gate itself passed unchanged.