### PR TITLE
fix(preview): align source GUI acceptance with workspace menus

### DIFF
--- a/scripts/preview-source-gui-journey.mjs
+++ b/scripts/preview-source-gui-journey.mjs
@@ -91,13 +91,15 @@ const digest = (value) => createHash("sha256").update(value).digest("hex");
 async function edit(path, text) {
   if (path === folder.input.configPath) {
     await panel.getByRole("button", { name: "More code actions" }).click();
-    await panel.getByRole("button", { name: "Advanced configuration" }).click();
+    await page
+      .getByRole("menuitem", { name: "Advanced configuration" })
+      .click();
   } else await panel.getByRole("tab", { name: path, exact: false }).click();
   const editor = panel.getByRole("textbox", {
     name: "Simulation source editor",
   });
   await editor.click();
-  await editor.press("Control+A");
+  await editor.press("ControlOrMeta+A");
   await page.keyboard.insertText(text);
 }
 async function download(button, name) {
@@ -204,7 +206,7 @@ try {
     ),
   );
   await panel.getByRole("button", { name: "More code actions" }).click();
-  await panel.getByRole("button", { name: "View final deck" }).click();
+  await page.getByRole("menuitem", { name: "View final deck" }).click();
   await expect(panel).toContainText("missing-gui-acceptance.spice", {
     timeout: 30_000,
   });
@@ -299,7 +301,7 @@ try {
   };
   await edit(folder.input.configPath, JSON.stringify(config, null, 2));
   await panel.getByRole("button", { name: "More code actions" }).click();
-  await panel.getByRole("button", { name: "View final deck" }).click();
+  await page.getByRole("menuitem", { name: "View final deck" }).click();
   await panel.getByTitle("Batch queue", { exact: true }).click();
   await expect(panel.locator(".simulation-batch-menu-popover")).toContainText(
     "Batch · prepared",


### PR DESCRIPTION
## Scope

Finish Preview-only delivery of #762. Its merged commit `1423e168` is already serving the exact verified entry graph, and both PR/merge-queue CI gates passed.

Deploy run 34630558940 passed deployment, shell checks, numerical acceptance and the Agent/MCP journey, then failed because the source GUI acceptance still looked for pre-#761 panel buttons. The new shared workspace menu is portalled and exposes menuitems.

- Update the three stale configuration/final-deck action locators.
- Use platform-neutral select-all for the same authored text operation.
- Preserve all existing assertions, thresholds, simulator/model qualification, batch, export and save/reload coverage.
- No application behavior, Worker, secrets, production deployment or component changes.

## Validation

- Syntax, formatting, diff and existing Preview workflow tests: passed (7 tests).
- Preflight/static and full workspace units passed: 3149 tests passed, 4 skipped.
- Corrected source-GUI journey passed against the real Preview at 2026-09-11T19:23:49Z: mapped W edit and restoration, malformed-input recovery, qualified ngspice-46/SKY130 OP/DC/AC/TRAN and noise, SVG/PNG/result exports, two-temperature batch, Project export and save/reload. Candidate entry bytes matched `/assets/index-CyWthDTl.js` with SHA-256 `a2d57db4aef6064ce142cd4d97910659ee61a4adcf23a2fbe3379675f36acbf2`. The current deployed commit is `1423e168`; this patch changes the acceptance script only, so the app entry graph is identical.
- Seven additional live Preview browser checks passed: full component library, NMOS/PMOS W/L dragging through parameter editing and file reload, hierarchy semantics, Project/SVG/PNG/PDF export, SPICE/Spectre export, portable Project upgrade.
- All required PR and full merge-queue checks, then exact-SHA green Preview deployment, remain required before completion.
- Production is forbidden for this task. No release tag or production dispatch.
