### PR TITLE
fix(render): keep MOS multiplier beside W/L fraction

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -3727,6 +3727,7 @@ test("value display projects MOS W/L and passive values beside the reference", a
   await openSelectionShelf(page);
   await page.getByLabel("Component w", { exact: true }).fill("2u");
   await page.getByLabel("Component l", { exact: true }).fill("180n");
+  await page.getByLabel("Component m", { exact: true }).fill("4");
   await editComponentPropertyCode(page, (propertyCode) => {
     propertyCode.display.value = true;
   });
@@ -3739,7 +3740,21 @@ test("value display projects MOS W/L and passive values beside the reference", a
   // numerator and denominator are separate part texts around a fraction bar.
   await expect(value).toContainText("2um");
   await expect(value).toContainText("180nm");
+  await expect(value).toContainText("×4");
   await expect(page.locator('[data-role="fraction-bar"]')).toHaveCount(1);
+  const multiplierGap = await value.evaluate((element) => {
+    const bar = element.querySelector<SVGLineElement>(
+      '[data-role="fraction-bar"]',
+    );
+    const multiplier = [
+      ...element.querySelectorAll<SVGTextElement>("text"),
+    ].find((text) => text.getAttribute("text-anchor") === "start");
+    if (!bar || !multiplier) throw new Error("Value geometry is incomplete");
+    const barBox = bar.getBBox();
+    return multiplier.getStartPositionOfChar(1).x - (barBox.x + barBox.width);
+  });
+  expect(multiplierGap).toBeGreaterThan(0);
+  expect(multiplierGap).toBeLessThan(12);
   // The value block is the second upright row under the reference.
   const referenceBox = await reference.boundingBox();
   const valueBox = await value.boundingBox();
@@ -3772,6 +3787,7 @@ test("value display projects MOS W/L and passive values beside the reference", a
   expect(svg).toContain('data-role="fraction-bar"');
   expect(svg).toContain("2um");
   expect(svg).toContain("180nm");
+  expect(svg).toContain("×4");
   expect(svg).toContain("33kΩ");
 });
 

--- a/packages/derived/src/instance-value.test.ts
+++ b/packages/derived/src/instance-value.test.ts
@@ -54,6 +54,29 @@ describe("displayableInstanceValue", () => {
     });
   });
 
