### PR TITLE
fix(editor): make W/L labels fully hittable and freely draggable

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -1,4 +1,5 @@
 import { createRoutePath } from "@icm/model";
+import type { SchematicDocument } from "@icm/model";
 import { razaviProductSymbols } from "@icm/symbols";
 import { expect, test } from "@playwright/test";
 import type { Locator, Page } from "@playwright/test";
@@ -3870,6 +3871,136 @@ test("reference and value code refreshes content after parameter edits", async (
   ).toHaveCount(0);
 });
 
+for (const symbol of ["nmos", "pmos"]) {
+  test(`${symbol} W/L numerator drags freely and retains its offset through editing and file reload`, async ({
+    page,
+  }) => {
+    await page.goto("/editor");
+    await placeComponent(page, symbol, { x: 350, y: 250 });
+    const canvas = page.getByTestId("schematic-canvas");
+    const instance = page.getByTestId("hit-M1");
+    await instance.click();
+    await openSelectionShelf(page);
+    await page.getByLabel("Component w", { exact: true }).fill("2u");
+    await page.getByLabel("Component l", { exact: true }).fill("180n");
+    await page.getByLabel("Component m", { exact: true }).fill("4");
+    await editComponentPropertyCode(page, (code) => {
+      code.display.value = true;
+    });
+    await canvas.click({ position: { x: 70, y: 70 } });
+
+    const value = page.locator('[data-object-id="instance-value-M1"]');
+    const numerator = value.locator('[data-role="fraction-numerator"]');
+    await expect(numerator).toContainText("2um");
+    const before = (await value.boundingBox())!;
+    const ownerBefore = (await instance.boundingBox())!;
+    const grip = (await numerator.boundingBox())!;
+    const start = { x: grip.x + grip.width / 2, y: grip.y + grip.height / 2 };
+    // Grab the numerator itself, not the lower hit rectangle or an Alt cycle.
+    await page.mouse.move(start.x, start.y);
+    await page.mouse.down();
+    await page.mouse.move(start.x + 180, start.y + 120, { steps: 12 });
+    await expect
+      .poll(async () => (await value.boundingBox())!.x)
+      .toBeCloseTo(before.x + 180, 0);
+    await page.mouse.up();
+    // The only allowed difference on release is annotation-grid rounding.
+    await expect
+      .poll(async () =>
+        Math.abs((await value.boundingBox())!.x - before.x - 180),
+      )
+      .toBeLessThan(3);
+    await expect
+      .poll(async () =>
+        Math.abs((await value.boundingBox())!.y - before.y - 120),
+      )
+      .toBeLessThan(3);
+    expect(await instance.boundingBox()).toEqual(ownerBefore);
+    const dropped = (await value.boundingBox())!;
+
+    await page.keyboard.press("ControlOrMeta+z");
+    await expect
+      .poll(async () => (await value.boundingBox())!.x)
+      .toBeCloseTo(before.x, 0);
+    await page.keyboard.press("ControlOrMeta+Shift+z");
+    await expect
+      .poll(async () => (await value.boundingBox())!.x)
+      .toBeCloseTo(dropped.x, 0);
+
+    const readDocument = async (): Promise<SchematicDocument> => {
+      const bytes = await downloadBytes(page, "File", "Export Project File…");
+      return JSON.parse(bytes.toString("utf8")).documents[0];
+    };
+    const valueAnchor = (document: SchematicDocument) => {
+      const anchor = document.annotations.find(
+        (annotation) => annotation.id === "instance-value-M1",
+      )!.anchor;
+      if (anchor.kind !== "object")
+        throw new Error("Value must retain its component anchor");
+      return anchor;
+    };
+    const authored = await readDocument();
+    const anchor = valueAnchor(authored);
+    expect(anchor.objectId).toBe("M1");
+    expect(
+      Math.hypot(anchor.localOffset.x, anchor.localOffset.y),
+    ).toBeGreaterThan(200);
+
+    // Updating W refreshes the fraction without restoring its default slot.
+    await instance.click();
+    await openSelectionShelf(page);
+    await page.getByLabel("Component w", { exact: true }).fill("3u");
+    await canvas.click({ position: { x: 70, y: 70 } });
+    await expect(numerator).toContainText("3um");
+    expect(valueAnchor(await readDocument())).toEqual(anchor);
+
+    // Move and rotate the host: the authored vector follows, never reflows.
+    const host = (await instance.boundingBox())!;
+    await page.mouse.move(host.x + host.width / 2, host.y + host.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(
+      host.x + host.width / 2 + 60,
+      host.y + host.height / 2 - 40,
+      { steps: 8 },
+    );
+    await page.mouse.up();
+    const moved = await readDocument();
+    const movedAnchor = valueAnchor(moved);
+    expect(movedAnchor.localOffset).toEqual(anchor.localOffset);
+    const movedPosition = moved.instances.find((item) => item.id === "M1")!
+      .placement!.position;
+    expect(movedAnchor.fallbackPosition).toEqual({
+      x: movedPosition.x + anchor.localOffset.x,
+      y: movedPosition.y + anchor.localOffset.y,
+    });
+    await instance.click();
+    await page.keyboard.press("r");
+    const rotated = await readDocument();
+    const rotatedAnchor = valueAnchor(rotated);
+    expect(
+      rotated.instances.find((item) => item.id === "M1")!.placement!.rotation,
+    ).toBe(90);
+    expect(rotatedAnchor.localOffset).toEqual({
+      x: -anchor.localOffset.y,
+      y: anchor.localOffset.x,
+    });
+    await expect(numerator).toContainText("3um");
+
+    // Reopen a real exported file, then export again to verify persisted data.
+    const saved = await downloadBytes(page, "File", "Export Project File…");
+    await page.getByTestId("project-file").setInputFiles({
+      name: `${symbol}-value-drag.icproj.json`,
+      mimeType: "application/json",
+      buffer: saved,
+    });
+    await expect(numerator).toContainText("3um");
+    const reopened = await readDocument();
+    expect(valueAnchor(reopened)).toEqual(rotatedAnchor);
+    expect(reopened.instances).toEqual(rotated.instances);
+    expect(reopened.nets).toEqual(authored.nets);
+  });
+}
+
 test("drag value annotation keeps the user offset through rotation", async ({
   page,
 }) => {
@@ -3909,8 +4040,7 @@ test("drag value annotation keeps the user offset through rotation", async ({
   ).toContainText("33kΩ");
   const rotated = await value.boundingBox();
   if (!rotated) throw new Error("Rotated value is not measurable");
-  // The user vector rotates rigidly; on the drag-clamp circle a quarter turn
-  // may keep one coordinate, so assert total displacement instead.
+  // A quarter turn may keep one coordinate, so assert total displacement.
   expect(
     Math.hypot(rotated.x - dragged.x, rotated.y - dragged.y),
   ).toBeGreaterThan(10);

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -2715,14 +2715,8 @@ export function App({
   const textEditingBounds = editingAnnotation
     ? annotationHitBox(
         document,
+        resolver,
         editingAnnotation,
-        annotationAnchor(
-          document,
-          resolver,
-          editingAnnotation,
-          routeGeometryRecords,
-          styleProfile,
-        ),
         routeGeometryRecords,
         styleProfile,
       )

--- a/apps/editor/src/canvas/editor-canvas-hit-layer.tsx
+++ b/apps/editor/src/canvas/editor-canvas-hit-layer.tsx
@@ -17,7 +17,6 @@ import {
 import type { SymbolResolver } from "@icm/symbols";
 
 import {
-  annotationAnchor,
   annotationHitBox,
   instanceHitBox,
 } from "../features/wiring/route-interaction-geometry";
@@ -274,17 +273,10 @@ function SelectionHitTargets({
           isSchematicAnnotationVisible(document, annotation),
         )
         .map((annotation) => {
-          const anchor = annotationAnchor(
+          const hitBox = annotationHitBox(
             document,
             resolver,
             annotation,
-            routeGeometryRecords,
-            styleProfile,
-          );
-          const hitBox = annotationHitBox(
-            document,
-            annotation,
-            anchor,
             routeGeometryRecords,
             styleProfile,
           );

--- a/apps/editor/src/features/selection/marquee-selection.test.ts
+++ b/apps/editor/src/features/selection/marquee-selection.test.ts
@@ -9,7 +9,6 @@ import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
 import { describe, expect, it } from "vitest";
 
 import {
-  annotationAnchor,
   annotationHitBox,
   defaultInstanceLabel,
   instanceHitBox,
@@ -115,8 +114,8 @@ function fixture(): {
   if (!instanceBounds) throw new Error("Fixture instance must resolve");
   const labelBounds = annotationHitBox(
     document,
+    resolver,
     label,
-    annotationAnchor(document, resolver, label, records, styleProfile),
     records,
     styleProfile,
   );

--- a/apps/editor/src/features/selection/marquee-selection.ts
+++ b/apps/editor/src/features/selection/marquee-selection.ts
@@ -16,7 +16,6 @@ import {
   segmentIntersectsRect,
 } from "../../canvas/canvas-geometry";
 import {
-  annotationAnchor,
   annotationHitBox,
   instanceHitBox,
   type RouteGeometryRecord,
@@ -111,14 +110,8 @@ export function marqueeSelection(
           boxSelected(
             annotationHitBox(
               document,
+              resolver,
               annotation,
-              annotationAnchor(
-                document,
-                resolver,
-                annotation,
-                routeGeometryRecords,
-                styleProfile,
-              ),
               routeGeometryRecords,
               styleProfile,
             ),

--- a/apps/editor/src/features/text-editing/annotation-drag-model.test.ts
+++ b/apps/editor/src/features/text-editing/annotation-drag-model.test.ts
@@ -84,6 +84,58 @@ describe("annotation drag model", () => {
     });
   });
 
+  it.each(["nmos", "pmos", "resistor"])(
+    "freely places a %s value while keeping its host-relative anchor",
+    (symbolId) => {
+      const document = createEmptyDocument("document", "Document");
+      document.instances.push({
+        id: "device",
+        symbolId,
+        placement: {
+          position: { x: 100, y: 100 },
+          rotation: 0,
+          mirror: "none",
+        },
+      });
+      const annotation: Annotation = {
+        id: "value",
+        kind: "instance-value",
+        binding: { kind: "instance-value", instanceId: "device" },
+        anchor: {
+          kind: "object",
+          objectId: "device",
+          localOffset: { x: 30, y: 30 },
+          fallbackPosition: { x: 130, y: 130 },
+        },
+        alignment: "start",
+        rotation: 0,
+        locked: false,
+      };
+
+      for (const candidate of [
+        { x: 1003, y: 997 },
+        { x: -503, y: -697 },
+      ]) {
+        const dragged = draggedAnnotationAtPosition(
+          context(document),
+          annotation,
+          candidate,
+        );
+        const x = Math.round(candidate.x / 10) * 10;
+        const y = Math.round(candidate.y / 10) * 10;
+        expect(dragged).toEqual({
+          ...annotation,
+          anchor: {
+            kind: "object",
+            objectId: "device",
+            localOffset: { x: x - 100, y: y - 100 },
+            fallbackPosition: { x, y },
+          },
+        });
+      }
+    },
+  );
+
   it("moves a power label anchored to its rail Junction", () => {
     // A power rail's label anchors to the Junction at the rail's end, not to
     // an Instance. Rendering resolves it as junction position + localOffset,

--- a/apps/editor/src/features/text-editing/annotation-drag-model.ts
+++ b/apps/editor/src/features/text-editing/annotation-drag-model.ts
@@ -43,8 +43,9 @@ function constrainAnnotationPosition(
   candidate: DerivedPoint,
 ): Point {
   if (
-    (annotation.kind === "instance-label" ||
-      annotation.kind === "instance-value") &&
+    // Value labels are authored layout: their object anchor keeps them tied
+    // to the component without limiting how far the user can place them.
+    annotation.kind === "instance-label" &&
     annotation.anchor.kind === "object"
   ) {
     const anchor = annotation.anchor;

--- a/apps/editor/src/features/wiring/route-interaction-geometry.test.ts
+++ b/apps/editor/src/features/wiring/route-interaction-geometry.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 
 import { createEmptyDocument } from "@icm/model";
 import {
+  resolveAnnotationPresentation,
   resolveRouteGeometry,
   resolveSchematicStyleProfile,
 } from "@icm/derived";
@@ -10,6 +11,7 @@ import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
 
 import {
   annotationAnchor,
+  annotationHitBox,
   attachmentAtPoint,
   routeTapPoint,
   defaultInstanceLabel,
@@ -63,6 +65,45 @@ function routeRecord(document: ReturnType<typeof looseRouteDocument>) {
 }
 
 describe("route interaction geometry", () => {
+  it.each([0.5, 1, 2])(
+    "includes a W/L numerator in the shared text hit bounds at scale %s",
+    (sizeScale) => {
+      const document = createEmptyDocument("labels", "Labels");
+      const annotation = {
+        id: "value",
+        kind: "instance-value" as const,
+        content: {
+          runs: [
+            {
+              kind: "fraction" as const,
+              numerator: { runs: [{ kind: "text" as const, value: "2um" }] },
+              denominator: {
+                runs: [{ kind: "text" as const, value: "180nm" }],
+              },
+            },
+          ],
+        },
+        anchor: { kind: "free" as const, position: { x: 100, y: 100 } },
+        alignment: "start" as const,
+        rotation: 0 as const,
+        locked: false,
+        sizeScale,
+      };
+      const profile = resolveSchematicStyleProfile(
+        document.presentation.styleProfileId,
+      );
+      const presentation = resolveAnnotationPresentation(
+        document,
+        resolver,
+        annotation,
+        profile,
+      );
+      expect(
+        annotationHitBox(document, resolver, annotation, [], profile),
+      ).toEqual(presentation.bounds);
+    },
+  );
+
   it("recognizes a free route backed by two loose route anchors", () => {
     const document = looseRouteDocument();
     expect(looseRouteAnchorIds(document, document.routes[0]!)).toEqual([

--- a/apps/editor/src/features/wiring/route-interaction-geometry.ts
+++ b/apps/editor/src/features/wiring/route-interaction-geometry.ts
@@ -400,11 +400,29 @@ export function annotationAnchor(
 
 export function annotationHitBox(
   document: SchematicDocument,
+  resolver: SymbolResolver,
   annotation: Annotation,
-  anchor: Point,
   routeGeometryRecords: readonly RouteGeometryRecord[],
   styleProfile: SchematicStyleProfile,
 ): Rect {
+  // Ordinary text uses the same bounds as rendering/export, including the
+  // extra ascent of a stacked W/L numerator. Only current markers need the
+  // editor's additional arrow/route hit geometry below.
+  if (!isRoutedMarker(annotation)) {
+    return resolveAnnotationPresentation(
+      document,
+      resolver,
+      annotation,
+      styleProfile,
+    ).bounds;
+  }
+  const anchor = annotationAnchor(
+    document,
+    resolver,
+    annotation,
+    routeGeometryRecords,
+    styleProfile,
+  );
   const sizeScale = annotation.sizeScale ?? 1;
   const fontSize =
     schematicTextFontSize(annotation.kind, styleProfile) * sizeScale;

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -463,7 +463,11 @@ follows the live property draft — typing a value enables it without
 reopening the panel — and checking it commits the typed parameters and shows
 the projected value in one transaction. Showing a value re-projects its text
 without touching electrical parameters or a user-dragged anchor; the Edit
-Engine refreshes a non-hand-edited value after parameter edits. Net/power
+Engine refreshes a non-hand-edited value after parameter edits. Value labels
+can be grabbed anywhere in their visible text, including a fraction's
+numerator, and dragged without a host-distance limit. The annotation grid
+still rounds their position; their object anchor retains the authored offset
+when the component moves or rotates and through Project file save/load. Net/power
 labels carry Net identity separately from their
 visual anchor. A resolved anchor drives both the glyph and every text
 hit/marquee surface; its fallback is only for an orphaned target, never an


### PR DESCRIPTION
## Summary

- Use shared annotation presentation bounds for canvas hits, marquee selection and text editing so the complete W/L fraction, including its raised numerator, is selectable.
- Allow component value annotations to be dragged without the old host-distance clamp. Keep object-relative anchors, annotation-grid rounding, reference-label constraints and route-marker behavior.
- Add regressions for NMOS/PMOS numerator grabbing, exact far-drop position, undo/redo, parameter refresh, host movement/rotation and exported Project file reload.

## Validation

- Six added unit cases reproduced the two defects before implementation; all 41 focused unit tests pass after the fix.
- `pnpm install --frozen-lockfile`, `pnpm gate:preflight -- --base a8557cd6` and `pnpm build` passed.
- Focused browser checks: both new NMOS/PMOS scenarios and the existing value rotation scenario passed (3/3).
- `pnpm gate:affected -- --base a8557cd6` passed: 3,140 unit tests (4 existing skips), 143 editor browser tests, 13 selection tests, 7 wiring tests and 15 symbol-text tests, for 178 affected browser tests total. Full fallback is not selected; no shared model or electrical contracts changed.
- Require all seven remote checks and successful Preview acceptance before Production promotion. The user explicitly requested release to the main public site.

Test-Impact: tests-updated
