### PR TITLE
Unify native save authoring and simulation source navigation

### DIFF
--- a/apps/editor/e2e/helpers/simulation-code-harness.tsx
+++ b/apps/editor/e2e/helpers/simulation-code-harness.tsx
@@ -2,7 +2,10 @@
 import { useState } from "react";
 import { createRoot } from "react-dom/client";
 import SimulationCodeEditor from "../../src/features/simulation/code-editor";
-import { SimulationCodeWorkspace } from "../../src/features/simulation/code-workspace";
+import {
+  SimulationCodeWorkspace,
+  type SimulationCodeWorkspaceProps,
+} from "../../src/features/simulation/code-workspace";
 import "../../src/styles/editor-entry.css";
 
 const initial =
@@ -17,7 +20,8 @@ function Harness() {
   const [revision, setRevision] = useState(0);
   const [saved, setSaved] = useState(initial);
   const [cursor, setCursor] = useState(0);
-  const [pane, setPane] = useState<"console" | "results">("console");
+  const [pane, setPane] =
+    useState<SimulationCodeWorkspaceProps["outputPane"]>("console");
   const [maximized, setMaximized] = useState(false);
   const save = () => {
     setSaved(files[path]!);

--- a/apps/editor/e2e/simulation-code-editor.spec.ts
+++ b/apps/editor/e2e/simulation-code-editor.spec.ts
@@ -96,7 +96,7 @@ test("Files opens sideways, configuration is advanced, and results maximize/rest
     page.getByRole("tab", { name: "Configuration" }),
   ).toHaveAttribute("aria-selected", "true");
   await expect(editor).toContainText('"version"');
-  await page.getByRole("tab", { name: "Results", exact: true }).click();
+  await page.getByRole("tab", { name: "Plot", exact: true }).click();
   await page.getByRole("button", { name: "Maximize results" }).click();
   await expect(editor).not.toBeVisible();
   await expect(
@@ -156,6 +156,19 @@ test("invalid text stays editable and saveable and known command errors are inli
   await expect(page.getByTestId("saved-source")).toContainText("tran");
   await editor.fill("* test\n.control\ntran 1n 10u\n.endc\n.end\n");
   await expect(page.locator(".cm-lintRange-error")).toHaveCount(0);
+});
+
+test("Helper trigger toggles closed and stays compact", async ({ page }) => {
+  const trigger = page.getByRole("button", { name: /Helper/ }).first();
+  await trigger.click();
+  const popup = page.getByRole("dialog", { name: "Insert / Helper" });
+  await expect(popup).toBeVisible();
+  expect((await popup.boundingBox())!.width).toBeLessThanOrEqual(400);
+  await trigger.click();
+  await expect(popup).toHaveCount(0);
+  await trigger.click();
+  await page.keyboard.press("Escape");
+  await expect(popup).toHaveCount(0);
 });
 
 test("file switching preserves caret, selection, scroll and local Undo history", async ({

--- a/apps/editor/e2e/simulation-setup.spec.ts
+++ b/apps/editor/e2e/simulation-setup.spec.ts
@@ -98,38 +98,27 @@ test("the qualified OTA folder opens unchanged and preserves all root and hierar
   });
   await clickNetlistWorkflowCommand(page, "open-analog-simulation");
   const panel = page.getByRole("region", { name: "Analog simulation" });
-  // Canvas picking and authored scoped expressions share the same config file.
+  // Ordinary picks write native save text; current instrumentation keeps its owner.
   const helper = async (name: string) => {
     await panel.getByRole("button", { name: /Helper.*Ctrl\+Space/ }).click();
     await panel.getByRole("option", { name, exact: true }).click();
   };
   await helper("Pick Net on Canvas");
   await page.getByTestId("route-hit-tb-vinp-route").click({ force: true });
-  // One-shot Canvas picking opens the config; observations must stay reachable
-  // there without offering SPICE snippets that would corrupt the JSON file.
   await expect(
-    panel.getByRole("tab", { name: "Configuration", exact: false }),
-  ).toHaveAttribute("aria-selected", "true");
-  await panel.getByRole("button", { name: /Helper.*Ctrl\+Space/ }).click();
-  await expect(
-    panel.getByRole("option", { name: ".include", exact: true }),
-  ).toHaveCount(0);
-  await page.keyboard.press("Escape");
+    panel.getByRole("textbox", { name: "Simulation source editor" }),
+  ).toContainText("save ");
   await helper("Pick current on Canvas");
   await page.getByTestId("terminal-VINP-+").click();
   await expect(
     page.getByTestId("terminal-VINP-+-current-pick-marker"),
   ).toHaveClass(/origin/u);
   await page.getByTestId("terminal-VINP--").click();
-  await helper("Observe differential voltage");
-  const observe = panel.getByRole("dialog", { name: "Observe signal" });
+  await helper("Save voltage…");
+  const observe = panel.getByRole("dialog", { name: "Save signal" });
   await observe.getByRole("textbox", { name: "Search signal" }).fill("v(out)");
   await observe
     .getByRole("button", { name: "Use native vector: v(out)", exact: true })
-    .click();
-  await observe.getByRole("textbox", { name: "Search signal" }).fill("v(in)");
-  await observe
-    .getByRole("button", { name: "Use native vector: v(in)", exact: true })
     .click();
   const pickedProject = parseProject(
     (await downloadBytes(page, "File", "Export Project File…")).toString(),
@@ -137,14 +126,10 @@ test("the qualified OTA folder opens unchanged and preserves all root and hierar
   const pickedConfig = readSimulationExperimentConfig(
     pickedProject.simulationFolders[0]!,
   );
-  expect(pickedConfig.ok && pickedConfig.config.outputs.length).toBe(7);
+  expect(pickedConfig.ok && pickedConfig.config.outputs.length).toBe(5);
   expect(
     pickedConfig.ok && pickedConfig.config.outputs.at(-1)?.expression,
-  ).toEqual({
-    kind: "subtract",
-    left: { kind: "vector", vector: "v(out)" },
-    right: { kind: "vector", vector: "v(in)" },
-  });
+  ).toMatchObject({ kind: "current" });
   const circuit = {
     bindingId: savedSetup.input.circuitBindings[0]!.id,
     callPath: [],
@@ -228,7 +213,9 @@ test("the qualified OTA folder opens unchanged and preserves all root and hierar
       (f) => f.path === savedSetup.input.entry,
     )?.text,
   ).toBe(
-    savedSetup.input.files.find((f) => f.path === savedSetup.input.entry)?.text,
+    pickedProject.simulationFolders[0]!.input.files.find(
+      (f) => f.path === savedSetup.input.entry,
+    )?.text,
   );
   await page.reload();
   await page.getByTestId("project-file").setInputFiles({
@@ -358,20 +345,22 @@ test("one Testbench persists several independently named folders", async ({
       exact: true,
     }),
   ).toBeVisible();
-  page.once("dialog", (dialog) => void dialog.accept("Bias sweep"));
   await folders.getByRole("button", { name: "+ New folder…" }).click();
-  await panel.getByRole("button", { name: /Run current Cell/ }).click();
+  await folders
+    .getByRole("textbox", { name: "Folder name" })
+    .fill("Bias sweep");
+  await folders.getByRole("textbox", { name: "Folder name" }).press("Enter");
   await expect(
     folders.getByRole("button", { name: "Folder Bias sweep", exact: true }),
   ).toBeVisible();
   await folders
     .getByRole("button", { name: "Folder Bias sweep", exact: true })
     .click({ button: "right" });
-  page.once(
-    "dialog",
-    (dialog) => void dialog.accept("OTA OP, DC, AC, and TRAN"),
-  );
   await folders.getByRole("menuitem", { name: "Rename…" }).click();
+  await folders
+    .getByRole("textbox", { name: "Folder name" })
+    .fill("OTA OP, DC, AC, and TRAN");
+  await folders.getByRole("textbox", { name: "Folder name" }).press("Enter");
   await panel.getByRole("tab", { name: "Console", exact: true }).click();
   await expect(panel.getByLabel("Simulation results")).toContainText(
     "already exists",
@@ -387,7 +376,7 @@ test("one Testbench persists several independently named folders", async ({
     saved.simulationFolders.find(
       (folder: { name: string }) => folder.name === "Bias sweep",
     )?.input.circuitBindings[0]?.documentId,
-  ).toBe(activeTestbenchId);
+  ).toBeUndefined();
   expect(
     new Set(
       saved.simulationFolders.map(
@@ -396,7 +385,11 @@ test("one Testbench persists several independently named folders", async ({
       ),
     ),
   ).toEqual(
-    new Set(["document-ota-5t-testbench", "document-ota-5t-testbench-sin"]),
+    new Set([
+      "document-ota-5t-testbench",
+      "document-ota-5t-testbench-sin",
+      undefined,
+    ]),
   );
 
   await folders

--- a/apps/editor/e2e/simulation-workspace.spec.ts
+++ b/apps/editor/e2e/simulation-workspace.spec.ts
@@ -96,8 +96,9 @@ test("incomplete circuit opens Code and saves invalid parameter drafts across re
   await panel
     .getByRole("button", { name: "Folder Draft", exact: true })
     .click({ button: "right" });
-  page.once("dialog", (dialog) => void dialog.accept("Draft copy"));
   await panel.getByRole("menuitem", { name: "Duplicate…" }).click();
+  await panel.getByRole("textbox", { name: "Folder name" }).fill("Draft copy");
+  await panel.getByRole("textbox", { name: "Folder name" }).press("Enter");
   await expect(
     panel.getByRole("button", { name: "Folder Draft copy", exact: true }),
   ).toBeVisible();
@@ -352,12 +353,39 @@ test("human simulation uses saved folder, survives minimizing, recovers a bad in
   await clickNetlistWorkflowCommand(page, "open-analog-simulation");
   await expect(panel.getByRole("status")).toHaveText("finished · completed");
   // A completed run belongs to its folder, not whichever folder is currently visible.
-  page.once("dialog", (dialog) => void dialog.accept("Second folder"));
   await panel.getByRole("button", { name: "+ New folder…" }).click();
-  await panel.getByRole("button", { name: /Run current Cell/ }).click();
+  await panel
+    .getByRole("textbox", { name: "Folder name" })
+    .fill("Second folder");
+  await panel.getByRole("textbox", { name: "Folder name" }).press("Enter");
   await expect(panel.getByRole("status")).not.toHaveText(
     "finished · completed",
   );
+  await expect(
+    panel.getByRole("button", { name: "Toggle E2E folder" }),
+  ).toHaveAttribute("aria-expanded", "true");
+  await expect(
+    panel.getByRole("button", { name: "Toggle Second folder" }),
+  ).toHaveAttribute("aria-expanded", "true");
+  await panel
+    .getByRole("button", { name: "Folder Second folder", exact: true })
+    .click({ button: "right" });
+  await panel.getByRole("menuitem", { name: "New file…", exact: true }).click();
+  await panel.getByRole("textbox", { name: "File name" }).fill("bias.spice");
+  await panel.getByRole("textbox", { name: "File name" }).press("Enter");
+  await expect(panel.getByRole("tab", { name: /bias.spice/ })).toBeVisible();
+  await panel.getByRole("button", { name: /Helper.*Ctrl\+Space/ }).click();
+  await panel
+    .getByRole("textbox", { name: "Search commands or purpose" })
+    .fill("Save voltage");
+  await panel.getByRole("option", { name: "Save voltage…" }).click();
+  await panel.getByRole("textbox", { name: "Search signal" }).fill("v(out)");
+  await panel
+    .getByRole("button", { name: "Use native vector: v(out)" })
+    .click();
+  await expect(
+    panel.getByRole("textbox", { name: "Simulation source editor" }),
+  ).toContainText(".save v(out)");
   await panel
     .getByRole("button", { name: "Folder E2E folder", exact: true })
     .click();
@@ -369,7 +397,7 @@ test("human simulation uses saved folder, survives minimizing, recovers a bad in
     "finished · completed",
   );
   await expect(panel.locator(".simulation-console-view > pre")).toBeVisible();
-  await panel.getByRole("tab", { name: "Results", exact: true }).click();
+  await panel.getByRole("tab", { name: "Plot", exact: true }).click();
   await panel.getByRole("tab", { name: "Operating Point" }).click();
   await expect(panel.getByRole("region", { name: "OP results" })).toContainText(
     "0.500000",
@@ -851,7 +879,7 @@ test("human simulation uses saved folder, survives minimizing, recovers a bad in
   await expect(panel.locator(".simulation-code-status")).toContainText(
     "earlier Project revision",
   );
-  await panel.getByRole("tab", { name: "Results", exact: true }).click();
+  await panel.getByRole("tab", { name: "Plot", exact: true }).click();
   await panel.getByRole("button", { name: "Maximize results" }).click();
   await panel.getByRole("tab", { name: "Plot" }).click();
   await expect(
@@ -1064,7 +1092,7 @@ test("human simulation uses saved folder, survives minimizing, recovers a bad in
     panel.getByRole("textbox", { name: "Simulation source editor" }),
   ).toContainText(".temp 30");
   await expect(panel.getByRole("status")).toHaveText("No run yet");
-  await panel.getByRole("tab", { name: "Results", exact: true }).click();
+  await panel.getByRole("tab", { name: "Plot", exact: true }).click();
   await panel.getByRole("tab", { name: "Compare" }).click();
   const savedArchives = panel.getByRole("region", {
     name: "Saved result archives",
@@ -1106,11 +1134,12 @@ test("Simulation creates an ordinary testbench and offers the current Cell at th
   expect(saved.simulationFolders).toEqual([]);
   await clickNetlistWorkflowCommand(page, "open-analog-simulation");
   await expect(page.getByLabel("Testbench Cell")).toHaveCount(0);
-  page.once("dialog", (dialog) => void dialog.accept("Main experiment"));
   await page
     .getByRole("button", { name: "Create experiment for this Cell" })
     .click();
-  await page.getByRole("button", { name: /Run current Cell/ }).click();
+  await page
+    .getByRole("button", { name: "Template: current Canvas Cell" })
+    .click();
   const configured = JSON.parse(
     (await downloadBytes(page, "File", "Export Project File…")).toString(),
   );

--- a/apps/editor/src/features/simulation/code-editor.tsx
+++ b/apps/editor/src/features/simulation/code-editor.tsx
@@ -65,6 +65,7 @@ import {
   parameterGuide,
 } from "./code-parameter-guide";
 import { CodeHelperList, type CodeHelperAction } from "./code-helper-list";
+import { nativeSaveEdit } from "./native-save-edit";
 
 export interface SimulationCodeEditorProps {
   path: string;
@@ -91,6 +92,8 @@ export interface SimulationCodeEditorProps {
   onCursor?(sourceOffset: number): void;
   helperActions?: readonly CodeHelperAction[];
   relatedSources?: readonly string[];
+  signalNames?: (() => Readonly<Record<string, string>>) | undefined;
+  saveRequest?: { id: string; vectors: string[] } | undefined;
   reveal?:
     { sourceOffset: number; requestId: string; focus?: boolean } | undefined;
 }
@@ -334,6 +337,29 @@ export default function SimulationCodeEditor(props: SimulationCodeEditorProps) {
     if (props.reveal.focus !== false) editor.focus();
   }, [props.reveal?.requestId]);
 
+  useEffect(() => {
+    const editor = view.current;
+    if (
+      !editor ||
+      !props.saveRequest ||
+      props.generated ||
+      props.mode === "json"
+    )
+      return;
+    const edit = nativeSaveEdit(
+      editor.state.doc.toString(),
+      editor.state.selection.main.head,
+      props.saveRequest.vectors,
+      !!props.entry,
+    );
+    editor.dispatch({
+      changes: { from: edit.from, insert: edit.insert },
+      selection: { anchor: edit.from + edit.insert.length },
+      scrollIntoView: true,
+    });
+    editor.focus();
+  }, [props.saveRequest?.id]);
+
   return (
     <div className="simulation-code-editor-shell">
       <div
@@ -347,6 +373,8 @@ export default function SimulationCodeEditor(props: SimulationCodeEditorProps) {
         <button
           type="button"
           title="Insert / Helper · Ctrl+Space"
+          data-simulation-helper-trigger
+          aria-expanded={helperOpen}
           onClick={() => setHelperOpen((open) => !open)}
         >
           Helper <kbd>Ctrl+Space</kbd>
@@ -478,7 +506,11 @@ function sourceExtensions(
           autocompletion({
             override: [
               (context) =>
-                spiceCompletion(context, callbacks.current.relatedSources),
+                spiceCompletion(
+                  context,
+                  callbacks.current.relatedSources,
+                  callbacks.current.signalNames,
+                ),
             ],
             activateOnTypingDelay: 350,
           }),

--- a/apps/editor/src/features/simulation/code-helper-list.tsx
+++ b/apps/editor/src/features/simulation/code-helper-list.tsx
@@ -41,7 +41,7 @@ export function CodeHelperList({
         key: action.id,
         label: action.label,
         detail: "",
-        group: "Observe",
+        group: "Signals",
         run: action.run,
       })),
     ...rules.map((rule) => ({
@@ -54,7 +54,11 @@ export function CodeHelperList({
   ];
   useEffect(() => {
     const close = (event: PointerEvent) => {
-      if (!root.current?.contains(event.target as Node)) onClose();
+      if (
+        !root.current?.contains(event.target as Node) &&
+        !(event.target as Element).closest?.("[data-simulation-helper-trigger]")
+      )
+        onClose();
     };
     document.addEventListener("pointerdown", close);
     return () => document.removeEventListener("pointerdown", close);

--- a/apps/editor/src/features/simulation/code-parameter-guide.ts
+++ b/apps/editor/src/features/simulation/code-parameter-guide.ts
@@ -102,6 +102,10 @@ export function parameterGuide(state: EditorState) {
     else if (excitation !== "DC")
       parameters = [...parameters.slice(0, 2), { label: "value" }];
   }
+  const repeated = parameters.at(-1);
+  if (repeated?.repeat) {
+    while (parameters.length <= index) parameters.push({ ...repeated });
+  }
   return { line, help, tokens, index, parameters };
 }
 

--- a/apps/editor/src/features/simulation/code-spice-language.ts
+++ b/apps/editor/src/features/simulation/code-spice-language.ts
@@ -66,6 +66,7 @@ export const spiceCodeLanguage = StreamLanguage.define(parser);
 export function spiceCompletion(
   context: CompletionContext,
   relatedSources: readonly string[] = [],
+  signalNames?: () => Readonly<Record<string, string>>,
 ): CompletionResult | null {
   const line = context.state.doc.lineAt(context.pos);
   const word = context.matchBefore(/[.\w]+/u);
@@ -84,6 +85,13 @@ export function spiceCompletion(
       const wantsNode = parameter === "n+" || parameter === "n-";
       if (!wantsSource && !wantsVector && !wantsNode) return null;
       const symbols = new Set<string>();
+      if (
+        wantsVector &&
+        guide.help.name.replace(/^\./u, "").toLowerCase() === "save"
+      )
+        symbols.add("all");
+      const mapped = wantsVector ? (signalNames?.() ?? {}) : {};
+      for (const vector of Object.keys(mapped)) symbols.add(vector);
       for (const text of [context.state.doc.toString(), ...relatedSources]) {
         let subckt = false;
         for (const row of text.split(/\r?\n/u)) {
@@ -105,7 +113,11 @@ export function spiceCompletion(
       const vectorWord = context.matchBefore(/[\w().,:]+/u);
       return {
         from: vectorWord?.from ?? context.pos,
-        options: [...symbols].map((label) => ({ label, type: "variable" })),
+        options: [...symbols].map((label) => ({
+          label,
+          type: "variable",
+          ...(mapped[label] ? { detail: mapped[label] } : {}),
+        })),
       };
     }
     return {

--- a/apps/editor/src/features/simulation/code-workspace.css
+++ b/apps/editor/src/features/simulation/code-workspace.css
@@ -116,6 +116,23 @@
 .simulation-folder-tree {
   min-height: 100%;
 }
+.simulation-folder-row {
+  display: flex;
+  align-items: center;
+}
+.simulation-folder-row > button:first-child {
+  width: 24px;
+  flex: 0 0 24px;
+}
+.simulation-folder-row > button:last-child {
+  flex: 1;
+  min-width: 0;
+}
+.simulation-code-files input {
+  width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+}
 .simulation-folder-tree ul {
   padding-left: 12px;
 }
@@ -305,7 +322,7 @@
   position: absolute;
   top: 32px;
   left: 8px;
-  right: 8px;
+  width: min(380px, calc(100% - 16px));
   max-height: 80%;
   display: flex;
   flex-direction: column;

--- a/apps/editor/src/features/simulation/code-workspace.test.tsx
+++ b/apps/editor/src/features/simulation/code-workspace.test.tsx
@@ -65,5 +65,8 @@ describe("approved simulation Code layout", () => {
       markup.indexOf("Run console"),
     );
     expect(markup).not.toContain("Settings");
+    expect(markup).toContain(">Compare</button>");
+    expect(markup).toContain(">OP</button>");
+    expect(markup).not.toContain(">Results</button>");
   });
 });

--- a/apps/editor/src/features/simulation/code-workspace.tsx
+++ b/apps/editor/src/features/simulation/code-workspace.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useId, useState, type ReactNode } from "react";
+import { InlineSourceName } from "./inline-source-name";
 import {
   SimulationFolderTree,
   type SimulationFolderTreeProps,
@@ -16,12 +17,14 @@ export interface SimulationCodeWorkspaceProps {
   configPath: string;
   activePath: string;
   onSelectFile(path: string): void;
-  onNewFile?(): void;
+  onNewFile?(path: string): void;
+  newFileRequest?: string | undefined;
   onCopyFile?(): void;
   onExportFile?(): void;
   onFileAction?(
     action: "rename" | "delete" | "entry" | "discard",
     path: string,
+    newPath?: string,
   ): void;
   folders?: Omit<SimulationFolderTreeProps, "children"> | undefined;
   additionalActions?: ReactNode;
@@ -30,8 +33,8 @@ export interface SimulationCodeWorkspaceProps {
   status?: ReactNode;
   console: ReactNode;
   results: ReactNode;
-  outputPane: "console" | "results";
-  onSelectOutputPane(pane: "console" | "results"): void;
+  outputPane: "console" | "plot" | "operating-point" | "compare" | "files";
+  onSelectOutputPane(pane: SimulationCodeWorkspaceProps["outputPane"]): void;
   maximized?: boolean;
   onToggleMaximize?(): void;
 }
@@ -50,8 +53,16 @@ export function SimulationCodeWorkspace(props: SimulationCodeWorkspaceProps) {
   const [resultsHeight, setResultsHeight] = useState(38);
   const [collapsed, setCollapsed] = useState(false);
   const [fileMenu, setFileMenu] = useState<string>();
+  const [naming, setNaming] = useState<{ path?: string; initial: string }>();
+  useEffect(() => {
+    if (props.newFileRequest) {
+      setFilesOpen(true);
+      setNaming({ initial: "untitled.spice" });
+    }
+  }, [props.newFileRequest]);
   useEffect(() => {
     setOpened(defaults());
+    setFileMenu(undefined);
     setMoreOpen(false);
   }, [props.workspaceKey]);
   useEffect(() => {
@@ -75,6 +86,29 @@ export function SimulationCodeWorkspace(props: SimulationCodeWorkspaceProps) {
   };
   const fileList = () => (
     <ul>
+      <li>
+        <button
+          type="button"
+          onClick={() => setNaming({ initial: "untitled.spice" })}
+        >
+          + New file
+        </button>
+      </li>
+      {naming && (
+        <li>
+          <InlineSourceName
+            label="File name"
+            initial={naming.initial}
+            onCancel={() => setNaming(undefined)}
+            onSubmit={(name) => {
+              if (naming.path)
+                props.onFileAction?.("rename", naming.path, name);
+              else props.onNewFile?.(name);
+              setNaming(undefined);
+            }}
+          />
+        </li>
+      )}
       {props.files
         .filter((file) => file.path !== props.configPath)
         .map((file) => (
@@ -134,7 +168,7 @@ export function SimulationCodeWorkspace(props: SimulationCodeWorkspaceProps) {
                     <button
                       role="menuitem"
                       onClick={() => {
-                        props.onFileAction?.("rename", file.path);
+                        setNaming({ path: file.path, initial: file.path });
                         setFileMenu(undefined);
                       }}
                     >
@@ -255,7 +289,8 @@ export function SimulationCodeWorkspace(props: SimulationCodeWorkspaceProps) {
                 <button
                   type="button"
                   onClick={() => {
-                    props.onNewFile?.();
+                    setFilesOpen(true);
+                    setNaming({ initial: "untitled.spice" });
                     setMoreOpen(false);
                   }}
                 >
@@ -385,18 +420,37 @@ export function SimulationCodeWorkspace(props: SimulationCodeWorkspaceProps) {
       >
         <header className="simulation-code-output-tabs">
           <div role="tablist" aria-label="Code output view">
-            {(["console", "results"] as const).map((pane) => (
+            {(
+              [
+                "console",
+                "plot",
+                "operating-point",
+                "compare",
+                "files",
+              ] as const
+            ).map((pane) => (
               <button
                 key={pane}
                 type="button"
                 role="tab"
                 aria-selected={pane === props.outputPane}
+                aria-label={
+                  pane === "operating-point" ? "Operating Point" : undefined
+                }
                 onClick={() => {
                   props.onSelectOutputPane(pane);
                   setCollapsed(false);
                 }}
               >
-                {pane === "console" ? "Console" : "Results"}
+                {
+                  {
+                    console: "Console",
+                    plot: "Plot",
+                    "operating-point": "OP",
+                    compare: "Compare",
+                    files: "Files",
+                  }[pane]
+                }
               </button>
             ))}
           </div>

--- a/apps/editor/src/features/simulation/inline-source-name.tsx
+++ b/apps/editor/src/features/simulation/inline-source-name.tsx
@@ -1,0 +1,36 @@
+import { useState } from "react";
+
+/** A cancellable local name draft; the caller owns validation and persistence. */
+export function InlineSourceName(props: {
+  label: string;
+  initial: string;
+  onSubmit(name: string): void;
+  onCancel(): void;
+  onChange?(name: string): void;
+}) {
+  const [name, setName] = useState(props.initial);
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        if (name.trim()) props.onSubmit(name.trim());
+      }}
+    >
+      <input
+        autoFocus
+        aria-label={props.label}
+        value={name}
+        onFocus={(event) => event.currentTarget.select()}
+        onChange={(event) => {
+          const next = event.currentTarget.value;
+          setName(next);
+          props.onChange?.(next);
+        }}
+        onKeyDown={(event) => {
+          event.stopPropagation();
+          if (event.key === "Escape") props.onCancel();
+        }}
+      />
+    </form>
+  );
+}

--- a/apps/editor/src/features/simulation/native-save-edit.test.ts
+++ b/apps/editor/src/features/simulation/native-save-edit.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { EditorState } from "@codemirror/state";
+import { nativeSaveEdit } from "./native-save-edit";
+import { parameterGuide } from "./code-parameter-guide";
+
+describe("native save authoring", () => {
+  it("inserts before control analyses rather than after their write", () => {
+    const text = "* title\n.control\nop\nwrite out.raw\n.endc\n.end\n";
+    const edit = nativeSaveEdit(text, text.length, ["v(out)"], true);
+    expect(
+      text.slice(0, edit.from) + edit.insert + text.slice(edit.from),
+    ).toContain(".control\nsave v(out)\nop");
+  });
+  it("extends save under the cursor without duplicating a vector", () => {
+    const text = "save v(out)";
+    expect(
+      nativeSaveEdit(text, text.length, ["v(out)", "i(vdd)"], false),
+    ).toEqual({ from: text.length, insert: " i(vdd)" });
+  });
+  it("preserves the deck title and CRLF", () => {
+    const text = "My deck\r\nR1 a 0 1k\r\n.end\r\n";
+    expect(nativeSaveEdit(text, 0, ["v(a)"], true)).toEqual({
+      from: 9,
+      insert: ".save v(a)\r\n",
+    });
+  });
+  it("continues vector help beyond the first argument", () => {
+    const doc = ".control\nsave v(a) v(b) ";
+    const guide = parameterGuide(
+      EditorState.create({ doc, selection: { anchor: doc.length } }),
+    );
+    expect(guide?.parameters[guide.index]?.label).toBe("vector");
+  });
+});

--- a/apps/editor/src/features/simulation/native-save-edit.ts
+++ b/apps/editor/src/features/simulation/native-save-edit.ts
@@ -1,0 +1,36 @@
+/** Insert before analyses, or extend the save statement under the cursor. */
+export function nativeSaveEdit(
+  text: string,
+  cursor: number,
+  vectors: readonly string[],
+  entry: boolean,
+) {
+  const eol = text.includes("\r\n") ? "\r\n" : "\n";
+  const start = text.lastIndexOf("\n", Math.max(0, cursor - 1)) + 1;
+  const newline = text.indexOf("\n", cursor);
+  const end = newline < 0 ? text.length : newline;
+  const line = text.slice(start, end).replace(/\r$/u, "");
+  if (/^\s*\.?save(?:\s|$)/iu.test(line)) {
+    const missing = vectors.filter(
+      (v) => !line.toLowerCase().split(/\s+/u).includes(v.toLowerCase()),
+    );
+    return {
+      from: start + line.length,
+      insert: missing.length ? " " + missing.join(" ") : "",
+    };
+  }
+  const control = /^\s*\.control[^\r\n]*(?:\r?\n|$)/imu.exec(text);
+  const from = control
+    ? control.index + control[0].length
+    : entry
+      ? text.indexOf("\n") < 0
+        ? text.length
+        : text.indexOf("\n") + 1
+      : 0;
+  return {
+    from,
+    insert:
+      (from > 0 && text[from - 1] !== "\n" ? eol : "") +
+      `${control ? "save" : ".save"} ${vectors.join(" ")}${eol}`,
+  };
+}

--- a/apps/editor/src/features/simulation/simulation-file-tree.tsx
+++ b/apps/editor/src/features/simulation/simulation-file-tree.tsx
@@ -1,16 +1,19 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
+import { InlineSourceName } from "./inline-source-name";
 
 export interface SimulationFolderNode {
   id: string;
   name: string;
+  paths?: readonly string[];
 }
 export type FolderAction =
   "new" | "duplicate" | "rename" | "delete" | "run" | "export" | "batch";
 export interface SimulationFolderTreeProps {
   folders: readonly SimulationFolderNode[];
   activeId: string;
-  onSelect(id: string): void;
-  onAction(action: FolderAction, ids: string[]): void;
+  onSelect(id: string, path?: string): void;
+  onAction(action: FolderAction, ids: string[], name?: string): void;
+  onNewFile?(id: string): void;
   children: ReactNode;
   busy?: boolean;
 }
@@ -18,6 +21,17 @@ export interface SimulationFolderTreeProps {
 /** One execution root per folder. The tree owns selection, never source or run state. */
 export function SimulationFolderTree(props: SimulationFolderTreeProps) {
   const [selected, setSelected] = useState<string[]>([]);
+  const [expanded, setExpanded] = useState<string[]>([props.activeId]);
+  const [naming, setNaming] = useState<{
+    action: "new" | "rename" | "duplicate";
+    ids: string[];
+    initial: string;
+  }>();
+  useEffect(() => {
+    setExpanded((ids) =>
+      ids.includes(props.activeId) ? ids : [...ids, props.activeId],
+    );
+  }, [props.activeId]);
   const [menu, setMenu] = useState<{ x: number; y: number; ids: string[] }>();
   const menuRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
@@ -44,7 +58,17 @@ export function SimulationFolderTree(props: SimulationFolderTreeProps) {
     });
   };
   const action = (name: FolderAction, ids = menu?.ids ?? []) => {
-    props.onAction(name, ids);
+    if (name === "new" || name === "rename" || name === "duplicate") {
+      const folder = props.folders.find((f) => f.id === ids[0]);
+      setNaming({
+        action: name,
+        ids,
+        initial:
+          name === "new"
+            ? "Untitled"
+            : `${folder?.name ?? "Untitled"}${name === "duplicate" ? " copy" : ""}`,
+      });
+    } else props.onAction(name, ids);
     setMenu(undefined);
   };
   return (
@@ -57,47 +81,91 @@ export function SimulationFolderTree(props: SimulationFolderTreeProps) {
         open(event.clientX, event.clientY);
       }}
     >
-      <button type="button" onClick={() => props.onAction("new", [])}>
+      <button type="button" onClick={() => action("new", [])}>
         + New folder…
       </button>
+      {naming && (
+        <InlineSourceName
+          label="Folder name"
+          initial={naming.initial}
+          onCancel={() => setNaming(undefined)}
+          onSubmit={(name) => {
+            props.onAction(naming.action, naming.ids, name);
+            setNaming(undefined);
+          }}
+        />
+      )}
       {props.folders.map((folder) => (
         <div key={folder.id}>
-          <button
-            type="button"
-            className={folder.id === props.activeId ? "is-active" : ""}
-            aria-label={`Folder ${folder.name}`}
-            aria-pressed={selected.includes(folder.id)}
-            onClick={(event) => {
-              if (event.ctrlKey || event.metaKey)
-                setSelected((ids) =>
+          <div className="simulation-folder-row">
+            <button
+              type="button"
+              aria-label={`Toggle ${folder.name}`}
+              aria-expanded={expanded.includes(folder.id)}
+              onClick={() =>
+                setExpanded((ids) =>
                   ids.includes(folder.id)
                     ? ids.filter((id) => id !== folder.id)
                     : [...ids, folder.id],
-                );
-              else {
-                setSelected([folder.id]);
-                props.onSelect(folder.id);
+                )
               }
-            }}
-            onContextMenu={(event) => {
-              event.preventDefault();
-              event.stopPropagation();
-              open(event.clientX, event.clientY, folder.id);
-            }}
-            onKeyDown={(event) => {
-              if (
-                event.key === "ContextMenu" ||
-                (event.shiftKey && event.key === "F10")
-              ) {
+            >
+              {expanded.includes(folder.id) ? "▾" : "▸"}
+            </button>
+            <button
+              type="button"
+              className={folder.id === props.activeId ? "is-active" : ""}
+              aria-label={`Folder ${folder.name}`}
+              aria-pressed={selected.includes(folder.id)}
+              onClick={(event) => {
+                if (event.ctrlKey || event.metaKey)
+                  setSelected((ids) =>
+                    ids.includes(folder.id)
+                      ? ids.filter((id) => id !== folder.id)
+                      : [...ids, folder.id],
+                  );
+                else {
+                  setSelected([folder.id]);
+                  props.onSelect(folder.id);
+                }
+              }}
+              onContextMenu={(event) => {
                 event.preventDefault();
-                const rect = event.currentTarget.getBoundingClientRect();
-                open(rect.left, rect.bottom, folder.id);
-              }
-            }}
-          >
-            {folder.id === props.activeId ? "▾" : "▸"} {folder.name}
-          </button>
-          {folder.id === props.activeId ? props.children : null}
+                event.stopPropagation();
+                open(event.clientX, event.clientY, folder.id);
+              }}
+              onKeyDown={(event) => {
+                if (
+                  event.key === "ContextMenu" ||
+                  (event.shiftKey && event.key === "F10")
+                ) {
+                  event.preventDefault();
+                  const rect = event.currentTarget.getBoundingClientRect();
+                  open(rect.left, rect.bottom, folder.id);
+                }
+              }}
+            >
+              {folder.name}
+            </button>
+          </div>
+          {expanded.includes(folder.id) ? (
+            folder.id === props.activeId ? (
+              props.children
+            ) : (
+              <ul>
+                {folder.paths?.map((path) => (
+                  <li key={path}>
+                    <button
+                      type="button"
+                      onClick={() => props.onSelect(folder.id, path)}
+                    >
+                      {path}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )
+          ) : null}
         </div>
       ))}
       {menu ? (
@@ -115,17 +183,21 @@ export function SimulationFolderTree(props: SimulationFolderTreeProps) {
             }
           }}
         >
-          <button role="menuitem" onClick={() => action("new", ["op"])}>
-            New OP folder…
-          </button>
-          <button role="menuitem" onClick={() => action("new", ["ac"])}>
-            New AC folder…
-          </button>
-          <button role="menuitem" onClick={() => action("new", ["tran"])}>
-            New transient folder…
+          <button role="menuitem" onClick={() => action("new", [])}>
+            New folder…
           </button>
           {menu.ids.length === 1 ? (
             <>
+              <button
+                role="menuitem"
+                onClick={() => {
+                  props.onSelect(menu.ids[0]!);
+                  props.onNewFile?.(menu.ids[0]!);
+                  setMenu(undefined);
+                }}
+              >
+                New file…
+              </button>
               <button
                 role="menuitem"
                 disabled={props.busy}

--- a/apps/editor/src/features/simulation/source-code-pane.tsx
+++ b/apps/editor/src/features/simulation/source-code-pane.tsx
@@ -20,7 +20,12 @@ import {
   matchSimulationTerminalCurrentProbeOptions,
   type SimulationProbeOption,
 } from "./simulation-probe-options";
-import { generateCircuitSource, planCircuitSourceEdit } from "@icm/netlist";
+import {
+  generateCircuitSource,
+  planCircuitSourceEdit,
+  compileSourceSimulation,
+  simulationSignalNames,
+} from "@icm/netlist";
 import type { SimulationFiles } from "@icm/simulation-service/files";
 import { sha256 } from "@icm/simulation-service/files";
 import type {
@@ -60,6 +65,8 @@ interface Props extends Pick<
   selectedCircuitObject?:
     { documentId: string; instanceId: string } | undefined;
   folder: ProjectSimulationFolder;
+  selectedFile?: { folderId: string; path: string } | undefined;
+  newFileRequest?: string | undefined;
   files: SimulationFiles;
   actions: ReactNode;
   folders?: SimulationCodeWorkspaceProps["folders"];
@@ -67,11 +74,12 @@ interface Props extends Pick<
   console: ReactNode;
   results: ReactNode;
   status?: ReactNode;
-  outputPane: "console" | "results";
-  onSelectOutputPane(pane: "console" | "results"): void;
+  outputPane: SimulationCodeWorkspaceProps["outputPane"];
+  onSelectOutputPane: SimulationCodeWorkspaceProps["onSelectOutputPane"];
   maximized: boolean;
   onToggleMaximize(): void;
   onDirty(dirty: boolean): void;
+  onActiveDirty(dirty: boolean): void;
   onProblem(problem: Problem | undefined): void;
   diagnostics?: Problem["diagnostics"];
   onRun(): void;
@@ -123,6 +131,13 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
       setRecoveryAvailable(cache.write(drafts.current));
     }, [cache, draftRevision]);
     const [path, setPath] = useState(props.folder.input.entry);
+    useEffect(() => {
+      setPath(
+        props.selectedFile?.folderId === props.folder.id
+          ? props.selectedFile.path
+          : props.folder.input.entry,
+      );
+    }, [props.folder.id, props.selectedFile]);
     const [saving, setSaving] = useState(false);
     const [reveal, setReveal] = useState<{
       sourceOffset: number;
@@ -130,15 +145,17 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
       focus?: boolean;
     }>();
     const [sourceDigest, setSourceDigest] = useState("");
+    const [saveRequest, setSaveRequest] = useState<{
+      id: string;
+      vectors: string[];
+    }>();
     const savingRef = useRef(false);
     const picked = useRef({
       net: props.pickedNet?.sequence,
       terminal: props.pickedTerminal?.sequence,
     });
     const input = props.folder.input;
-    const [probePicker, setProbePicker] = useState<
-      "voltage" | "current" | "difference"
-    >();
+    const [probePicker, setProbePicker] = useState<"voltage" | "current">();
     const probeChoices = useMemo(
       () =>
         probePicker
@@ -164,10 +181,31 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
           : undefined,
       [props.project, binding],
     );
-    const addOutput = (
+    const saveSignal = (
       label: string,
       expression: SimulationSourceExpression,
     ) => {
+      const insert = (vectors: string[]) => {
+        if (
+          input.circuitBindings.some((b) => b.path === path) ||
+          path.endsWith(".json")
+        )
+          setPath(input.entry);
+        setSaveRequest({ id: crypto.randomUUID(), vectors });
+      };
+      if (expression.kind === "vector") {
+        if (/[\r\n;]/u.test(expression.vector)) {
+          props.onProblem(
+            inputProblem(
+              "SIMULATION_VECTOR_INVALID",
+              "Enter a vector, not a command.",
+            ),
+          );
+          return;
+        }
+        insert([expression.vector]);
+        return;
+      }
       const file = props.folder.input.files.find(
           (f) => f.path === input.configPath,
         ),
@@ -194,23 +232,70 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
         setPath(input.configPath);
         return;
       }
-      if (
-        parsed.config.outputs.some(
-          (o) => JSON.stringify(o.expression) === JSON.stringify(expression),
-        )
-      )
-        return;
+      const previousOutputs = [...parsed.config.outputs];
       parsed.config.outputs.push({
         id: `output-${crypto.randomUUID()}`,
         label,
         expression,
       });
-      drafts.current.set(`${props.folder.id}\u0000${input.configPath}`, {
-        base: draft?.base ?? file?.text ?? "",
-        text: JSON.stringify(parsed.config, null, 2) + "\n",
-        committed: draft?.committed ?? props.project.structureRevision,
-      });
-      setPath(input.configPath);
+      const projected = {
+        ...props.folder,
+        input: {
+          ...input,
+          drafts: [],
+          files: input.files.map((source) => ({
+            ...source,
+            text:
+              source.path === input.configPath
+                ? JSON.stringify(parsed.config)
+                : (drafts.current.get(`${props.folder.id}\u0000${source.path}`)
+                    ?.text ?? source.text),
+          })),
+        },
+      };
+      const resolved = compileSourceSimulation(props.project, projected);
+      if (!resolved.ok) {
+        props.onProblem(
+          inputProblem(
+            "SIMULATION_SIGNAL_UNRESOLVED",
+            resolved.diagnostics.map((d) => d.message).join("; "),
+          ),
+        );
+        return;
+      }
+      const output = resolved.outputs.at(-1)!;
+      const acquisitionIds = new Set<string>();
+      const visit = (value: typeof output.expression) => {
+        if (value.kind === "acquisition")
+          acquisitionIds.add(value.acquisitionId);
+        if ("operand" in value) visit(value.operand);
+        if ("left" in value) {
+          visit(value.left);
+          visit(value.right);
+        }
+      };
+      visit(output.expression);
+      const nativeVectors = resolved.vectors
+        .filter((v) => acquisitionIds.has(v.probeId))
+        .map((v) => v.vector);
+      // Only terminal-current targets require a durable instrumentation owner.
+      // Ordinary voltage picks are native save text, not a second output setup.
+      if (expression.kind !== "current")
+        parsed.config.outputs = previousOutputs;
+      else if (
+        previousOutputs.some(
+          (o) => JSON.stringify(o.expression) === JSON.stringify(expression),
+        )
+      )
+        parsed.config.outputs = previousOutputs;
+      if (expression.kind === "current") {
+        drafts.current.set(`${props.folder.id}\u0000${input.configPath}`, {
+          base: draft?.base ?? file?.text ?? "",
+          text: JSON.stringify(parsed.config, null, 2) + "\n",
+          committed: draft?.committed ?? props.project.structureRevision,
+        });
+      }
+      insert(nativeVectors.length ? nativeVectors : ["v(0)"]);
       render((v) => v + 1);
     };
     const addPicked = (matches: readonly SimulationProbeOption[]) => {
@@ -222,7 +307,7 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
         return;
       }
       const match = matches[0]!;
-      addOutput(match.label, {
+      saveSignal(match.label, {
         ...match.target,
         circuit: { bindingId: binding.id, callPath: [] },
       });
@@ -264,11 +349,11 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
       [props.project, input.circuitBindings],
     );
     useEffect(() => {
-      setPath(input.entry);
       setReveal(undefined);
     }, [props.folder.id]);
     useEffect(() => {
       const selected = props.selectedCircuitObject;
+      if (props.selectedFile?.folderId === props.folder.id) return;
       if (!selected) return;
       for (const { binding, result } of generated) {
         if (!result.ok) continue;
@@ -335,7 +420,7 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
         current = false;
       };
     }, [text]);
-    const dirty = [...drafts.current].some(([key, value]) => {
+    const unsaved = [...drafts.current].filter(([key, value]) => {
       const owner = props.project.simulationFolders.find((folder) =>
         key.startsWith(`${folder.id}\u0000`),
       );
@@ -347,7 +432,15 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
           saved.text === value.text,
       );
     });
+    const dirty = unsaved.length > 0;
+    const activeDirty = unsaved.some(([key]) =>
+      key.startsWith(`${props.folder.id}\u0000`),
+    );
     useEffect(() => props.onDirty(dirty), [dirty, props.folder.id]);
+    useEffect(
+      () => props.onActiveDirty(activeDirty),
+      [activeDirty, props.folder.id],
+    );
     useEffect(() => {
       // Clean buffers follow remote edits. A dirty buffer remains visible for explicit repair.
       for (const file of sourceFiles) {
@@ -596,7 +689,7 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
         }))}
         activePath={path}
         onSelectFile={setPath}
-        onFileAction={async (action, filePath) => {
+        onFileAction={async (action, filePath, newPath) => {
           if (action === "discard") {
             const listed = await props.files.handle({
               action: "list",
@@ -635,10 +728,7 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
             )
           )
             return;
-          const nextPath =
-            action === "rename"
-              ? window.prompt("Relative file path", filePath)
-              : filePath;
+          const nextPath = action === "rename" ? newPath : filePath;
           if (!nextPath || (action === "rename" && nextPath === filePath))
             return;
           if (action === "rename" && ownFiles.includes(nextPath)) {
@@ -691,8 +781,7 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
               inputProblem("SOURCE_EXPORT_FAILED", result.message),
             );
         }}
-        onNewFile={() => {
-          const path = window.prompt("Relative file path", "stimulus.cir");
+        onNewFile={(path) => {
           if (!path) return;
           if (ownFiles.includes(path)) {
             setPath(path);
@@ -706,6 +795,7 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
           setPath(path);
           render((value) => value + 1);
         }}
+        newFileRequest={props.newFileRequest}
         actions={
           <>
             <button
@@ -744,7 +834,7 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
                   Discard local draft
                 </button>
               </>
-            ) : dirty ? (
+            ) : activeDirty ? (
               "Unsaved source"
             ) : buffer && buffer.text !== buffer.base ? (
               "Draft saved · finish or discard before Run"
@@ -758,11 +848,21 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
           <SourceProbePicker
             choices={probeChoices}
             kind={probePicker}
-            onAdd={addOutput}
+            onAdd={saveSignal}
             onClose={() => setProbePicker(undefined)}
           />
         )}
         <SimulationCodeEditor
+          signalNames={() =>
+            simulationSignalNames(props.project, {
+              ...input,
+              files: input.files.map((file) => ({
+                ...file,
+                text: drafts.current.get(key(file.path))?.text ?? file.text,
+              })),
+            })
+          }
+          saveRequest={saveRequest}
           relatedSources={sourceFiles.map(
             (file) =>
               drafts.current.get(`${props.folder.id}\u0000${file.path}`)
@@ -770,20 +870,14 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
           )}
           helperActions={[
             {
-              id: "observe-voltage",
-              label: "Observe voltage",
+              id: "save-voltage",
+              label: "Save voltage…",
               keywords: "probe voltage 电压 信号 看输出",
               run: () => setProbePicker("voltage"),
             },
             {
-              id: "observe-difference",
-              label: "Observe differential voltage",
-              keywords: "probe 差分 两节点",
-              run: () => setProbePicker("difference"),
-            },
-            {
-              id: "observe-current",
-              label: "Observe terminal current",
+              id: "save-current",
+              label: "Save terminal current…",
               keywords: "probe current 电流 MOS 端口",
               run: () => setProbePicker("current"),
             },

--- a/apps/editor/src/features/simulation/source-probe-choices.test.ts
+++ b/apps/editor/src/features/simulation/source-probe-choices.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { parseProject } from "@icm/project-protocol";
-import { createSimulationStarter } from "@icm/netlist";
+import { createSimulationStarter, simulationSignalNames } from "@icm/netlist";
 import ota from "../../examples/five-transistor-ota-sky130.icproj.json";
 import { sourceProbeChoices } from "./source-probe-choices";
 
@@ -24,6 +24,27 @@ describe("source Probe discovery", () => {
         .find((line) => line.startsWith("XDUT "))!
         .replace("XDUT ", "XSECOND ");
     const choices = sourceProbeChoices(project, input);
+    const names = simulationSignalNames(project, input);
+    expect(Object.keys(names).every((name) => name.startsWith("v("))).toBe(
+      true,
+    );
+    expect(Object.values(names).some((name) => name.includes("XDUT/"))).toBe(
+      true,
+    );
+    const callNodes = tb.text
+      .split("\n")
+      .find((line) => line.startsWith("XDUT "))!
+      .trim()
+      .split(/\s+/u)
+      .slice(1, -1);
+    for (const node of callNodes)
+      expect(names[`v(${node.toLowerCase()})`]).toBeDefined();
+    expect(names["v(xdut.0)"]).toBeUndefined();
+    expect(
+      choices
+        .filter((c) => c.kind === "voltage")
+        .every((c) => c.expression.kind === "vector"),
+    ).toBe(true);
     expect(
       choices.some((c) => c.kind === "voltage" && c.label.startsWith("XDUT ·")),
     ).toBe(true);

--- a/apps/editor/src/features/simulation/source-probe-choices.ts
+++ b/apps/editor/src/features/simulation/source-probe-choices.ts
@@ -7,6 +7,7 @@ import {
   analyzeDesignNetlist,
   inspectSimulationSourceGraph,
   listAuthoredCircuitScopes,
+  simulationSignalNames,
 } from "@icm/netlist";
 import { deriveSimulationProbeOptions } from "./simulation-probe-options";
 
@@ -22,6 +23,7 @@ export function sourceProbeChoices(
   const graph = inspectSimulationSourceGraph(input);
   const choices: SourceProbeChoice[] = [];
   for (const binding of input.circuitBindings) {
+    if (!graph.paths.includes(binding.path)) continue;
     const analysis = analyzeDesignNetlist(project, {
       format: "spice",
       rootDocumentId: binding.documentId,
@@ -33,12 +35,6 @@ export function sourceProbeChoices(
       const prefix = scope.callPath.length
         ? `${scope.callPath.join("/")} · `
         : "";
-      for (const option of options.voltage)
-        choices.push({
-          kind: "voltage",
-          label: prefix + option.label,
-          expression: { ...option.target, circuit: scope },
-        });
       for (const option of options.terminalCurrent)
         choices.push({
           kind: "current",
@@ -49,6 +45,15 @@ export function sourceProbeChoices(
   }
   // Native top-level nodes and independent voltage-source currents need no Canvas mapping.
   const vectors = new Set<string>();
+  const names = simulationSignalNames(project, input);
+  for (const [vector, name] of Object.entries(names)) {
+    choices.push({
+      kind: "voltage",
+      label: `${name.replaceAll("/", " · ")} — ${vector}`,
+      expression: { kind: "vector", vector },
+    });
+    vectors.add(vector);
+  }
   let depth = 0;
   for (const { statement } of graph.statements) {
     if (statement.kind === "subckt_start") depth++;
@@ -59,10 +64,11 @@ export function sourceProbeChoices(
       vectors.add(`i(${statement.name})`);
   }
   for (const vector of vectors)
-    choices.push({
-      kind: vector.startsWith("v(") ? "voltage" : "current",
-      label: vector,
-      expression: { kind: "vector", vector },
-    });
+    if (!names[vector.toLowerCase()])
+      choices.push({
+        kind: vector.startsWith("v(") ? "voltage" : "current",
+        label: vector,
+        expression: { kind: "vector", vector },
+      });
   return choices;
 }

--- a/apps/editor/src/features/simulation/source-probe-picker.tsx
+++ b/apps/editor/src/features/simulation/source-probe-picker.tsx
@@ -9,52 +9,31 @@ export function SourceProbePicker({
   onClose,
 }: {
   choices: readonly SourceProbeChoice[];
-  kind: "voltage" | "current" | "difference";
+  kind: "voltage" | "current";
   onAdd(label: string, expression: SimulationSourceExpression): void;
   onClose(): void;
 }) {
   const [query, setQuery] = useState("");
-  const [positive, setPositive] = useState<SourceProbeChoice>();
   const filtered = choices.filter(
     (c) =>
       c.kind === (kind === "current" ? "current" : "voltage") &&
       c.label.toLowerCase().includes(query.toLowerCase()),
   );
   const add = (choice: SourceProbeChoice) => {
-    if (kind === "difference" && !positive) {
-      setPositive(choice);
-      setQuery("");
-      return;
-    }
-    onAdd(
-      positive ? `${positive.label} − ${choice.label}` : choice.label,
-      positive
-        ? {
-            kind: "subtract",
-            left: positive.expression,
-            right: choice.expression,
-          }
-        : choice.expression,
-    );
+    onAdd(choice.label, choice.expression);
     onClose();
   };
   return (
     <div
       className="simulation-probe-picker"
       role="dialog"
-      aria-label="Observe signal"
+      aria-label="Save signal"
       onKeyDown={(e) => {
         e.stopPropagation();
         if (e.key === "Escape") onClose();
       }}
     >
-      <strong>
-        {kind === "difference"
-          ? positive
-            ? `Negative node (positive: ${positive.label})`
-            : "Choose positive node"
-          : `Observe ${kind}`}
-      </strong>
+      <strong>Save {kind}</strong>
       <input
         autoFocus
         value={query}
@@ -83,8 +62,8 @@ export function SourceProbePicker({
         </button>
       )}
       <small>
-        New outputs are collected on the next Run. Existing results stay
-        unchanged.
+        Inserts a native save statement. Terminal currents may require generated
+        measurement wiring.
       </small>
       <button onClick={onClose}>Cancel</button>
     </div>

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -5,6 +5,8 @@ import {
   type SimulationRunPlanAxis,
 } from "@icm/model";
 import { createSimulationStarter } from "@icm/netlist";
+import { InlineSourceName } from "./inline-source-name";
+import type { SimulationCodeWorkspaceProps } from "./code-workspace";
 import type {
   ArtifactRef,
   Capabilities,
@@ -73,16 +75,8 @@ import {
   type SimulationRunArchiveSummary,
 } from "./simulation-run-archive";
 
-const RESULT_TABS = [
-  ["plot", "Plot"],
-  ["operating-point", "Operating Point"],
-  ["compare", "Compare"],
-  ["console", "Console"],
-  ["files", "Files"],
-] as const;
-
 const MAX_COMPARISON_RUNS = 5;
-type ResultTab = (typeof RESULT_TABS)[number][0];
+type ResultTab = SimulationCodeWorkspaceProps["outputPane"];
 
 function preferredResultTab(run: Run): ResultTab {
   const analyses = run.outputData?.analyses ?? run.result?.data?.analyses ?? [];
@@ -141,6 +135,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
   const [problem, setProblem] = useState<Problem>();
   const [busy, setBusy] = useState(false);
   const [dirty, setDirty] = useState(false);
+  const [activeDirty, setActiveDirty] = useState(false);
   const [resultsMaximized, setResultsMaximized] = useState(false);
   const restoreDockAfterResults = useRef(false);
   useEffect(() => {
@@ -925,6 +920,14 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
     (runPresentation?.outputs ?? []).map((output) => [output.id, output.label]),
   );
   const [requestedRun, setRequestedRun] = useState<string>();
+  const [selectedFile, setSelectedFile] = useState<{
+    folderId: string;
+    path: string;
+  }>();
+  const [newFileRequest, setNewFileRequest] = useState<{
+    folderId: string;
+    id: string;
+  }>();
   useEffect(() => {
     if (requestedRun && requestedRun === selectedFolder?.id) {
       setRequestedRun(undefined);
@@ -961,6 +964,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
   const folderAction = async (
     action: import("./simulation-file-tree").FolderAction,
     ids: string[],
+    suppliedName?: string,
   ) => {
     if (action === "batch") {
       await executeBatch(ids);
@@ -993,14 +997,15 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
       );
       return;
     }
-    const name = window.prompt(
-      action === "rename" ? "Folder name" : "New simulation folder name",
-      action === "rename"
-        ? current?.name
-        : action === "duplicate"
-          ? `${current?.name} copy`
-          : `Simulation ${project.simulationFolders.length + 1}`,
-    );
+    const name = suppliedName;
+    if (!name && action === "new") {
+      setNewFolder({
+        id: `simulation-folder-${crypto.randomUUID()}`,
+        name: "Untitled",
+        template: "op",
+      });
+      return;
+    }
     if (!name?.trim()) return;
     const identity = {
       id:
@@ -1010,10 +1015,23 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
       name: name.trim(),
     };
     if (!current || (action !== "rename" && action !== "duplicate")) {
-      setNewFolder({
+      const starter = createSimulationStarter(latestProject, {
         ...identity,
-        template: ids[0] === "ac" ? "ac" : ids[0] === "tran" ? "tran" : "op",
+        template: "op",
+        mode: "text",
+        documentId: props.activeDocumentId,
+        profileId: capabilities?.profiles[0]?.id ?? authoringProfile.id,
       });
+      if (!starter.ok)
+        setProblem(uiProblem("SIMULATION_STARTER_INVALID", starter.message));
+      else {
+        const saved = props.onSaveFolder(
+          starter.folder,
+          latestProject.structureRevision,
+        );
+        if (saved.status === "rejected") setProblem(saved.problem);
+        else props.onSelectFolderId(starter.folder.id);
+      }
       return;
     }
     const created = { ...structuredClone(current), ...identity };
@@ -1028,19 +1046,6 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
       aria-label="Simulation results"
     >
       <header className="simulation-results-header">
-        <div role="tablist" aria-label="Result views">
-          {RESULT_TABS.filter(([id]) => id !== "console").map(([id, label]) => (
-            <button
-              key={id}
-              type="button"
-              role="tab"
-              aria-selected={resultTab === id}
-              onClick={() => setResultTab(id)}
-            >
-              {label}
-            </button>
-          ))}
-        </div>
         {run ? (
           <div className="simulation-result-actions">
             <button
@@ -1689,17 +1694,22 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
             }
           }}
         >
-          <strong>Start an experiment</strong>
+          <InlineSourceName
+            label="Folder name"
+            initial={newFolder.name}
+            onChange={(name) => setNewFolder({ ...newFolder, name })}
+            onCancel={() => setNewFolder(undefined)}
+            onSubmit={(name) => {
+              setNewFolder(undefined);
+              void folderAction("new", [], name);
+            }}
+          />
           <button onClick={() => void createStarter("circuit")}>
-            Run current Cell — use its existing sources and wiring
+            Template: current Canvas Cell
           </button>
           <button onClick={() => void createStarter("dut")}>
-            Write a text TB for this DUT — no TB Cell needed
+            Template: text TB for current Cell
           </button>
-          <button onClick={() => void createStarter("text")}>
-            Start with text only — no Canvas binding
-          </button>
-          <button onClick={() => setNewFolder(undefined)}>Cancel</button>
         </div>
       )}
       <header className="simulation-taskbar">
@@ -1709,7 +1719,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
             className={`simulation-status-chip simulation-status-${batch?.state ?? run?.state ?? (prepared ? "prepared" : "idle")}`}
             role="status"
           >
-            {dirty ? "Source changed" : statusLabel}
+            {activeDirty ? "Source changed" : statusLabel}
           </span>
         </div>
         <div className="simulation-task-actions">
@@ -1869,6 +1879,12 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
           diagnostics={activeProblem?.diagnostics}
           project={project}
           folder={selectedFolder}
+          selectedFile={selectedFile}
+          newFileRequest={
+            newFileRequest?.folderId === selectedFolder.id
+              ? newFileRequest.id
+              : undefined
+          }
           selectedCircuitObject={props.selectedCircuitObject}
           files={session.files}
           {...{
@@ -1888,29 +1904,36 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
           actions={null}
           status={staleMessage || statusLabel}
           onDirty={setDirty}
+          onActiveDirty={setActiveDirty}
           onProblem={setProblem}
           console={resultContent}
           results={resultContent}
-          outputPane={resultTab === "console" ? "console" : "results"}
-          onSelectOutputPane={(pane) =>
-            setResultTab(
-              pane === "console"
-                ? "console"
-                : resultTab === "console"
-                  ? "plot"
-                  : resultTab,
-            )
-          }
+          outputPane={resultTab}
+          onSelectOutputPane={setResultTab}
           maximized={resultsMaximized}
           onToggleMaximize={toggleResultsMaximized}
           onRun={() => void execute(true)}
           onPrepare={() => void execute(false)}
           folders={{
-            folders: project.simulationFolders,
+            folders: project.simulationFolders.map((folder) => ({
+              ...folder,
+              paths: [
+                ...folder.input.files
+                  .filter((file) => file.path !== folder.input.configPath)
+                  .map((file) => file.path),
+                ...folder.input.circuitBindings.map((binding) => binding.path),
+              ],
+            })),
             activeId: selectedFolder.id,
             busy: busy || !!running,
-            onSelect: (id) => props.onSelectFolderId(id),
-            onAction: (action, ids) => void folderAction(action, ids),
+            onSelect: (id, path) => {
+              setSelectedFile(path ? { folderId: id, path } : undefined);
+              props.onSelectFolderId(id);
+            },
+            onAction: (action, ids, name) =>
+              void folderAction(action, ids, name),
+            onNewFile: (folderId) =>
+              setNewFileRequest({ folderId, id: crypto.randomUUID() }),
           }}
           onHistoryBoundary={props.onHistoryBoundary}
           onSaveProject={props.onSaveProject}

--- a/docs/specs/simulation-code-workspace.md
+++ b/docs/specs/simulation-code-workspace.md
@@ -20,8 +20,8 @@ The execution and numeric contracts remain in
 [execution](simulation-execution.md) and [results](simulation-results.md).
 Only the changes explicitly identified here amend those boundaries.
 
-The goal is ordinary Canvas editing plus a right-hand code dock, with Console
-and Results beneath the code. It is not a general IDE, a second circuit model,
+The goal is ordinary Canvas editing plus a right-hand code dock, with flat
+Console/Plot/OP/Compare/Files tabs beneath code. It is not a general IDE, a second circuit model,
 a new executor, or unrestricted remote shell access. Timing/Digital Simulation,
 new model qualification, live cross-Project libraries, and Production promotion
 are outside this work.
@@ -98,10 +98,10 @@ IDs and exact files. Older data is read only at that compatibility boundary.
   otherwise retain the now-unresolved entry/reference for diagnosis. Deleting
   a binding is explicit, not a side effect of editing its displayed filename.
 
-New experiments explicitly choose one of three starting points: run the current
-Cell directly (top-level binding), write a text TB around the current DUT
-(subcircuit binding and an authored call using the exported port order), or
-start with text only (no binding). None creates a TB Cell or guesses stimuli.
+New folders default to text-only input without a questionnaire. Optional templates
+run the current Cell directly (top-level binding) or write a text TB around the
+current DUT (subcircuit binding and an authored call using exported port order).
+None creates a TB Cell or guesses stimuli.
 Existing experiments reopen unchanged; duplication is an explicit action.
 `circuit.spice`, `testbench.spice`, and `run.cir` are conventions, not mandatory
 file counts. A drawn TB does not need an additional authored TB file.
@@ -115,12 +115,21 @@ ghosts. Tab/Shift+Tab navigate arguments, Escape dismisses guidance, and no ghos
 or implicit default enters saved/exported/executed text. Parameter guidance is
 advisory: users and Agents may continue writing native syntax beyond the catalog.
 
-Helper's Observe actions add ordinary output expressions to the configuration:
-voltage, differential voltage, or terminal current. Canvas targets include the
-proven authored DUT call path, so two calls to one Cell remain distinct; native
-vectors remain available for text-only or statically unresolvable scopes.
-Discovery runs when the picker opens, not on every ordinary keystroke.
+Helper signal actions insert native `save`/`.save` statements, not a parallel
+voltage-output configuration. Terminal-current picks retain their existing
+configuration owner when generated measurement wiring is required. An explicit
+save list is never silently widened to `all` by that instrumentation.
+Discovery and completion use the compiler's authored call-path mapping; they
+show the Canvas name alongside the executable native vector. Native vectors
+remain available for text-only or statically unresolvable scopes.
 `experiment.json` is available through Files, not a compulsory fourth panel.
+
+Folder expansion is independent of active execution and batch selection. New
+files/folders and renames use inline text input (Enter accepts, Escape cancels),
+not browser prompts or an obligatory analysis/TB questionnaire. A new file is
+ordinary authored text; entry/includes determine whether it executes. Optional
+Canvas templates produce protected generated bindings, not a writable copy of
+the circuit. All persistence still uses the shared folder/file operations.
 
 ### Experiment configuration
 
@@ -449,7 +458,7 @@ Ordinary Canvas                 | Code | Properties           x
                                 | Circuit / TB / Run file tabs
                                 |   code editor with line numbers
                                 |------------------------------
-                                | Console | Results    expand
+                                | Console | Plot | OP | Compare | Files    expand
                                 | selected run / plot / OP
                                 | history, compare, export on demand
 ```
@@ -473,8 +482,8 @@ Ordinary Canvas                 | Code | Properties           x
 - No permanent Setup/Settings/AC-response selection bar. Multiple experiments
   retain IDs and lifecycle under Files. Run always targets the explicit entry
   of the active experiment; viewing its Circuit or TB does not change entry.
-- Console/Results occupy only the code dock below the editor. Results contains
-  Plot, OP, measurements, history, comparison and export as needed. Maximize
+- Console/Plot/OP/Compare/Files occupy one tab row below the code editor;
+  measurements, history and export remain within these views. Maximize
   temporarily uses the main workspace, then restores the exact previous split.
 - Canvas selection highlights related code without forcibly opening Properties.
   Switching tabs preserves draft, caret, selection, scroll and result state.

--- a/docs/specs/simulation-results.md
+++ b/docs/specs/simulation-results.md
@@ -9,6 +9,13 @@ Owners: `packages/spice-run`, `packages/simulation-service`
 
 ## Result data
 
+The shared service exposes every returned native vector alongside configured
+expressions, without requiring an output binding for `save` to work. Direct
+acquisition duplicates are suppressed. Prepared `signalNames` is optional,
+derived run-local metadata mapping native voltage vectors to Canvas paths/names;
+it does not rename the raw data or change connectivity. Native results retain
+their executable spelling alongside friendly names, including in MCP and CSV.
+
 Numbers are read from ngspice's ASCII rawfile, never from console text. The
 parsed result extends `SimulationResult` with:
 

--- a/docs/user/analog-simulation.md
+++ b/docs/user/analog-simulation.md
@@ -121,8 +121,8 @@ refuse a run with a repairable explanation.
 
 ## Results, history and exports
 
-Console and Results sit below code. Results includes plots, OP, measurements,
-comparison, history and files. Maximize results temporarily uses the workspace;
+Console, Plot, OP, Compare and Files share one tab row below code. Measurements,
+history and exports stay inside these views. Maximize results temporarily uses the workspace;
 Restore returns to the previous dock size. Maximize Code keeps the editor.
 
 Friendly output labels, complex AC values, solver-recorded DC/time axes and

--- a/packages/netlist/src/index.ts
+++ b/packages/netlist/src/index.ts
@@ -13,3 +13,4 @@ export * from "./simulation-source-map.js";
 export * from "./simulation-source-projection.js";
 export * from "./simulation-starter.js";
 export * from "./simulation-source-scopes.js";
+export * from "./simulation-signal-names.js";

--- a/packages/netlist/src/simulation-signal-names.ts
+++ b/packages/netlist/src/simulation-signal-names.ts
@@ -1,0 +1,82 @@
+import type { CircuitProject, SimulationSourceInput } from "@icm/model";
+import { analyzeDesignNetlist } from "./extract.js";
+import type { DesignNetlistCell } from "./ir.js";
+import { inspectSimulationSourceGraph } from "./simulation-source-graph.js";
+import {
+  listAuthoredCircuitScopes,
+  resolveAuthoredCircuitScope,
+} from "./simulation-source-scopes.js";
+
+/** Run-local display metadata. Native vector spelling and electrical identity never change. */
+export function simulationSignalNames(
+  project: CircuitProject,
+  input: SimulationSourceInput,
+): Record<string, string> {
+  const graph = inspectSimulationSourceGraph(input);
+  const labels = new Map<string, Set<string>>();
+  for (const binding of input.circuitBindings) {
+    if (!graph.paths.includes(binding.path)) continue;
+    const ir = analyzeDesignNetlist(project, {
+      format: "spice",
+      rootDocumentId: binding.documentId,
+    }).ir;
+    if (!ir) continue;
+    const root = ir.cells.find((cell) => cell.id === ir.topCellId);
+    if (!root) continue;
+    for (const scope of listAuthoredCircuitScopes(graph, binding, ir)) {
+      const resolved = resolveAuthoredCircuitScope(graph, binding, ir, scope);
+      if (!resolved.ok) continue;
+      const qualify = resolved.node;
+      let visits = 0;
+      function visit(
+        cell: DesignNetlistCell,
+        nodes: Map<string, string>,
+        path: string[],
+        ancestors: Set<string>,
+      ) {
+        if (++visits > 4096 || ancestors.has(cell.id)) return;
+        const local = new Map(nodes);
+        for (const net of cell.nets) {
+          const key = net.name.toLowerCase();
+          const node =
+            local.get(key) ??
+            qualify(
+              net.scope === "global" ? net.name : [...path, net.name].join("."),
+            );
+          local.set(key, node);
+          const vector = `v(${node})`.toLowerCase();
+          const name = [...scope.callPath, ...path, net.name].join("/");
+          const names = labels.get(vector) ?? new Set<string>();
+          names.add(name);
+          labels.set(vector, names);
+        }
+        for (const instance of cell.instances) {
+          if (instance.deviceClass !== "hierarchical") continue;
+          const child = ir!.cells.find(
+            (candidate) => candidate.name === instance.target,
+          );
+          if (!child) continue;
+          const ports = new Map<string, string>();
+          for (const port of child.ports) {
+            const connection = instance.nodes.find(
+              (node) => node.pinName === port.name,
+            );
+            const node =
+              connection && local.get(connection.netName.toLowerCase());
+            if (node) ports.set(port.netName.toLowerCase(), node);
+          }
+          visit(
+            child,
+            ports,
+            [...path, instance.reference],
+            new Set([...ancestors, cell.id]),
+          );
+        }
+      }
+      visit(root, new Map(), [], new Set());
+    }
+  }
+  return Object.fromEntries(
+    [...labels].map(([vector, names]) => [vector, [...names].join(" · ")]),
+  );
+}

--- a/packages/netlist/src/simulation-source-compile.test.ts
+++ b/packages/netlist/src/simulation-source-compile.test.ts
@@ -158,6 +158,25 @@ describe("source simulation compiler", () => {
     }
     expect(before).toEqual(project());
   });
+  it("does not widen an explicit native save list to all when adding Canvas captures", () => {
+    const before = project();
+    const original = legacySetups().find(
+      (s) => s.input.kind === "structured" && s.input.outputs.length,
+    )!;
+    const folder = migrateSimulationSetupToSource(before, original).folder;
+    const entry = folder.input.files.find(
+      (f) => f.path === folder.input.entry,
+    )!;
+    entry.text = entry.text.replace(".control", ".control\nsave v(0)");
+    const compiled = compileSourceSimulation(before, folder);
+    expect(compiled.ok).toBe(true);
+    if (!compiled.ok) return;
+    const prepared = compiled.files.find(
+      (f) => f.path === folder.input.entry,
+    )!.text;
+    expect(prepared).toContain("save v(0)");
+    expect(prepared).not.toContain(".save all");
+  });
   it("distinguishes two authored DUT calls and maps formal ports to actual top-level nodes", () => {
     const before = project();
     const original = legacySetups().find(

--- a/packages/netlist/src/simulation-source-compile.ts
+++ b/packages/netlist/src/simulation-source-compile.ts
@@ -461,7 +461,13 @@ export function compileSourceSimulation(
     const index = mappedFiles.findIndex((f) => f.path === folder.input.entry);
     const entry = mappedFiles[index]!;
     const end = entry.text.indexOf("\n");
-    const prefix = `* Canvas acquisitions (generated)\n.save all ${[...capture].join(" ")}\n`;
+    const explicitSave =
+      graph.statements.some(
+        ({ statement }) =>
+          statement.kind === "control_command" &&
+          statement.command.toLowerCase() === "save",
+      ) || folder.input.files.some((file) => /^\s*\.save\b/imu.test(file.text));
+    const prefix = `* Canvas acquisitions (generated)\n.save ${explicitSave ? "" : "all "}${[...capture].join(" ")}\n`;
     // Keep the native title in place. Other author bytes are never reformatted.
     mappedFiles[index] = insertSimulationText(
       entry,

--- a/packages/simulation-service/src/contract.ts
+++ b/packages/simulation-service/src/contract.ts
@@ -152,6 +152,7 @@ export const PreparedSchema = z.strictObject({
   mode: z.enum(["source", "structured", "raw"]),
   environment: EnvironmentSchema,
   vectors: z.array(VectorSchema),
+  signalNames: z.record(z.string(), z.string()).optional(),
   outputs: z.array(CompiledOutputSchema),
   deviceOperatingPoints: z.array(CompiledDeviceOperatingPointSchema),
   measurements: z.array(SimulationMeasurementSpecSchema).optional(),

--- a/packages/simulation-service/src/output-evaluation.test.ts
+++ b/packages/simulation-service/src/output-evaluation.test.ts
@@ -7,6 +7,44 @@ import {
 import { SimulationOutputDataSchema } from "./contract.js";
 
 describe("simulation output evaluation", () => {
+  it("exposes saved native vectors alongside configured outputs with run-local names", () => {
+    const result = evaluateSimulationOutputs(
+      {
+        schemaVersion: 1,
+        analyses: [
+          {
+            analysis: "op",
+            plotName: "OP",
+            probes: [
+              { name: "v(out)", quantity: "voltage", unit: "V", value: 0.8 },
+              { name: "v(in)", quantity: "voltage", unit: "V", value: 1 },
+            ],
+          },
+        ],
+      },
+      [{ probeId: "input", vector: "v(in)", quantity: "voltage" }],
+      [
+        {
+          id: "input-voltage",
+          label: "Input",
+          expression: {
+            kind: "acquisition",
+            acquisitionId: "input",
+            quantity: "voltage",
+          },
+        },
+      ],
+      [],
+      [],
+      true,
+      { "v(out)": "XDUT/Vout" },
+    );
+    expect(result.analyses[0]!.outputs.map((o) => o.label)).toEqual([
+      "Input",
+      "XDUT/Vout — v(out)",
+    ]);
+    expect(result.analyses[0]!.outputs[1]!.values).toEqual([0.8]);
+  });
   it("keeps MOS terminal values and automatic/authored measurements for each raw OP record", () => {
     const result = evaluateSimulationOutputs(
       {

--- a/packages/simulation-service/src/output-evaluation.ts
+++ b/packages/simulation-service/src/output-evaluation.ts
@@ -242,6 +242,8 @@ export function evaluateSimulationOutputs(
   outputs: readonly CompiledSimulationOutput[],
   measurementSpecs: readonly SimulationMeasurementSpec[] = [],
   deviceOperatingPointSpecs: readonly CompiledSimulationDeviceOperatingPoint[] = [],
+  includeNative = false,
+  signalNames: Readonly<Record<string, string>> = {},
 ): SimulationOutputData {
   const diagnostics: SimulationOutputData["diagnostics"] = [];
   const analyses: SimulationOutputData["analyses"] = data.analyses.map(
@@ -322,6 +324,34 @@ export function evaluateSimulationOutputs(
           return [];
         }
       });
+      if (includeNative) {
+        const represented = new Set(
+          outputs.flatMap(({ expression }) =>
+            expression.kind === "acquisition"
+              ? vectors
+                  .filter((v) => v.probeId === expression.acquisitionId)
+                  .map((v) => v.vector.toLowerCase())
+              : [],
+          ),
+        );
+        for (const probe of analysis.probes) {
+          if (represented.has(probe.name.toLowerCase())) continue;
+          const native = {
+            probeId: `native:${probe.name.toLowerCase()}`,
+            vector: probe.name,
+            quantity: "native" as const,
+          };
+          const series = sourceSeries(analysis, [native]).get(native.probeId)!;
+          const friendly = signalNames[probe.name.toLowerCase()];
+          evaluated.push({
+            id: native.probeId,
+            label: friendly ? `${friendly} — ${probe.name}` : probe.name,
+            unit: series.unit,
+            values: [...series.real],
+            ...(series.complex ? { imaginary: [...series.imaginary] } : {}),
+          });
+        }
+      }
       const domain =
         analysis.analysis === "ac"
           ? {

--- a/packages/simulation-service/src/prepare-source.ts
+++ b/packages/simulation-service/src/prepare-source.ts
@@ -5,6 +5,7 @@ import type {
 } from "@icm/model";
 import {
   compileSourceSimulation,
+  simulationSignalNames,
   inspectSimulationSourceGraph,
   insertSimulationText,
   type SimulationSourceDiagnostic,
@@ -272,6 +273,7 @@ export async function prepareSourceExecutionInput(
     input,
     digest: await sha256(JSON.stringify(input)),
     vectors: compiled.vectors,
+    signalNames: simulationSignalNames(project, folder.input),
     outputs: compiled.outputs,
     deviceOperatingPoints: compiled.deviceOperatingPoints,
     measurements: config.measurements,

--- a/packages/simulation-service/src/service.ts
+++ b/packages/simulation-service/src/service.ts
@@ -642,6 +642,7 @@ export class SimulationService {
       mode: "source",
       environment: input.environment,
       vectors,
+      signalNames: preparation.signalNames,
       outputs,
       deviceOperatingPoints,
       measurements,
@@ -757,20 +758,15 @@ export class SimulationService {
       });
       if (epoch !== this.epoch) return;
       run.view.result = output.result;
-      if (
-        output.result.data &&
-        (run.prepared.outputs.length > 0 ||
-          run.prepared.deviceOperatingPoints.length > 0 ||
-          output.result.data.analyses.some(
-            (analysis) => analysis.analysis === "noise",
-          ))
-      ) {
+      if (output.result.data) {
         run.view.outputData = evaluateSimulationOutputs(
           output.result.data,
           run.prepared.vectors,
           run.prepared.outputs,
           run.prepared.measurements ?? [],
           run.prepared.deviceOperatingPoints,
+          true,
+          run.prepared.signalNames,
         );
       }
       const artifact = async (name: string, type: string, text: string) =>
@@ -840,6 +836,7 @@ export class SimulationService {
               mode: run.prepared.mode,
               environment: run.prepared.environment,
               vectors: run.prepared.vectors,
+              signalNames: run.prepared.signalNames,
               outputs: run.prepared.outputs,
               deviceOperatingPoints: run.prepared.deviceOperatingPoints,
               measurements: run.prepared.measurements ?? [],

--- a/packages/spice/src/simulation-language.ts
+++ b/packages/spice/src/simulation-language.ts
@@ -19,6 +19,7 @@ export interface SimulationLanguageHelp {
     label: string;
     choices?: readonly string[];
     optional?: boolean;
+    repeat?: boolean;
   }[];
 }
 export const NGSPICE_LANGUAGE_REFERENCE =
@@ -271,8 +272,8 @@ const parameterHints: Record<
     { label: "startHz" },
     { label: "stopHz" },
   ],
-  save: [{ label: "vector" }],
-  write: [{ label: "file" }, { label: "vector", optional: true }],
+  save: [{ label: "vector", repeat: true }],
+  write: [{ label: "file" }, { label: "vector", optional: true, repeat: true }],
   param: [{ label: "name=expression" }],
   temp: [{ label: "temperature / °C" }],
   include: [{ label: '"relative-file.spice"' }],


### PR DESCRIPTION
## Summary
- Flatten output navigation and use compact native-save helpers.
- Add inline file/folder naming and independent folder expansion; preserve project draft tracking.
- Share captured Canvas/vector names and native results across GUI, Agent and CSV.
- Preserve terminal-current instrumentation without widening explicit save lists.

## Validation
- Focused tests: 344 passed, 4 existing skips.
- Simulation browser tests: 17 passed.
- Static checks and preflight passed.
- Full local delivery gate running; required CI must pass before merge.

Test-Impact: tests-updated