+  it("appends a non-default parallel multiplier without flattening W/L", () => {
+    const result = displayableInstanceValue(
+      instance("nmos", { w: "2u", l: "600n", m: "4" }),
+    );
+    expect(result).toEqual({
+      kind: "displayable",
+      content: {
+        runs: [
+          {
+            kind: "fraction",
+            numerator: { runs: [bold("2um")] },
+            denominator: { runs: [bold("600nm")] },
+          },
+          {
+            kind: "span",
+            style: "bold",
+            children: [{ kind: "text", value: " ×4" }],
+          },
+        ],
+      },
+    });
+  });
+
   it("rejects a MOS device with either dimension missing", () => {
     expect(displayableInstanceValue(instance("nmos", { w: "10u" })).kind).toBe(
       "undisplayable",

--- a/packages/render-svg/src/drafting-render.test.ts
+++ b/packages/render-svg/src/drafting-render.test.ts
@@ -14,6 +14,11 @@ import { renderDocumentSvg } from "./render.js";
 import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
 
 const resolver = new InMemorySymbolResolver(builtInSymbols);
+const bold = (value: string) => ({
+  kind: "span" as const,
+  style: "bold" as const,
+  children: [{ kind: "text" as const, value }],
+});
 
 describe("drafting layer rendering", () => {
   it("exports a transparent complete outline, without a center shaft or duplicated head", () => {
@@ -818,6 +823,56 @@ describe("instance value fraction rendering", () => {
     // Fraction parts render three A+ levels (30%) above the subscript scale:
     // 15.116 × (0.76 × 1.3) ≈ 14.93px, roughly level with the reference label.
     expect(svg).toContain('font-size="14.93"');
+  });
+
+  it("keeps the bar when a multiplier follows the fraction", () => {
+    const document = createEmptyDocument("doc", "Multiplied value fraction");
+    document.instances.push({
+      id: "M1",
+      symbolId: "nmos",
+      placement: {
+        position: { x: 100, y: 100 },
+        rotation: 0,
+        mirror: "none",
+      },
+    });
+    document.annotations.push({
+      id: "instance-value-M1",
+      kind: "instance-value",
+      content: {
+        runs: [
+          {
+            kind: "fraction",
+            numerator: { runs: [bold("2um")] },
+            denominator: { runs: [bold("600nm")] },
+          },
+          bold(" ×4"),
+        ],
+      },
+      anchor: {
+        kind: "object",
+        objectId: "M1",
+        localOffset: { x: 40, y: 30 },
+        fallbackPosition: { x: 140, y: 130 },
+      },
+      alignment: "start",
+      rotation: 0,
+      locked: false,
+    });
+    const svg = renderDocumentSvg(document, resolver);
+    expect(svg).toContain('data-kind="instance-value"');
+    expect(svg).toContain('data-role="fraction-numerator"');
+    expect(svg).toContain('data-role="fraction-denominator"');
+    expect(svg).toContain('data-role="fraction-bar"');
+    expect(svg).toContain('xml:space="preserve"');
+    expect(svg).toContain("> ×4</tspan>");
+    const barEnd = Number(
+      svg.match(/data-role="fraction-bar"[^>]* x2="([^"]+)"/u)?.[1],
+    );
+    const multiplierStart = Number(
+      svg.match(/<text x="([^"]+)"[^>]*><tspan[^>]*> ×4<\/tspan>/u)?.[1],
+    );
+    expect(multiplierStart).toBeCloseTo(barEnd, 5);
   });
 });
 

--- a/packages/render-svg/src/render.ts
+++ b/packages/render-svg/src/render.ts
@@ -24,6 +24,7 @@ import {
   resolveDocumentStyleProfile,
   resolveDocumentLogicalNets,
   draftTextLayoutContent,
+  measureRichTextDocument,
   richTextMetrics,
   resolveRouteAttachment,
   razaviTextbookProfile,
@@ -119,7 +120,7 @@ function renderAnnotationText(
 function renderStackedFractionAnnotation(
   fraction: Extract<RichTextRun, { kind: "fraction" }>,
   options: {
-    attributes: string;
+    attributes?: string;
     position: Point;
     alignment: "start" | "middle" | "end";
     width: number;
@@ -154,7 +155,87 @@ function renderStackedFractionAnnotation(
   const textColor = options.color
     ? ` fill="${options.color}" color="${options.color}"`
     : "";
-  return `<g ${options.attributes}><text data-role="fraction-numerator" x="${centerX}" y="${numeratorY}" text-anchor="middle" font-size="${partFont}"${textColor} style="${partStyle}">${renderRichTextDocument(fraction.numerator, profile, { defaultBold: true, fontSize: partFont })}</text><line data-role="fraction-bar" x1="${centerX - halfWidth}" y1="${barY}" x2="${centerX + halfWidth}" y2="${barY}" stroke="${options.color ?? profile.foreground}" stroke-width="${profile.strokes.annotation}"/><text data-role="fraction-denominator" x="${centerX}" y="${denominatorY}" text-anchor="middle" font-size="${partFont}"${textColor} style="${partStyle}">${renderRichTextDocument(fraction.denominator, profile, { defaultBold: true, fontSize: partFont })}</text></g>`;
+  const attributes = options.attributes ? ` ${options.attributes}` : "";
+  return `<g${attributes}><text data-role="fraction-numerator" x="${centerX}" y="${numeratorY}" text-anchor="middle" font-size="${partFont}"${textColor} style="${partStyle}">${renderRichTextDocument(fraction.numerator, profile, { defaultBold: true, fontSize: partFont })}</text><line data-role="fraction-bar" x1="${centerX - halfWidth}" y1="${barY}" x2="${centerX + halfWidth}" y2="${barY}" stroke="${options.color ?? profile.foreground}" stroke-width="${profile.strokes.annotation}"/><text data-role="fraction-denominator" x="${centerX}" y="${denominatorY}" text-anchor="middle" font-size="${partFont}"${textColor} style="${partStyle}">${renderRichTextDocument(fraction.denominator, profile, { defaultBold: true, fontSize: partFont })}</text></g>`;
+}
+
+function isPositionableFractionCompanion(run: RichTextRun): boolean {
+  return (
+    run.kind === "text" ||
+    (run.kind === "span" && run.children.every(isPositionableFractionCompanion))
+  );
+}
+
+/**
+ * Paint one top-level fraction and its ordinary styled companions as siblings.
+ * SVG forbids the fraction's line inside a <text>, so the generic inline path
+ * cannot preserve its bar. Explicit x positions keep the bar and continuation
+ * on the same measured line without changing the canonical RichText AST.
+ */
+function renderPositionedFractionAnnotation(
+  content: RichTextDocument,
+  options: {
+    attributes: string;
+    position: Point;
+    alignment: "start" | "middle" | "end";
+    fontSize: number;
+    color?: string;
+    profile: SchematicStyleProfile;
+  },
+): string | null {
+  const fractionIndexes = content.runs.flatMap((run, index) =>
+    run.kind === "fraction" ? [index] : [],
+  );
+  if (fractionIndexes.length !== 1) return null;
+  const fractionIndex = fractionIndexes[0]!;
+  const companions = content.runs.filter((_, index) => index !== fractionIndex);
+  if (!companions.every(isPositionableFractionCompanion)) return null;
+
+  const fraction = content.runs[fractionIndex] as Extract<
+    RichTextRun,
+    { kind: "fraction" }
+  >;
+  const prefix: RichTextDocument = {
+    runs: content.runs.slice(0, fractionIndex),
+  };
+  const suffix: RichTextDocument = {
+    runs: content.runs.slice(fractionIndex + 1),
+  };
+  const metrics = {
+    ...richTextMetrics(options.profile),
+    fontSize: options.fontSize,
+  };
+  const widthOf = (document: RichTextDocument): number =>
+    document.runs.length === 0
+      ? 0
+      : measureRichTextDocument(document, metrics).width;
+  const prefixWidth = widthOf(prefix);
+  const fractionWidth = widthOf({ runs: [fraction] });
+  const suffixWidth = widthOf(suffix);
+  const totalWidth = prefixWidth + fractionWidth + suffixWidth;
+  const startX =
+    options.alignment === "start"
+      ? options.position.x
+      : options.alignment === "end"
+        ? options.position.x - totalWidth
+        : options.position.x - totalWidth / 2;
+  const textColor = options.color
+    ? ` fill="${options.color}" color="${options.color}"`
+    : "";
+  const renderCompanion = (document: RichTextDocument, x: number): string =>
+    document.runs.length === 0
+      ? ""
+      : `<text x="${x}" y="${options.position.y}" text-anchor="start" font-size="${options.fontSize}" xml:space="preserve"${textColor}>${renderRichTextDocument(document, options.profile, { lineOriginX: x, fontSize: options.fontSize })}</text>`;
+  const fractionX = startX + prefixWidth;
+  const fractionMarkup = renderStackedFractionAnnotation(fraction, {
+    position: { x: fractionX, y: options.position.y },
+    alignment: "start",
+    width: fractionWidth,
+    fontSize: options.fontSize,
+    ...(options.color ? { color: options.color } : {}),
+    profile: options.profile,
+  });
+  return `<g ${options.attributes}>${renderCompanion(prefix, startX)}${fractionMarkup}${renderCompanion(suffix, fractionX + fractionWidth)}</g>`;
 }
 
 function escapeXml(value: string): string {
@@ -1285,25 +1366,19 @@ export function buildSvgScene(
         return `<g ${attributes}><text data-role="polarity-positive" x="${position.x + positiveOffset.x}" y="${position.y + positiveOffset.y + 4}" text-anchor="middle" font-size="${profile.typography.polarityFontSize}" style="${polarityStyle}">+</text><text data-role="polarity-negative" x="${position.x + negativeOffset.x}" y="${position.y + negativeOffset.y + 4}" text-anchor="middle" font-size="${profile.typography.polarityFontSize}" style="${polarityStyle}">−</text>${text}</g>`;
       }
       const emphasis = "";
-      const fractionRun =
-        annotation.rotation === 0 &&
-        content.runs.length === 1 &&
-        content.runs[0]!.kind === "fraction"
-          ? (content.runs[0] as Extract<RichTextRun, { kind: "fraction" }>)
+      const positionedFraction =
+        annotation.rotation === 0
+          ? renderPositionedFractionAnnotation(content, {
+              attributes,
+              position,
+              alignment: annotation.alignment,
+              fontSize: annotationFontSize,
+              ...(colorOverride ? { color: colorOverride } : {}),
+              profile,
+            })
           : null;
-      if (fractionRun) {
-        const fraction = renderStackedFractionAnnotation(fractionRun, {
-          attributes,
-          position,
-          alignment: annotation.alignment,
-          width: presentation.bounds.width,
-          fontSize:
-            schematicTextFontSize(annotation.kind, profile) *
-            (annotation.sizeScale ?? 1),
-          ...(colorOverride ? { color: colorOverride } : {}),
-          profile,
-        });
-        return `<g>${fraction}${globalBadge}</g>`;
+      if (positionedFraction) {
+        return `<g>${positionedFraction}${globalBadge}</g>`;
       }
       const formula = renderFormulaDocument(content, profile, {
         x: position.x,


### PR DESCRIPTION
## Summary
- preserve the real SVG fraction bar when a MOS W/L annotation also includes a multiplier
- position the multiplier beside the measured fraction without changing the canonical RichText AST
- cover derived projection, SVG structure/spacing, canvas editing, and export parity

## Root cause
The renderer only used its structured fraction path when the fraction was the sole top-level run. Appending the multiplier made it fall back to an inline text path that cannot draw the fraction line.

## Validation
- `pnpm gate:preflight -- --base origin/main`
- focused derived and render unit tests: 42 passed
- focused MOS value browser/export regression: 1 passed
- full static, unit, build, and release verification completed
- full Playwright suite: 381 passed

Fixes #752