### PR TITLE
Simplify component property controls

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -166,7 +166,7 @@ test("writes an Instance Reference through post-placement Properties", async ({
     .toContain('"reference": "R7"');
 });
 
-test("returns a component to the Placement Tray and places the retained Instance again", async ({
+test("keeps the Placement Tray out of the manual component workflow", async ({
   page,
 }) => {
   await page.goto("/editor");
@@ -177,56 +177,14 @@ test("returns a component to the Placement Tray and places the retained Instance
   await page.getByTestId("hit-R1").click();
   await page.getByTestId("selection-shelf").click();
 
-  await page
-    .getByRole("button", { name: "Return component to Placement Tray" })
-    .click();
   await expect(
-    page
-      .getByRole("region", { name: "Placement Tray" })
-      .getByLabel("1 retained Instance"),
-  ).toBeVisible();
+    page.getByRole("button", { name: "Return component to Placement Tray" }),
+  ).toHaveCount(0);
   await expect(
     page.getByRole("region", { name: "Placement Tray" }),
-  ).not.toContainText("drag to the canvas");
-  await expect(page.getByTestId("unplaced-R1")).toContainText("R1 · resistor");
-  await expect(page.getByTestId("hit-R1")).toHaveCount(0);
-  await expect(
-    page.getByTestId("annotation-hit-instance-label-R1"),
   ).toHaveCount(0);
-
-  await page
-    .getByRole("region", { name: "Placement Tray" })
-    .locator(":scope > summary")
-    .click();
-  await page
-    .getByRole("button", { name: "Place R1 · resistor from tray" })
-    .click();
-  await canvas.hover({ position: { x: 480, y: 260 } });
-  await expect(page.getByTestId("component-placement-preview")).toBeVisible();
-  await canvas.click({ position: { x: 480, y: 260 } });
-
   await expect(page.getByTestId("hit-R1")).toBeVisible();
-  await expect(
-    page.getByTestId("annotation-hit-instance-label-R1"),
-  ).toBeVisible();
-  await expect(
-    page
-      .getByRole("region", { name: "Placement Tray" })
-      .getByLabel("0 retained Instances"),
-  ).toBeVisible();
-  await expect(page.getByTestId("revision")).toHaveText("3");
-
-  await page.getByTestId("hit-R1").click();
-  await page
-    .getByRole("button", { name: "Return component to Placement Tray" })
-    .click();
-  await page
-    .getByRole("region", { name: "Placement Tray" })
-    .getByRole("button", { name: "Place all" })
-    .click();
-
-  await expect(page.getByTestId("hit-R1")).toBeVisible();
-  await expect(page.getByTestId("revision")).toHaveText("5");
+  await expect(page.getByTestId("revision")).toHaveText("1");
 });
 
 test("refreshes explicitly only after flushing and automatically restoring recovery", async ({
@@ -1282,7 +1240,7 @@ test("keeps differential amplifier swaps in a dedicated placement row", async ({
   ).toBeVisible();
   await expect(
     page.getByRole("button", { name: "Return component to Placement Tray" }),
-  ).toBeVisible();
+  ).toHaveCount(0);
 });
 
 test("keeps the workspace inside the viewport and exposes low-interference zoom controls", async ({

--- a/apps/editor/e2e/hierarchy.spec.ts
+++ b/apps/editor/e2e/hierarchy.spec.ts
@@ -519,7 +519,7 @@ test("edits a Cell Pin name and RichText presentation in place", async ({
   );
 });
 
-test("returns a formal Cell Pin to the Tray without deleting its interface", async ({
+test("keeps the Placement Tray out of the manually authored Cell Pin workflow", async ({
   page,
 }) => {
   await page.goto("/editor");
@@ -539,25 +539,13 @@ test("returns a formal Cell Pin to the Tray without deleting its interface", asy
   if ((await shelf.getAttribute("aria-expanded")) === "false") {
     await shelf.click();
   }
-  await page
-    .getByRole("button", { name: "Return component to Placement Tray" })
-    .click();
-
-  await expect(page.getByTestId("status")).toContainText(
-    "Cell interfaces and electrical facts were retained",
-  );
-  await expect(page.getByTestId("unplaced-P1")).toContainText("Vout · port");
-  await expect(page.getByTestId("hit-P1")).toHaveCount(0);
-  await page
-    .getByRole("region", { name: "Placement Tray" })
-    .locator(":scope > summary")
-    .click();
-  await page
-    .getByRole("region", { name: "Placement Tray" })
-    .getByRole("button", { name: "Place all" })
-    .click();
+  await expect(
+    page.getByRole("button", { name: "Return component to Placement Tray" }),
+  ).toHaveCount(0);
+  await expect(
+    page.getByRole("region", { name: "Placement Tray" }),
+  ).toHaveCount(0);
   await expect(page.getByTestId("hit-P1")).toBeVisible();
-  await page.getByTestId("hit-P1").click();
   await expect(page.getByLabel("Cell Pin properties")).toBeVisible();
 });
 

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -1461,10 +1461,10 @@ export function App({
       })`
     : undefined;
   const unplaced = document.instances.filter(
-    (instance) => instance.placement === null,
+    (instance) => instance.importProvenance && instance.placement === null,
   );
   const returnablePlacedInstances = document.instances.filter(
-    (instance) => instance.placement !== null,
+    (instance) => instance.importProvenance && instance.placement !== null,
   );
   const styleProfile = resolveDocumentStyleProfile(document.presentation);
   const {

--- a/apps/editor/src/features/component-insert/placement-tray-panel.test.tsx
+++ b/apps/editor/src/features/component-insert/placement-tray-panel.test.tsx
@@ -12,6 +12,11 @@ describe("placement tray panel", () => {
       symbolId: "resistor",
       placement: null,
       reference: "R1",
+      importProvenance: {
+        kind: "primitive",
+        sourceMasterName: "R",
+        sourceTarget: "primitive:R",
+      },
     };
     const markup = renderToStaticMarkup(
       <PlacementTrayPanel
@@ -33,5 +38,22 @@ describe("placement tray panel", () => {
     expect(tray).not.toContain('open=""');
     expect(markup).toContain('aria-label="1 retained Instance"');
     expect(markup).toContain("R1 · resistor");
+  });
+
+  it("does not render outside an imported placement workflow", () => {
+    const document = createEmptyDocument("cell", "Cell");
+    const markup = renderToStaticMarkup(
+      <PlacementTrayPanel
+        document={document}
+        unplaced={[]}
+        returnablePlaced={[]}
+        onPlaceAll={vi.fn()}
+        onReturnAll={vi.fn()}
+        onSelect={vi.fn()}
+        onPlace={vi.fn()}
+      />,
+    );
+
+    expect(markup).toBe("");
   });
 });

--- a/apps/editor/src/features/component-insert/placement-tray-panel.tsx
+++ b/apps/editor/src/features/component-insert/placement-tray-panel.tsx
@@ -32,6 +32,10 @@ export function PlacementTrayPanel({
   onSelect: (instance: Instance, label: string) => void;
   onPlace: (instanceId: string) => void;
 }) {
+  if (unplaced.length === 0 && returnablePlaced.length === 0) {
+    return null;
+  }
+
   return (
     <PropertyDisclosure
       title="Placement Tray"

--- a/apps/editor/src/features/properties/component-electrical-properties.test.tsx
+++ b/apps/editor/src/features/properties/component-electrical-properties.test.tsx
@@ -67,7 +67,7 @@ describe("component electrical properties", () => {
     expect(markup).not.toContain("Component compatibility field");
   });
 
-  it("keeps W, L, and NF labels compact while retaining other device guidance", () => {
+  it("packs multi-parameter devices into pairs and keeps their labels compact", () => {
     const document = createEmptyDocument("cell", "Cell");
     const instance: (typeof document.instances)[number] = {
       id: "M1",
@@ -108,7 +108,9 @@ describe("component electrical properties", () => {
     expect(markup).not.toContain("(Total width)");
     expect(markup).not.toContain("(Length)");
     expect(markup).not.toContain("(Finger count)");
-    expect(markup).toContain("(Multiplier)");
+    expect(markup).not.toContain("(Multiplier)");
+    expect(markup).toContain('data-parameter-row="w-l"');
+    expect(markup).toContain('data-parameter-row="nf-m"');
     expect(markup).toContain('title="Total width"');
   });
 

--- a/apps/editor/src/features/properties/component-electrical-properties.tsx
+++ b/apps/editor/src/features/properties/component-electrical-properties.tsx
@@ -10,7 +10,6 @@ import { derivedFingerWidth } from "./finger-width";
 import { PropertyDisclosure } from "./property-disclosure";
 
 type Instance = SchematicDocument["instances"][number];
-const COMPACT_PARAMETER_LABELS = new Set(["W", "L", "NF"]);
 
 const SOURCE_BASE_PARAMETER_ROWS = [
   ["dc", "waveform"],
@@ -32,7 +31,11 @@ function parameterRows(
   waveform: string | undefined,
 ): readonly (readonly ComponentParameter[])[] {
   if (!parameters.some(({ key }) => key === "waveform")) {
-    return parameters.map((parameter) => [parameter]);
+    const rows: ComponentParameter[][] = [];
+    for (let index = 0; index < parameters.length; index += 2) {
+      rows.push(parameters.slice(index, index + 2));
+    }
+    return rows;
   }
 
   const byKey = new Map(
@@ -147,7 +150,7 @@ export function ComponentElectricalProperties({
   const referenceToggleable = referenceLabelRenderable && referenceAvailable;
   const displayable = referenceToggleable || valueSupported;
   const renderedDisplayable = displayControls && displayable;
-  const isMos = descriptor?.deviceClass === "mos";
+  const compactParameterLabels = primaryParameters.length > 1;
   if (
     primaryParameters.length === 0 &&
     !renderedDisplayable &&
@@ -177,9 +180,7 @@ export function ComponentElectricalProperties({
                 <span className="property-parameter-name">
                   {parameter.label}
                   {parameter.unit ? ` / ${parameter.unit}` : ""}
-                  {isIndependentSource ||
-                  (isMos &&
-                    COMPACT_PARAMETER_LABELS.has(parameter.label)) ? null : (
+                  {isIndependentSource || compactParameterLabels ? null : (
                     <em>({parameter.help})</em>
                   )}
                 </span>

--- a/apps/editor/src/features/properties/component-placement-properties.test.tsx
+++ b/apps/editor/src/features/properties/component-placement-properties.test.tsx
@@ -38,6 +38,43 @@ describe("component placement properties", () => {
     );
     expect(markup).toContain('aria-label="Component geometry"');
     expect(markup).toContain("Swap + / − outputs");
+    expect(markup).not.toContain("Return to tray");
     expect(markup).toContain("Discard changes");
+  });
+
+  it("offers return to tray only for a netlist-imported instance", () => {
+    const document = createEmptyDocument("cell", "Cell");
+    const instance: (typeof document.instances)[number] = {
+      id: "M1",
+      symbolId: "nmos",
+      placement: {
+        position: { x: 10, y: 20 },
+        rotation: 0,
+        mirror: "none",
+      },
+      importProvenance: {
+        kind: "model",
+        sourceMasterName: "nmos",
+        sourceTarget: "model:nmos",
+      },
+    };
+    const markup = renderToStaticMarkup(
+      <ComponentPlacementProperties
+        instance={instance}
+        x="10"
+        y="20"
+        rotation="0"
+        draftChanged={false}
+        onXChange={vi.fn()}
+        onYChange={vi.fn()}
+        onRotate={vi.fn()}
+        onMirror={vi.fn()}
+        onReturnToTray={vi.fn()}
+        onDiscard={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain("Imported source evidence");
+    expect(markup).toContain("Return to tray");
   });
 });

--- a/apps/editor/src/features/properties/component-placement-properties.tsx
+++ b/apps/editor/src/features/properties/component-placement-properties.tsx
@@ -66,8 +66,8 @@ export function ComponentPlacementProperties({
               className="component-geometry-row property-placement-controls"
               aria-label="Component geometry"
             >
-              <label>
-                X
+              <label className="property-coordinate-field">
+                <span>X</span>
                 <input
                   aria-label="Component X position"
                   inputMode="decimal"
@@ -75,8 +75,8 @@ export function ComponentPlacementProperties({
                   onChange={(event) => onXChange(event.currentTarget.value)}
                 />
               </label>
-              <label>
-                Y
+              <label className="property-coordinate-field">
+                <span>Y</span>
                 <input
                   aria-label="Component Y position"
                   inputMode="decimal"
@@ -113,14 +113,16 @@ export function ComponentPlacementProperties({
               </button>
             </div>
           ) : null}
-          <button
-            type="button"
-            className="property-return-to-tray"
-            aria-label="Return component to Placement Tray"
-            onClick={onReturnToTray}
-          >
-            Return to tray
-          </button>
+          {instance.importProvenance ? (
+            <button
+              type="button"
+              className="property-return-to-tray"
+              aria-label="Return component to Placement Tray"
+              onClick={onReturnToTray}
+            >
+              Return to tray
+            </button>
+          ) : null}
           {onSwapContactStyle ? (
             <div className="component-mirror-row" aria-label="Switch drawing">
               <button

--- a/apps/editor/src/styles/editor-properties.css
+++ b/apps/editor/src/styles/editor-properties.css
@@ -194,6 +194,19 @@
   align-items: end;
 }
 
+.property-placement-controls .property-coordinate-field {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 0.3rem;
+  font-size: var(--icm-font-xs);
+}
+
+.property-placement-controls .property-coordinate-field input {
+  min-width: 0;
+  font-size: var(--icm-font-sm);
+}
+
 .property-placement-controls .property-placement-icon-button {
   display: inline-grid;
   place-items: center;


### PR DESCRIPTION
## Summary
- show Placement Tray and Return to tray only for netlist-imported instances
- arrange multi-parameter devices in compact two-column rows and remove redundant inline explanations
- place X/Y labels beside their values in the Placement section

## Validation
- pnpm ci:static
- pnpm build
- pnpm gate:affected -- --base origin/main
  - 3,079 unit tests passed
  - 34 component-insert browser tests passed
  - 141 manual-editor browser tests passed
- pnpm gate:preflight -- --base origin/main

Test-Impact: tests-updated