### PR TITLE
Polish simulation source navigation and native completion

### DIFF
--- a/apps/editor/e2e/helpers/simulation-code-harness.tsx
+++ b/apps/editor/e2e/helpers/simulation-code-harness.tsx
@@ -63,6 +63,11 @@ function Harness() {
             }
             onSave={save}
             onCursor={setCursor}
+            relatedSources={["VBIAS vdd 0 DC 1.8\nR1 vdd out 1k"]}
+            signalNames={() => ({ "v(out)": "Output" })}
+            onFocusSignal={(vector) => {
+              document.body.dataset.focusedSignal = vector;
+            }}
           />
         </SimulationCodeWorkspace>
       </div>

--- a/apps/editor/e2e/simulation-code-editor.spec.ts
+++ b/apps/editor/e2e/simulation-code-editor.spec.ts
@@ -1,5 +1,40 @@
 import { expect, test } from "@playwright/test";
 
+test("native save and dc arguments open automatically and preview their Canvas target", async ({
+  page,
+}) => {
+  const editor = page.getByRole("textbox", {
+    name: "Simulation source editor",
+  });
+  await editor.fill("* test\n.control\nsave");
+  await page.keyboard.press("End");
+  await page.keyboard.type(" ");
+  const output = page.getByRole("option").filter({ hasText: "v(out)" });
+  await expect(output).toBeVisible();
+  await page.keyboard.press("ArrowDown");
+  const selected = await page
+    .locator(
+      '.cm-tooltip-autocomplete [aria-selected="true"] .cm-completionLabel',
+    )
+    .textContent();
+  await expect(page.locator("body")).toHaveAttribute(
+    "data-focused-signal",
+    selected!,
+  );
+  await output.hover();
+  await expect(page.locator("body")).toHaveAttribute(
+    "data-focused-signal",
+    "v(out)",
+  );
+  await page.keyboard.press("Escape");
+  await editor.fill("* test\n.control\ndc");
+  await page.keyboard.press("End");
+  await page.keyboard.type(" ");
+  await expect(
+    page.getByRole("option").filter({ hasText: "VBIAS" }),
+  ).toBeVisible();
+});
+
 test("flat Helper finds an analysis by purpose and ghost arguments never enter saved source", async ({
   page,
 }) => {

--- a/apps/editor/e2e/simulation-setup.spec.ts
+++ b/apps/editor/e2e/simulation-setup.spec.ts
@@ -345,7 +345,8 @@ test("one Testbench persists several independently named folders", async ({
       exact: true,
     }),
   ).toBeVisible();
-  await folders.getByRole("button", { name: "+ New folder…" }).click();
+  await folders.click({ button: "right", position: { x: 3, y: 3 } });
+  await folders.getByRole("menuitem", { name: "New folder…" }).click();
   await folders
     .getByRole("textbox", { name: "Folder name" })
     .fill("Bias sweep");

--- a/apps/editor/e2e/simulation-workspace.spec.ts
+++ b/apps/editor/e2e/simulation-workspace.spec.ts
@@ -352,8 +352,17 @@ test("human simulation uses saved folder, survives minimizing, recovers a bad in
   release();
   await clickNetlistWorkflowCommand(page, "open-analog-simulation");
   await expect(panel.getByRole("status")).toHaveText("finished · completed");
+  await expect(
+    panel
+      .locator(".simulation-code-output-tabs")
+      .getByRole("button", { name: "Archive", exact: true }),
+  ).toBeVisible();
+  await expect(panel.locator(".simulation-results-header")).toHaveCount(0);
   // A completed run belongs to its folder, not whichever folder is currently visible.
-  await panel.getByRole("button", { name: "+ New folder…" }).click();
+  await panel
+    .getByLabel("Simulation folders", { exact: true })
+    .click({ button: "right", position: { x: 3, y: 3 } });
+  await panel.getByRole("menuitem", { name: "New folder…" }).click();
   await panel
     .getByRole("textbox", { name: "Folder name" })
     .fill("Second folder");
@@ -951,7 +960,7 @@ test("human simulation uses saved folder, survives minimizing, recovers a bad in
     const surfaceBox = (await panel.boundingBox())!;
     for (const selector of [
       ".simulation-taskbar",
-      ".simulation-results-header",
+      ".simulation-code-output-tabs",
     ]) {
       const headerBox = (await panel.locator(selector).boundingBox())!;
       expect(headerBox.x).toBeCloseTo(surfaceBox.x, 0);
@@ -1026,7 +1035,7 @@ test("human simulation uses saved folder, survives minimizing, recovers a bad in
     expect(modeBox.x).toBeCloseTo(shellBox.x, 0);
     const [resultsHeaderZIndex, plotToolbarZIndex] = await Promise.all([
       panel
-        .locator(".simulation-results-header")
+        .locator(".simulation-code-output-tabs")
         .evaluate((element) => Number(getComputedStyle(element).zIndex)),
       shell
         .locator(".ac-plot-toolbar")
@@ -1134,9 +1143,7 @@ test("Simulation creates an ordinary testbench and offers the current Cell at th
   expect(saved.simulationFolders).toEqual([]);
   await clickNetlistWorkflowCommand(page, "open-analog-simulation");
   await expect(page.getByLabel("Testbench Cell")).toHaveCount(0);
-  await page
-    .getByRole("button", { name: "Create experiment for this Cell" })
-    .click();
+  await page.getByRole("button", { name: "Set up", exact: true }).click();
   await page
     .getByRole("button", { name: "Template: current Canvas Cell" })
     .click();

--- a/apps/editor/src/features/simulation/code-editor.tsx
+++ b/apps/editor/src/features/simulation/code-editor.tsx
@@ -8,6 +8,7 @@ import {
 } from "@codemirror/state";
 import {
   EditorView,
+  ViewPlugin,
   drawSelection,
   highlightActiveLine,
   highlightActiveLineGutter,
@@ -34,6 +35,7 @@ import {
   completionKeymap,
   startCompletion,
   CompletionContext,
+  selectedCompletion,
 } from "@codemirror/autocomplete";
 import { json, jsonParseLinter } from "@codemirror/lang-json";
 import { linter, lintGutter, type Diagnostic } from "@codemirror/lint";
@@ -93,6 +95,7 @@ export interface SimulationCodeEditorProps {
   helperActions?: readonly CodeHelperAction[];
   relatedSources?: readonly string[];
   signalNames?: (() => Readonly<Record<string, string>>) | undefined;
+  onFocusSignal?: ((vector: string) => void) | undefined;
   saveRequest?: { id: string; vectors: string[] } | undefined;
   reveal?:
     { sourceOffset: number; requestId: string; focus?: boolean } | undefined;
@@ -513,6 +516,39 @@ function sourceExtensions(
                 ),
             ],
             activateOnTypingDelay: 350,
+          }),
+          EditorView.updateListener.of((update) => {
+            const previous = selectedCompletion(update.startState)?.label;
+            const selected = selectedCompletion(update.state)?.label;
+            if (selected && selected !== previous)
+              callbacks.current.onFocusSignal?.(selected);
+            if (!selected && update.selectionSet) {
+              const cursor = update.state.selection.main.head;
+              const line = update.state.doc.lineAt(cursor);
+              const vector = [...line.text.matchAll(/\bv\([^\s)]+\)/giu)].find(
+                (match) =>
+                  line.from + match.index <= cursor &&
+                  cursor <= line.from + match.index + match[0].length,
+              );
+              if (vector) callbacks.current.onFocusSignal?.(vector[0]);
+            }
+          }),
+          ViewPlugin.define((view) => {
+            const preview = (event: MouseEvent) => {
+              const row = (event.target as Element).closest?.(
+                ".cm-tooltip-autocomplete li",
+              );
+              const label = row?.querySelector(
+                ".cm-completionLabel",
+              )?.textContent;
+              if (label) callbacks.current.onFocusSignal?.(label);
+            };
+            view.dom.addEventListener("mouseover", preview);
+            return {
+              destroy() {
+                view.dom.removeEventListener("mouseover", preview);
+              },
+            };
           }),
           spiceHoverHelp,
         ];

--- a/apps/editor/src/features/simulation/code-spice-language.ts
+++ b/apps/editor/src/features/simulation/code-spice-language.ts
@@ -70,7 +70,6 @@ export function spiceCompletion(
 ): CompletionResult | null {
   const line = context.state.doc.lineAt(context.pos);
   const word = context.matchBefore(/[.\w]+/u);
-  if (!context.explicit && !word) return null;
   const before = line.text.slice(0, context.pos - line.from);
   if (/^\s*\*/u.test(before)) return null;
   const head = /^\s*[.\w]*$/u.test(before);
@@ -144,6 +143,7 @@ export function spiceCompletion(
     };
   }
   if (!head) return null;
+  if (!context.explicit && !word) return null;
   // Partial lines need a lexical context for completion; the authoritative parser diagnoses whole files separately.
   const preceding = context.state.doc.sliceString(0, line.from);
   const boundaries = [...preceding.matchAll(/^\s*\.(control|endc)\b/gimu)];

--- a/apps/editor/src/features/simulation/code-workspace.css
+++ b/apps/editor/src/features/simulation/code-workspace.css
@@ -121,8 +121,11 @@
   align-items: center;
 }
 .simulation-folder-row > button:first-child {
-  width: 24px;
-  flex: 0 0 24px;
+  width: 1.5em;
+  flex: 0 0 1.5em;
+  padding: 3px 0;
+  text-align: center;
+  font-size: inherit;
 }
 .simulation-folder-row > button:last-child {
   flex: 1;
@@ -159,6 +162,12 @@
   text-align: left;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+  font: inherit;
+  padding: 3px 6px;
 }
 .simulation-code-files button.is-active {
   background: #eaf2f8;
@@ -237,6 +246,16 @@
 }
 .simulation-code-output-tabs {
   background: var(--icm-surface-muted);
+  position: relative;
+  z-index: 3;
+}
+.simulation-code-output-tabs > [role="tablist"] {
+  display: flex;
+  min-width: 0;
+  overflow-x: auto;
+}
+.simulation-code-output:has(.simulation-result-export[open]) {
+  overflow: visible;
 }
 .simulation-code-output-tabs [aria-selected="true"] {
   color: #155782;

--- a/apps/editor/src/features/simulation/code-workspace.test.tsx
+++ b/apps/editor/src/features/simulation/code-workspace.test.tsx
@@ -32,7 +32,8 @@ describe("approved simulation Code layout", () => {
     );
     expect(markup).toContain("OTA AC");
     expect(markup).toContain("OTA transient");
-    expect(markup).toContain("New folder");
+    expect(markup).not.toContain("New folder");
+    expect(markup).not.toContain("New file");
     expect(markup).not.toContain("Setup");
   });
   it("opens only circuit/run tabs by default, with output below the editor and configuration on demand", () => {

--- a/apps/editor/src/features/simulation/code-workspace.tsx
+++ b/apps/editor/src/features/simulation/code-workspace.tsx
@@ -33,6 +33,7 @@ export interface SimulationCodeWorkspaceProps {
   status?: ReactNode;
   console: ReactNode;
   results: ReactNode;
+  outputActions?: ReactNode;
   outputPane: "console" | "plot" | "operating-point" | "compare" | "files";
   onSelectOutputPane(pane: SimulationCodeWorkspaceProps["outputPane"]): void;
   maximized?: boolean;
@@ -86,14 +87,6 @@ export function SimulationCodeWorkspace(props: SimulationCodeWorkspaceProps) {
   };
   const fileList = () => (
     <ul>
-      <li>
-        <button
-          type="button"
-          onClick={() => setNaming({ initial: "untitled.spice" })}
-        >
-          + New file
-        </button>
-      </li>
       {naming && (
         <li>
           <InlineSourceName
@@ -145,6 +138,15 @@ export function SimulationCodeWorkspace(props: SimulationCodeWorkspaceProps) {
             </button>
             {fileMenu === file.path ? (
               <div role="menu" aria-label={`Actions for ${file.path}`}>
+                <button
+                  role="menuitem"
+                  onClick={() => {
+                    setNaming({ initial: "untitled.spice" });
+                    setFileMenu(undefined);
+                  }}
+                >
+                  New file…
+                </button>
                 <button
                   role="menuitem"
                   onClick={() => {
@@ -283,18 +285,6 @@ export function SimulationCodeWorkspace(props: SimulationCodeWorkspaceProps) {
                   }}
                 >
                   Export current file…
-                </button>
-              ) : null}
-              {props.onNewFile ? (
-                <button
-                  type="button"
-                  onClick={() => {
-                    setFilesOpen(true);
-                    setNaming({ initial: "untitled.spice" });
-                    setMoreOpen(false);
-                  }}
-                >
-                  New file…
                 </button>
               ) : null}
               {props.additionalActions}
@@ -455,6 +445,7 @@ export function SimulationCodeWorkspace(props: SimulationCodeWorkspaceProps) {
             ))}
           </div>
           <span className="simulation-code-output-spacer" />
+          {props.outputActions}
           <button
             type="button"
             aria-label={

--- a/apps/editor/src/features/simulation/simulation-file-tree.tsx
+++ b/apps/editor/src/features/simulation/simulation-file-tree.tsx
@@ -81,9 +81,6 @@ export function SimulationFolderTree(props: SimulationFolderTreeProps) {
         open(event.clientX, event.clientY);
       }}
     >
-      <button type="button" onClick={() => action("new", [])}>
-        + New folder…
-      </button>
       {naming && (
         <InlineSourceName
           label="Folder name"
@@ -97,7 +94,14 @@ export function SimulationFolderTree(props: SimulationFolderTreeProps) {
       )}
       {props.folders.map((folder) => (
         <div key={folder.id}>
-          <div className="simulation-folder-row">
+          <div
+            className="simulation-folder-row"
+            onContextMenu={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              open(event.clientX, event.clientY, folder.id);
+            }}
+          >
             <button
               type="button"
               aria-label={`Toggle ${folder.name}`}

--- a/apps/editor/src/features/simulation/source-code-pane.tsx
+++ b/apps/editor/src/features/simulation/source-code-pane.tsx
@@ -24,7 +24,7 @@ import {
   generateCircuitSource,
   planCircuitSourceEdit,
   compileSourceSimulation,
-  simulationSignalNames,
+  simulationSignals,
 } from "@icm/netlist";
 import type { SimulationFiles } from "@icm/simulation-service/files";
 import { sha256 } from "@icm/simulation-service/files";
@@ -60,6 +60,7 @@ interface Props extends Pick<
   | "pickTerminalsActive"
   | "onPickNetsChange"
   | "onPickTerminalsChange"
+  | "onFocusProbe"
 > {
   project: CircuitProject;
   selectedCircuitObject?:
@@ -73,6 +74,7 @@ interface Props extends Pick<
   onPrepare?(): void;
   console: ReactNode;
   results: ReactNode;
+  outputActions?: ReactNode;
   status?: ReactNode;
   outputPane: SimulationCodeWorkspaceProps["outputPane"];
   onSelectOutputPane: SimulationCodeWorkspaceProps["onSelectOutputPane"];
@@ -155,6 +157,19 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
       terminal: props.pickedTerminal?.sequence,
     });
     const input = props.folder.input;
+    const signals = useMemo(
+      () =>
+        simulationSignals(props.project, {
+          ...input,
+          files: input.files.map((file) => ({
+            ...file,
+            text:
+              drafts.current.get(`${props.folder.id}\u0000${file.path}`)
+                ?.text ?? file.text,
+          })),
+        }),
+      [props.project, input, draftRevision],
+    );
     const [probePicker, setProbePicker] = useState<"voltage" | "current">();
     const probeChoices = useMemo(
       () =>
@@ -811,6 +826,7 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
         }
         console={props.console}
         results={props.results}
+        outputActions={props.outputActions}
         outputPane={props.outputPane}
         onSelectOutputPane={props.onSelectOutputPane}
         maximized={props.maximized}
@@ -854,14 +870,26 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
         )}
         <SimulationCodeEditor
           signalNames={() =>
-            simulationSignalNames(props.project, {
-              ...input,
-              files: input.files.map((file) => ({
-                ...file,
-                text: drafts.current.get(key(file.path))?.text ?? file.text,
-              })),
-            })
+            Object.fromEntries(
+              Object.entries(signals).map(([vector, signal]) => [
+                vector,
+                signal.label,
+              ]),
+            )
           }
+          onFocusSignal={(vector) => {
+            const target = signals[vector.toLowerCase()]?.targets[0];
+            if (target)
+              props.onFocusProbe?.(
+                {
+                  kind: "voltage",
+                  documentId: target.documentId,
+                  occurrence: target.occurrence,
+                  anchor: { kind: "base-net", netId: target.netId },
+                },
+                target.rootDocumentId,
+              );
+          }}
           saveRequest={saveRequest}
           relatedSources={sourceFiles.map(
             (file) =>

--- a/apps/editor/src/features/simulation/source-probe-choices.test.ts
+++ b/apps/editor/src/features/simulation/source-probe-choices.test.ts
@@ -1,11 +1,45 @@
 import { describe, it, expect } from "vitest";
 import { parseProject } from "@icm/project-protocol";
-import { createSimulationStarter, simulationSignalNames } from "@icm/netlist";
+import {
+  createSimulationStarter,
+  simulationSignalNames,
+  simulationSignals,
+} from "@icm/netlist";
+import { resolveSimulationVoltageProbeNetId } from "./simulation-probe-options";
 import ota from "../../examples/five-transistor-ota-sky130.icproj.json";
 import { sourceProbeChoices } from "./source-probe-choices";
 
 const project = parseProject(JSON.stringify(ota));
 describe("source Probe discovery", () => {
+  it("maps native vectors back to valid Canvas nets through the same naming traversal", () => {
+    const input = project.simulationFolders[0]!.input;
+    const signals = simulationSignals(project, input);
+    expect(Object.keys(signals).length).toBeGreaterThan(0);
+    expect(
+      Object.fromEntries(
+        Object.entries(signals).map(([vector, signal]) => [
+          vector,
+          signal.label,
+        ]),
+      ),
+    ).toEqual(simulationSignalNames(project, input));
+    for (const signal of Object.values(signals))
+      for (const target of signal.targets) {
+        expect(
+          resolveSimulationVoltageProbeNetId(project, {
+            kind: "voltage",
+            documentId: target.documentId,
+            occurrence: target.occurrence,
+            anchor: { kind: "base-net", netId: target.netId },
+          }),
+        ).toBeDefined();
+      }
+    expect(
+      Object.values(signals).some((signal) =>
+        signal.targets.some((target) => target.occurrence.length > 0),
+      ),
+    ).toBe(true);
+  });
   it("addresses multiple DUT occurrences rather than silently choosing the first", () => {
     const result = createSimulationStarter(project, {
       id: "test",

--- a/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
@@ -44,7 +44,8 @@ function render(saved: boolean, broken = false) {
 describe("source workspace default cutover", () => {
   it("offers creation without restoring the retired Settings form", () => {
     const markup = render(false);
-    expect(markup).toContain("Create experiment");
+    expect(markup).toContain("Set up");
+    expect(markup).not.toContain("Create experiment");
     expect(markup).not.toContain('aria-label="Analyses settings"');
     expect(markup).not.toContain('aria-label="Setup settings"');
   });

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -1040,80 +1040,82 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
     else props.onSelectFolderId(created.id);
   };
   const createFolder = () => void folderAction("new", []);
+  const outputActions = (
+    <>
+      {run ? (
+        <div className="simulation-result-actions">
+          <button
+            type="button"
+            disabled={
+              artifactBusy !== undefined ||
+              (!run.result && !run.outputData) ||
+              !selectedFolder ||
+              selectedFolder.id !== runPresentation?.folderId
+            }
+            onClick={() => void archiveCurrentRun()}
+          >
+            {artifactBusy === "archive:save" ? "Archiving…" : "Archive"}
+          </button>
+          <details className="simulation-result-export">
+            <summary>Export</summary>
+            <div>
+              {resultTab === "plot" ? (
+                <>
+                  <button
+                    type="button"
+                    disabled={artifactBusy !== undefined}
+                    onClick={() => void exportVisiblePlots("svg")}
+                  >
+                    {artifactBusy === "plots:svg"
+                      ? "Preparing SVG…"
+                      : "Visible plots · SVG"}
+                  </button>
+                  <button
+                    type="button"
+                    disabled={artifactBusy !== undefined}
+                    onClick={() => void exportVisiblePlots("png")}
+                  >
+                    {artifactBusy === "plots:png"
+                      ? "Preparing PNG…"
+                      : "Visible plots · PNG"}
+                  </button>
+                </>
+              ) : null}
+              {resultCsvArtifacts.length ? (
+                <section>
+                  <small>Complete result data</small>
+                  {resultCsvArtifacts.map((artifact) => (
+                    <button
+                      key={artifact.id}
+                      type="button"
+                      disabled={artifactBusy !== undefined}
+                      onClick={() => void download(artifact)}
+                    >
+                      {artifact.name}
+                    </button>
+                  ))}
+                </section>
+              ) : null}
+              <button
+                type="button"
+                disabled={
+                  artifactBusy !== undefined || run.artifacts.length === 0
+                }
+                onClick={() => void downloadBundle("run", run.artifacts)}
+              >
+                Complete run · ZIP
+              </button>
+            </div>
+          </details>
+        </div>
+      ) : null}
+    </>
+  );
   const resultContent = (
     <section
       className="simulation-results-dock"
       aria-label="Simulation results"
     >
-      <header className="simulation-results-header">
-        {run ? (
-          <div className="simulation-result-actions">
-            <button
-              type="button"
-              disabled={
-                artifactBusy !== undefined ||
-                (!run.result && !run.outputData) ||
-                !selectedFolder ||
-                selectedFolder.id !== runPresentation?.folderId
-              }
-              onClick={() => void archiveCurrentRun()}
-            >
-              {artifactBusy === "archive:save" ? "Archiving…" : "Archive"}
-            </button>
-            <details className="simulation-result-export">
-              <summary>Export</summary>
-              <div>
-                {resultTab === "plot" ? (
-                  <>
-                    <button
-                      type="button"
-                      disabled={artifactBusy !== undefined}
-                      onClick={() => void exportVisiblePlots("svg")}
-                    >
-                      {artifactBusy === "plots:svg"
-                        ? "Preparing SVG…"
-                        : "Visible plots · SVG"}
-                    </button>
-                    <button
-                      type="button"
-                      disabled={artifactBusy !== undefined}
-                      onClick={() => void exportVisiblePlots("png")}
-                    >
-                      {artifactBusy === "plots:png"
-                        ? "Preparing PNG…"
-                        : "Visible plots · PNG"}
-                    </button>
-                  </>
-                ) : null}
-                {resultCsvArtifacts.length ? (
-                  <section>
-                    <small>Complete result data</small>
-                    {resultCsvArtifacts.map((artifact) => (
-                      <button
-                        key={artifact.id}
-                        type="button"
-                        disabled={artifactBusy !== undefined}
-                        onClick={() => void download(artifact)}
-                      >
-                        {artifact.name}
-                      </button>
-                    ))}
-                  </section>
-                ) : null}
-                <button
-                  type="button"
-                  disabled={
-                    artifactBusy !== undefined || run.artifacts.length === 0
-                  }
-                  onClick={() => void downloadBundle("run", run.artifacts)}
-                >
-                  Complete run · ZIP
-                </button>
-              </div>
-            </details>
-          </div>
-        ) : null}
-      </header>
       <div ref={resultsBodyRef} className="simulation-results-body">
         {resultTab === "plot" ? (
           <div className="simulation-analysis-view simulation-plot-view">
@@ -1686,7 +1688,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
         <div
           className="simulation-starter-choices"
           role="dialog"
-          aria-label="New experiment"
+          aria-label="Simulation setup"
           onKeyDown={(event) => {
             if (event.key === "Escape") {
               event.stopPropagation();
@@ -1753,7 +1755,10 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
               ▶
             </button>
           ) : (
-            <button className="simulation-primary-button" onClick={() => {}}>
+            <button
+              className="simulation-primary-button"
+              onClick={createFolder}
+            >
               Set up
             </button>
           )}
@@ -1886,6 +1891,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
               : undefined
           }
           selectedCircuitObject={props.selectedCircuitObject}
+          {...(props.onFocusProbe ? { onFocusProbe: props.onFocusProbe } : {})}
           files={session.files}
           {...{
             ...(props.pickedNet !== undefined
@@ -1908,6 +1914,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
           onProblem={setProblem}
           console={resultContent}
           results={resultContent}
+          outputActions={outputActions}
           outputPane={resultTab}
           onSelectOutputPane={setResultTab}
           maximized={resultsMaximized}
@@ -1939,11 +1946,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
           onSaveProject={props.onSaveProject}
         />
       ) : (
-        <div className="simulation-empty-result">
-          <button onClick={createFolder}>
-            Create experiment for this Cell
-          </button>
-        </div>
+        <div className="simulation-empty-result" />
       )}
     </section>
   );

--- a/docs/specs/simulation-code-workspace.md
+++ b/docs/specs/simulation-code-workspace.md
@@ -102,6 +102,9 @@ New folders default to text-only input without a questionnaire. Optional templat
 run the current Cell directly (top-level binding) or write a text TB around the
 current DUT (subcircuit binding and an authored call using exported port order).
 None creates a TB Cell or guesses stimuli.
+The empty workspace uses the top **Set up** action for templates. Folder and file
+creation live in tree context menus (also available with Shift+F10), not permanent
+New buttons. Archive and Export share the output tab bar with Console/Plot/OP.
 Existing experiments reopen unchanged; duplication is an explicit action.
 `circuit.spice`, `testbench.spice`, and `run.cir` are conventions, not mandatory
 file counts. A drawn TB does not need an additional authored TB file.
@@ -109,6 +112,10 @@ file counts. A drawn TB does not need an additional authored TB file.
 The flat **Helper** list and Ctrl+Space share the ngspice help catalog. Search
 accepts command names and purpose keywords; contextual typing completion is
 limited to commands and relevant arguments, not comments or arbitrary text.
+Argument completion opens after the space in `save`/`dc`; native vector names stay
+unchanged. Candidate selection and hover can locate mapped Canvas Nets through
+the same derived naming traversal. Text-only signals remain usable without a
+Canvas target.
 An unknown command offers a quiet Helper hint instead of opening a large list.
 Choosing a command inserts its name and presents missing arguments as display-only
 ghosts. Tab/Shift+Tab navigate arguments, Escape dismisses guidance, and no ghost

--- a/packages/netlist/src/simulation-signal-names.ts
+++ b/packages/netlist/src/simulation-signal-names.ts
@@ -7,13 +7,33 @@ import {
   resolveAuthoredCircuitScope,
 } from "./simulation-source-scopes.js";
 
+export interface SimulationSignalTarget {
+  rootDocumentId: string;
+  documentId: string;
+  netId: string;
+  occurrence: string[];
+}
+
 /** Run-local display metadata. Native vector spelling and electrical identity never change. */
 export function simulationSignalNames(
   project: CircuitProject,
   input: SimulationSourceInput,
 ): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(simulationSignals(project, input)).map(
+      ([vector, signal]) => [vector, signal.label],
+    ),
+  );
+}
+
+/** Native vectors and Canvas addresses share the same resolved traversal. */
+export function simulationSignals(
+  project: CircuitProject,
+  input: SimulationSourceInput,
+): Record<string, { label: string; targets: SimulationSignalTarget[] }> {
   const graph = inspectSimulationSourceGraph(input);
   const labels = new Map<string, Set<string>>();
+  const targets = new Map<string, SimulationSignalTarget[]>();
   for (const binding of input.circuitBindings) {
     if (!graph.paths.includes(binding.path)) continue;
     const ir = analyzeDesignNetlist(project, {
@@ -33,6 +53,7 @@ export function simulationSignalNames(
         nodes: Map<string, string>,
         path: string[],
         ancestors: Set<string>,
+        occurrence: string[],
       ) {
         if (++visits > 4096 || ancestors.has(cell.id)) return;
         const local = new Map(nodes);
@@ -49,6 +70,15 @@ export function simulationSignalNames(
           const names = labels.get(vector) ?? new Set<string>();
           names.add(name);
           labels.set(vector, names);
+          targets.set(vector, [
+            ...(targets.get(vector) ?? []),
+            {
+              rootDocumentId: binding.documentId,
+              documentId: cell.id,
+              netId: net.id,
+              occurrence,
+            },
+          ]);
         }
         for (const instance of cell.instances) {
           if (instance.deviceClass !== "hierarchical") continue;
@@ -70,13 +100,20 @@ export function simulationSignalNames(
             ports,
             [...path, instance.reference],
             new Set([...ancestors, cell.id]),
+            [...occurrence, instance.id],
           );
         }
       }
-      visit(root, new Map(), [], new Set());
+      visit(root, new Map(), [], new Set(), []);
     }
   }
   return Object.fromEntries(
-    [...labels].map(([vector, names]) => [vector, [...names].join(" · ")]),
+    [...labels].map(([vector, names]) => [
+      vector,
+      {
+        label: [...names].join(" · "),
+        targets: targets.get(vector) ?? [],
+      },
+    ]),
   );
 }


### PR DESCRIPTION
Simplify source folders and template setup; move Archive/Export into the output tab bar. Restore automatic save/dc argument completion and reuse resolved native signal mapping for Canvas highlighting from keyboard/mouse selection. No persisted Net or simulation protocol change. Validation: full local delivery run passed static, 3109 unit/integration tests, build and release/performance smoke; 382/383 browser tests passed, with the one stale header locator updated and all three workspace journeys subsequently passing. Eight code-editor browser contracts passed. Require all remote checks and queue validation before merge.