### PR TITLE
Trim excess canvas text editor width

### DIFF
--- a/apps/editor/e2e/drafting.spec.ts
+++ b/apps/editor/e2e/drafting.spec.ts
@@ -235,7 +235,7 @@ test("adds formatted drafting text and undo/redo restores it", async ({
   expect(editorBounds.x + editorBounds.width).toBeLessThanOrEqual(
     canvasBounds.x + canvasBounds.width + 1,
   );
-  expect(editorBounds.width).toBeCloseTo(400, 0);
+  expect(editorBounds.width).toBeCloseTo(332, 0);
   const [boldTop, increaseTop, applyTop, cancelTop, deleteTop] =
     await Promise.all([
       controlTop(page.getByRole("button", { name: "Bold" })),
@@ -258,7 +258,7 @@ test("adds formatted drafting text and undo/redo restores it", async ({
         .boundingBox()
         .then((bounds) => bounds?.width),
     )
-    .toBeCloseTo(400, 0);
+    .toBeCloseTo(332, 0);
   const [narrowBoldTop, narrowIncreaseTop, narrowApplyTop, narrowCancelTop] =
     await Promise.all([
       controlTop(page.getByRole("button", { name: "Bold" })),

--- a/apps/editor/e2e/reference-label.spec.ts
+++ b/apps/editor/e2e/reference-label.spec.ts
@@ -59,6 +59,15 @@ test("canvas edits one visual annotation without changing the Netlist Reference"
     actionControls.every(({ y }) => Math.abs(y - actionControls[0]!.y) < 1),
   ).toBe(true);
   expect(actionControls[0]!.y).toBeGreaterThan(sizeControl!.y);
+  const toolbarBounds = await page
+    .getByRole("toolbar", { name: "Text formatting" })
+    .boundingBox();
+  if (!toolbarBounds) throw new Error("Text toolbar is not measurable");
+  expect(
+    toolbarBounds.x +
+      toolbarBounds.width -
+      (sizeControl!.x + sizeControl!.width),
+  ).toBeLessThanOrEqual(12);
   await editor.fill("R2");
   await editor.press("End");
   await editor.press("Shift+Enter");

--- a/apps/editor/src/features/text-editing/canvas-text-editor-overlay.test.ts
+++ b/apps/editor/src/features/text-editing/canvas-text-editor-overlay.test.ts
@@ -39,17 +39,17 @@ describe("canvas text editor frame", () => {
         1,
         pixelsPerUnit,
       );
-      expect(view.width * pixelsPerUnit).toBeGreaterThan(400);
-      expect(frame.width * pixelsPerUnit).toBeCloseTo(400, 10);
-      expect(frame.layoutWidth).toBeCloseTo(400, 10);
+      expect(view.width * pixelsPerUnit).toBeGreaterThan(332);
+      expect(frame.width * pixelsPerUnit).toBeCloseTo(332, 10);
+      expect(frame.layoutWidth).toBeCloseTo(332, 10);
     }
   });
 
   it("shrinks only when the canvas cannot fit the standard editor", () => {
-    const frame = resolveCanvasTextEditorFrame(target, camera(400, 640), 1, 1);
-    expect(frame.layoutWidth).toBe(384);
+    const frame = resolveCanvasTextEditorFrame(target, camera(300, 640), 1, 1);
+    expect(frame.layoutWidth).toBe(284);
     expect(frame.x).toBeGreaterThanOrEqual(8);
-    expect(frame.x + frame.width).toBeLessThanOrEqual(392);
+    expect(frame.x + frame.width).toBeLessThanOrEqual(292);
   });
 
   it("holds one apparent size however far the camera is zoomed", () => {

--- a/apps/editor/src/features/text-editing/canvas-text-editor-overlay.tsx
+++ b/apps/editor/src/features/text-editing/canvas-text-editor-overlay.tsx
@@ -34,7 +34,10 @@ export interface CanvasTextEditorOverlayProps {
  * text — are laid out at this size and then scaled as one, so the panel keeps
  * its proportions instead of reflowing as the camera moves.
  */
-const EDITOR_LAYOUT_WIDTH = 400;
+// The full formatting row is the widest part of the editor. Keep only its
+// normal trailing padding instead of stretching the panel into a long empty
+// box after the A+ control.
+const EDITOR_LAYOUT_WIDTH = 332;
 const EDITOR_LAYOUT_MIN_HEIGHT = 150;
 
 /**


### PR DESCRIPTION
## Summary
- reduce the canvas text editor from 400px to its measured 332px content width
- keep the full formatting row, including A+, on one line
- preserve the deliberate second row for Apply, Cancel, Delete, and contextual actions
- add a browser geometry contract limiting trailing space after A+ to 12px

## Validation
- 10 focused frame unit tests
- 2 focused Playwright text-editor journeys
- `pnpm gate:preflight -- --base origin/main`
- `pnpm gate:affected -- --base origin/main` (2969 unit; 139 editor interaction; 12 symbol-body-text)

Test-Impact: tests-updated