### PR TITLE
Fold workflow actions into Netlist menu

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -1875,9 +1875,9 @@ test("keeps a usable canvas while toggling Library at the narrow breakpoint", as
     chromeBox.x + chromeBox.width,
   );
 
-  // Publish is the primary half-screen action. Simulation and Check and Save
-  // may continue to the horizontally scrollable tail, but Publish must be in
-  // the command surface's initial visible segment without any manual scroll.
+  // Publish is the primary half-screen action. Secondary workflow actions
+  // live in Netlist, while Publish remains in the command surface's initial
+  // visible segment without any manual scroll.
   const commandSurface = page.locator(".app-command-surface");
   const publish = page.getByTestId("publish-gallery-button");
   const commandBox = await commandSurface.boundingBox();

--- a/apps/editor/e2e/diagnostics-surfacing.spec.ts
+++ b/apps/editor/e2e/diagnostics-surfacing.spec.ts
@@ -1,6 +1,9 @@
 import { expect, test } from "@playwright/test";
 
-import { chooseComponent } from "./editor-fixtures";
+import {
+  chooseComponent,
+  clickNetlistWorkflowCommand,
+} from "./editor-fixtures";
 
 /**
  * Findings must reach the person drawing: the statusbar carries a persistent
@@ -26,7 +29,7 @@ test("Check and Save surfaces findings in the existing workbench and canvas", as
   await page.keyboard.press("Escape");
   await expect(badge).toHaveText("Not checked");
   await expect(page.locator(".diagnostic-marker")).toHaveCount(0);
-  await page.getByTestId("check-and-save").click();
+  await clickNetlistWorkflowCommand(page, "check-and-save");
   await expect(badge).toHaveAttribute("data-severity", "warning");
   await expect(badge).toContainText("warning");
   await expect(page.getByTestId("check-and-save")).toBeEnabled();
@@ -85,7 +88,7 @@ test("signed-out Save does not suppress ERC or visual check results", async ({
     await page.keyboard.press("Escape");
   }
   await expect(page.getByTestId("statusbar-issues")).toHaveText("Not checked");
-  await page.getByTestId("check-and-save").click();
+  await clickNetlistWorkflowCommand(page, "check-and-save");
   await expect(page.getByTestId("status")).toContainText("Sign in to save");
   await expect(page.getByTestId("project-diagnostics")).toContainText(
     "ERC_UNCONNECTED_PIN",

--- a/apps/editor/e2e/editor-fixtures.ts
+++ b/apps/editor/e2e/editor-fixtures.ts
@@ -56,6 +56,15 @@ export async function clickCommand(
   await details.getByRole("button", { name: button, exact: true }).click();
 }
 
+/** Run one workflow command from the Netlist menu. */
+export async function clickNetlistWorkflowCommand(
+  page: Page,
+  command: "open-analog-simulation" | "check-and-save",
+): Promise<void> {
+  const details = await openMenu(page, "Netlist");
+  await details.getByTestId(command).click();
+}
+
 export type DrawTool =
   | "insert"
   | "wire"

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -12,6 +12,7 @@ import {
   chooseComponent,
   clickCommand,
   clickDrawTool,
+  clickNetlistWorkflowCommand,
   downloadBytes,
   openMenu,
   readRecoveryRecords,
@@ -5280,9 +5281,26 @@ test("keeps the production command surface compact and publishes PWA metadata", 
 }) => {
   await page.goto("/editor");
   const toolbar = page.getByRole("navigation", { name: "Editor commands" });
-  for (const label of ["File", "Edit"]) {
+  for (const label of ["File", "Edit", "Netlist"]) {
     await expect(toolbar.locator("summary", { hasText: label })).toBeVisible();
   }
+  await expect(
+    toolbar.locator("summary").filter({ hasText: /^Run$/u }),
+  ).toHaveCount(0);
+  const netlistSummary = toolbar
+    .locator("summary")
+    .filter({ hasText: /^Netlist$/u });
+  await expect(page.getByTestId("open-analog-simulation")).toBeHidden();
+  await expect(page.getByTestId("check-and-save")).toBeHidden();
+  await netlistSummary.click();
+  await expect(page.getByTestId("open-analog-simulation")).toBeVisible();
+  await expect(page.getByTestId("check-and-save")).toBeVisible();
+  await netlistSummary.click();
+  await clickNetlistWorkflowCommand(page, "open-analog-simulation");
+  await expect(
+    page.getByRole("region", { name: "Analog simulation" }),
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Exit Simulation" }).click();
   // Drawing tools live in the always-visible toolbar, not behind a menu.
   await expect(toolbar.locator("summary", { hasText: "Draw" })).toHaveCount(0);
   await expect(page.getByTestId("draw-toolbar")).toBeVisible();
@@ -5853,7 +5871,7 @@ test("surfaces and locates current-document ERC diagnostics", async ({
 }) => {
   await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 380, y: 260 });
-  await page.getByTestId("check-and-save").click();
+  await clickNetlistWorkflowCommand(page, "check-and-save");
   await expect(page.getByTestId("check-and-save")).toBeEnabled();
 
   await expect(page.getByTestId("project-diagnostics")).toContainText(
@@ -5880,7 +5898,7 @@ test("rechecks resolved diagnostics and invalidates them through undo", async ({
 }) => {
   await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 380, y: 260 });
-  await page.getByTestId("check-and-save").click();
+  await clickNetlistWorkflowCommand(page, "check-and-save");
   await expect(page.getByTestId("check-and-save")).toBeEnabled();
   const diagnostics = page.getByTestId("project-diagnostics");
   await expect(diagnostics).toContainText("ERC_UNCONNECTED_PIN");
@@ -5893,7 +5911,7 @@ test("rechecks resolved diagnostics and invalidates them through undo", async ({
     "Check out of date",
   );
   await expect(page.locator(".diagnostic-marker")).toHaveCount(0);
-  await page.getByTestId("check-and-save").click();
+  await clickNetlistWorkflowCommand(page, "check-and-save");
   await expect(page.getByTestId("check-and-save")).toBeEnabled();
   await expect(diagnostics).not.toContainText("ERC_UNCONNECTED_PIN");
   await expect(page.getByTestId("no-current-diagnostics")).toBeVisible();
@@ -5902,7 +5920,7 @@ test("rechecks resolved diagnostics and invalidates them through undo", async ({
   await expect(page.getByTestId("statusbar-issues")).toHaveText(
     "Check out of date",
   );
-  await page.getByTestId("check-and-save").click();
+  await clickNetlistWorkflowCommand(page, "check-and-save");
   await expect(page.getByTestId("check-and-save")).toBeEnabled();
   await expect(diagnostics).toContainText("ERC_UNCONNECTED_PIN");
 
@@ -5910,7 +5928,7 @@ test("rechecks resolved diagnostics and invalidates them through undo", async ({
   await expect(page.getByTestId("statusbar-issues")).toHaveText(
     "Check out of date",
   );
-  await page.getByTestId("check-and-save").click();
+  await clickNetlistWorkflowCommand(page, "check-and-save");
   await expect(diagnostics).not.toContainText("ERC_UNCONNECTED_PIN");
 });
 
@@ -5920,7 +5938,7 @@ test("filters and navigates locator-backed visual diagnostics", async ({
   await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 420, y: 300 });
   await placeComponent(page, "resistor", { x: 420, y: 300 });
-  await page.getByTestId("check-and-save").click();
+  await clickNetlistWorkflowCommand(page, "check-and-save");
   await expect(page.getByTestId("check-and-save")).toBeEnabled();
 
   await page.getByTestId("diagnostic-observations-toggle").click();

--- a/apps/editor/e2e/project-file.spec.ts
+++ b/apps/editor/e2e/project-file.spec.ts
@@ -10,6 +10,7 @@ import {
 import { CLOUD_PROJECT_LIMIT } from "../src/features/editor-shell/cloud-projects";
 import {
   chooseComponent,
+  clickNetlistWorkflowCommand,
   downloadBytes,
   openMenu,
   recoveryProjectTexts,
@@ -114,7 +115,7 @@ for (const duringSave of ["edit", "replace"] as const) {
       .click({ position: { x: 360, y: 230 } });
     await page.keyboard.press("Escape");
     const check = page.getByTestId("check-and-save");
-    await check.click();
+    await clickNetlistWorkflowCommand(page, "check-and-save");
     await expect.poll(() => captured?.documents[0]?.instances.length).toBe(1);
     await expect(page.getByTestId("statusbar-issues")).toHaveAttribute(
       "data-check-status",

--- a/apps/editor/e2e/simulation-batch.spec.ts
+++ b/apps/editor/e2e/simulation-batch.spec.ts
@@ -6,6 +6,7 @@ import {
 } from "@icm/spice-run";
 import { parseProject } from "@icm/project-protocol";
 
+import { clickNetlistWorkflowCommand } from "./editor-fixtures.js";
 import { ota, profile } from "./simulation-e2e-fixtures.js";
 test("a saved-setup batch prepares first and exposes each ordinary run", async ({
   page,
@@ -94,9 +95,7 @@ test("a saved-setup batch prepares first and exposes each ordinary run", async (
     mimeType: "application/json",
     buffer: Buffer.from(JSON.stringify(project)),
   });
-  await page
-    .getByRole("button", { name: "Analog simulation", exact: true })
-    .click();
+  await clickNetlistWorkflowCommand(page, "open-analog-simulation");
   const panel = page.getByRole("region", { name: "Analog simulation" });
   await panel.getByTitle("Simulation setup", { exact: true }).click();
   await panel.getByLabel("Include TT in batch").check();
@@ -221,9 +220,7 @@ test("a saved Run Plan prepares without executing and Run starts its ordinary ba
     mimeType: "application/json",
     buffer: Buffer.from(JSON.stringify(project)),
   });
-  await page
-    .getByRole("button", { name: "Analog simulation", exact: true })
-    .click();
+  await clickNetlistWorkflowCommand(page, "open-analog-simulation");
   const panel = page.getByRole("region", { name: "Analog simulation" });
   const runPlan = panel.getByLabel("Run Plan settings");
   await runPlan.locator(":scope > summary").click();

--- a/apps/editor/e2e/simulation-setup.spec.ts
+++ b/apps/editor/e2e/simulation-setup.spec.ts
@@ -1,7 +1,10 @@
 import { test, expect } from "@playwright/test";
 import { parseProject } from "@icm/project-protocol";
 
-import { downloadBytes } from "./editor-fixtures.js";
+import {
+  clickNetlistWorkflowCommand,
+  downloadBytes,
+} from "./editor-fixtures.js";
 import { ota, profile } from "./simulation-e2e-fixtures.js";
 test("the qualified OTA setup opens unchanged and preserves all root and hierarchical outputs", async ({
   page,
@@ -80,9 +83,7 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
     mimeType: "application/json",
     buffer: Buffer.from(JSON.stringify(project)),
   });
-  await page
-    .getByRole("button", { name: "Analog simulation", exact: true })
-    .click();
+  await clickNetlistWorkflowCommand(page, "open-analog-simulation");
   const panel = page.getByRole("region", { name: "Analog simulation" });
   await panel
     .locator('details[aria-label="Run Plan settings"] > summary')
@@ -226,9 +227,7 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
     mimeType: "application/json",
     buffer: Buffer.from(JSON.stringify(saved)),
   });
-  await page
-    .getByRole("button", { name: "Analog simulation", exact: true })
-    .click();
+  await clickNetlistWorkflowCommand(page, "open-analog-simulation");
   await panel.getByRole("button", { name: "Settings" }).click();
   await panel
     .locator('details[aria-label="Analyses settings"] > summary')
@@ -280,9 +279,7 @@ test("one Testbench persists several independently named setups", async ({
     mimeType: "application/json",
     buffer: Buffer.from(JSON.stringify(project)),
   });
-  await page
-    .getByRole("button", { name: "Analog simulation", exact: true })
-    .click();
+  await clickNetlistWorkflowCommand(page, "open-analog-simulation");
   const panel = page.getByRole("region", { name: "Analog simulation" });
   const selector = panel.getByTitle("Simulation setup", { exact: true });
   await expect(selector).toContainText("OTA OP, DC, AC, and TRAN");

--- a/apps/editor/e2e/simulation-workspace.spec.ts
+++ b/apps/editor/e2e/simulation-workspace.spec.ts
@@ -9,7 +9,10 @@ import {
 } from "@icm/spice-run";
 import { parseProject } from "@icm/project-protocol";
 
-import { downloadBytes } from "./editor-fixtures.js";
+import {
+  clickNetlistWorkflowCommand,
+  downloadBytes,
+} from "./editor-fixtures.js";
 import { ota, profile } from "./simulation-e2e-fixtures.js";
 
 const loadModule = createRequire(import.meta.url);
@@ -205,9 +208,7 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   });
   await expect(page.getByTestId("schematic-canvas")).toBeVisible();
   expect(calls).toBe(0);
-  await page
-    .getByRole("button", { name: "Analog simulation", exact: true })
-    .click();
+  await clickNetlistWorkflowCommand(page, "open-analog-simulation");
   const panel = page.getByRole("region", { name: "Analog simulation" });
   await panel.getByRole("button", { name: "Run", exact: true }).click();
   await expect(panel.getByRole("alert")).toContainText(/PROBE|probe/);
@@ -290,7 +291,7 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   await panel.getByRole("button", { name: "Minimize simulation" }).click();
   expect(cancellations).toBe(0);
   release();
-  await page.getByTestId("open-analog-simulation").click();
+  await clickNetlistWorkflowCommand(page, "open-analog-simulation");
   await expect(panel.getByRole("status")).toHaveText("finished · completed");
   // A completed run belongs to its setup, not whichever setup is currently visible.
   await panel.getByTitle("Simulation setup", { exact: true }).click();
@@ -988,7 +989,7 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
     mimeType: "application/json",
     buffer: saved,
   });
-  await page.getByTestId("open-analog-simulation").click();
+  await clickNetlistWorkflowCommand(page, "open-analog-simulation");
   await panel.getByRole("button", { name: "Settings" }).click();
   await expect(panel.getByLabel("Temperature (°C)")).toHaveValue("30");
   await expect(panel.getByLabel("TRAN", { exact: true })).toBeChecked();
@@ -1034,7 +1035,7 @@ test("Simulation creates an ordinary testbench and offers the current Cell at th
   });
   expect(saved.topDocumentId).toBe("document-main");
   expect(saved.simulationSetups).toEqual([]);
-  await page.getByTestId("open-analog-simulation").click();
+  await clickNetlistWorkflowCommand(page, "open-analog-simulation");
   await expect(page.getByLabel("Testbench Cell")).toHaveCount(0);
   await page.getByRole("button", { name: "Apply setup" }).click();
   const configured = JSON.parse(
@@ -1074,7 +1075,7 @@ test("Simulation creates an ordinary testbench and offers the current Cell at th
   await expect(page.getByTestId("open-analog-simulation")).toContainText(
     "Minimized",
   );
-  await page.getByTestId("open-analog-simulation").click();
+  await clickNetlistWorkflowCommand(page, "open-analog-simulation");
   await page.getByRole("button", { name: "Exit simulation" }).click();
   const exitConfirmation = page.getByRole("alertdialog");
   await expect(exitConfirmation).toContainText("temporary run files");

--- a/apps/editor/e2e/wiring-semantics.spec.ts
+++ b/apps/editor/e2e/wiring-semantics.spec.ts
@@ -1,7 +1,11 @@
 import { createEmptyProject } from "@icm/model";
 import { expect, test, type Locator, type Page } from "@playwright/test";
 
-import { chooseComponent, clickDrawTool } from "./editor-fixtures";
+import {
+  chooseComponent,
+  clickDrawTool,
+  clickNetlistWorkflowCommand,
+} from "./editor-fixtures";
 
 async function placeComponent(
   page: Page,
@@ -199,7 +203,7 @@ test("dragging a wire's end onto another wire joins them into one net", async ({
   await page.keyboard.press("Escape");
   await expect(page.locator('[data-canvas-hit-kind="route"]')).toHaveCount(2);
   await expect(page.getByTestId("statusbar-issues")).toHaveText("Not checked");
-  await page.getByTestId("check-and-save").click();
+  await clickNetlistWorkflowCommand(page, "check-and-save");
   await expect(page.getByTestId("statusbar-issues")).toHaveText(
     "No issues found",
   );
@@ -258,7 +262,7 @@ test("dragging a wire's end onto another wire joins them into one net", async ({
   await expect(page.getByTestId("statusbar-issues")).toHaveText(
     "Check out of date",
   );
-  await page.getByTestId("check-and-save").click();
+  await clickNetlistWorkflowCommand(page, "check-and-save");
   await expect(page.getByTestId("statusbar-issues")).toHaveText(
     "No issues found",
   );
@@ -294,7 +298,7 @@ test("a power rail drawn across the tops of wires connects to them", async ({
   // over them as one unconnected conductor.
   await expect(page.locator('[data-canvas-hit-kind="route"]')).toHaveCount(5);
   await page.keyboard.press("Escape");
-  await page.getByTestId("check-and-save").click();
+  await clickNetlistWorkflowCommand(page, "check-and-save");
   await expect(page.getByTestId("statusbar-issues")).toHaveText(
     "No issues found",
   );
@@ -341,7 +345,7 @@ test("a component dragged onto a wire lands and connects", async ({ page }) => {
   // The pin became a real endpoint on the conductor, so the wire is now two
   // pieces meeting at it.
   await expect(page.locator('[data-canvas-hit-kind="route"]')).toHaveCount(2);
-  await page.getByTestId("check-and-save").click();
+  await clickNetlistWorkflowCommand(page, "check-and-save");
   await expect(page.getByTestId("statusbar-issues")).toHaveText(
     "No issues found",
   );

--- a/apps/editor/src/app/App.test.tsx
+++ b/apps/editor/src/app/App.test.tsx
@@ -106,20 +106,19 @@ describe("editor shell", () => {
     expect(markup).not.toContain('data-testid="cell-command-menu"');
     expect(markup).toContain("Manage Cells…");
     expect(markup).toContain("Instance Table…");
-    expect(markup).toContain("<summary>Netlist</summary>");
+    const netlistStart = markup.indexOf("<summary>Netlist</summary>");
+    const netlistEnd = markup.indexOf("</details>", netlistStart);
+    const netlistMenu = markup.slice(netlistStart, netlistEnd);
+    expect(netlistStart).toBeGreaterThan(-1);
     expect(markup).toContain("Check Report…");
-    expect(markup).toContain('data-testid="check-and-save"');
+    expect(netlistMenu).toContain('data-testid="open-analog-simulation"');
+    expect(netlistMenu).toContain('data-testid="check-and-save"');
+    expect(markup).not.toContain("<summary>Run</summary>");
     const agentEnd =
       markup.indexOf("</details>", markup.indexOf("<summary>Agent</summary>")) +
       "</details>".length;
     expect(markup.slice(agentEnd)).toMatch(
       /^<button[^>]*data-testid="publish-gallery-button"/u,
-    );
-    expect(markup.indexOf('data-testid="publish-gallery-button"')).toBeLessThan(
-      markup.indexOf('data-testid="open-analog-simulation"'),
-    );
-    expect(markup.indexOf('data-testid="open-analog-simulation"')).toBeLessThan(
-      markup.indexOf('data-testid="check-and-save"'),
     );
     expect(markup).toContain("Not checked");
     expect(erc).not.toHaveBeenCalled();
@@ -127,7 +126,7 @@ describe("editor shell", () => {
     erc.mockRestore();
     checks.mockRestore();
     // "Preflight" named a stage of a netlist pipeline, not the question the
-    // person is asking; the toolbar carries the plain action.
+    // person is asking; the Netlist menu carries the plain action.
     expect(markup).not.toContain("Preflight…");
     // Formal Cloud Save has one File-menu entry; the retired snapshot action
     // cannot return as a second control source.

--- a/apps/editor/src/app/editor-app-chrome.tsx
+++ b/apps/editor/src/app/editor-app-chrome.tsx
@@ -323,6 +323,25 @@ export function EditorAppChrome({
                 >
                   Instance Table…
                 </button>
+                {simulationAction ? (
+                  <>
+                    <span className="command-group-label">Simulation</span>
+                    <button
+                      type="button"
+                      data-testid="open-analog-simulation"
+                      aria-label="Analog simulation"
+                      aria-pressed={
+                        simulationState === "open" ||
+                        simulationState === "maximized"
+                      }
+                      onClick={simulationAction}
+                    >
+                      {simulationState === "minimized"
+                        ? "Simulation · Minimized"
+                        : "Simulation"}
+                    </button>
+                  </>
+                ) : null}
                 <span className="command-group-label">Check</span>
                 <button
                   type="button"
@@ -331,6 +350,16 @@ export function EditorAppChrome({
                   onClick={onOpenNetlistPreflight}
                 >
                   Check Report…
+                </button>
+                <button
+                  type="button"
+                  data-testid="check-and-save"
+                  disabled={!checkAndSave.enabled}
+                  onClick={checkAndSave.execute}
+                  title={`Check ERC and visual issues, and save this ${fileCommands.projectStoreItemLabel}`}
+                >
+                  <span className="toolbar-check-glyph" aria-hidden="true" />
+                  Check and Save
                 </button>
               </div>
             </details>
@@ -345,8 +374,8 @@ export function EditorAppChrome({
               </details>
             ) : null}
             {/* Publishing is the primary narrow-window action. Keeping it
-                before optional workflow controls makes it visible before the
-                command row needs horizontal scrolling. */}
+                immediately after the compact menus makes it visible before
+                the command row needs horizontal scrolling. */}
             <button
               type="button"
               data-testid="publish-gallery-button"
@@ -356,31 +385,6 @@ export function EditorAppChrome({
               onClick={onPublishGallery}
             >
               Publish<span className="publish-label-long"> to Gallery</span>
-            </button>
-            {simulationAction ? (
-              <button
-                type="button"
-                data-testid="open-analog-simulation"
-                aria-label="Analog simulation"
-                aria-pressed={
-                  simulationState === "open" || simulationState === "maximized"
-                }
-                onClick={simulationAction}
-              >
-                {simulationState === "minimized"
-                  ? "Simulation · Minimized"
-                  : "Simulation"}
-              </button>
-            ) : null}
-            <button
-              type="button"
-              data-testid="check-and-save"
-              disabled={!checkAndSave.enabled}
-              onClick={checkAndSave.execute}
-              title={`Check ERC and visual issues, and save this ${fileCommands.projectStoreItemLabel}`}
-            >
-              <span className="toolbar-check-glyph" aria-hidden="true" />
-              Check and Save
             </button>
           </div>
         </nav>


### PR DESCRIPTION
## Summary
- remove the top-level Simulation and Check and Save actions
- place both commands directly in the existing Netlist dropdown
- keep Publish as the prominent top-level workflow action
- update unit and browser coverage to use the Netlist menu contract

## Validation
- `pnpm gate:preflight -- --base origin/main`
- `pnpm gate:affected -- --base origin/main` (2969 unit tests; 201 affected Playwright tests)

Test-Impact: tests-updated