### PR TITLE
feat(editor): make Properties code-first and resizable

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -5,6 +5,7 @@ import {
   chooseComponent,
   clickCommand,
   downloadBytes,
+  editComponentPropertyCode,
   recoveryProjectTexts,
 } from "./editor-fixtures.js";
 
@@ -1121,53 +1122,19 @@ test("carries a manual Value through placement and Q property editing", async ({
     "aria-expanded",
     "true",
   );
-  const placementControls = page.getByLabel("Component geometry");
-  await expect(placementControls).toContainText("XY");
-  await expect(
-    placementControls.getByRole("button", {
-      name: /Rotate component clockwise 90 degrees/,
-    }),
-  ).toBeVisible();
-  await expect(
-    placementControls.getByRole("button", {
-      name: "Mirror component left to right, Shift+R",
-    }),
-  ).toBeVisible();
-  await expect(
-    placementControls.getByRole("button", {
-      name: "Mirror component top to bottom, Ctrl+R",
-    }),
-  ).toBeVisible();
-  expect(
-    await placementControls.evaluate(
-      (element) =>
-        getComputedStyle(element).gridTemplateColumns.split(" ").length,
-    ),
-  ).toBe(5);
+  await expect(page.getByLabel("Component geometry")).toHaveCount(0);
+  const propertyCode = page.getByLabel("Editable Canvas property code");
+  await expect(propertyCode).toHaveValue(/"at": \[/u);
+  await expect(propertyCode).toHaveValue(/"rotation": 0/u);
+  await expect(propertyCode).toHaveValue(/"mirror": "none"/u);
   await expect(page.locator(".selection-overview")).toHaveCount(0);
   await expect(page.getByTestId("selection-shelf")).toContainText(
     "R1 · resistor",
   );
-  const displayCard = page.locator(".property-display-card");
-  await expect(
-    displayCard.getByLabel("Component display toggles"),
-  ).toContainText("Visual annotationValue");
-  expect(
-    await displayCard.evaluate((element) => ({
-      columns: getComputedStyle(element).gridTemplateColumns.split(" ").length,
-      height: element.getBoundingClientRect().height,
-      toggleBackgrounds: Array.from(
-        element.querySelectorAll<HTMLElement>(".display-toggle"),
-        (toggle) => getComputedStyle(toggle).backgroundColor,
-      ),
-    })),
-  ).toEqual({
-    columns: 2,
-    height: expect.any(Number),
-    toggleBackgrounds: ["rgba(0, 0, 0, 0)", "rgba(0, 0, 0, 0)"],
-  });
-  expect((await displayCard.boundingBox())?.height).toBeLessThan(48);
-  await expect(page.getByText("Placement", { exact: true })).toBeVisible();
+  await expect(page.getByLabel("Component display toggles")).toHaveCount(0);
+  await expect(propertyCode).toHaveValue(/"reference": true/u);
+  await expect(propertyCode).toHaveValue(/"value": false/u);
+  await expect(page.getByText("Actions", { exact: true })).toBeVisible();
   const propertyValue = page.getByLabel("Component value");
   // Opening focuses the shelf header, never the first field: Q stays a pure
   // toggle and editing starts only when the user clicks an input.
@@ -1487,9 +1454,9 @@ test("sets MOS parameters and orientation through the ghost and Properties", asy
   await page.getByLabel("Component l", { exact: true }).fill("180n");
   await page.getByLabel("Component m", { exact: true }).fill("4");
   await page.getByLabel("Component m", { exact: true }).press("Tab");
-  await page
-    .getByRole("checkbox", { name: "Visual annotation", exact: true })
-    .uncheck();
+  await editComponentPropertyCode(page, (value) => {
+    value.display.reference = false;
+  });
   await expect(
     page.locator('[data-object-id="instance-label-M1"]'),
   ).toHaveCount(0);
@@ -1502,11 +1469,9 @@ test("sets MOS parameters and orientation through the ghost and Properties", asy
   await expect(page.getByLabel("Component m", { exact: true })).toHaveValue(
     "4",
   );
-  await expect(
-    page.getByRole("button", {
-      name: /Rotate component clockwise 90 degrees; current rotation 90 degrees/,
-    }),
-  ).toBeVisible();
+  await expect(page.getByLabel("Editable Canvas property code")).toHaveValue(
+    /"rotation": 90/u,
+  );
 });
 
 test("keeps component placement active across independent canvas commits", async ({

--- a/apps/editor/e2e/editor-fixtures.ts
+++ b/apps/editor/e2e/editor-fixtures.ts
@@ -95,6 +95,18 @@ export async function chooseComponent(
   await dialog.getByTestId(`insert-component-${symbolId}`).click();
 }
 
+/** Edit the selected component's strict Canvas-property JSON and apply it. */
+export async function editComponentPropertyCode(
+  page: Page,
+  update: (value: Record<string, any>) => void,
+): Promise<void> {
+  const input = page.getByLabel("Editable Canvas property code");
+  const value = JSON.parse(await input.inputValue()) as Record<string, any>;
+  update(value);
+  await input.fill(JSON.stringify(value, null, 2));
+  await page.getByRole("button", { name: "Apply code" }).click();
+}
+
 export async function downloadBytes(
   page: Page,
   menu: string,

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -14,6 +14,7 @@ import {
   clickDrawTool,
   clickNetlistWorkflowCommand,
   downloadBytes,
+  editComponentPropertyCode,
   openMenu,
   readRecoveryRecords,
   recoveryProjectTexts,
@@ -790,28 +791,28 @@ test("a part with no designator offers no Reference toggle", async ({
   await openSelectionShelf(page);
   const properties = page.getByRole("complementary", { name: "Properties" });
   await expect(properties).toContainText("voltage-amplifier");
-  // The row switched something that does not exist, so it is not there.
-  await expect(properties.getByLabel("Component display toggles")).toHaveCount(
-    0,
-  );
+  await expect(
+    properties.getByLabel("Editable Canvas property code"),
+  ).not.toHaveValue(/"display"/u);
 
   // The brake: a resistor designates R1 and carries a value, so its toggles
   // are untouched and still work.
   await placeComponent(page, "resistor", { x: 500, y: 200 });
   await openSelectionShelf(page);
-  const toggles = properties.getByLabel("Component display toggles");
-  await expect(toggles).toBeVisible();
-  await expect(toggles).toContainText("Visual annotation");
-  await expect(toggles).toContainText("Value");
-  const reference = toggles.getByLabel("Visual annotation");
-  await expect(reference).toBeChecked();
+  const code = properties.getByLabel("Editable Canvas property code");
+  await expect(code).toHaveValue(/"reference": true/u);
+  await expect(code).toHaveValue(/"value": false/u);
   const drawnLabel = page.locator(
     '[data-layer="annotations"] [data-object-id="instance-label-R1"]',
   );
   await expect(drawnLabel).toHaveCount(1);
-  await reference.uncheck();
+  await editComponentPropertyCode(page, (value) => {
+    value.display.reference = false;
+  });
   await expect(drawnLabel).toHaveCount(0);
-  await reference.check();
+  await editComponentPropertyCode(page, (value) => {
+    value.display.reference = true;
+  });
   await expect(drawnLabel).toHaveCount(1);
 });
 
@@ -3294,8 +3295,8 @@ test("Properties offers no dead Reference controls for a schematic-only block", 
   );
 
   // A summing junction hides its designator on the canvas, so the panel
-  // offers neither a Reference field nor the display toggles that could
-  // never change the drawing. Its raw component code and Appearance remain.
+  // offers neither a Reference field nor display keys that could never
+  // change the drawing. Its Canvas property code still owns placement/style.
   await page.locator('[data-canvas-hit-kind="instance"]').first().click();
   await expect(
     properties.locator('[aria-label="SPICE component code"]'),
@@ -3303,20 +3304,113 @@ test("Properties offers no dead Reference controls for a schematic-only block", 
   await expect(referenceField).toHaveCount(0);
   await expect(parametersCard).toHaveCount(0);
   await expect(
+    properties.getByLabel("Editable Canvas property code"),
+  ).not.toHaveValue(/"display"/u);
+  await expect(
     properties.locator('details[aria-label="Component appearance"]'),
-  ).not.toHaveAttribute("open", "");
-  await properties
-    .locator('details[aria-label="Component appearance"] > summary')
-    .click();
-  await expect(properties.getByText("Line", { exact: true })).toBeVisible();
+  ).toHaveCount(0);
 
   // An ordinary device keeps both.
   await page.getByTestId("hit-R1").click();
   await expect(referenceField).toHaveCount(1);
   await expect(parametersCard).toHaveCount(1);
+  await expect(
+    properties.getByLabel("Editable Canvas property code"),
+  ).toHaveValue(/"display"/u);
+});
+
+test("resizes Properties and applies component presentation as editable code", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await placeComponent(page, "resistor", { x: 360, y: 240 });
+  await openSelectionShelf(page);
+
+  const properties = page.getByRole("complementary", { name: "Properties" });
+  const resize = page.getByTestId("properties-resize-handle");
+  const code = properties.getByLabel("Editable Canvas property code");
+  await expect(resize).toBeVisible();
+  await expect(code).toBeVisible();
+  await expect(properties.getByLabel("Component geometry")).toHaveCount(0);
+  await expect(
+    properties.locator('details[aria-label="Component appearance"]'),
+  ).toHaveCount(0);
   await expect(properties.getByLabel("Component display toggles")).toHaveCount(
-    1,
+    0,
   );
+
+  const beforeWidth = (await properties.boundingBox())!.width;
+  const resizeBox = await resize.boundingBox();
+  if (!resizeBox) throw new Error("Properties resize handle is not measurable");
+  await page.mouse.move(
+    resizeBox.x + resizeBox.width / 2,
+    resizeBox.y + resizeBox.height / 2,
+  );
+  await page.mouse.down();
+  await page.mouse.move(
+    resizeBox.x + resizeBox.width / 2 - 24,
+    resizeBox.y + resizeBox.height / 2,
+  );
+  await page.mouse.up();
+  await expect
+    .poll(async () => (await properties.boundingBox())?.width ?? 0)
+    .toBeCloseTo(beforeWidth + 24, 0);
+
+  await resize.focus();
+  await resize.press("Shift+ArrowLeft");
+  await expect
+    .poll(async () => (await properties.boundingBox())?.width ?? 0)
+    .toBeCloseTo(beforeWidth + 56, 0);
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        Number(localStorage.getItem("icm.properties-panel-width.v1")),
+      ),
+    )
+    .toBeCloseTo(beforeWidth + 56, 0);
+
+  // The half-window overlay keeps the same adjustable left edge rather than
+  // falling back to a fixed narrow Properties panel.
+  await page.setViewportSize({ width: 760, height: 900 });
+  await expect(resize).toBeVisible();
+  const compactWidth = (await properties.boundingBox())!.width;
+  await resize.focus();
+  await resize.press("ArrowLeft");
+  await expect
+    .poll(async () => (await properties.boundingBox())?.width ?? 0)
+    .toBeCloseTo(compactWidth + 8, 0);
+
+  const edited = JSON.parse(await code.inputValue());
+  edited.placement.at = [420, 280];
+  edited.placement.rotation = 90;
+  edited.placement.mirror = "x";
+  edited.display.reference = false;
+  edited.appearance.foreground = "#DC2626";
+  await code.fill(JSON.stringify(edited, null, 2));
+  await properties.getByRole("button", { name: "Apply code" }).click();
+
+  await expect(page.getByTestId("revision")).toHaveText("2");
+  await expect(
+    page.locator(
+      '[data-layer="formal"] [data-object-id="R1"] [data-role="instance-symbol"]',
+    ),
+  ).toHaveAttribute("stroke", "#DC2626");
+  await expect(
+    page.getByTestId("annotation-hit-instance-label-R1"),
+  ).toHaveCount(0);
+  const saved = JSON.parse(
+    (await downloadBytes(page, "File", "Export Project File…")).toString(
+      "utf8",
+    ),
+  );
+  expect(saved.documents[0].instances[0]).toMatchObject({
+    placement: {
+      position: { x: 420, y: 280 },
+      rotation: 90,
+      mirror: "x",
+    },
+    styleOverride: { foreground: "#DC2626" },
+  });
 });
 
 test("Properties toggles reference label visibility for one or many components", async ({
@@ -3329,12 +3423,7 @@ test("Properties toggles reference label visibility for one or many components",
   await page.getByTestId("hit-R1").click();
   await openSelectionShelf(page);
   const properties = page.getByRole("complementary", { name: "Properties" });
-  for (const sectionName of [
-    "Parameters",
-    "Display",
-    "Netlist overrides",
-    "Placement",
-  ]) {
+  for (const sectionName of ["Parameters", "Netlist overrides", "Actions"]) {
     await expect(
       properties.getByText(sectionName, { exact: true }),
     ).toBeVisible();
@@ -3344,12 +3433,12 @@ test("Properties toggles reference label visibility for one or many components",
   });
   await expect(
     componentProperties.locator(":scope > .property-disclosure"),
-  ).toHaveCount(3);
+  ).toHaveCount(2);
   expect(
     await componentProperties
       .locator(":scope > .property-disclosure > summary > span")
       .allTextContents(),
-  ).toEqual(["Parameters", "Placement", "Appearance"]);
+  ).toEqual(["Parameters", "Actions"]);
   await expect(componentProperties.locator(":scope > :last-child")).toHaveText(
     /R1.*<unconnected:1>.*<unconnected:2>.*<value>/u,
   );
@@ -3360,10 +3449,7 @@ test("Properties toggles reference label visibility for one or many components",
     componentProperties.locator(
       ':scope > details[aria-label="Component appearance"]',
     ),
-  ).not.toHaveAttribute("open", "");
-  await expect(
-    componentProperties.getByText("Appearance", { exact: true }),
-  ).toBeVisible();
+  ).toHaveCount(0);
   await expect(
     componentProperties.getByText("Built-in primitive: resistor", {
       exact: true,
@@ -3375,12 +3461,9 @@ test("Properties toggles reference label visibility for one or many components",
   await expect(
     componentProperties.getByLabel("Component model target"),
   ).toBeVisible();
-  const singleToggle = page.getByRole("checkbox", {
-    name: "Visual annotation",
-    exact: true,
+  await editComponentPropertyCode(page, (value) => {
+    value.display.reference = false;
   });
-  await expect(singleToggle).toBeChecked();
-  await singleToggle.uncheck();
   await expect(
     page.getByTestId("annotation-hit-instance-label-R1"),
   ).toHaveCount(0);
@@ -3391,7 +3474,9 @@ test("Properties toggles reference label visibility for one or many components",
     page.getByTestId("annotation-hit-instance-label-R2"),
   ).toHaveCount(1);
   // Hiding is recoverable: the annotation is still in the project.
-  await singleToggle.check();
+  await editComponentPropertyCode(page, (value) => {
+    value.display.reference = true;
+  });
   await expect(
     page.getByTestId("annotation-hit-instance-label-R1"),
   ).toHaveCount(1);
@@ -3444,13 +3529,10 @@ test("Properties keeps component and Annotation text colors independent", async 
   const label = page.locator('[data-object-id="instance-label-R1"]');
   const secondLabel = page.locator('[data-object-id="instance-label-R2"]');
 
-  await properties
-    .locator('details[aria-label="Component appearance"] > summary')
-    .click();
-  await properties.getByRole("button", { name: "Use Red for line" }).click();
-  await properties
-    .getByRole("button", { name: "Use Blue for background" })
-    .click();
+  await editComponentPropertyCode(page, (value) => {
+    value.appearance.foreground = "#dc2626";
+    value.appearance.background = "#2563eb";
+  });
   await expect(symbol).toHaveAttribute("stroke", "#dc2626");
   await expect(
     component.locator('[data-role="instance-background"]'),
@@ -3611,7 +3693,9 @@ test("value display projects MOS W/L and passive values beside the reference", a
   await openSelectionShelf(page);
   await page.getByLabel("Component w", { exact: true }).fill("2u");
   await page.getByLabel("Component l", { exact: true }).fill("180n");
-  await page.getByRole("checkbox", { name: "Value", exact: true }).check();
+  await editComponentPropertyCode(page, (propertyCode) => {
+    propertyCode.display.value = true;
+  });
   await canvas.click({ position: { x: 80, y: 80 } });
 
   const reference = page.locator('[data-object-id="instance-label-M1"]');
@@ -3637,7 +3721,9 @@ test("value display projects MOS W/L and passive values beside the reference", a
   await page.getByTestId("hit-R1").click();
   await openSelectionShelf(page);
   await page.getByLabel("Component value", { exact: true }).fill("33k");
-  await page.getByRole("checkbox", { name: "Value", exact: true }).check();
+  await editComponentPropertyCode(page, (propertyCode) => {
+    propertyCode.display.value = true;
+  });
   await canvas.click({ position: { x: 80, y: 80 } });
   await expect(
     page.locator('[data-object-id="instance-value-R1"]'),
@@ -3655,34 +3741,36 @@ test("value display projects MOS W/L and passive values beside the reference", a
   expect(svg).toContain("33kΩ");
 });
 
-test("reference and value toggles refresh content after parameter edits", async ({
+test("reference and value code refreshes content after parameter edits", async ({
   page,
 }) => {
   await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 300, y: 200 });
   await placeComponent(page, "resistor", { x: 500, y: 200 });
 
-  // Quick-place leaves the parameters blank, so the Value toggle starts
-  // disabled and no hidden annotation exists at all.
+  // Quick-place leaves the parameters blank, so code cannot enable the value
+  // display and no hidden annotation exists at all.
   await page.getByTestId("hit-R1").click();
   await openSelectionShelf(page);
-  const valueToggle = page.getByRole("checkbox", {
-    name: "Value",
-    exact: true,
-  });
-  await expect(valueToggle).toBeDisabled();
+  const properties = page.getByRole("complementary", { name: "Properties" });
+  const propertyCode = properties.getByLabel("Editable Canvas property code");
+  const missingValueCode = JSON.parse(await propertyCode.inputValue());
+  missingValueCode.display.value = true;
+  await propertyCode.fill(JSON.stringify(missingValueCode, null, 2));
+  await properties.getByRole("button", { name: "Apply code" }).click();
+  await expect(
+    properties.getByText(/Set a valid component value/u),
+  ).toBeVisible();
   await expect(
     page.getByTestId("annotation-hit-instance-value-R1"),
   ).toHaveCount(0);
 
-  // Typing a value enables the toggle immediately from the live draft,
-  // without closing and reopening the properties panel.
+  // Typing a value makes the same pending code applicable without closing and
+  // reopening Properties.
   await page.getByLabel("Component value").click();
   await page.getByLabel("Component value").fill("33k");
-  await expect(valueToggle).toBeEnabled();
-  // Checking commits the typed parameters and shows the projected value in
-  // one step.
-  await valueToggle.check();
+  await page.getByLabel("Component value").press("Tab");
+  await properties.getByRole("button", { name: "Apply code" }).click();
   await expect(
     page.locator('[data-object-id="instance-value-R1"]'),
   ).toContainText("33kΩ");
@@ -3700,7 +3788,9 @@ test("reference and value toggles refresh content after parameter edits", async 
   // Hiding keeps the annotation recoverable.
   await page.getByTestId("hit-R1").click();
   await openSelectionShelf(page);
-  await page.getByRole("checkbox", { name: "Value", exact: true }).uncheck();
+  await editComponentPropertyCode(page, (code) => {
+    code.display.value = false;
+  });
   await expect(
     page.getByTestId("annotation-hit-instance-value-R1"),
   ).toHaveCount(0);
@@ -3744,7 +3834,9 @@ test("drag value annotation keeps the user offset through rotation", async ({
     .click({ position: { x: 60, y: 60 } });
   await page.getByTestId("hit-R1").click();
   await openSelectionShelf(page);
-  await page.getByRole("checkbox", { name: "Value", exact: true }).check();
+  await editComponentPropertyCode(page, (propertyCode) => {
+    propertyCode.display.value = true;
+  });
   await expect(
     page.locator('[data-object-id="instance-value-R1"]'),
   ).toContainText("33kΩ");

--- a/apps/editor/e2e/reference-label.spec.ts
+++ b/apps/editor/e2e/reference-label.spec.ts
@@ -3,6 +3,7 @@ import {
   awaitEditorReady,
   chooseComponent,
   downloadBytes,
+  editComponentPropertyCode,
 } from "./editor-fixtures.js";
 
 async function placeResistor(page: Page) {
@@ -128,12 +129,13 @@ test("Properties renames the electrical identity explicitly; restore is an in-pl
   await reference.fill("gm");
   await reference.press("Enter");
   await expect(reference).toHaveValue("R7");
-  const toggle = properties
-    .getByLabel("Component display toggles")
-    .getByLabel("Visual annotation");
-  await toggle.uncheck();
+  await editComponentPropertyCode(page, (value) => {
+    value.display.reference = false;
+  });
   await expect(visual(page)).toHaveCount(0);
-  await toggle.check();
+  await editComponentPropertyCode(page, (value) => {
+    value.display.reference = true;
+  });
   await expect(visual(page)).toContainText("load");
 
   await properties.getByRole("button", { name: "Edit annotation" }).click();

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -22,6 +22,7 @@ import {
   planProjectCellImport,
   planSetCellSymbolPresentation,
   type CellResetPlan,
+  type SchematicEdit,
   type WireSource,
 } from "@icm/edit-engine";
 import {
@@ -276,6 +277,8 @@ import { deriveSelectionInspectionModel } from "../features/selection/selection-
 import { usePropertiesEditor } from "../features/properties/use-properties-editor";
 import { createPropertyEditPlanner } from "../features/properties/property-edit-planner";
 import { createSelectionPropertyCommands } from "../features/properties/selection-property-commands";
+import { planComponentPropertyCodeEdits } from "../features/properties/component-property-code-edits";
+import type { ComponentPropertyCodeValue } from "../features/properties/component-property-code";
 import {
   LIBRARY_WIDTH_MAX,
   LIBRARY_WIDTH_MIN,
@@ -319,7 +322,11 @@ const DEFAULT_VIEWBOX: GridRect = { x: 0, y: 0, width: 960, height: 640 };
 const RECENT_COMPONENTS_STORAGE_KEY = "icm.recent-components.v1";
 const LIBRARY_PANEL_STORAGE_KEY = "icm.library-panel-open.v1";
 const LIBRARY_WIDTH_STORAGE_KEY = "icm.library-panel-width.v1";
+const PROPERTIES_WIDTH_STORAGE_KEY = "icm.properties-panel-width.v1";
 const SIMULATION_WIDTH_STORAGE_KEY = "icm.simulation-panel-width.v2";
+const PROPERTIES_WIDTH_MIN = 280;
+const PROPERTIES_WIDTH_MAX = 760;
+const PROPERTIES_WIDTH_RATIO = 0.24;
 const SIMULATION_WIDTH_MIN = 320;
 const SIMULATION_WIDTH_MAX = 1200;
 const SIMULATION_WIDTH_RATIO = 0.4;
@@ -329,6 +336,15 @@ function defaultSimulationWidth(viewportWidth: number): number {
     Math.min(
       SIMULATION_WIDTH_MAX,
       Math.max(SIMULATION_WIDTH_MIN, viewportWidth * SIMULATION_WIDTH_RATIO),
+    ),
+  );
+}
+
+function defaultPropertiesWidth(viewportWidth: number): number {
+  return Math.round(
+    Math.min(
+      PROPERTIES_WIDTH_MAX,
+      Math.max(PROPERTIES_WIDTH_MIN, viewportWidth * PROPERTIES_WIDTH_RATIO),
     ),
   );
 }
@@ -376,6 +392,34 @@ export function App({
     pointerX: number;
     width: number;
   } | null>(null);
+  const propertiesResizeOriginRef = useRef<{
+    pointerX: number;
+    width: number;
+  } | null>(null);
+  const [propertiesWidth, setPropertiesWidthState] = useState(() => {
+    if (typeof window === "undefined") return defaultPropertiesWidth(1100);
+    try {
+      const stored = Number(
+        window.localStorage.getItem(PROPERTIES_WIDTH_STORAGE_KEY),
+      );
+      return Number.isFinite(stored) && stored > 0
+        ? Math.min(PROPERTIES_WIDTH_MAX, Math.max(PROPERTIES_WIDTH_MIN, stored))
+        : defaultPropertiesWidth(window.innerWidth);
+    } catch {
+      return defaultPropertiesWidth(window.innerWidth);
+    }
+  });
+  const setPropertiesWidth = (width: number): void => {
+    const next = Math.round(
+      Math.min(PROPERTIES_WIDTH_MAX, Math.max(PROPERTIES_WIDTH_MIN, width)),
+    );
+    setPropertiesWidthState(next);
+    try {
+      window.localStorage.setItem(PROPERTIES_WIDTH_STORAGE_KEY, String(next));
+    } catch {
+      // Resizing remains available when browser storage is unavailable.
+    }
+  };
   const [simulationWidth, setSimulationWidthState] = useState(() => {
     if (typeof window === "undefined") return defaultSimulationWidth(1100);
     try {
@@ -5108,10 +5152,53 @@ export function App({
         style={
           {
             "--icm-shapes-width": `${libraryWidth}px`,
+            "--icm-properties-width": `${propertiesWidth}px`,
             "--icm-simulation-width": `${simulationWidth}px`,
           } as CSSProperties
         }
       >
+        {selectionOpen && !analogSimulationMaximized ? (
+          <div
+            className="properties-resize-handle"
+            role="separator"
+            aria-orientation="vertical"
+            aria-label="Resize the Properties panel"
+            aria-valuenow={propertiesWidth}
+            aria-valuemin={PROPERTIES_WIDTH_MIN}
+            aria-valuemax={PROPERTIES_WIDTH_MAX}
+            tabIndex={0}
+            data-testid="properties-resize-handle"
+            onPointerDown={(event) => {
+              event.preventDefault();
+              event.currentTarget.setPointerCapture(event.pointerId);
+              propertiesResizeOriginRef.current = {
+                pointerX: event.clientX,
+                width: propertiesWidth,
+              };
+            }}
+            onPointerMove={(event) => {
+              const origin = propertiesResizeOriginRef.current;
+              if (!origin) return;
+              setPropertiesWidth(
+                origin.width - (event.clientX - origin.pointerX),
+              );
+            }}
+            onPointerUp={(event) => {
+              propertiesResizeOriginRef.current = null;
+              event.currentTarget.releasePointerCapture(event.pointerId);
+            }}
+            onKeyDown={(event) => {
+              const step = event.shiftKey ? 32 : 8;
+              if (event.key === "ArrowLeft") {
+                event.preventDefault();
+                setPropertiesWidth(propertiesWidth + step);
+              } else if (event.key === "ArrowRight") {
+                event.preventDefault();
+                setPropertiesWidth(propertiesWidth - step);
+              }
+            }}
+          />
+        ) : null}
         {analogSimulationOpen &&
         !selectionOpen &&
         !analogSimulationMaximized ? (
@@ -5492,6 +5579,88 @@ export function App({
               component={
                 selectedInstance
                   ? {
+                      code: {
+                        instance: selectedInstance,
+                        revision: document.revision,
+                        referenceVisible:
+                          selectedLabelRenderable &&
+                          symbolCarriesReference(selectedInstance.symbolId)
+                            ? selectedInstanceLabel !== undefined &&
+                              selectedInstanceLabel.visible !== false
+                            : null,
+                        valueVisible: symbolSupportsValueAnnotation(
+                          selectedInstance.symbolId,
+                        )
+                          ? selectedInstanceValue !== null &&
+                            selectedInstanceValue.visible !== false
+                          : null,
+                        onApply: (value: ComponentPropertyCodeValue) => {
+                          const edits: SchematicEdit[] =
+                            planComponentPropertyCodeEdits(
+                              document,
+                              selectedInstance,
+                              value,
+                            );
+                          const desiredReference = value.display?.reference;
+                          const currentReference =
+                            selectedInstanceLabel !== undefined &&
+                            selectedInstanceLabel.visible !== false;
+                          if (
+                            typeof desiredReference === "boolean" &&
+                            desiredReference !== currentReference
+                          ) {
+                            edits.push(
+                              ...referenceLabelVisibilityEdits(
+                                [selectedInstance.id],
+                                desiredReference,
+                              ),
+                            );
+                          }
+                          const desiredValue = value.display?.value;
+                          const currentValue =
+                            selectedInstanceValue !== null &&
+                            selectedInstanceValue.visible !== false;
+                          if (
+                            typeof desiredValue === "boolean" &&
+                            desiredValue !== currentValue
+                          ) {
+                            if (
+                              desiredValue &&
+                              !selectedInstanceValueAvailable
+                            ) {
+                              return {
+                                ok: false as const,
+                                message:
+                                  "Set a valid component value before enabling its display",
+                              };
+                            }
+                            edits.push(
+                              ...valueVisibilityEdits(
+                                document,
+                                [selectedInstance.id],
+                                desiredValue,
+                              ),
+                            );
+                          }
+                          if (edits.length === 0) {
+                            setStatus(
+                              `Canvas properties for ${selectedInstance.id} are already up to date`,
+                            );
+                            return { ok: true as const };
+                          }
+                          if (!transact(edits).ok) {
+                            return {
+                              ok: false as const,
+                              message:
+                                "Canvas property code was rejected; see the status bar",
+                            };
+                          }
+                          setStatus(
+                            `Applied Canvas property code to ${selectedInstance.id}`,
+                          );
+                          return { ok: true as const };
+                        },
+                      },
                       formalPort: selectedFormalTerminal
                         ? {
                             terminal: selectedFormalTerminal,
@@ -5697,26 +5866,6 @@ export function App({
                         onAdditionalParametersApply: applyAdditionalParameters,
                         onAdditionalParametersCancel:
                           cancelAdditionalParameters,
-                      },
-                      style: {
-                        instance: selectedInstance,
-                        defaultForeground: styleProfile.foreground,
-                        onChange: (styleOverride) => {
-                          const result = transact([
-                            {
-                              kind: "set_instance_style_override",
-                              instanceId: selectedInstance.id,
-                              styleOverride,
-                            },
-                          ]);
-                          if (result.ok) {
-                            setStatus(
-                              styleOverride
-                                ? `Updated appearance for ${selectedInstance.id}`
-                                : `Reset appearance for ${selectedInstance.id}`,
-                            );
-                          }
-                        },
                       },
                       placement: {
                         instance: selectedInstance,

--- a/apps/editor/src/app/editor-properties-dock.tsx
+++ b/apps/editor/src/app/editor-properties-dock.tsx
@@ -11,7 +11,7 @@ import { ComponentIdentityProperties } from "../features/properties/component-id
 import { ComponentElectricalProperties } from "../features/properties/component-electrical-properties";
 import { ComponentSignalFlowProperties } from "../features/properties/component-signal-flow-properties";
 import { ComponentPlacementProperties } from "../features/properties/component-placement-properties";
-import { ComponentStyleProperties } from "../features/properties/component-style-properties";
+import { ComponentPropertyCodeEditor } from "../features/properties/component-property-code-editor";
 import { AnnotationColorProperties } from "../features/properties/annotation-color-properties";
 import { NetNameProperties } from "../features/properties/net-name-properties";
 import { DraftingPropertiesPanel } from "../features/drafting/drafting-properties-panel";
@@ -31,12 +31,12 @@ import {
 import { LazyAgentPropertiesSection } from "./lazy-editor-dialogs";
 
 interface ComponentPropertiesModel {
+  code: ComponentProps<typeof ComponentPropertyCodeEditor>;
   formalPort: ComponentProps<typeof FormalPortProperties> | null;
   cellSymbolLayout: ComponentProps<typeof CellSymbolLayoutProperties> | null;
   identity: ComponentProps<typeof ComponentIdentityProperties>;
   signalFlow: ComponentProps<typeof ComponentSignalFlowProperties> | null;
   electrical: ComponentProps<typeof ComponentElectricalProperties>;
-  style: ComponentProps<typeof ComponentStyleProperties>;
   placement: ComponentProps<typeof ComponentPlacementProperties>;
 }
 
@@ -141,6 +141,10 @@ export function EditorPropertiesDock({
               className="property-section component-properties"
               aria-label="Component properties"
             >
+              <ComponentPropertyCodeEditor
+                key={component.code.instance.id}
+                {...component.code}
+              />
               {component.formalPort ? (
                 <FormalPortProperties {...component.formalPort} />
               ) : null}
@@ -150,11 +154,13 @@ export function EditorPropertiesDock({
               {component.signalFlow ? (
                 <ComponentSignalFlowProperties {...component.signalFlow} />
               ) : null}
-              <ComponentElectricalProperties {...component.electrical} />
-              <ComponentPlacementProperties {...component.placement} />
-              <ComponentStyleProperties
-                key={component.style.instance.id}
-                {...component.style}
+              <ComponentElectricalProperties
+                {...component.electrical}
+                displayControls={false}
+              />
+              <ComponentPlacementProperties
+                {...component.placement}
+                geometryControls={false}
               />
               <ComponentIdentityProperties {...component.identity} />
             </section>

--- a/apps/editor/src/features/properties/component-electrical-properties.tsx
+++ b/apps/editor/src/features/properties/component-electrical-properties.tsx
@@ -77,6 +77,7 @@ export function ComponentElectricalProperties({
   onAdditionalParameterAdd,
   onAdditionalParametersApply,
   onAdditionalParametersCancel,
+  displayControls = true,
 }: {
   instance: Instance;
   parameters: readonly ComponentParameter[];
@@ -119,6 +120,8 @@ export function ComponentElectricalProperties({
   onAdditionalParameterAdd: () => void;
   onAdditionalParametersApply: () => void;
   onAdditionalParametersCancel: () => void;
+  /** Display flags are edited in Canvas property code on the composed dock. */
+  displayControls?: boolean;
 }) {
   const fingerWidth = derivedFingerWidth(parameterValues.w, parameterValues.nf);
   const descriptor = deviceDescriptor(instance.symbolId);
@@ -143,8 +146,13 @@ export function ComponentElectricalProperties({
   // instance has and this Symbol draws, and a value this device supports.
   const referenceToggleable = referenceLabelRenderable && referenceAvailable;
   const displayable = referenceToggleable || valueSupported;
+  const renderedDisplayable = displayControls && displayable;
   const isMos = descriptor?.deviceClass === "mos";
-  if (primaryParameters.length === 0 && !displayable && !instance.netlist) {
+  if (
+    primaryParameters.length === 0 &&
+    !renderedDisplayable &&
+    !instance.netlist
+  ) {
     return null;
   }
   return (
@@ -221,7 +229,7 @@ export function ComponentElectricalProperties({
           Finger width {fingerWidth} · W = FW × NF
         </p>
       ) : null}
-      {displayable ? (
+      {renderedDisplayable ? (
         <div className="property-display-card">
           <div className="property-section-heading">Display</div>
           <div

--- a/apps/editor/src/features/properties/component-placement-properties.tsx
+++ b/apps/editor/src/features/properties/component-placement-properties.tsx
@@ -20,6 +20,7 @@ export function ComponentPlacementProperties({
   onSwapContactStyle,
   onSwapInputs,
   onDiscard,
+  geometryControls = true,
 }: {
   instance: Instance;
   x: string;
@@ -35,6 +36,8 @@ export function ComponentPlacementProperties({
   onSwapContactStyle?: { label: string; run: () => void };
   onSwapInputs?: () => void;
   onDiscard: () => void;
+  /** The composed dock edits coordinates and orientation as property code. */
+  geometryControls?: boolean;
 }) {
   return (
     <>
@@ -51,61 +54,65 @@ export function ComponentPlacementProperties({
       ) : null}
       {instance.placement ? (
         <PropertyDisclosure
-          title="Placement"
+          title={geometryControls ? "Placement" : "Actions"}
           className="property-placement-card"
-          ariaLabel="Component placement"
+          ariaLabel={
+            geometryControls ? "Component placement" : "Component actions"
+          }
           defaultOpen
         >
-          <div
-            className="component-geometry-row property-placement-controls"
-            aria-label="Component geometry"
-          >
-            <label>
-              X
-              <input
-                aria-label="Component X position"
-                inputMode="decimal"
-                value={x}
-                onChange={(event) => onXChange(event.currentTarget.value)}
-              />
-            </label>
-            <label>
-              Y
-              <input
-                aria-label="Component Y position"
-                inputMode="decimal"
-                value={y}
-                onChange={(event) => onYChange(event.currentTarget.value)}
-              />
-            </label>
-            <button
-              type="button"
-              className="property-placement-icon-button"
-              aria-label={`Rotate component clockwise 90 degrees; current rotation ${rotation} degrees; shortcut R`}
-              title={`Rotate 90° clockwise · current ${rotation}° (R)`}
-              onClick={onRotate}
+          {geometryControls ? (
+            <div
+              className="component-geometry-row property-placement-controls"
+              aria-label="Component geometry"
             >
-              <ToolIcon name="rotate" />
-            </button>
-            <button
-              type="button"
-              className="property-placement-icon-button"
-              aria-label="Mirror component left to right, Shift+R"
-              title="Mirror left/right (Shift+R)"
-              onClick={() => onMirror("left-right")}
-            >
-              <ToolIcon name="mirror-horizontal" />
-            </button>
-            <button
-              type="button"
-              className="property-placement-icon-button"
-              aria-label="Mirror component top to bottom, Ctrl+R"
-              title="Mirror top/bottom (Ctrl+R)"
-              onClick={() => onMirror("top-bottom")}
-            >
-              <ToolIcon name="mirror-vertical" />
-            </button>
-          </div>
+              <label>
+                X
+                <input
+                  aria-label="Component X position"
+                  inputMode="decimal"
+                  value={x}
+                  onChange={(event) => onXChange(event.currentTarget.value)}
+                />
+              </label>
+              <label>
+                Y
+                <input
+                  aria-label="Component Y position"
+                  inputMode="decimal"
+                  value={y}
+                  onChange={(event) => onYChange(event.currentTarget.value)}
+                />
+              </label>
+              <button
+                type="button"
+                className="property-placement-icon-button"
+                aria-label={`Rotate component clockwise 90 degrees; current rotation ${rotation} degrees; shortcut R`}
+                title={`Rotate 90° clockwise · current ${rotation}° (R)`}
+                onClick={onRotate}
+              >
+                <ToolIcon name="rotate" />
+              </button>
+              <button
+                type="button"
+                className="property-placement-icon-button"
+                aria-label="Mirror component left to right, Shift+R"
+                title="Mirror left/right (Shift+R)"
+                onClick={() => onMirror("left-right")}
+              >
+                <ToolIcon name="mirror-horizontal" />
+              </button>
+              <button
+                type="button"
+                className="property-placement-icon-button"
+                aria-label="Mirror component top to bottom, Ctrl+R"
+                title="Mirror top/bottom (Ctrl+R)"
+                onClick={() => onMirror("top-bottom")}
+              >
+                <ToolIcon name="mirror-vertical" />
+              </button>
+            </div>
+          ) : null}
           <button
             type="button"
             className="property-return-to-tray"

--- a/apps/editor/src/features/properties/component-property-code-editor.test.tsx
+++ b/apps/editor/src/features/properties/component-property-code-editor.test.tsx
@@ -1,0 +1,32 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { ComponentPropertyCodeEditor } from "./component-property-code-editor";
+
+describe("ComponentPropertyCodeEditor", () => {
+  it("renders one editable code surface without coordinate or style widgets", () => {
+    const markup = renderToStaticMarkup(
+      <ComponentPropertyCodeEditor
+        instance={{
+          id: "R1",
+          symbolId: "resistor",
+          reference: "R1",
+          placement: {
+            position: { x: 360, y: 240 },
+            rotation: 0,
+            mirror: "none",
+          },
+        }}
+        revision={1}
+        referenceVisible
+        valueVisible={false}
+        onApply={vi.fn(() => ({ ok: true as const }))}
+      />,
+    );
+    expect(markup).toContain('aria-label="Editable Canvas property code"');
+    expect(markup).toContain("&quot;at&quot;");
+    expect(markup).toContain("Apply code");
+    expect(markup).not.toContain('inputMode="decimal"');
+    expect(markup).not.toContain("mirror-horizontal");
+  });
+});

--- a/apps/editor/src/features/properties/component-property-code-editor.tsx
+++ b/apps/editor/src/features/properties/component-property-code-editor.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import type { SchematicDocument } from "@icm/model";
+
+import {
+  formatComponentPropertyCode,
+  parseComponentPropertyCode,
+  serializeComponentPropertyCode,
+  type ComponentPropertyCodeContext,
+  type ComponentPropertyCodeValue,
+} from "./component-property-code";
+
+type Instance = SchematicDocument["instances"][number];
+
+export interface ComponentPropertyCodeEditorProps {
+  instance: Instance;
+  revision: number;
+  referenceVisible: boolean | null;
+  valueVisible: boolean | null;
+  onApply: (
+    value: ComponentPropertyCodeValue,
+  ) => { ok: true } | { ok: false; message: string };
+}
+
+/** Compact editable JSON for placement, display, and appearance. */
+export function ComponentPropertyCodeEditor({
+  instance,
+  revision,
+  referenceVisible,
+  valueVisible,
+  onApply,
+}: ComponentPropertyCodeEditorProps) {
+  const context = useMemo<ComponentPropertyCodeContext>(
+    () => ({ instance, referenceVisible, valueVisible }),
+    [instance, referenceVisible, valueVisible],
+  );
+  const baseline = useMemo(
+    () => formatComponentPropertyCode(context),
+    [context, revision],
+  );
+  const previousBaseline = useRef(baseline);
+  const [draft, setDraft] = useState(baseline);
+  const [applyMessage, setApplyMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    setDraft((current) =>
+      current === previousBaseline.current ? baseline : current,
+    );
+    previousBaseline.current = baseline;
+  }, [baseline]);
+
+  const parsed = useMemo(
+    () => parseComponentPropertyCode(draft, context),
+    [context, draft],
+  );
+  const changed = draft !== baseline;
+
+  const apply = (): void => {
+    if (!parsed.ok) {
+      setApplyMessage(parsed.message);
+      return;
+    }
+    const result = onApply(parsed.value);
+    if (!result.ok) {
+      setApplyMessage(result.message);
+      return;
+    }
+    const normalized = serializeComponentPropertyCode(parsed.value);
+    previousBaseline.current = normalized;
+    setDraft(normalized);
+    setApplyMessage("Applied");
+  };
+
+  return (
+    <section
+      className="component-property-code-editor"
+      aria-label="Canvas property code"
+      data-testid="component-property-code-editor"
+    >
+      <header>
+        <div>
+          <strong>Canvas properties</strong>
+          <span>{instance.reference ?? instance.id}</span>
+        </div>
+        <code>{instance.symbolId}</code>
+      </header>
+      <textarea
+        aria-label="Editable Canvas property code"
+        value={draft}
+        rows={15}
+        spellCheck={false}
+        onChange={(event) => {
+          setDraft(event.currentTarget.value);
+          setApplyMessage(null);
+        }}
+        onKeyDown={(event) => {
+          if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+            event.preventDefault();
+            apply();
+          }
+        }}
+      />
+      <div className="component-property-code-status" aria-live="polite">
+        <span>
+          {parsed.ok
+            ? (applyMessage ?? "JSON · Ctrl/⌘ + Enter to apply")
+            : parsed.message}
+        </span>
+        <div>
+          <button
+            type="button"
+            disabled={!changed}
+            onClick={() => {
+              setDraft(baseline);
+              setApplyMessage(null);
+            }}
+          >
+            Revert
+          </button>
+          <button
+            type="button"
+            disabled={!changed || !parsed.ok}
+            onClick={apply}
+          >
+            Apply code
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/editor/src/features/properties/component-property-code-edits.test.ts
+++ b/apps/editor/src/features/properties/component-property-code-edits.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import { createEmptyDocument } from "@icm/model";
+
+import { planComponentPropertyCodeEdits } from "./component-property-code-edits";
+
+describe("planComponentPropertyCodeEdits", () => {
+  it("plans snapped placement, orientation, and appearance as typed edits", () => {
+    const document = createEmptyDocument("main", "Main");
+    const instance = {
+      id: "R1",
+      symbolId: "resistor",
+      placement: {
+        position: { x: 100, y: 100 },
+        rotation: 0 as const,
+        mirror: "none" as const,
+      },
+      reference: "R1",
+    };
+    document.instances.push(instance);
+    expect(
+      planComponentPropertyCodeEdits(document, instance, {
+        placement: { at: [123, 177], rotation: 90, mirror: "x" },
+        display: { reference: true, value: false },
+        appearance: { foreground: "#DC2626", background: "auto" },
+      }),
+    ).toEqual([
+      {
+        kind: "move_instance",
+        instanceId: "R1",
+        position: { x: 120, y: 180 },
+      },
+      { kind: "rotate_instance", instanceId: "R1", rotation: 90 },
+      { kind: "mirror_instance", instanceId: "R1", mirror: "x" },
+      {
+        kind: "set_instance_style_override",
+        instanceId: "R1",
+        styleOverride: { foreground: "#DC2626" },
+      },
+    ]);
+  });
+
+  it("emits no edit for the current presentation", () => {
+    const document = createEmptyDocument("main", "Main");
+    const instance = {
+      id: "R1",
+      symbolId: "resistor",
+      placement: {
+        position: { x: 100, y: 100 },
+        rotation: 0 as const,
+        mirror: "none" as const,
+      },
+      reference: "R1",
+    };
+    document.instances.push(instance);
+    expect(
+      planComponentPropertyCodeEdits(document, instance, {
+        placement: { at: [100, 100], rotation: 0, mirror: "none" },
+        display: { reference: true, value: false },
+        appearance: { foreground: "auto", background: "auto" },
+      }),
+    ).toEqual([]);
+  });
+});

--- a/apps/editor/src/features/properties/component-property-code-edits.ts
+++ b/apps/editor/src/features/properties/component-property-code-edits.ts
@@ -1,0 +1,74 @@
+import type { SchematicEdit } from "@icm/edit-engine";
+import type { SchematicDocument } from "@icm/model";
+
+import { snapCoordinate } from "../../snap/engine";
+import type { ComponentPropertyCodeValue } from "./component-property-code";
+
+type Instance = SchematicDocument["instances"][number];
+
+function sameStyle(
+  left: Instance["styleOverride"] | null,
+  right: Instance["styleOverride"] | null,
+): boolean {
+  return (
+    (left?.foreground ?? null) === (right?.foreground ?? null) &&
+    (left?.background ?? null) === (right?.background ?? null)
+  );
+}
+
+/**
+ * Translate presentation code into the existing typed edit contract. Display
+ * annotations are appended by the caller because they need the live Symbol
+ * resolver and annotation policy.
+ */
+export function planComponentPropertyCodeEdits(
+  document: SchematicDocument,
+  instance: Instance,
+  value: ComponentPropertyCodeValue,
+): SchematicEdit[] {
+  const edits: SchematicEdit[] = [];
+  if (instance.placement && value.placement) {
+    const position = {
+      x: snapCoordinate(value.placement.at[0], document.presentation.grid),
+      y: snapCoordinate(value.placement.at[1], document.presentation.grid),
+    };
+    if (
+      position.x !== instance.placement.position.x ||
+      position.y !== instance.placement.position.y
+    ) {
+      edits.push({ kind: "move_instance", instanceId: instance.id, position });
+    }
+    if (value.placement.rotation !== instance.placement.rotation) {
+      edits.push({
+        kind: "rotate_instance",
+        instanceId: instance.id,
+        rotation: value.placement.rotation,
+      });
+    }
+    if (value.placement.mirror !== instance.placement.mirror) {
+      edits.push({
+        kind: "mirror_instance",
+        instanceId: instance.id,
+        mirror: value.placement.mirror,
+      });
+    }
+  }
+
+  const styleOverride = {
+    ...(value.appearance.foreground === "auto"
+      ? {}
+      : { foreground: value.appearance.foreground }),
+    ...(value.appearance.background === "auto"
+      ? {}
+      : { background: value.appearance.background }),
+  };
+  const nextStyle = Object.keys(styleOverride).length ? styleOverride : null;
+  if (!sameStyle(instance.styleOverride ?? null, nextStyle)) {
+    edits.push({
+      kind: "set_instance_style_override",
+      instanceId: instance.id,
+      styleOverride: nextStyle,
+    });
+  }
+  return edits;
+}

--- a/apps/editor/src/features/properties/component-property-code.test.ts
+++ b/apps/editor/src/features/properties/component-property-code.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+
+import type { SchematicDocument } from "@icm/model";
+
+import {
+  formatComponentPropertyCode,
+  parseComponentPropertyCode,
+} from "./component-property-code";
+
+type Instance = SchematicDocument["instances"][number];
+
+const instance: Instance = {
+  id: "instance-1",
+  symbolId: "resistor",
+  reference: "R1",
+  placement: {
+    position: { x: 360, y: 240 },
+    rotation: 90,
+    mirror: "none",
+  },
+  netlist: {
+    binding: { kind: "primitive", deviceClass: "resistor" },
+    parameters: { value: "10k" },
+  },
+};
+
+const context = {
+  instance,
+  referenceVisible: true,
+  valueVisible: false,
+};
+
+describe("component property code", () => {
+  it("formats placement as one coordinate and makes display/style explicit", () => {
+    expect(formatComponentPropertyCode(context)).toBe(`{
+  "placement": {
+    "at": [
+      360,
+      240
+    ],
+    "rotation": 90,
+    "mirror": "none"
+  },
+  "display": {
+    "reference": true,
+    "value": false
+  },
+  "appearance": {
+    "foreground": "auto",
+    "background": "auto"
+  }
+}`);
+  });
+
+  it("round-trips edited coordinates, orientation, display, and colors", () => {
+    const source = formatComponentPropertyCode(context)
+      .replace("360", "420")
+      .replace('"rotation": 90', '"rotation": 180')
+      .replace('"mirror": "none"', '"mirror": "x"')
+      .replace('"value": false', '"value": true')
+      .replace('"foreground": "auto"', '"foreground": "#DC2626"');
+    expect(parseComponentPropertyCode(source, context)).toEqual({
+      ok: true,
+      value: {
+        placement: { at: [420, 240], rotation: 180, mirror: "x" },
+        display: { reference: true, value: true },
+        appearance: { foreground: "#DC2626", background: "auto" },
+      },
+    });
+  });
+
+  it("rejects unsupported and malformed properties instead of guessing", () => {
+    const source = formatComponentPropertyCode(context).replace(
+      '"rotation": 90',
+      '"rotation": 45',
+    );
+    expect(parseComponentPropertyCode(source, context)).toEqual({
+      ok: false,
+      message: "placement.rotation must be 0, 90, 180, or 270",
+    });
+
+    const extra = formatComponentPropertyCode(context).replace(
+      '"background": "auto"',
+      '"background": "auto", "opacity": 0.5',
+    );
+    expect(parseComponentPropertyCode(extra, context)).toEqual({
+      ok: false,
+      message: "appearance.opacity is not a supported property",
+    });
+  });
+
+  it("omits display for a component with no display capability", () => {
+    const noDisplayContext = {
+      instance: { ...instance, reference: undefined },
+      referenceVisible: null,
+      valueVisible: null,
+    };
+    const source = formatComponentPropertyCode(noDisplayContext);
+    expect(source).not.toContain('"display"');
+    expect(parseComponentPropertyCode(source, noDisplayContext).ok).toBe(true);
+  });
+
+  it("keeps tray membership outside free-form property edits", () => {
+    const source = formatComponentPropertyCode(context).replace(
+      /"placement": \{[\s\S]*?\n  \},\n  "display"/u,
+      '"placement": null,\n  "display"',
+    );
+    expect(parseComponentPropertyCode(source, context)).toEqual({
+      ok: false,
+      message: "placement cannot be changed to null here; use Return to tray",
+    });
+  });
+});

--- a/apps/editor/src/features/properties/component-property-code.ts
+++ b/apps/editor/src/features/properties/component-property-code.ts
@@ -1,0 +1,232 @@
+import type { SchematicDocument } from "@icm/model";
+
+type Instance = SchematicDocument["instances"][number];
+
+export type ComponentPropertyColor = "auto" | `#${string}`;
+
+export interface ComponentPropertyPlacementCode {
+  at: [number, number];
+  rotation: 0 | 90 | 180 | 270;
+  mirror: "none" | "x";
+}
+
+export interface ComponentPropertyDisplayCode {
+  reference?: boolean;
+  value?: boolean;
+}
+
+export interface ComponentPropertyCodeValue {
+  placement: ComponentPropertyPlacementCode | null;
+  display?: ComponentPropertyDisplayCode;
+  appearance: {
+    foreground: ComponentPropertyColor;
+    background: ComponentPropertyColor;
+  };
+}
+
+export interface ComponentPropertyCodeContext {
+  instance: Instance;
+  referenceVisible: boolean | null;
+  valueVisible: boolean | null;
+}
+
+export type ComponentPropertyCodeParseResult =
+  | { ok: true; value: ComponentPropertyCodeValue }
+  | { ok: false; message: string };
+
+const COLOR_PATTERN = /^#[0-9A-Fa-f]{6}$/u;
+const ROOT_KEYS = new Set(["placement", "display", "appearance"]);
+const PLACEMENT_KEYS = new Set(["at", "rotation", "mirror"]);
+const APPEARANCE_KEYS = new Set(["foreground", "background"]);
+
+function formattedColor(value: string | undefined): ComponentPropertyColor {
+  return (value ?? "auto") as ComponentPropertyColor;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function unexpectedKey(
+  value: Record<string, unknown>,
+  allowed: ReadonlySet<string>,
+  path: string,
+): string | null {
+  const key = Object.keys(value).find((candidate) => !allowed.has(candidate));
+  return key ? `${path}.${key} is not a supported property` : null;
+}
+
+function parseColor(value: unknown, path: string): ComponentPropertyColor {
+  if (value === "auto") return value;
+  if (typeof value === "string" && COLOR_PATTERN.test(value)) {
+    return value as `#${string}`;
+  }
+  throw new Error(`${path} must be "auto" or a #RRGGBB color`);
+}
+
+function parsePlacement(
+  value: unknown,
+  currentlyPlaced: boolean,
+): ComponentPropertyPlacementCode | null {
+  if (value === null) {
+    if (currentlyPlaced) {
+      throw new Error(
+        "placement cannot be changed to null here; use Return to tray",
+      );
+    }
+    return null;
+  }
+  if (!currentlyPlaced) {
+    throw new Error(
+      "placement is read-only while this component is in the Placement Tray",
+    );
+  }
+  if (!isRecord(value)) throw new Error("placement must be an object");
+  const unknown = unexpectedKey(value, PLACEMENT_KEYS, "placement");
+  if (unknown) throw new Error(unknown);
+  const at = value.at;
+  if (
+    !Array.isArray(at) ||
+    at.length !== 2 ||
+    at.some((coordinate) =>
+      typeof coordinate === "number" ? !Number.isFinite(coordinate) : true,
+    )
+  ) {
+    throw new Error("placement.at must be a finite [x, y] coordinate");
+  }
+  const rotation = value.rotation;
+  if (![0, 90, 180, 270].includes(rotation as number)) {
+    throw new Error("placement.rotation must be 0, 90, 180, or 270");
+  }
+  const mirror = value.mirror;
+  if (mirror !== "none" && mirror !== "x") {
+    throw new Error('placement.mirror must be "none" or "x"');
+  }
+  return {
+    at: [at[0] as number, at[1] as number],
+    rotation: rotation as 0 | 90 | 180 | 270,
+    mirror,
+  };
+}
+
+function parseDisplay(
+  value: unknown,
+  context: ComponentPropertyCodeContext,
+): ComponentPropertyDisplayCode | undefined {
+  const supported = new Set<string>();
+  if (context.referenceVisible !== null) supported.add("reference");
+  if (context.valueVisible !== null) supported.add("value");
+  if (supported.size === 0) {
+    if (value !== undefined) {
+      throw new Error("display is not available for this component");
+    }
+    return undefined;
+  }
+  if (!isRecord(value)) throw new Error("display must be an object");
+  const unknown = unexpectedKey(value, supported, "display");
+  if (unknown) throw new Error(unknown);
+  const display: ComponentPropertyDisplayCode = {};
+  for (const key of supported) {
+    if (typeof value[key] !== "boolean") {
+      throw new Error(`display.${key} must be true or false`);
+    }
+    display[key as keyof ComponentPropertyDisplayCode] = value[key] as boolean;
+  }
+  return display;
+}
+
+export function componentPropertyCodeValue(
+  context: ComponentPropertyCodeContext,
+): ComponentPropertyCodeValue {
+  const { instance } = context;
+  const display: ComponentPropertyDisplayCode = {};
+  if (context.referenceVisible !== null) {
+    display.reference = context.referenceVisible;
+  }
+  if (context.valueVisible !== null) display.value = context.valueVisible;
+  return {
+    placement: instance.placement
+      ? {
+          at: [instance.placement.position.x, instance.placement.position.y],
+          rotation: instance.placement.rotation,
+          mirror: instance.placement.mirror,
+        }
+      : null,
+    ...(Object.keys(display).length > 0 ? { display } : {}),
+    appearance: {
+      foreground: formattedColor(instance.styleOverride?.foreground),
+      background: formattedColor(instance.styleOverride?.background),
+    },
+  };
+}
+
+export function serializeComponentPropertyCode(
+  value: ComponentPropertyCodeValue,
+): string {
+  return JSON.stringify(value, null, 2);
+}
+
+export function formatComponentPropertyCode(
+  context: ComponentPropertyCodeContext,
+): string {
+  return serializeComponentPropertyCode(componentPropertyCodeValue(context));
+}
+
+/** Parse the strict, component-local JSON surface. Connectivity is deliberately absent. */
+export function parseComponentPropertyCode(
+  source: string,
+  context: ComponentPropertyCodeContext,
+): ComponentPropertyCodeParseResult {
+  try {
+    const decoded: unknown = JSON.parse(source);
+    if (!isRecord(decoded))
+      throw new Error("Property code must be a JSON object");
+    const unknown = unexpectedKey(decoded, ROOT_KEYS, "component");
+    if (unknown) throw new Error(unknown);
+    if (!("placement" in decoded)) {
+      throw new Error("placement is required");
+    }
+    if (!isRecord(decoded.appearance)) {
+      throw new Error("appearance must be an object");
+    }
+    const appearanceUnknown = unexpectedKey(
+      decoded.appearance,
+      APPEARANCE_KEYS,
+      "appearance",
+    );
+    if (appearanceUnknown) throw new Error(appearanceUnknown);
+    if (!("foreground" in decoded.appearance)) {
+      throw new Error("appearance.foreground is required");
+    }
+    if (!("background" in decoded.appearance)) {
+      throw new Error("appearance.background is required");
+    }
+    const display = parseDisplay(decoded.display, context);
+    return {
+      ok: true,
+      value: {
+        placement: parsePlacement(
+          decoded.placement,
+          context.instance.placement !== null,
+        ),
+        ...(display ? { display } : {}),
+        appearance: {
+          foreground: parseColor(
+            decoded.appearance.foreground,
+            "appearance.foreground",
+          ),
+          background: parseColor(
+            decoded.appearance.background,
+            "appearance.background",
+          ),
+        },
+      },
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      message:
+        error instanceof Error ? error.message : "Property code is invalid",
+    };
+  }
+}

--- a/apps/editor/src/styles/editor-inspection.css
+++ b/apps/editor/src/styles/editor-inspection.css
@@ -14,7 +14,8 @@
 }
 
 .selection-dock.open {
-  width: min(var(--icm-props-open), 42vw);
+  width: min(var(--icm-properties-width, var(--icm-props-open)), 70vw);
+  transition: none;
 }
 
 .selection-panel h2 {
@@ -323,6 +324,9 @@
   }
 
   .selection-dock.open {
-    width: min(var(--icm-props-open), calc(100% - var(--icm-rail-width)));
+    width: min(
+      var(--icm-properties-width, var(--icm-props-open)),
+      calc(100% - var(--icm-rail-width))
+    );
   }
 }

--- a/apps/editor/src/styles/editor-properties.css
+++ b/apps/editor/src/styles/editor-properties.css
@@ -324,6 +324,94 @@
   font-size: var(--icm-font-xs);
 }
 
+.component-property-code-editor {
+  display: grid;
+  gap: 0.5rem;
+  min-width: 0;
+  padding: 0.65rem;
+  border: 1px solid var(--icm-border-strong);
+  border-radius: var(--icm-radius-md);
+  background: var(--icm-surface-muted);
+}
+
+.component-property-code-editor > header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--icm-space-2);
+}
+
+.component-property-code-editor > header > div {
+  display: flex;
+  align-items: baseline;
+  min-width: 0;
+  gap: var(--icm-space-2);
+}
+
+.component-property-code-editor > header strong {
+  font-size: var(--icm-font-sm);
+}
+
+.component-property-code-editor > header span,
+.component-property-code-editor > header code {
+  overflow: hidden;
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.component-property-code-editor > textarea {
+  box-sizing: border-box;
+  width: 100%;
+  min-width: 0;
+  min-height: 15.5rem;
+  resize: vertical;
+  padding: 0.65rem 0.75rem;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  color: var(--icm-text);
+  background: var(--icm-surface);
+  font-family: var(--icm-font-mono, ui-monospace, monospace);
+  font-size: 12px;
+  line-height: 1.5;
+  tab-size: 2;
+  white-space: pre;
+}
+
+.component-property-code-editor > textarea:focus {
+  border-color: var(--icm-accent);
+  outline: 2px solid var(--icm-accent-soft);
+  outline-offset: 0;
+}
+
+.component-property-code-status {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--icm-space-2);
+  min-width: 0;
+}
+
+.component-property-code-status > span {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+}
+
+.component-property-code-status > div {
+  display: flex;
+  flex: none;
+  gap: var(--icm-space-1);
+}
+
+.component-property-code-status button {
+  min-height: var(--icm-control-h);
+  padding: 0 var(--icm-space-2);
+  font-size: var(--icm-font-xs);
+}
+
 .net-name-properties {
   display: grid;
   gap: 0.55rem;

--- a/apps/editor/src/styles/editor-workspace.css
+++ b/apps/editor/src/styles/editor-workspace.css
@@ -64,6 +64,16 @@
   background: transparent;
 }
 
+.properties-resize-handle {
+  grid-area: props;
+  z-index: 14;
+  width: 9px;
+  margin-left: -5px;
+  cursor: col-resize;
+  touch-action: none;
+  background: transparent;
+}
+
 .editor-right-dock {
   grid-area: props;
   display: flex;
@@ -110,7 +120,9 @@
 }
 
 .simulation-resize-handle:hover,
-.simulation-resize-handle:focus-visible {
+.simulation-resize-handle:focus-visible,
+.properties-resize-handle:hover,
+.properties-resize-handle:focus-visible {
   background: linear-gradient(
     to right,
     transparent 3px,
@@ -710,6 +722,21 @@
 
   .app-workspace.library-collapsed .shapes-panel {
     display: none;
+  }
+
+  .properties-resize-handle {
+    grid-area: auto;
+    position: absolute;
+    top: 0;
+    right: calc(
+      min(
+          var(--icm-properties-width, var(--icm-props-open)),
+          calc(100% - var(--icm-rail-width))
+        ) -
+        5px
+    );
+    bottom: 0;
+    margin-left: 0;
   }
 
   .shapes-panel {

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -61,6 +61,46 @@ removes electrical memberships, NoConnects, owned labels, layout references,
 and the Instance in one transaction. The formal-terminal and caller projection
 is appended only by the Project transaction.
 
+## Component property code
+
+Selecting a placed component and opening **Properties** presents its canvas
+properties first as strict, editable JSON:
+
+```json
+{
+  "placement": {
+    "at": [360, 240],
+    "rotation": 90,
+    "mirror": "none"
+  },
+  "display": {
+    "reference": true,
+    "value": false
+  },
+  "appearance": {
+    "foreground": "auto",
+    "background": "auto"
+  }
+}
+```
+
+`placement.at` is the `[x, y]` grid coordinate, rotation is restricted to
+quarter turns, and mirror is `"none"` or `"x"`. Display keys appear only for
+annotations supported by that Symbol. Colors are `"auto"` or six-digit hex
+values. Applying valid code plans the existing typed placement, annotation,
+and style edits and submits them as one transaction. Unknown keys and invalid
+values are rejected without changing the Document. Connectivity, pins, Netlist
+identity, and Placement Tray lifecycle are intentionally absent from this
+surface; their dedicated typed commands remain authoritative.
+
+The old component placement, display, and appearance button grids are not
+mounted in the composed Properties dock. Electrical parameters, Reference,
+model bindings, Symbol-specific actions, and the exact read-only SPICE card
+remain in their focused sections below the canvas code. The left edge of
+Properties is draggable and keyboard-adjustable in both docked and compact
+overlay layouts; its independent width is retained locally without becoming
+Project data.
+
 The **Placement Tray** is the only retained-unplaced presentation surface. A
 tray item may be dragged, entered into the ordinary placement cursor, or placed
 with **Place all** into a deterministic starter grid in the current view.

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -39,6 +39,13 @@ palette-first manual authoring; no Project file needs to be opened first.
   the rest of the wire. Use the contextual
   **Remove route geometry** action to keep logical membership while deleting
   only the drawn route.
+- Select a component and press `Q` to open **Properties**. Its editable
+  **Canvas properties** JSON keeps position as `"at": [x, y]`, plus quarter-turn
+  rotation, mirror, supported Reference/Value visibility, and automatic or hex
+  foreground/background colors. Edit the code and choose **Apply code** (or
+  press `Ctrl`/`Cmd`+`Enter`); invalid or unknown properties are reported
+  without changing the drawing. Electrical parameters and the read-only SPICE
+  card remain below it. Drag the panel's left edge to set a comfortable width.
 - Right-click an endpoint for the distinct **Disconnect endpoint** and
   **Delete connection** actions.
 - `Delete` on a connected component now removes the component while preserving


### PR DESCRIPTION
## Summary

- add a strict editable Canvas-property JSON surface at the top of component Properties
- represent placement as an [x, y] coordinate plus rotation/mirror, and represent display/appearance as code
- apply valid code through existing typed edits in one transaction without exposing connectivity or tray lifecycle
- remove the duplicate placement/display/appearance GUI grids from the composed component dock
- make the Properties left edge draggable and keyboard-adjustable in both docked and half-window overlay layouts
- retain focused electrical/model/identity/actions and the read-only SPICE card below the code

## Validation

- pnpm gate:preflight -- --base origin/main
- 3,098 unit tests passed
- component-insert browser group: 34/34 passed
- manual-editor browser group: 137 unaffected cases passed; the 3 migrated Value-display cases passed after updating them to the code surface
- focused resize/editable-code browser regression passed, including pointer drag, keyboard resize, persistence, compact layout, and one-transaction edits
- local Chromium visual inspection at 1440px and 760px

## Deployment

Merge to main deploys only the isolated Preview channel. Do not trigger the Production workflow or create a release tag; this change needs human review on Preview first.

Test-Impact: tests-updated