### PR TITLE
Fix Preview GUI acceptance for flat result tabs

### DIFF
--- a/scripts/preview-source-gui-journey.mjs
+++ b/scripts/preview-source-gui-journey.mjs
@@ -216,9 +216,11 @@ try {
   await expect(
     panel.getByRole("button", { name: "Cancel run", exact: true }),
   ).toHaveCount(0, { timeout: 240_000 });
-  await panel.getByRole("tab", { name: "Results", exact: true }).click();
-  await panel.getByRole("button", { name: "Maximize results" }).click();
+  await expect(
+    panel.getByRole("tab", { name: "Results", exact: true }),
+  ).toHaveCount(0);
   await panel.getByRole("tab", { name: "Files", exact: true }).click();
+  await panel.getByRole("button", { name: "Maximize results" }).click();
   const preparedEntries = unzipSync(
     await download(
       panel


### PR DESCRIPTION
The Preview rerun passed the public MCP journey but failed because the GUI journey still clicked the removed Results wrapper. Select Files directly and assert the retired wrapper is absent. All numeric, export, batch and save/reload checks remain unchanged. No product code or deployment gates are weakened. Static contracts passed; targeted live Preview acceptance and the gate-selected workspace tests are being verified.