### PR TITLE
feat(editor): unify component properties in a guided JSON editor

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -1082,16 +1082,16 @@ test("carries a manual Value through placement and Q property editing", async ({
   );
   await expect(page.getByLabel("Component geometry")).toHaveCount(0);
   const propertyCode = page.getByLabel("Editable Canvas property code");
-  await expect(propertyCode).toHaveValue(/"at": \[/u);
-  await expect(propertyCode).toHaveValue(/"rotation": 0/u);
-  await expect(propertyCode).toHaveValue(/"mirror": "none"/u);
+  await expect(propertyCode).toContainText(/"at": \[/u);
+  await expect(propertyCode).toContainText(/"rotation": 0/u);
+  await expect(propertyCode).toContainText(/"mirror": "none"/u);
   await expect(page.locator(".selection-overview")).toHaveCount(0);
   await expect(page.getByTestId("selection-shelf")).toContainText(
     "R1 · resistor",
   );
   await expect(page.getByLabel("Component display toggles")).toHaveCount(0);
-  await expect(propertyCode).toHaveValue(/"reference": true/u);
-  await expect(propertyCode).toHaveValue(/"value": false/u);
+  await expect(propertyCode).toContainText(/"reference": true/u);
+  await expect(propertyCode).toContainText(/"value": false/u);
   await expect(page.getByText("Actions", { exact: true })).toBeVisible();
   const propertyValue = page.getByLabel("Component value");
   // Opening focuses the shelf header, never the first field: Q stays a pure
@@ -1427,7 +1427,7 @@ test("sets MOS parameters and orientation through the ghost and Properties", asy
   await expect(page.getByLabel("Component m", { exact: true })).toHaveValue(
     "4",
   );
-  await expect(page.getByLabel("Editable Canvas property code")).toHaveValue(
+  await expect(page.getByLabel("Editable Canvas property code")).toContainText(
     /"rotation": 90/u,
   );
 });

--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -6,6 +6,9 @@ import {
   clickCommand,
   downloadBytes,
   editComponentPropertyCode,
+  setComponentParameter,
+  expectComponentCodeField,
+  readComponentPropertyCode,
   recoveryProjectTexts,
 } from "./editor-fixtures.js";
 
@@ -157,9 +160,9 @@ test("writes an Instance Reference through post-placement Properties", async ({
   // The quick pick carries no reference field; naming happens in Properties.
   await page.getByTestId("hit-R1").click();
   await page.getByTestId("selection-shelf").click();
-  const instanceReference = page.getByLabel("Netlist Reference");
-  await instanceReference.fill("R7");
-  await instanceReference.press("Tab");
+  await editComponentPropertyCode(page, (code) => {
+    code.reference = "R7";
+  });
 
   await expect
     .poll(() => recoveryProjectTexts(page))
@@ -1092,14 +1095,14 @@ test("carries a manual Value through placement and Q property editing", async ({
   await expect(page.getByLabel("Component display toggles")).toHaveCount(0);
   await expect(propertyCode).toContainText(/"reference": true/u);
   await expect(propertyCode).toContainText(/"value": false/u);
-  await expect(page.getByText("Actions", { exact: true })).toBeVisible();
-  const propertyValue = page.getByLabel("Component value");
+  await expect(page.getByText("Actions", { exact: true })).toHaveCount(0);
   // Opening focuses the shelf header, never the first field: Q stays a pure
   // toggle and editing starts only when the user clicks an input.
   await expect(page.getByTestId("selection-shelf")).toBeFocused();
-  await expect(propertyValue).not.toBeFocused();
+  await expect(propertyCode).not.toBeFocused();
   // Quick placement leaves the value blank; it arrives through Q editing.
-  await expect(propertyValue).toHaveValue("");
+  await expectComponentCodeField(page, "parameters.value", "");
+  await page.getByTestId("selection-shelf").focus();
   await page.keyboard.press("q");
   await expect(page.getByTestId("selection-shelf")).toHaveAttribute(
     "aria-expanded",
@@ -1110,62 +1113,36 @@ test("carries a manual Value through placement and Q property editing", async ({
     "aria-expanded",
     "true",
   );
-  await expect(propertyValue).not.toBeFocused();
-  await expect(propertyValue).toHaveValue("");
-  await propertyValue.click();
-  await expect(propertyValue).toBeFocused();
-  await propertyValue.fill("10k");
-  await expect(propertyValue).toHaveValue("10k");
-  await expect(page.getByTestId("revision")).toHaveText("2");
+  await expect(propertyCode).not.toBeFocused();
+  const draft = JSON.parse(await readComponentPropertyCode(page));
+  draft.parameters.value = "10k";
+  await propertyCode.fill(JSON.stringify(draft, null, 2));
+  await expect(page.getByTestId("revision")).toHaveText("1");
   await expect(
     page.getByRole("button", { name: "Apply component properties" }),
   ).toHaveCount(0);
-  await page.getByRole("button", { name: "Discard changes" }).click();
-  await expect(page.getByTestId("revision")).toHaveText("3");
-  await expect(propertyValue).toHaveValue("");
-  await expect(
-    page.getByRole("button", { name: "Discard changes" }),
-  ).toHaveCount(0);
+  await page.getByRole("button", { name: "Discard draft" }).click();
+  await expect(page.getByTestId("revision")).toHaveText("1");
+  await expectComponentCodeField(page, "parameters.value", "");
   // Electrical renaming and the shared visual editor are distinct actions;
   // there is no second, plain-text Label field or heavyweight Identity card.
   await expect(page.getByText("Identity", { exact: true })).toHaveCount(0);
-  await expect(page.getByLabel("Component controls")).toContainText(
-    "Netlist ReferenceVisual annotationEdit annotation",
-  );
-  await expect(page.getByLabel("Component controls")).not.toContainText(
-    "Device class",
-  );
+  await expect(page.getByLabel("Component controls")).toHaveCount(0);
   const componentCode = page.locator(
     '[aria-label="Component properties"] > :last-child',
   );
   await expect(componentCode).toHaveAttribute(
     "aria-label",
-    "SPICE component code",
+    "Canvas property code",
   );
-  await expect(componentCode).toHaveText(
-    /R1.*<unconnected:1>.*<unconnected:2>.*<value>/u,
-  );
-  const instanceReference = page.getByLabel("Netlist Reference");
-  await expect(instanceReference).toHaveValue("R1");
-  await instanceReference.fill("R7");
-  await instanceReference.press("Tab");
-  await expect(page.getByTestId("revision")).toHaveText("4");
-  await expect(instanceReference).toHaveValue("R7");
-  await page
-    .locator("summary")
-    .filter({ hasText: "Netlist overrides" })
-    .click();
-  await page.getByRole("button", { name: "Add parameter" }).click();
-  await page.getByLabel("Additional parameter name 1").fill("tc");
-  await page.getByLabel("Additional parameter value 1").fill("0.1");
-  await page.getByRole("button", { name: "Apply parameters" }).click();
-  await expect(page.getByTestId("revision")).toHaveText("5");
-  await expect(page.getByLabel("Additional parameter name 1")).toHaveValue(
-    "tc",
-  );
-  await expect(page.getByLabel("Additional parameter value 1")).toHaveValue(
-    "0.1",
-  );
+  await expectComponentCodeField(page, "reference", "R1");
+  await editComponentPropertyCode(page, (code) => {
+    code.reference = "R7";
+    code.parameters.tc = "0.1";
+  });
+  await expect(page.getByTestId("revision")).toHaveText("2");
+  await expectComponentCodeField(page, "reference", "R7");
+  await expectComponentCodeField(page, "parameters.tc", "0.1");
 });
 
 test("ordinary source Properties switch waveforms without erasing inactive values", async ({
@@ -1181,45 +1158,38 @@ test("ordinary source Properties switch waveforms without erasing inactive value
   await page.getByTestId("hit-V1").click();
   await page.keyboard.press("q");
 
-  const waveform = page.getByLabel("Component transient");
+  const waveform = page.getByLabel("Transient options");
   await expect(waveform).toHaveValue("dc");
   await expect(waveform.locator('option[value="dc"]')).toHaveText("None");
-  const parameters = page.getByLabel("Component parameters and display");
-  await expect(parameters).toContainText("AC phase / deg");
-  await expect(parameters).not.toContainText("Small-signal phase");
-  await expect(page.getByLabel("Component low")).toHaveCount(0);
-  await expect(page.getByLabel("Component amplitude")).toHaveCount(0);
+  await expect(page.getByLabel("Component parameters and display")).toHaveCount(
+    0,
+  );
 
   await waveform.selectOption("pulse");
-  const low = page.getByLabel("Component low");
-  const high = page.getByLabel("Component high");
-  const rise = page.getByLabel("Component rise time");
-  const fall = page.getByLabel("Component fall time");
-  const [lowBox, highBox, riseBox, fallBox] = await Promise.all([
-    low.boundingBox(),
-    high.boundingBox(),
-    rise.boundingBox(),
-    fall.boundingBox(),
-  ]);
-  expect(lowBox?.y).toBe(highBox?.y);
-  expect(riseBox?.y).toBe(fallBox?.y);
-  expect(lowBox!.x).toBeLessThan(highBox!.x);
-  expect(riseBox!.x).toBeLessThan(fallBox!.x);
-  await expect(high).toHaveValue("1");
-  await high.fill("2.5");
+  await page.getByRole("button", { name: "Apply code" }).click();
+  await expectComponentCodeField(page, "parameters.high", "1");
+  await setComponentParameter(page, "high", "2.5");
 
+  await page
+    .getByLabel("Editable Canvas property code")
+    .press("ControlOrMeta+Home");
   await waveform.selectOption("sin");
-  await expect(page.getByLabel("Component amplitude")).toHaveValue("1");
-  await expect(page.getByLabel("Component high")).toHaveCount(0);
+  await page.getByRole("button", { name: "Apply code" }).click();
+  await expectComponentCodeField(page, "parameters.amplitude", "1");
+  await expectComponentCodeField(page, "parameters.high", "2.5");
 
+  await page
+    .getByLabel("Editable Canvas property code")
+    .press("ControlOrMeta+Home");
   await waveform.selectOption("pulse");
-  await expect(page.getByLabel("Component high")).toHaveValue("2.5");
+  await page.getByRole("button", { name: "Apply code" }).click();
+  await expectComponentCodeField(page, "parameters.high", "2.5");
   await expect
     .poll(() => recoveryProjectTexts(page))
     .toContain('"waveform": "pulse"');
 });
 
-test("keeps differential amplifier swaps in a dedicated placement row", async ({
+test("exposes pin-compatible amplifier variants inside the property code", async ({
   page,
 }) => {
   await page.goto("/editor");
@@ -1232,12 +1202,14 @@ test("keeps differential amplifier swaps in a dedicated placement row", async ({
   await page.getByTestId("selection-shelf").click();
 
   const amplifierActions = page.getByLabel("Amplifier placement actions");
+  await expect(amplifierActions).toHaveCount(0);
+  const variants = page.getByLabel("Drawing variant options");
   await expect(
-    amplifierActions.getByRole("button", { name: "Swap the + and - outputs" }),
-  ).toBeVisible();
+    variants.locator('option[value="opamp-differential-crossed"]'),
+  ).toHaveCount(1);
   await expect(
-    amplifierActions.getByRole("button", { name: "Swap the + and - inputs" }),
-  ).toBeVisible();
+    variants.locator('option[value="opamp-differential-inputs-swapped"]'),
+  ).toHaveCount(1);
   await expect(
     page.getByRole("button", { name: "Return component to Placement Tray" }),
   ).toHaveCount(0);
@@ -1405,28 +1377,20 @@ test("sets MOS parameters and orientation through the ghost and Properties", asy
   // Parameters and label visibility are Properties decisions.
   await page.getByTestId("hit-M1").click();
   await page.keyboard.press("q");
-  await expect(page.getByLabel("Component w", { exact: true })).toHaveValue(
-    "1u",
-  );
-  await page.getByLabel("Component w", { exact: true }).fill("2u");
-  await page.getByLabel("Component l", { exact: true }).fill("180n");
-  await page.getByLabel("Component m", { exact: true }).fill("4");
-  await page.getByLabel("Component m", { exact: true }).press("Tab");
+  await expectComponentCodeField(page, "parameters.w", "1u");
+  await setComponentParameter(page, "w", "2u");
+  await setComponentParameter(page, "l", "180n");
+  await setComponentParameter(page, "m", "4");
+
   await editComponentPropertyCode(page, (value) => {
     value.display.reference = false;
   });
   await expect(
     page.locator('[data-object-id="instance-label-M1"]'),
   ).toHaveCount(0);
-  await expect(page.getByLabel("Component w", { exact: true })).toHaveValue(
-    "2u",
-  );
-  await expect(page.getByLabel("Component l", { exact: true })).toHaveValue(
-    "180n",
-  );
-  await expect(page.getByLabel("Component m", { exact: true })).toHaveValue(
-    "4",
-  );
+  await expectComponentCodeField(page, "parameters.w", "2u");
+  await expectComponentCodeField(page, "parameters.l", "180n");
+  await expectComponentCodeField(page, "parameters.m", "4");
   await expect(page.getByLabel("Editable Canvas property code")).toContainText(
     /"rotation": 90/u,
   );
@@ -1665,7 +1629,7 @@ test("shows the complete foldable categorized Library, quick-places a device, an
   await expect(page.getByTestId("shapes-chip-nmos")).toBeVisible();
 
   await page.keyboard.press("q");
-  await expect(page.getByLabel("Component value")).toHaveValue("");
+  await expectComponentCodeField(page, "parameters.value", "");
   await page.getByTestId("library-toggle").click();
   await expect(panel).toHaveAttribute("data-open", "false");
   await expect
@@ -1891,7 +1855,7 @@ test("double-clicking a placed device opens Properties for editing", async ({
     "aria-expanded",
     "true",
   );
-  const propertyValue = page.getByLabel("Component value");
+  const propertyValue = page.getByLabel("Editable Canvas property code");
   await expect(propertyValue).toBeVisible();
   await expect(propertyValue).toBeFocused();
 });

--- a/apps/editor/e2e/editor-fixtures.ts
+++ b/apps/editor/e2e/editor-fixtures.ts
@@ -1,4 +1,4 @@
-import type { Locator, Page } from "@playwright/test";
+import { expect, type Locator, type Page } from "@playwright/test";
 
 /** Wait until the route-split editor shell is ready to receive shortcuts. */
 export async function awaitEditorReady(page: Page): Promise<void> {
@@ -105,10 +105,53 @@ export async function editComponentPropertyCode(
   update: (value: Record<string, any>) => void,
 ): Promise<void> {
   const input = page.getByLabel("Editable Canvas property code");
-  const value = JSON.parse(await input.inputValue()) as Record<string, any>;
+  const value = JSON.parse(await readComponentPropertyCode(page)) as Record<
+    string,
+    any
+  >;
   update(value);
   await input.fill(JSON.stringify(value, null, 2));
   await page.getByRole("button", { name: "Apply code" }).click();
+}
+
+/** Read rendered JSON lines only; the inline controls/help are not source text. */
+export async function readComponentPropertyCode(page: Page): Promise<string> {
+  await expect(page.getByLabel("Editable Canvas property code")).toBeVisible();
+  await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
+  await page.getByRole("button", { name: "Copy JSON", exact: true }).click();
+  await expect(
+    page.getByText("JSON copied · hints and controls excluded", {
+      exact: true,
+    }),
+  ).toBeVisible();
+  return page.evaluate(() => navigator.clipboard.readText());
+}
+
+export async function setComponentParameter(
+  page: Page,
+  key: string,
+  value: string,
+): Promise<void> {
+  await editComponentPropertyCode(page, (code) => {
+    code.parameters[key] = value;
+  });
+}
+
+export async function expectComponentCodeField(
+  page: Page,
+  path: string,
+  expected: unknown,
+): Promise<void> {
+  await expect
+    .poll(async () =>
+      path
+        .split(".")
+        .reduce(
+          (value, key) => value?.[key],
+          JSON.parse(await readComponentPropertyCode(page)),
+        ),
+    )
+    .toEqual(expected);
 }
 
 export async function downloadBytes(

--- a/apps/editor/e2e/editor-fixtures.ts
+++ b/apps/editor/e2e/editor-fixtures.ts
@@ -137,6 +137,19 @@ export async function setComponentParameter(
   });
 }
 
+export async function setComponentCodeField(
+  page: Page,
+  path: string,
+  value: unknown,
+): Promise<void> {
+  await editComponentPropertyCode(page, (code) => {
+    const parts = path.split(".");
+    const key = parts.pop()!;
+    const target = parts.reduce((target, part) => (target[part] ??= {}), code);
+    target[key] = value;
+  });
+}
+
 export async function expectComponentCodeField(
   page: Page,
   path: string,

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -18,6 +18,7 @@ import {
   editComponentPropertyCode,
   readComponentPropertyCode,
   setComponentParameter,
+  setComponentCodeField,
   expectComponentCodeField,
   openMenu,
   readRecoveryRecords,
@@ -82,13 +83,11 @@ test("guided JSON properties keep controls in one draft and round-trip raw param
   await expectComponentCodeField(page, "parameters.w", "1u");
   await clickCommand(page, "Edit", "Redo");
   await expectComponentCodeField(page, "parameters.w", "EV");
-  await page
-    .getByTestId("project-file")
-    .setInputFiles({
-      name: "raw.icproj.json",
-      mimeType: "application/json",
-      buffer: Buffer.from(JSON.stringify(saved)),
-    });
+  await page.getByTestId("project-file").setInputFiles({
+    name: "raw.icproj.json",
+    mimeType: "application/json",
+    buffer: Buffer.from(JSON.stringify(saved)),
+  });
   await page.getByTestId("hit-M1").click();
   await openSelectionShelf(page);
   await expectComponentCodeField(page, "parameters.w", "EV");
@@ -936,7 +935,7 @@ test("a switch changes contact style in place, keeping its wires", async ({
 
   await page.locator('[data-canvas-hit-kind="instance"]').first().click();
   await page.getByTestId("selection-shelf").click();
-  const toggle = page.getByTestId("swap-switch-contact-style");
+  const toggle = page.getByLabel("Drawing variant options");
   await expect(toggle).toBeVisible();
 
   // The plain drawing is a state of this component, not a second part: the
@@ -945,7 +944,8 @@ test("a switch changes contact style in place, keeping its wires", async ({
     0,
   );
 
-  await toggle.click();
+  await toggle.selectOption("simple-spdt-switch");
+  await page.getByRole("button", { name: "Apply code" }).click();
   await expect(page.locator("[data-symbol-id]").first()).toHaveAttribute(
     "data-symbol-id",
     "simple-spdt-switch",
@@ -955,7 +955,8 @@ test("a switch changes contact style in place, keeping its wires", async ({
   await expect(page.getByTestId("hit-S1")).toHaveCount(1);
   await expect(page.locator('[data-layer="routes"] polyline')).toHaveCount(1);
 
-  await toggle.click();
+  await toggle.selectOption("spdt-switch");
+  await page.getByRole("button", { name: "Apply code" }).click();
   await expect(page.locator("[data-symbol-id]").first()).toHaveAttribute(
     "data-symbol-id",
     "spdt-switch",
@@ -3434,8 +3435,8 @@ test("Properties offers no dead Reference controls for a schematic-only block", 
   // change the drawing. Its Canvas property code still owns placement/style.
   await page.locator('[data-canvas-hit-kind="instance"]').first().click();
   await expect(
-    properties.locator('[aria-label="SPICE component code"]'),
-  ).toContainText("<subcircuit-model>");
+    properties.getByLabel("Editable Canvas property code"),
+  ).toBeVisible();
   await expect(referenceField).toHaveCount(0);
   await expect(parametersCard).toHaveCount(0);
   await expect(
@@ -3445,10 +3446,11 @@ test("Properties offers no dead Reference controls for a schematic-only block", 
     properties.locator('details[aria-label="Component appearance"]'),
   ).toHaveCount(0);
 
-  // An ordinary device keeps both.
+  // An ordinary device exposes both in the single code editor, not forms.
   await page.getByTestId("hit-R1").click();
-  await expect(referenceField).toHaveCount(1);
-  await expect(parametersCard).toHaveCount(1);
+  await expect(referenceField).toHaveCount(0);
+  await expect(parametersCard).toHaveCount(0);
+  await expectComponentCodeField(page, "reference", "R1");
   await expect(
     properties.getByLabel("Editable Canvas property code"),
   ).toContainText(/"display"/u);
@@ -3561,25 +3563,17 @@ test("Properties toggles reference label visibility for one or many components",
   for (const sectionName of ["Parameters", "Netlist overrides", "Actions"]) {
     await expect(
       properties.getByText(sectionName, { exact: true }),
-    ).toBeVisible();
+    ).toHaveCount(0);
   }
   const componentProperties = properties.getByRole("region", {
     name: "Component properties",
   });
   await expect(
     componentProperties.locator(":scope > .property-disclosure"),
-  ).toHaveCount(2);
-  expect(
-    await componentProperties
-      .locator(":scope > .property-disclosure > summary > span")
-      .allTextContents(),
-  ).toEqual(["Parameters", "Actions"]);
-  await expect(componentProperties.locator(":scope > :last-child")).toHaveText(
-    /R1.*<unconnected:1>.*<unconnected:2>.*<value>/u,
-  );
+  ).toHaveCount(0);
   await expect(
     componentProperties.locator(":scope > :last-child"),
-  ).toHaveAttribute("aria-label", "SPICE component code");
+  ).toHaveAttribute("aria-label", "Canvas property code");
   await expect(
     componentProperties.locator(
       ':scope > details[aria-label="Component appearance"]',
@@ -3592,10 +3586,11 @@ test("Properties toggles reference label visibility for one or many components",
   ).toHaveCount(0);
   await expect(
     componentProperties.getByText("Netlist target", { exact: true }),
-  ).toBeVisible();
+  ).toHaveCount(0);
   await expect(
     componentProperties.getByLabel("Component model target"),
-  ).toBeVisible();
+  ).toHaveCount(0);
+  await expectComponentCodeField(page, "netlistTarget", "");
   await editComponentPropertyCode(page, (value) => {
     value.display.reference = false;
   });
@@ -3826,9 +3821,9 @@ test("value display projects MOS W/L and passive values beside the reference", a
   // Geometry and the Value display are Properties decisions after placement.
   await page.getByTestId("hit-M1").click();
   await openSelectionShelf(page);
-  await page.getByLabel("Component w", { exact: true }).fill("2u");
-  await page.getByLabel("Component l", { exact: true }).fill("180n");
-  await page.getByLabel("Component m", { exact: true }).fill("4");
+  await setComponentParameter(page, "w", "2u");
+  await setComponentParameter(page, "l", "180n");
+  await setComponentParameter(page, "m", "4");
   await editComponentPropertyCode(page, (propertyCode) => {
     propertyCode.display.value = true;
   });
@@ -3839,8 +3834,8 @@ test("value display projects MOS W/L and passive values beside the reference", a
   await expect(reference).toContainText("M1");
   // MOS values render as a stacked fraction with engineering units: the
   // numerator and denominator are separate part texts around a fraction bar.
-  await expect(value).toContainText("2um");
-  await expect(value).toContainText("180nm");
+  await expect(value).toContainText("2u");
+  await expect(value).toContainText("180n");
   await expect(value).toContainText("×4");
   await expect(page.locator('[data-role="fraction-bar"]')).toHaveCount(1);
   const multiplierGap = await value.evaluate((element) => {
@@ -3870,14 +3865,14 @@ test("value display projects MOS W/L and passive values beside the reference", a
   await page.keyboard.press("Escape");
   await page.getByTestId("hit-R1").click();
   await openSelectionShelf(page);
-  await page.getByLabel("Component value", { exact: true }).fill("33k");
+  await setComponentParameter(page, "value", "33k");
   await editComponentPropertyCode(page, (propertyCode) => {
     propertyCode.display.value = true;
   });
   await canvas.click({ position: { x: 80, y: 80 } });
   await expect(
     page.locator('[data-object-id="instance-value-R1"]'),
-  ).toContainText("33kΩ");
+  ).toContainText("33k");
 
   // The formal SVG export carries the fraction bar and unit text through the
   // shared annotation path.
@@ -3886,10 +3881,10 @@ test("value display projects MOS W/L and passive values beside the reference", a
   );
   expect(svg).toContain('data-kind="instance-value"');
   expect(svg).toContain('data-role="fraction-bar"');
-  expect(svg).toContain("2um");
-  expect(svg).toContain("180nm");
+  expect(svg).toContain("2u");
+  expect(svg).toContain("180n");
   expect(svg).toContain("×4");
-  expect(svg).toContain("33kΩ");
+  expect(svg).toContain("33k");
 });
 
 test("reference and value code refreshes content after parameter edits", async ({
@@ -3918,23 +3913,22 @@ test("reference and value code refreshes content after parameter edits", async (
 
   // Typing a value makes the same pending code applicable without closing and
   // reopening Properties.
-  await page.getByLabel("Component value").click();
-  await page.getByLabel("Component value").fill("33k");
-  await page.getByLabel("Component value").press("Tab");
-  await properties.getByRole("button", { name: "Apply code" }).click();
+
+  await setComponentParameter(page, "value", "33k");
+
   await expect(
     page.locator('[data-object-id="instance-value-R1"]'),
-  ).toContainText("33kΩ");
+  ).toContainText("33k");
 
   // A later parameter edit re-projects the visible value text.
-  await page.getByLabel("Component value").click();
-  await page.getByLabel("Component value").fill("47k");
+
+  await setComponentParameter(page, "value", "47k");
   await page
     .getByTestId("schematic-canvas")
     .click({ position: { x: 60, y: 60 } });
   await expect(
     page.locator('[data-object-id="instance-value-R1"]'),
-  ).toContainText("47kΩ");
+  ).toContainText("47k");
 
   // Hiding keeps the annotation recoverable.
   await page.getByTestId("hit-R1").click();
@@ -3965,7 +3959,7 @@ test("reference and value code refreshes content after parameter edits", async (
     .click();
   await expect(
     page.locator('[data-object-id="instance-value-R1"]'),
-  ).toContainText("47kΩ");
+  ).toContainText("47k");
   await expect(
     page.locator('[data-object-id="instance-value-R2"]'),
   ).toHaveCount(0);
@@ -3981,9 +3975,9 @@ for (const symbol of ["nmos", "pmos"]) {
     const instance = page.getByTestId("hit-M1");
     await instance.click();
     await openSelectionShelf(page);
-    await page.getByLabel("Component w", { exact: true }).fill("2u");
-    await page.getByLabel("Component l", { exact: true }).fill("180n");
-    await page.getByLabel("Component m", { exact: true }).fill("4");
+    await setComponentParameter(page, "w", "2u");
+    await setComponentParameter(page, "l", "180n");
+    await setComponentParameter(page, "m", "4");
     await editComponentPropertyCode(page, (code) => {
       code.display.value = true;
     });
@@ -3991,7 +3985,7 @@ for (const symbol of ["nmos", "pmos"]) {
 
     const value = page.locator('[data-object-id="instance-value-M1"]');
     const numerator = value.locator('[data-role="fraction-numerator"]');
-    await expect(numerator).toContainText("2um");
+    await expect(numerator).toContainText("2u");
     const before = (await value.boundingBox())!;
     const ownerBefore = (await instance.boundingBox())!;
     const grip = (await numerator.boundingBox())!;
@@ -4049,9 +4043,9 @@ for (const symbol of ["nmos", "pmos"]) {
     // Updating W refreshes the fraction without restoring its default slot.
     await instance.click();
     await openSelectionShelf(page);
-    await page.getByLabel("Component w", { exact: true }).fill("3u");
+    await setComponentParameter(page, "w", "3u");
     await canvas.click({ position: { x: 70, y: 70 } });
-    await expect(numerator).toContainText("3um");
+    await expect(numerator).toContainText("3u");
     expect(valueAnchor(await readDocument())).toEqual(anchor);
 
     // Move and rotate the host: the authored vector follows, never reflows.
@@ -4084,7 +4078,7 @@ for (const symbol of ["nmos", "pmos"]) {
       x: -anchor.localOffset.y,
       y: anchor.localOffset.x,
     });
-    await expect(numerator).toContainText("3um");
+    await expect(numerator).toContainText("3u");
 
     // Reopen a real exported file, then export again to verify persisted data.
     const saved = await downloadBytes(page, "File", "Export Project File…");
@@ -4093,7 +4087,7 @@ for (const symbol of ["nmos", "pmos"]) {
       mimeType: "application/json",
       buffer: saved,
     });
-    await expect(numerator).toContainText("3um");
+    await expect(numerator).toContainText("3u");
     const reopened = await readDocument();
     expect(valueAnchor(reopened)).toEqual(rotatedAnchor);
     expect(reopened.instances).toEqual(rotated.instances);
@@ -4108,8 +4102,8 @@ test("drag value annotation keeps the user offset through rotation", async ({
   await placeComponent(page, "resistor", { x: 360, y: 220 });
   await page.getByTestId("hit-R1").click();
   await openSelectionShelf(page);
-  await page.getByLabel("Component value").click();
-  await page.getByLabel("Component value").fill("33k");
+
+  await setComponentParameter(page, "value", "33k");
   await page
     .getByTestId("schematic-canvas")
     .click({ position: { x: 60, y: 60 } });
@@ -4120,7 +4114,7 @@ test("drag value annotation keeps the user offset through rotation", async ({
   });
   await expect(
     page.locator('[data-object-id="instance-value-R1"]'),
-  ).toContainText("33kΩ");
+  ).toContainText("33k");
 
   // Drag the value away from its canonical slot.
   const value = page.getByTestId("annotation-hit-instance-value-R1");
@@ -4137,7 +4131,7 @@ test("drag value annotation keeps the user offset through rotation", async ({
   await page.keyboard.press("r");
   await expect(
     page.locator('[data-object-id="instance-value-R1"]'),
-  ).toContainText("33kΩ");
+  ).toContainText("33k");
   const rotated = await value.boundingBox();
   if (!rotated) throw new Error("Rotated value is not measurable");
   // A quarter turn may keep one coordinate, so assert total displacement.
@@ -4146,7 +4140,7 @@ test("drag value annotation keeps the user offset through rotation", async ({
   ).toBeGreaterThan(10);
 });
 
-test("property edits commit on blank click and Escape instead of vanishing", async ({
+test("applied property drafts survive blank click and Escape", async ({
   page,
 }) => {
   await page.goto("/editor");
@@ -4155,25 +4149,22 @@ test("property edits commit on blank click and Escape instead of vanishing", asy
 
   await page.getByTestId("hit-R1").click();
   await openSelectionShelf(page);
-  const value = page.getByLabel("Component value");
-  await value.click();
-  await value.fill("33k");
+  await setComponentParameter(page, "value", "33k");
   await canvas.click({ position: { x: 60, y: 60 } });
   await expect(page.getByTestId("revision")).toHaveText("2");
 
   await page.getByTestId("hit-R1").click();
   await openSelectionShelf(page);
-  await expect(page.getByLabel("Component value")).toHaveValue("33k");
+  await expectComponentCodeField(page, "parameters.value", "33k");
 
-  await page.getByLabel("Component value").click();
-  await page.getByLabel("Component value").fill("47k");
+  await setComponentParameter(page, "value", "47k");
   await page.keyboard.press("Escape");
   await expect(page.getByTestId("revision")).toHaveText("3");
 
   await canvas.click({ position: { x: 60, y: 60 } });
   await page.getByTestId("hit-R1").click();
   await openSelectionShelf(page);
-  await expect(page.getByLabel("Component value")).toHaveValue("47k");
+  await expectComponentCodeField(page, "parameters.value", "47k");
 });
 
 test("canvas text editor cancels explicitly and commits on Escape or outside click", async ({
@@ -5187,8 +5178,8 @@ test("exports structural SPICE and Spectre netlists while exposing instance auth
   const properties = page.getByRole("complementary", { name: "Properties" });
   await expect(properties.getByLabel("Cell netlist name")).toHaveCount(0);
   await expect(properties.getByLabel("Cell netlist port order")).toHaveCount(0);
-  await expect(properties.getByLabel("Netlist Reference")).toBeVisible();
-  await expect(properties.getByLabel("Component model target")).toBeVisible();
+  await expectComponentCodeField(page, "reference", "M1");
+  await expectComponentCodeField(page, "netlistTarget", "");
   await expect(properties.getByText(/^Model:/u)).toHaveCount(0);
 });
 
@@ -5199,7 +5190,6 @@ test("edits the transconductance trapezoid from gm to -gmL", async ({
   await placeComponent(page, "transconductance", { x: 360, y: 240 });
   await openSelectionShelf(page);
   const properties = page.getByRole("complementary", { name: "Properties" });
-  const formula = properties.getByLabel("Signal flow formula");
   const componentProperties = properties.locator(
     '[aria-label="Component properties"]',
   );
@@ -5209,13 +5199,10 @@ test("edits the transconductance trapezoid from gm to -gmL", async ({
   await expect(properties.getByText("Identity", { exact: true })).toHaveCount(
     0,
   );
-  await expect(componentProperties.locator(":scope > :last-child")).toHaveText(
-    /X1.*<subcircuit-model>/u,
-  );
   await expect(
     componentProperties.locator(":scope > :last-child"),
-  ).toHaveAttribute("aria-label", "SPICE component code");
-  await expect(formula).toHaveValue("g_m");
+  ).toHaveAttribute("aria-label", "Canvas property code");
+  await expectComponentCodeField(page, "signalFlow", {});
   await expect(frame).toHaveCount(1);
   await expect(frame).toHaveAttribute(
     "points",
@@ -5225,16 +5212,15 @@ test("edits the transconductance trapezoid from gm to -gmL", async ({
     formalScene.locator('[data-role="formula-subscript"]'),
   ).toHaveText("m");
 
-  await formula.fill("−gₘL");
-  await formula.press("Tab");
+  await setComponentCodeField(page, "signalFlow.formula", "−gₘL");
   await expect(
     formalScene.locator('[data-role="formula-subscript"]'),
   ).toHaveText("mL");
 
   await clickCommand(page, "Edit", "Undo");
-  await expect(formula).toHaveValue("g_m");
+  await expectComponentCodeField(page, "signalFlow", {});
   await clickCommand(page, "Edit", "Redo");
-  await expect(formula).toHaveValue("−gₘL");
+  await expectComponentCodeField(page, "signalFlow.formula", "−gₘL");
 });
 
 test("edits a formula-capable Signal Flow block with undo, redo, and Reset defaults", async ({
@@ -5258,17 +5244,8 @@ test("edits a formula-capable Signal Flow block with undo, redo, and Reset defau
   await placeComponent(page, symbol.id, { x: 360, y: 240 });
   await openSelectionShelf(page);
   const properties = page.getByRole("complementary", { name: "Properties" });
-  const formula = properties.getByLabel("Signal flow formula");
-  const coefficient = properties.getByLabel("Signal flow coefficient");
-
-  await expect(properties.getByText("Transfer function")).toBeVisible();
-  const minimumWidth = properties.getByLabel("Signal flow minimum width");
-  const minimumHeight = properties.getByLabel("Signal flow minimum height");
-  await expect(minimumWidth).toHaveAttribute("placeholder", "Auto");
-  await expect(minimumHeight).toHaveAttribute("placeholder", "Auto");
-  // A freshly placed block carries its own formula in the field, ready to
-  // be edited in place instead of retyped.
-  await expect(formula).toHaveValue(symbol.formulaPresentation!.defaultFormula);
+  // Empty presentation code inherits the canonical symbol's own formula.
+  await expectComponentCodeField(page, "signalFlow", {});
 
   const formalScene = page.locator('[data-layer="formal"]');
   const renderedFormula = formalScene.locator(
@@ -5280,8 +5257,7 @@ test("edits a formula-capable Signal Flow block with undo, redo, and Reset defau
     0,
   );
 
-  await formula.fill("z⁻¹/(1−z⁻¹)");
-  await formula.press("Tab");
+  await setComponentCodeField(page, "signalFlow.formula", "z⁻¹/(1−z⁻¹)");
   await expect(
     formalScene.locator('[data-role="formula-fraction-bar"]'),
   ).toHaveCount(1);
@@ -5293,17 +5269,14 @@ test("edits a formula-capable Signal Flow block with undo, redo, and Reset defau
   // expands to 50 units so superscript denominators clear the fraction bar.
   await expect(frame).toHaveAttribute("height", "50");
 
-  await coefficient.fill("K");
-  await coefficient.press("Tab");
+  await setComponentCodeField(page, "signalFlow.coefficient", "K");
   await expect(
     formalScene.locator('[data-role="formula-coefficient"]'),
   ).toHaveText("K·");
   await expect(frame).toHaveAttribute("width", "80");
 
-  await minimumWidth.fill("160");
-  await minimumWidth.press("Tab");
-  await minimumHeight.fill("80");
-  await minimumHeight.press("Tab");
+  await setComponentCodeField(page, "signalFlow.bodyWidth", 160);
+  await setComponentCodeField(page, "signalFlow.bodyHeight", 80);
   await expect(frame).toHaveAttribute("width", "160");
   await expect(frame).toHaveAttribute("height", "80");
 
@@ -5312,13 +5285,13 @@ test("edits a formula-capable Signal Flow block with undo, redo, and Reset defau
   await clickCommand(page, "Edit", "Redo");
   await expect(frame).toHaveAttribute("height", "80");
 
-  await properties.getByRole("button", { name: "Reset defaults" }).click();
+  await properties
+    .getByRole("button", { name: "Defaults", exact: true })
+    .click();
+  await properties.getByRole("button", { name: "Apply code" }).click();
   // Reset restores the Symbol's own formula as editable text, not an empty
   // box: the default is the starting point for the next edit.
-  await expect(formula).toHaveValue(symbol.formulaPresentation!.defaultFormula);
-  await expect(coefficient).toHaveValue("");
-  await expect(minimumWidth).toHaveValue("");
-  await expect(minimumHeight).toHaveValue("");
+  await expectComponentCodeField(page, "signalFlow", {});
   await expect(
     formalScene.locator('[data-role="formula-coefficient"]'),
   ).toHaveCount(0);
@@ -5331,43 +5304,33 @@ test("selects a reviewed SKY130 MOS through the existing Model field", async ({
   await placeComponent(page, "nmos", { x: 360, y: 220 });
   await openSelectionShelf(page);
   const properties = page.getByRole("complementary", { name: "Properties" });
-  const model = properties.getByLabel("Component model target", {
-    exact: true,
-  });
 
-  await expect(
-    model.locator('option[value="sky130_fd_pr__nfet_01v8"]'),
-  ).toHaveCount(1);
-  await model.selectOption("sky130_fd_pr__nfet_01v8");
+  await expect(properties).toContainText("sky130_fd_pr__nfet_01v8");
+  await setComponentCodeField(page, "netlistTarget", "sky130_fd_pr__nfet_01v8");
 
-  await expect(properties).toContainText(
-    "External subcircuit · SPICE emits an X card",
+  await expectComponentCodeField(
+    page,
+    "netlistTarget",
+    "sky130_fd_pr__nfet_01v8",
   );
-  await expect(properties.getByLabel("Netlist Reference")).toHaveValue("XM1");
-  await expect(properties.getByLabel("Component nf")).toBeVisible();
-  await expect(
-    properties.getByLabel("Component m", { exact: true }),
-  ).toBeVisible();
+  await expectComponentCodeField(page, "reference", "XM1");
+  await expectComponentCodeField(page, "parameters.nf", "1");
+  await expectComponentCodeField(page, "parameters.m", "1");
 
-  await model.selectOption("");
-  await expect(model).toHaveValue("");
-  await expect(properties.getByLabel("Netlist Reference")).toHaveValue("M1");
-  await expect(properties).not.toContainText(
-    "External subcircuit · SPICE emits an X card",
+  await setComponentCodeField(page, "netlistTarget", "");
+  await expectComponentCodeField(page, "netlistTarget", "");
+  await expectComponentCodeField(page, "reference", "M1");
+  await setComponentCodeField(page, "netlistTarget", "generic_nmos");
+  await expectComponentCodeField(page, "netlistTarget", "generic_nmos");
+  await expectComponentCodeField(page, "reference", "M1");
+
+  await setComponentCodeField(page, "netlistTarget", "sky130_fd_pr__nfet_01v8");
+  await expectComponentCodeField(
+    page,
+    "netlistTarget",
+    "sky130_fd_pr__nfet_01v8",
   );
-
-  await model.selectOption({ label: "Custom…" });
-  const customModel = properties.getByLabel("Custom model name");
-  await customModel.fill("generic_nmos");
-  await customModel.press("Enter");
-  await expect(customModel).toHaveValue("generic_nmos");
-  await expect(properties.getByLabel("Netlist Reference")).toHaveValue("M1");
-
-  await model.selectOption("sky130_fd_pr__nfet_01v8");
-  await expect(properties).toContainText(
-    "External subcircuit · SPICE emits an X card",
-  );
-  await expect(properties.getByLabel("Netlist Reference")).toHaveValue("XM1");
+  await expectComponentCodeField(page, "reference", "XM1");
 
   const saved = JSON.parse(
     (await downloadBytes(page, "File", "Export Project File…")).toString(
@@ -5405,14 +5368,15 @@ test("keeps the exact SKY130 PNP on its three-terminal model interface", async (
   const properties = page.getByRole("complementary", {
     name: "Properties",
   });
-  const model = properties.getByLabel("Component model target", {
-    exact: true,
-  });
 
   await expect(properties.getByLabel("Substrate Net")).toHaveCount(0);
-  await model.selectOption("sky130_fd_pr__pnp_05v5_W0p68L0p68");
+  await setComponentCodeField(
+    page,
+    "netlistTarget",
+    "sky130_fd_pr__pnp_05v5_W0p68L0p68",
+  );
   await expect(properties.getByLabel("Substrate Net")).toHaveCount(0);
-  await expect(properties.getByLabel("Netlist Reference")).toHaveValue("XQ1");
+  await expectComponentCodeField(page, "reference", "XQ1");
 
   const saved = JSON.parse(
     (await downloadBytes(page, "File", "Export Project File…")).toString(
@@ -5424,9 +5388,9 @@ test("keeps the exact SKY130 PNP on its three-terminal model interface", async (
     terminals: [{ name: "C" }, { name: "B" }, { name: "E" }],
   });
 
-  await model.selectOption("");
+  await setComponentCodeField(page, "netlistTarget", "");
   await expect(properties.getByLabel("Substrate Net")).toHaveCount(0);
-  await expect(properties.getByLabel("Netlist Reference")).toHaveValue("Q1");
+  await expectComponentCodeField(page, "reference", "Q1");
 });
 
 test("derives NPN substrate from its exact Model", async ({ page }) => {
@@ -5436,14 +5400,15 @@ test("derives NPN substrate from its exact Model", async ({ page }) => {
   const properties = page.getByRole("complementary", {
     name: "Properties",
   });
-  const model = properties.getByLabel("Component model target", {
-    exact: true,
-  });
 
   await expect(properties.getByLabel("Substrate Net")).toHaveCount(0);
-  await model.selectOption("sky130_fd_pr__npn_05v5_W1p00L1p00");
+  await setComponentCodeField(
+    page,
+    "netlistTarget",
+    "sky130_fd_pr__npn_05v5_W1p00L1p00",
+  );
   await expect(properties.getByLabel("Substrate Net")).toBeVisible();
-  await expect(properties.getByLabel("Netlist Reference")).toHaveValue("XQ1");
+  await expectComponentCodeField(page, "reference", "XQ1");
 
   const saved = JSON.parse(
     (await downloadBytes(page, "File", "Export Project File…")).toString(
@@ -5455,25 +5420,25 @@ test("derives NPN substrate from its exact Model", async ({ page }) => {
     terminals: [{ name: "C" }, { name: "B" }, { name: "E" }, { name: "S" }],
   });
 
-  await model.selectOption("");
+  await setComponentCodeField(page, "netlistTarget", "");
   await expect(properties.getByLabel("Substrate Net")).toHaveCount(0);
-  await expect(properties.getByLabel("Netlist Reference")).toHaveValue("Q1");
+  await expectComponentCodeField(page, "reference", "Q1");
 });
 
 for (const fixture of [
   {
     symbolId: "resistor",
     model: "sky130_fd_pr__res_high_po",
-    externalParameter: "Component mult",
-    primitiveParameter: "Component value",
+    externalParameter: "mult",
+    primitiveParameter: "value",
     nativeReference: "R1",
     externalReference: "XR1",
   },
   {
     symbolId: "capacitor",
     model: "sky130_fd_pr__cap_mim_m3_1",
-    externalParameter: "Component mf",
-    primitiveParameter: "Component value",
+    externalParameter: "mf",
+    primitiveParameter: "value",
     nativeReference: "C1",
     externalReference: "XC1",
   },
@@ -5484,34 +5449,34 @@ for (const fixture of [
     await page.goto("/editor");
     await placeComponent(page, fixture.symbolId, { x: 360, y: 220 });
     await openSelectionShelf(page);
-    const properties = page.getByRole("complementary", {
-      name: "Properties",
-    });
-    const model = properties.getByLabel("Component model target", {
-      exact: true,
-    });
 
-    await model.selectOption(fixture.model);
-    await expect(properties.getByLabel("Netlist Reference")).toHaveValue(
+    await setComponentCodeField(page, "netlistTarget", fixture.model);
+    await expectComponentCodeField(
+      page,
+      "reference",
       fixture.externalReference,
     );
-    await expect(
-      properties.getByLabel(fixture.externalParameter),
-    ).toBeVisible();
-    await expect(properties.getByLabel(fixture.primitiveParameter)).toHaveCount(
-      0,
+    expect(
+      JSON.parse(await readComponentPropertyCode(page)).parameters,
+    ).toHaveProperty(fixture.externalParameter);
+    await expectComponentCodeField(
+      page,
+      `parameters.${fixture.primitiveParameter}`,
+      undefined,
     );
 
-    await model.selectOption("");
-    await expect(model).toHaveValue("");
-    await expect(properties.getByLabel("Netlist Reference")).toHaveValue(
-      fixture.nativeReference,
+    await setComponentCodeField(page, "netlistTarget", "");
+    await expectComponentCodeField(page, "netlistTarget", "");
+    await expectComponentCodeField(page, "reference", fixture.nativeReference);
+    await expectComponentCodeField(
+      page,
+      `parameters.${fixture.primitiveParameter}`,
+      "",
     );
-    await expect(
-      properties.getByLabel(fixture.primitiveParameter),
-    ).toBeVisible();
-    await expect(properties.getByLabel(fixture.externalParameter)).toHaveCount(
-      0,
+    await expectComponentCodeField(
+      page,
+      `parameters.${fixture.externalParameter}`,
+      undefined,
     );
   });
 }
@@ -6702,7 +6667,7 @@ test("swaps a comparator's + and - without turning the body over", async ({
   expect(before.plusMarkY).toHaveLength(1);
   expect(before.plusMarkY[0]!).toBeGreaterThan(0);
 
-  await page.getByTestId("swap-differential-inputs").click();
+  await setComponentCodeField(page, "symbol", "comparator-inputs-swapped");
 
   const after = await readBody();
   // The + crossed to the other input.

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -16,10 +16,110 @@ import {
   clickNetlistWorkflowCommand,
   downloadBytes,
   editComponentPropertyCode,
+  readComponentPropertyCode,
+  setComponentParameter,
+  expectComponentCodeField,
   openMenu,
   readRecoveryRecords,
   recoveryProjectTexts,
 } from "./editor-fixtures.js";
+
+test("guided JSON properties keep controls in one draft and round-trip raw parameter strings", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await placeComponent(page, "nmos", { x: 360, y: 220 });
+  await openSelectionShelf(page);
+  const panel = page.getByRole("complementary", { name: "Properties" });
+  await expect(
+    panel.getByLabel("Component parameters and display"),
+  ).toHaveCount(0);
+  await expect(panel.getByLabel("Component actions")).toHaveCount(0);
+  await expect(panel.getByLabel("Netlist target", { exact: true })).toHaveCount(
+    0,
+  );
+  const revision = await page.getByTestId("revision").textContent();
+  await panel.getByLabel("Rotation options").selectOption("90");
+  await panel
+    .getByRole("switch", { name: "Show reference", exact: true })
+    .click();
+  await panel.getByLabel("Foreground color picker").fill("#dc2626");
+  await expect(page.getByTestId("revision")).toHaveText(revision!);
+  const draft = JSON.parse(await readComponentPropertyCode(page));
+  expect(draft.placement.rotation).toBe(90);
+  expect(draft.display.reference).toBe(false);
+  expect(draft.appearance.foreground).toEqual([220, 38, 38]);
+  draft.parameters.w = "EV";
+  draft.parameters.l = "L";
+  draft.parameters.custom = "{raw_expression}";
+  draft.display.value = true;
+  await panel
+    .getByLabel("Editable Canvas property code")
+    .fill(JSON.stringify(draft, null, 2));
+  await panel.getByRole("button", { name: "Apply code" }).click();
+  await expect(page.getByTestId("revision")).toHaveText(
+    String(Number(revision) + 1),
+  );
+  const value = page.locator(
+    '[data-layer="formal"] [data-object-id="instance-value-M1"]',
+  );
+  await expect(value).toContainText("EV");
+  await expect(value).not.toContainText("EVm");
+  const source = await readComponentPropertyCode(page);
+  expect(source).not.toContain("Clockwise");
+  expect(source).not.toContain("Enter any unit");
+  const saved = JSON.parse(
+    (await downloadBytes(page, "File", "Export Project File…")).toString(
+      "utf8",
+    ),
+  );
+  expect(saved.documents[0].instances[0]).toMatchObject({
+    netlist: { parameters: { w: "EV", l: "L", custom: "{raw_expression}" } },
+    styleOverride: { foreground: "#dc2626" },
+    placement: { rotation: 90 },
+  });
+  await clickCommand(page, "Edit", "Undo");
+  await expectComponentCodeField(page, "parameters.w", "1u");
+  await clickCommand(page, "Edit", "Redo");
+  await expectComponentCodeField(page, "parameters.w", "EV");
+  await page
+    .getByTestId("project-file")
+    .setInputFiles({
+      name: "raw.icproj.json",
+      mimeType: "application/json",
+      buffer: Buffer.from(JSON.stringify(saved)),
+    });
+  await page.getByTestId("hit-M1").click();
+  await openSelectionShelf(page);
+  await expectComponentCodeField(page, "parameters.w", "EV");
+});
+
+test("Defaults and Discard draft have distinct non-destructive behavior", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await placeComponent(page, "nmos", { x: 360, y: 220 });
+  await openSelectionShelf(page);
+  await setComponentParameter(page, "w", "7u");
+  const revision = await page.getByTestId("revision").textContent();
+  await page.getByRole("button", { name: "Defaults", exact: true }).click();
+  await expectComponentCodeField(page, "parameters.w", "1u");
+  await expect(page.getByTestId("revision")).toHaveText(revision!);
+  await page
+    .getByRole("button", { name: "Discard draft", exact: true })
+    .click();
+  await expectComponentCodeField(page, "parameters.w", "7u");
+  const code = page.getByLabel("Editable Canvas property code");
+  const invalid = JSON.parse(await readComponentPropertyCode(page));
+  invalid.appearance.foreground = [256, 0, 0];
+  await code.fill(JSON.stringify(invalid, null, 2));
+  await expect(page.getByRole("button", { name: "Apply code" })).toBeDisabled();
+  await expect(page.getByLabel("Rotation options")).toBeDisabled();
+  await page.getByRole("button", { name: "Discard draft" }).click();
+  await expectComponentCodeField(page, "parameters.w", "7u");
+  await expect(page.locator(".cm-json-key").first()).toBeVisible();
+  await expect(page.locator(".cm-json-string").first()).toBeVisible();
+});
 
 test("a directly connected device can move away and return with its wire, undo and redo", async ({
   page,
@@ -794,15 +894,15 @@ test("a part with no designator offers no Reference toggle", async ({
   await expect(properties).toContainText("voltage-amplifier");
   await expect(
     properties.getByLabel("Editable Canvas property code"),
-  ).not.toHaveValue(/"display"/u);
+  ).not.toContainText(/"display"/u);
 
   // The brake: a resistor designates R1 and carries a value, so its toggles
   // are untouched and still work.
   await placeComponent(page, "resistor", { x: 500, y: 200 });
   await openSelectionShelf(page);
   const code = properties.getByLabel("Editable Canvas property code");
-  await expect(code).toHaveValue(/"reference": true/u);
-  await expect(code).toHaveValue(/"value": false/u);
+  await expect(code).toContainText(/"reference": true/u);
+  await expect(code).toContainText(/"value": false/u);
   const drawnLabel = page.locator(
     '[data-layer="annotations"] [data-object-id="instance-label-R1"]',
   );
@@ -3340,7 +3440,7 @@ test("Properties offers no dead Reference controls for a schematic-only block", 
   await expect(parametersCard).toHaveCount(0);
   await expect(
     properties.getByLabel("Editable Canvas property code"),
-  ).not.toHaveValue(/"display"/u);
+  ).not.toContainText(/"display"/u);
   await expect(
     properties.locator('details[aria-label="Component appearance"]'),
   ).toHaveCount(0);
@@ -3351,7 +3451,7 @@ test("Properties offers no dead Reference controls for a schematic-only block", 
   await expect(parametersCard).toHaveCount(1);
   await expect(
     properties.getByLabel("Editable Canvas property code"),
-  ).toHaveValue(/"display"/u);
+  ).toContainText(/"display"/u);
 });
 
 test("resizes Properties and applies component presentation as editable code", async ({
@@ -3415,7 +3515,7 @@ test("resizes Properties and applies component presentation as editable code", a
     .poll(async () => (await properties.boundingBox())?.width ?? 0)
     .toBeCloseTo(compactWidth + 8, 0);
 
-  const edited = JSON.parse(await code.inputValue());
+  const edited = JSON.parse(await readComponentPropertyCode(page));
   edited.placement.at = [420, 280];
   edited.placement.rotation = 90;
   edited.placement.mirror = "x";
@@ -3805,7 +3905,7 @@ test("reference and value code refreshes content after parameter edits", async (
   await openSelectionShelf(page);
   const properties = page.getByRole("complementary", { name: "Properties" });
   const propertyCode = properties.getByLabel("Editable Canvas property code");
-  const missingValueCode = JSON.parse(await propertyCode.inputValue());
+  const missingValueCode = JSON.parse(await readComponentPropertyCode(page));
   missingValueCode.display.value = true;
   await propertyCode.fill(JSON.stringify(missingValueCode, null, 2));
   await properties.getByRole("button", { name: "Apply code" }).click();

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -120,6 +120,70 @@ test("Defaults and Discard draft have distinct non-destructive behavior", async 
   await expect(page.locator(".cm-json-string").first()).toBeVisible();
 });
 
+test("one JSON Apply combines model, dimensions and appearance in one undo boundary", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await placeComponent(page, "nmos", { x: 360, y: 220 });
+  await openSelectionShelf(page);
+  await editComponentPropertyCode(page, (code) => {
+    code.netlistTarget = "sky130_fd_pr__nfet_01v8";
+    code.parameters.w = "5u";
+    code.appearance.foreground = [20, 30, 40];
+  });
+  await expectComponentCodeField(page, "reference", "XM1");
+  await expectComponentCodeField(page, "parameters.w", "5u");
+  await expectComponentCodeField(page, "appearance.foreground", [20, 30, 40]);
+  await clickCommand(page, "Edit", "Undo");
+  await expectComponentCodeField(page, "reference", "M1");
+  await expectComponentCodeField(page, "parameters.w", "1u");
+  await expectComponentCodeField(page, "appearance.foreground", "auto");
+  await clickCommand(page, "Edit", "Redo");
+  await expectComponentCodeField(page, "reference", "XM1");
+  await expectComponentCodeField(page, "parameters.w", "5u");
+});
+
+test("property placement null retains a wired instance and re-places it with grid snapping", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await placeComponent(page, "resistor", { x: 360, y: 220 });
+  const canvas = page.getByTestId("schematic-canvas");
+  await clickDrawTool(page, "wire");
+  await page.getByTestId("terminal-R1-2").click();
+  await canvas.dblclick({ position: { x: 500, y: 350 } });
+  await page.keyboard.press("Escape");
+  await page.getByTestId("hit-R1").click();
+  await openSelectionShelf(page);
+  const before = JSON.parse(
+    (await downloadBytes(page, "File", "Export Project File…")).toString(
+      "utf8",
+    ),
+  );
+  await setComponentCodeField(page, "placement", null);
+  await expect(page.getByTestId("hit-R1")).toHaveCount(0);
+  await expectComponentCodeField(page, "placement", null);
+  const saved = JSON.parse(
+    (await downloadBytes(page, "File", "Export Project File…")).toString(
+      "utf8",
+    ),
+  );
+  expect(saved.documents[0].instances).toHaveLength(1);
+  expect(saved.documents[0].nets).toEqual(before.documents[0].nets);
+  expect(saved.documents[0].routes).toHaveLength(
+    before.documents[0].routes.length,
+  );
+  await setComponentCodeField(page, "placement", {
+    at: [421, 281],
+    rotation: 90,
+    mirror: "x",
+  });
+  await expect(page.getByTestId("hit-R1")).toHaveCount(1);
+  await expectComponentCodeField(page, "placement.at", [420, 280]);
+  await clickCommand(page, "Edit", "Undo");
+  await expect(page.getByTestId("hit-R1")).toHaveCount(0);
+});
+
 test("a directly connected device can move away and return with its wire, undo and redo", async ({
   page,
 }) => {

--- a/apps/editor/e2e/reference-label.spec.ts
+++ b/apps/editor/e2e/reference-label.spec.ts
@@ -4,6 +4,7 @@ import {
   chooseComponent,
   downloadBytes,
   editComponentPropertyCode,
+  expectComponentCodeField,
 } from "./editor-fixtures.js";
 
 async function placeResistor(page: Page) {
@@ -118,17 +119,20 @@ test("Properties renames the electrical identity explicitly; restore is an in-pl
   await page.getByTestId("hit-R1").click();
   await page.getByTestId("selection-shelf").click();
   const properties = page.getByRole("complementary", { name: "Properties" });
-  const reference = properties.getByLabel("Netlist Reference");
-  await expect(reference).toHaveValue("R1");
+  await expectComponentCodeField(page, "reference", "R1");
   await expect(properties.getByLabel("Component label")).toHaveCount(0);
-  await reference.fill("R7");
-  await reference.press("Enter");
-  await expect(reference).toHaveValue("R7");
+  await editComponentPropertyCode(page, (code) => {
+    code.reference = "R7";
+  });
+  await expectComponentCodeField(page, "reference", "R7");
   await expect(visual(page)).toContainText("load");
   // Prefix validation still applies to this explicitly electrical field.
-  await reference.fill("gm");
-  await reference.press("Enter");
-  await expect(reference).toHaveValue("R7");
+  await editComponentPropertyCode(page, (code) => {
+    code.reference = "gm";
+  });
+  await expect(properties).toContainText("Canvas property code was rejected");
+  await properties.getByRole("button", { name: "Discard draft" }).click();
+  await expectComponentCodeField(page, "reference", "R7");
   await editComponentPropertyCode(page, (value) => {
     value.display.reference = false;
   });
@@ -138,7 +142,7 @@ test("Properties renames the electrical identity explicitly; restore is an in-pl
   });
   await expect(visual(page)).toContainText("load");
 
-  await properties.getByRole("button", { name: "Edit annotation" }).click();
+  await page.getByTestId("annotation-hit-instance-label-R1").dblclick();
   const restore = page.getByRole("button", {
     name: "Use netlist name",
     exact: true,

--- a/apps/editor/e2e/symbol-body-text.spec.ts
+++ b/apps/editor/e2e/symbol-body-text.spec.ts
@@ -1,6 +1,11 @@
 import { expect, test, type Page } from "@playwright/test";
 
-import { chooseComponent, downloadBytes } from "./editor-fixtures";
+import {
+  chooseComponent,
+  downloadBytes,
+  expectComponentCodeField,
+  setComponentCodeField,
+} from "./editor-fixtures";
 
 async function placeSymbol(page: Page, symbolId: string): Promise<void> {
   await page.goto("/editor");
@@ -64,7 +69,14 @@ test("the Properties field shows what the canvas edit committed", async ({
   await page.getByRole("button", { name: "Apply text changes" }).click();
 
   await page.getByTestId("hit-X1").click();
-  await expect(page.getByLabel("Formula")).toHaveValue("current steering");
+  const shelf = page.getByTestId("selection-shelf");
+  if ((await shelf.getAttribute("aria-expanded")) !== "true")
+    await shelf.click();
+  await expectComponentCodeField(
+    page,
+    "signalFlow.formula",
+    "current steering",
+  );
 
   const saved = JSON.parse(
     (await downloadBytes(page, "File", "Export Project File…")).toString(
@@ -155,10 +167,7 @@ test("the swapped-input op-amp edits its body text too", async ({ page }) => {
   await placeSymbol(page, "opamp-lettered");
   await page.getByTestId("hit-X1").click();
   await page.getByTestId("selection-shelf").click();
-  await page
-    .getByLabel("Amplifier placement actions")
-    .getByRole("button", { name: "Swap the + and - inputs" })
-    .click();
+  await setComponentCodeField(page, "symbol", "opamp-lettered-inputs-swapped");
 
   await page.getByTestId("hit-X1").dblclick();
   const editor = page.getByRole("textbox", { name: "Canvas text editor" });

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -5687,8 +5687,14 @@ export function App({
                                 instanceId: selectedInstance.id,
                                 placement: {
                                   position: {
-                                    x: value.placement.at[0],
-                                    y: value.placement.at[1],
+                                    x: snapCoordinate(
+                                      value.placement.at[0],
+                                      document.presentation.grid,
+                                    ),
+                                    y: snapCoordinate(
+                                      value.placement.at[1],
+                                      document.presentation.grid,
+                                    ),
                                   },
                                   rotation: value.placement.rotation,
                                   mirror: value.placement.mirror,

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -1290,6 +1290,7 @@ export function App({
   const projectInputRef = useRef<HTMLInputElement>(null);
   const selectionShelfRef = useRef<HTMLButtonElement>(null);
   const instanceValueInputRef = useRef<HTMLInputElement>(null);
+  const [propertyCodeFocusRequest, setPropertyCodeFocusRequest] = useState(0);
   const netLabelPropertyInputRef = useRef<HTMLInputElement>(null);
   const netLabelEditorInputRef = useRef<HTMLInputElement>(null);
   const documentViewBoxes = useRef(new Map<string, GridRect>());
@@ -3327,9 +3328,7 @@ export function App({
     setImportReviewOpen(false);
     setSelectionOpen(true);
     setStatus(`Properties for ${instanceId}`);
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => instanceValueInputRef.current?.focus());
-    });
+    setPropertyCodeFocusRequest((current) => current + 1);
   }
 
   function toggleExamplesPanel(): void {
@@ -5643,6 +5642,7 @@ export function App({
                 selectedInstance
                   ? {
                       code: {
+                        focusRequest: propertyCodeFocusRequest,
                         instance: selectedInstance,
                         defaultForeground: styleProfile.foreground,
                         revision: document.revision,

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -21,6 +21,9 @@ import {
   planCreateCell,
   planProjectCellImport,
   planSetCellSymbolPresentation,
+  planSetDeviceModelTarget,
+  planInstanceUnplacement,
+  type ProjectStructureEdit,
   type CellResetPlan,
   type SchematicEdit,
   type WireSource,
@@ -5641,6 +5644,7 @@ export function App({
                   ? {
                       code: {
                         instance: selectedInstance,
+                        defaultForeground: styleProfile.foreground,
                         revision: document.revision,
                         referenceVisible:
                           selectedLabelRenderable &&
@@ -5655,70 +5659,176 @@ export function App({
                             selectedInstanceValue.visible !== false
                           : null,
                         onApply: (value: ComponentPropertyCodeValue) => {
-                          const edits: SchematicEdit[] =
-                            planComponentPropertyCodeEdits(
-                              document,
-                              selectedInstance,
-                              value,
-                            );
-                          const desiredReference = value.display?.reference;
-                          const currentReference =
-                            selectedInstanceLabel !== undefined &&
-                            selectedInstanceLabel.visible !== false;
-                          if (
-                            typeof desiredReference === "boolean" &&
-                            desiredReference !== currentReference
-                          ) {
-                            edits.push(
-                              ...referenceLabelVisibilityEdits(
-                                [selectedInstance.id],
-                                desiredReference,
-                              ),
-                            );
-                          }
-                          const desiredValue = value.display?.value;
-                          const currentValue =
-                            selectedInstanceValue !== null &&
-                            selectedInstanceValue.visible !== false;
-                          if (
-                            typeof desiredValue === "boolean" &&
-                            desiredValue !== currentValue
-                          ) {
+                          try {
+                            const edits: SchematicEdit[] =
+                              planComponentPropertyCodeEdits(
+                                document,
+                                selectedInstance,
+                                value,
+                              );
                             if (
-                              desiredValue &&
-                              !selectedInstanceValueAvailable
+                              selectedInstance.placement &&
+                              value.placement === null
                             ) {
+                              edits.push(
+                                ...planInstanceUnplacement(
+                                  document,
+                                  resolver,
+                                  [selectedInstance.id],
+                                  document.revision,
+                                ),
+                              );
+                            } else if (
+                              !selectedInstance.placement &&
+                              value.placement
+                            ) {
+                              edits.push({
+                                kind: "place_instance",
+                                instanceId: selectedInstance.id,
+                                placement: {
+                                  position: {
+                                    x: value.placement.at[0],
+                                    y: value.placement.at[1],
+                                  },
+                                  rotation: value.placement.rotation,
+                                  mirror: value.placement.mirror,
+                                },
+                              });
+                            }
+                            const candidateInstance = {
+                              ...selectedInstance,
+                              ...(value.parameters && selectedInstance.netlist
+                                ? {
+                                    netlist: {
+                                      ...selectedInstance.netlist,
+                                      parameters: Object.fromEntries(
+                                        Object.entries(value.parameters).filter(
+                                          ([, raw]) => raw.trim() !== "",
+                                        ),
+                                      ),
+                                    },
+                                  }
+                                : {}),
+                            };
+                            const candidateDocument = {
+                              ...document,
+                              instances: document.instances.map((instance) =>
+                                instance.id === selectedInstance.id
+                                  ? candidateInstance
+                                  : instance,
+                              ),
+                            };
+                            const desiredReference = value.display?.reference;
+                            const currentReference =
+                              selectedInstanceLabel !== undefined &&
+                              selectedInstanceLabel.visible !== false;
+                            if (
+                              typeof desiredReference === "boolean" &&
+                              desiredReference !== currentReference
+                            ) {
+                              edits.push(
+                                ...referenceLabelVisibilityEdits(
+                                  [selectedInstance.id],
+                                  desiredReference,
+                                ),
+                              );
+                            }
+                            const desiredValue = value.display?.value;
+                            const currentValue =
+                              selectedInstanceValue !== null &&
+                              selectedInstanceValue.visible !== false;
+                            if (
+                              typeof desiredValue === "boolean" &&
+                              desiredValue !== currentValue
+                            ) {
+                              if (
+                                desiredValue &&
+                                displayableInstanceValue(candidateInstance)
+                                  .kind !== "displayable"
+                              ) {
+                                return {
+                                  ok: false as const,
+                                  message:
+                                    "Set a valid component value before enabling its display",
+                                };
+                              }
+                              edits.push(
+                                ...valueVisibilityEdits(
+                                  candidateDocument,
+                                  [selectedInstance.id],
+                                  desiredValue,
+                                ),
+                              );
+                            }
+                            const currentTarget =
+                              selectedInstance.netlist?.binding?.kind ===
+                              "model"
+                                ? selectedInstance.netlist.binding.name
+                                : selectedReviewedExternalBinding
+                                  ? (selectedExternalSubcircuit?.name ?? "")
+                                  : "";
+                            const targetEdits: ProjectStructureEdit[] =
+                              value.netlistTarget !== undefined &&
+                              value.netlistTarget !== currentTarget
+                                ? planSetDeviceModelTarget(
+                                    project,
+                                    document.id,
+                                    selectedInstance.id,
+                                    value.netlistTarget,
+                                  )
+                                : [];
+                            if (
+                              edits.length === 0 &&
+                              targetEdits.length === 0
+                            ) {
+                              setStatus(
+                                `Canvas properties for ${selectedInstance.id} are already up to date`,
+                              );
+                              return { ok: true as const };
+                            }
+                            let applied: boolean;
+                            if (targetEdits.length > 0) {
+                              // Merge the target planner's document edits with the draft into
+                              // one project transaction and one undo boundary.
+                              const documentEdit = targetEdits.find(
+                                (edit) =>
+                                  edit.kind === "transact_document" &&
+                                  edit.documentId === document.id,
+                              );
+                              if (documentEdit?.kind === "transact_document")
+                                documentEdit.edits.push(...edits);
+                              else if (edits.length)
+                                targetEdits.push({
+                                  kind: "transact_document",
+                                  documentId: document.id,
+                                  expectedRevision: document.revision,
+                                  edits,
+                                });
+                              applied = commitStructure(
+                                "apply-component-property-code",
+                                targetEdits,
+                              );
+                            } else applied = transact(edits).ok;
+                            if (!applied) {
                               return {
                                 ok: false as const,
                                 message:
-                                  "Set a valid component value before enabling its display",
+                                  "Canvas property code was rejected; see the status bar",
                               };
                             }
-                            edits.push(
-                              ...valueVisibilityEdits(
-                                document,
-                                [selectedInstance.id],
-                                desiredValue,
-                              ),
-                            );
-                          }
-                          if (edits.length === 0) {
                             setStatus(
-                              `Canvas properties for ${selectedInstance.id} are already up to date`,
+                              `Applied Canvas property code to ${selectedInstance.id}`,
                             );
                             return { ok: true as const };
-                          }
-                          if (!transact(edits).ok) {
+                          } catch (error) {
                             return {
                               ok: false as const,
                               message:
-                                "Canvas property code was rejected; see the status bar",
+                                error instanceof Error
+                                  ? error.message
+                                  : "Could not apply component properties",
                             };
                           }
-                          setStatus(
-                            `Applied Canvas property code to ${selectedInstance.id}`,
-                          );
-                          return { ok: true as const };
                         },
                       },
                       formalPort: selectedFormalTerminal

--- a/apps/editor/src/app/editor-properties-dock.tsx
+++ b/apps/editor/src/app/editor-properties-dock.tsx
@@ -8,9 +8,9 @@ import {
   FormalPortProperties,
 } from "../features/properties/component-structure-properties";
 import { ComponentIdentityProperties } from "../features/properties/component-identity-properties";
-import { ComponentElectricalProperties } from "../features/properties/component-electrical-properties";
-import { ComponentSignalFlowProperties } from "../features/properties/component-signal-flow-properties";
-import { ComponentPlacementProperties } from "../features/properties/component-placement-properties";
+import type { ComponentElectricalProperties } from "../features/properties/component-electrical-properties";
+import type { ComponentSignalFlowProperties } from "../features/properties/component-signal-flow-properties";
+import type { ComponentPlacementProperties } from "../features/properties/component-placement-properties";
 import { ComponentPropertyCodeEditor } from "../features/properties/component-property-code-editor";
 import { AnnotationColorProperties } from "../features/properties/annotation-color-properties";
 import { NetNameProperties } from "../features/properties/net-name-properties";
@@ -144,6 +144,13 @@ export function EditorPropertiesDock({
               <ComponentPropertyCodeEditor
                 key={component.code.instance.id}
                 {...component.code}
+                details={{
+                  parameters: component.electrical.parameters,
+                  ...(component.identity.modelTarget
+                    ? { modelTarget: component.identity.modelTarget }
+                    : {}),
+                  signalFlow: component.signalFlow !== null,
+                }}
               />
               {component.formalPort ? (
                 <FormalPortProperties {...component.formalPort} />
@@ -151,18 +158,14 @@ export function EditorPropertiesDock({
               {component.cellSymbolLayout ? (
                 <CellSymbolLayoutProperties {...component.cellSymbolLayout} />
               ) : null}
-              {component.signalFlow ? (
-                <ComponentSignalFlowProperties {...component.signalFlow} />
+              {component.identity.portNet ||
+              component.identity.propertyTerminal ||
+              component.identity.capacitorPlateRows ? (
+                <ComponentIdentityProperties
+                  {...component.identity}
+                  fieldsMovedToCode
+                />
               ) : null}
-              <ComponentElectricalProperties
-                {...component.electrical}
-                displayControls={false}
-              />
-              <ComponentPlacementProperties
-                {...component.placement}
-                geometryControls={false}
-              />
-              <ComponentIdentityProperties {...component.identity} />
             </section>
           ) : null}
           {annotationText ? (

--- a/apps/editor/src/features/properties/component-identity-properties.tsx
+++ b/apps/editor/src/features/properties/component-identity-properties.tsx
@@ -186,6 +186,7 @@ export function ComponentIdentityProperties({
   onMarkerNameChange,
   onReferenceChange,
   onModelTargetChange,
+  fieldsMovedToCode = false,
 }: {
   instance: Instance;
   revision: number;
@@ -206,6 +207,7 @@ export function ComponentIdentityProperties({
   onMarkerNameChange: (value: string) => void;
   onReferenceChange: (value: string) => boolean | void;
   onModelTargetChange: (value: string) => void;
+  fieldsMovedToCode?: boolean;
 }) {
   const reference = instance.reference ?? "";
   const hasEditableIdentityControls = Boolean(
@@ -240,7 +242,7 @@ export function ComponentIdentityProperties({
                 </dd>
               </div>
             ) : null}
-            {instance.reference ? (
+            {instance.reference && !fieldsMovedToCode ? (
               <div>
                 <dt>Netlist Reference</dt>
                 <dd>
@@ -259,7 +261,7 @@ export function ComponentIdentityProperties({
                 </dd>
               </div>
             ) : null}
-            {onEditAnnotation ? (
+            {onEditAnnotation && !fieldsMovedToCode ? (
               <div>
                 <dt>Visual annotation</dt>
                 <dd>
@@ -269,7 +271,7 @@ export function ComponentIdentityProperties({
                 </dd>
               </div>
             ) : null}
-            {targetDescription ? (
+            {targetDescription && !fieldsMovedToCode ? (
               <div className="property-identity-target">
                 <dt>Target</dt>
                 <dd>{targetDescription}</dd>
@@ -325,7 +327,7 @@ export function ComponentIdentityProperties({
           </label>
         </div>
       ) : null}
-      {modelTarget ? (
+      {modelTarget && !fieldsMovedToCode ? (
         <div
           className="property-card property-target-card"
           aria-label="Netlist target"

--- a/apps/editor/src/features/properties/component-property-code-assists.test.ts
+++ b/apps/editor/src/features/properties/component-property-code-assists.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import { transformPoint } from "@icm/model";
+import {
+  formatComponentPropertyCode,
+  parseComponentPropertyCode,
+} from "./component-property-code";
+import {
+  propertyCodeSpans,
+  propertyCodeChanges,
+  reflectedPropertyCode,
+} from "./component-property-code-assists";
+import {
+  CANVAS_PROPERTY_FIELDS,
+  ROTATION_OPTIONS,
+  MIRROR_OPTIONS,
+} from "./component-property-fields";
+
+const context = {
+  instance: {
+    id: "M1",
+    symbolId: "nmos",
+    placement: {
+      position: { x: 210, y: 140 },
+      rotation: 0 as const,
+      mirror: "none" as const,
+    },
+  },
+  referenceVisible: true,
+  valueVisible: false,
+};
+function apply(
+  source: string,
+  changes: ReturnType<typeof propertyCodeChanges>,
+) {
+  return [...changes]
+    .reverse()
+    .reduce(
+      (text, change) =>
+        text.slice(0, change.from) + change.insert + text.slice(change.to),
+      source,
+    );
+}
+
+describe("Canvas property assistance", () => {
+  it("addresses all available fields by syntax path and preserves unrelated draft bytes", () => {
+    const source = formatComponentPropertyCode(context);
+    expect(propertyCodeSpans(source).map((span) => span.field.path)).toEqual(
+      CANVAS_PROPERTY_FIELDS.map((field) => field.path),
+    );
+    const changed = apply(
+      source,
+      propertyCodeChanges(source, context, { "display.value": true }),
+    );
+    expect(changed).toBe(source.replace('"value": false', '"value": true'));
+    const escaped = source.replace('"value"', '"val\\u0075e"');
+    expect(
+      apply(
+        escaped,
+        propertyCodeChanges(escaped, context, { "display.value": true }),
+      ),
+    ).toContain('"val\\u0075e": true');
+  });
+  it("uses the very same enum choices for controls and validation", () => {
+    const source = formatComponentPropertyCode(context);
+    for (const rotation of ROTATION_OPTIONS)
+      for (const mirror of MIRROR_OPTIONS) {
+        const changes = propertyCodeChanges(source, context, {
+          "placement.rotation": rotation.value,
+          "placement.mirror": mirror.value,
+        });
+        expect(changes).toHaveLength(2);
+        expect(
+          parseComponentPropertyCode(apply(source, changes), context).ok,
+        ).toBe(true);
+      }
+    expect(
+      propertyCodeChanges(source, context, { "placement.rotation": 45 }),
+    ).toEqual([]);
+    expect(
+      propertyCodeChanges(source, context, { "placement.mirror": "y" }),
+    ).toEqual([]);
+  });
+  it("does not repair invalid JSON implicitly, overwrite invalid drafts, or invent unsupported controls", () => {
+    const source = formatComponentPropertyCode(context);
+    expect(
+      propertyCodeChanges(source.slice(0, -1), context, {
+        "display.value": true,
+      }),
+    ).toEqual([]);
+    expect(
+      propertyCodeChanges(source, context, { "placement.unsupported": 0 }),
+    ).toEqual([]);
+    const noDisplay = {
+      ...context,
+      referenceVisible: null,
+      valueVisible: null,
+    };
+    const unavailable = formatComponentPropertyCode(noDisplay);
+    expect(
+      propertyCodeSpans(unavailable).some(
+        (span) => span.field.kind === "boolean",
+      ),
+    ).toBe(false);
+    expect(
+      propertyCodeChanges(unavailable, noDisplay, { "display.value": true }),
+    ).toEqual([]);
+  });
+  it("reflects in canvas directions at every rotation/mirror state without moving the origin", () => {
+    for (const rotation of ROTATION_OPTIONS)
+      for (const mirror of MIRROR_OPTIONS)
+        for (const direction of ["left-right", "top-bottom"] as const) {
+          const code = JSON.parse(formatComponentPropertyCode(context));
+          code.placement.rotation = rotation.value;
+          code.placement.mirror = mirror.value;
+          const source = JSON.stringify(code);
+          const changed = JSON.parse(
+            apply(source, reflectedPropertyCode(source, context, direction)),
+          );
+          expect(changed.placement.at).toEqual([210, 140]);
+          const before = transformPoint(
+            { x: 10, y: 20 },
+            { x: 0, y: 0 },
+            code.placement,
+          );
+          const after = transformPoint(
+            { x: 10, y: 20 },
+            { x: 0, y: 0 },
+            changed.placement,
+          );
+          expect(after).toEqual(
+            direction === "left-right"
+              ? { x: -before.x, y: before.y }
+              : { x: before.x, y: -before.y },
+          );
+          expect(
+            JSON.parse(
+              apply(
+                JSON.stringify(changed),
+                reflectedPropertyCode(
+                  JSON.stringify(changed),
+                  context,
+                  direction,
+                ),
+              ),
+            ),
+          ).toEqual(code);
+        }
+  });
+});

--- a/apps/editor/src/features/properties/component-property-code-assists.ts
+++ b/apps/editor/src/features/properties/component-property-code-assists.ts
@@ -1,0 +1,100 @@
+import { jsonLanguage } from "@codemirror/lang-json";
+import { reflectOrientation } from "@icm/model";
+import { componentDetailFields } from "./component-property-details";
+import {
+  parseComponentPropertyCode,
+  type ComponentPropertyCodeContext,
+} from "./component-property-code";
+import {
+  CANVAS_PROPERTY_FIELDS,
+  type CanvasPropertyField,
+} from "./component-property-fields";
+
+type JsonNode = ReturnType<typeof jsonLanguage.parser.parse>["topNode"];
+export interface PropertyCodeSpan {
+  field: CanvasPropertyField;
+  from: number;
+  to: number;
+  value: unknown;
+}
+
+/** Use syntax paths, not matching text: duplicate names in unrelated objects are not controls. */
+export function propertyCodeSpans(
+  source: string,
+  context?: ComponentPropertyCodeContext,
+): PropertyCodeSpan[] {
+  const spans: PropertyCodeSpan[] = [];
+  const fields = [
+    ...CANVAS_PROPERTY_FIELDS,
+    ...(context
+      ? componentDetailFields(context.instance, context.details)
+      : []),
+  ];
+  function visit(object: JsonNode, prefix: string) {
+    for (let node = object.firstChild; node; node = node.nextSibling) {
+      if (node.name !== "Property") continue;
+      const name = node.getChild("PropertyName");
+      const value = node.lastChild;
+      if (!name || !value || value === name) continue;
+      try {
+        const key = JSON.parse(source.slice(name.from, name.to)) as string;
+        const path = prefix ? `${prefix}.${key}` : key;
+        const field = fields.find((item) => item.path === path);
+        if (field)
+          spans.push({
+            field,
+            from: value.from,
+            to: value.to,
+            value: JSON.parse(source.slice(value.from, value.to)),
+          });
+        if (value.name === "Object") visit(value, path);
+      } catch {
+        /* Incomplete JSON stays editable; do not guess value boundaries. */
+      }
+    }
+  }
+  const root = jsonLanguage.parser.parse(source).topNode.getChild("Object");
+  if (root) visit(root, "");
+  return spans;
+}
+
+/** Controls edit the same draft, preserving whitespace and all unrelated authored bytes. */
+export function propertyCodeChanges(
+  source: string,
+  context: ComponentPropertyCodeContext,
+  values: Readonly<Record<string, unknown>>,
+) {
+  if (!parseComponentPropertyCode(source, context).ok) return [];
+  const spans = propertyCodeSpans(source, context);
+  const changes = Object.entries(values).map(([path, value]) => {
+    const span = spans.find((item) => item.field.path === path);
+    return span
+      ? { from: span.from, to: span.to, insert: JSON.stringify(value) }
+      : null;
+  });
+  if (changes.some((change) => !change)) return [];
+  const sorted = changes
+    .filter((change) => change !== null)
+    .sort((a, b) => a.from - b.from);
+  let candidate = source;
+  for (const change of [...sorted].reverse())
+    candidate =
+      candidate.slice(0, change.from) +
+      change.insert +
+      candidate.slice(change.to);
+  return parseComponentPropertyCode(candidate, context).ok ? sorted : [];
+}
+
+export function reflectedPropertyCode(
+  source: string,
+  context: ComponentPropertyCodeContext,
+  direction: "left-right" | "top-bottom",
+) {
+  const parsed = parseComponentPropertyCode(source, context);
+  if (!parsed.ok || !parsed.value.placement) return [];
+  const next = reflectOrientation(parsed.value.placement, direction);
+  return propertyCodeChanges(source, context, {
+    "placement.rotation": next.rotation,
+    "placement.mirror": next.mirror,
+  });
+}

--- a/apps/editor/src/features/properties/component-property-code-editor.test.tsx
+++ b/apps/editor/src/features/properties/component-property-code-editor.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import { ComponentPropertyCodeEditor } from "./component-property-code-editor";
 
 describe("ComponentPropertyCodeEditor", () => {
-  it("renders one editable code surface without coordinate or style widgets", () => {
+  it("keeps a readable loading fallback for the lazily loaded code surface", () => {
     const markup = renderToStaticMarkup(
       <ComponentPropertyCodeEditor
         instance={{
@@ -23,7 +23,7 @@ describe("ComponentPropertyCodeEditor", () => {
         onApply={vi.fn(() => ({ ok: true as const }))}
       />,
     );
-    expect(markup).toContain('aria-label="Editable Canvas property code"');
+    expect(markup).toContain('aria-label="Loading Canvas property code"');
     expect(markup).toContain("&quot;at&quot;");
     expect(markup).toContain("Apply code");
     expect(markup).not.toContain('inputMode="decimal"');

--- a/apps/editor/src/features/properties/component-property-code-editor.tsx
+++ b/apps/editor/src/features/properties/component-property-code-editor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { lazy, Suspense, useEffect, useMemo, useRef, useState } from "react";
 
 import type { SchematicDocument } from "@icm/model";
 
@@ -6,17 +6,23 @@ import {
   formatComponentPropertyCode,
   parseComponentPropertyCode,
   serializeComponentPropertyCode,
+  defaultComponentPropertyCode,
   type ComponentPropertyCodeContext,
   type ComponentPropertyCodeValue,
 } from "./component-property-code";
 
 type Instance = SchematicDocument["instances"][number];
+const PropertyJsonEditor = lazy(
+  () => import("./component-property-json-editor"),
+);
 
 export interface ComponentPropertyCodeEditorProps {
   instance: Instance;
   revision: number;
   referenceVisible: boolean | null;
   valueVisible: boolean | null;
+  defaultForeground?: string;
+  details?: ComponentPropertyCodeContext["details"];
   onApply: (
     value: ComponentPropertyCodeValue,
   ) => { ok: true } | { ok: false; message: string };
@@ -28,11 +34,18 @@ export function ComponentPropertyCodeEditor({
   revision,
   referenceVisible,
   valueVisible,
+  defaultForeground = "#000000",
+  details,
   onApply,
 }: ComponentPropertyCodeEditorProps) {
   const context = useMemo<ComponentPropertyCodeContext>(
-    () => ({ instance, referenceVisible, valueVisible }),
-    [instance, referenceVisible, valueVisible],
+    () => ({
+      instance,
+      referenceVisible,
+      valueVisible,
+      ...(details ? { details } : {}),
+    }),
+    [instance, referenceVisible, valueVisible, details],
   );
   const baseline = useMemo(
     () => formatComponentPropertyCode(context),
@@ -79,34 +92,68 @@ export function ComponentPropertyCodeEditor({
     >
       <header>
         <div>
-          <strong>Canvas properties</strong>
+          <strong>Component properties</strong>
           <span>{instance.reference ?? instance.id}</span>
         </div>
         <code>{instance.symbolId}</code>
       </header>
-      <textarea
-        aria-label="Editable Canvas property code"
-        value={draft}
-        rows={15}
-        spellCheck={false}
-        onChange={(event) => {
-          setDraft(event.currentTarget.value);
-          setApplyMessage(null);
-        }}
-        onKeyDown={(event) => {
-          if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
-            event.preventDefault();
-            apply();
-          }
-        }}
-      />
+      <Suspense
+        fallback={
+          <textarea
+            aria-label="Loading Canvas property code"
+            value={draft}
+            readOnly
+            rows={15}
+          />
+        }
+      >
+        <PropertyJsonEditor
+          value={draft}
+          historyKey={baseline}
+          context={context}
+          defaultForeground={defaultForeground}
+          onChange={(source) => {
+            setDraft(source);
+            setApplyMessage(null);
+          }}
+          onApply={apply}
+        />
+      </Suspense>
       <div className="component-property-code-status" aria-live="polite">
         <span>
           {parsed.ok
-            ? (applyMessage ?? "JSON · Ctrl/⌘ + Enter to apply")
+            ? (applyMessage ??
+              (changed
+                ? "Changes pending · Apply or Ctrl/⌘ + Enter"
+                : "JSON · hints and controls are not saved"))
             : parsed.message}
         </span>
         <div>
+          <button
+            type="button"
+            onClick={() => {
+              void navigator.clipboard.writeText(draft).then(
+                () =>
+                  setApplyMessage("JSON copied · hints and controls excluded"),
+                () =>
+                  setApplyMessage(
+                    "Clipboard unavailable; select the code and copy it",
+                  ),
+              );
+            }}
+          >
+            Copy JSON
+          </button>
+          <button
+            type="button"
+            title="Reset parameter and appearance defaults in the draft; keep position, identity, target, display flags, and unknown overrides. Apply to commit."
+            onClick={() => {
+              setDraft(defaultComponentPropertyCode(context));
+              setApplyMessage("Defaults loaded into draft · Apply to commit");
+            }}
+          >
+            Defaults
+          </button>
           <button
             type="button"
             disabled={!changed}
@@ -115,7 +162,7 @@ export function ComponentPropertyCodeEditor({
               setApplyMessage(null);
             }}
           >
-            Revert
+            Discard draft
           </button>
           <button
             type="button"

--- a/apps/editor/src/features/properties/component-property-code-editor.tsx
+++ b/apps/editor/src/features/properties/component-property-code-editor.tsx
@@ -23,6 +23,7 @@ export interface ComponentPropertyCodeEditorProps {
   valueVisible: boolean | null;
   defaultForeground?: string;
   details?: ComponentPropertyCodeContext["details"];
+  focusRequest?: number;
   onApply: (
     value: ComponentPropertyCodeValue,
   ) => { ok: true } | { ok: false; message: string };
@@ -36,6 +37,7 @@ export function ComponentPropertyCodeEditor({
   valueVisible,
   defaultForeground = "#000000",
   details,
+  focusRequest = 0,
   onApply,
 }: ComponentPropertyCodeEditorProps) {
   const context = useMemo<ComponentPropertyCodeContext>(
@@ -56,10 +58,11 @@ export function ComponentPropertyCodeEditor({
   const [applyMessage, setApplyMessage] = useState<string | null>(null);
 
   useEffect(() => {
-    setDraft((current) =>
-      current === previousBaseline.current ? baseline : current,
-    );
+    // Capture before enqueueing: React may run the updater after the ref has
+    // advanced. Reading the ref inside it leaves normalized target edits stale.
+    const previous = previousBaseline.current;
     previousBaseline.current = baseline;
+    setDraft((current) => (current === previous ? baseline : current));
   }, [baseline]);
 
   const parsed = useMemo(
@@ -112,6 +115,7 @@ export function ComponentPropertyCodeEditor({
           historyKey={baseline}
           context={context}
           defaultForeground={defaultForeground}
+          focusRequest={focusRequest}
           onChange={(source) => {
             setDraft(source);
             setApplyMessage(null);

--- a/apps/editor/src/features/properties/component-property-code-edits.ts
+++ b/apps/editor/src/features/properties/component-property-code-edits.ts
@@ -27,6 +27,48 @@ export function planComponentPropertyCodeEdits(
   value: ComponentPropertyCodeValue,
 ): SchematicEdit[] {
   const edits: SchematicEdit[] = [];
+  if (value.reference !== undefined && value.reference !== instance.reference)
+    edits.push({
+      kind: "set_instance_reference",
+      instanceId: instance.id,
+      reference: value.reference,
+    });
+  if (value.parameters && instance.netlist) {
+    const set = Object.fromEntries(
+      Object.entries(value.parameters).filter(
+        ([key, raw]) =>
+          raw.trim() !== "" && raw !== instance.netlist!.parameters[key],
+      ),
+    );
+    const unset = Object.keys(instance.netlist.parameters).filter(
+      (key) => !(value.parameters![key] ?? "").trim(),
+    );
+    if (Object.keys(set).length || unset.length)
+      edits.push({
+        kind: "patch_instance_netlist_parameters",
+        instanceId: instance.id,
+        ...(Object.keys(set).length ? { set } : {}),
+        ...(unset.length ? { unset } : {}),
+      });
+  }
+  if (value.symbol && value.symbol !== instance.symbolId)
+    edits.push({
+      kind: "set_instance_symbol",
+      instanceId: instance.id,
+      symbolId: value.symbol,
+    });
+  if (
+    value.signalFlow &&
+    JSON.stringify(value.signalFlow) !==
+      JSON.stringify(instance.signalFlowParameters ?? {})
+  )
+    edits.push({
+      kind: "set_instance_signal_flow_parameters",
+      instanceId: instance.id,
+      parameters: Object.keys(value.signalFlow).length
+        ? value.signalFlow
+        : null,
+    });
   if (instance.placement && value.placement) {
     const position = {
       x: snapCoordinate(value.placement.at[0], document.presentation.grid),

--- a/apps/editor/src/features/properties/component-property-code.test.ts
+++ b/apps/editor/src/features/properties/component-property-code.test.ts
@@ -5,6 +5,7 @@ import type { SchematicDocument } from "@icm/model";
 import {
   formatComponentPropertyCode,
   parseComponentPropertyCode,
+  serializeComponentPropertyCode,
 } from "./component-property-code";
 
 type Instance = SchematicDocument["instances"][number];
@@ -34,10 +35,7 @@ describe("component property code", () => {
   it("formats placement as one coordinate and makes display/style explicit", () => {
     expect(formatComponentPropertyCode(context)).toBe(`{
   "placement": {
-    "at": [
-      360,
-      240
-    ],
+    "at": [360, 240],
     "rotation": 90,
     "mirror": "none"
   },
@@ -76,7 +74,7 @@ describe("component property code", () => {
     );
     expect(parseComponentPropertyCode(source, context)).toEqual({
       ok: false,
-      message: "placement.rotation must be 0, 90, 180, or 270",
+      message: "placement.rotation must be 0, 90, 180, 270",
     });
 
     const extra = formatComponentPropertyCode(context).replace(
@@ -109,5 +107,37 @@ describe("component property code", () => {
       ok: false,
       message: "placement cannot be changed to null here; use Return to tray",
     });
+  });
+
+  it("accepts RGB authoring, persists hex, and displays fixed colors as compact RGB", () => {
+    const decoded = JSON.parse(formatComponentPropertyCode(context));
+    decoded.appearance.foreground = [255, 0, 128];
+    decoded.appearance.background = [255, 255, 255];
+    const parsed = parseComponentPropertyCode(JSON.stringify(decoded), context);
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) throw new Error(parsed.message);
+    expect(parsed.value.appearance).toEqual({
+      foreground: "#ff0080",
+      background: "#ffffff",
+    });
+    const formatted = serializeComponentPropertyCode(parsed.value);
+    expect(formatted).toContain('"foreground": [255, 0, 128]');
+    expect(parseComponentPropertyCode(formatted, context)).toEqual(parsed);
+  });
+
+  it.each([
+    [256, 0, 0],
+    [-1, 0, 0],
+    [0.5, 0, 0],
+    ["0", 0, 0],
+    [0, 0],
+    [0, 0, 0, 0],
+    [null, 0, 0],
+  ])("rejects invalid RGB channels %j", (...channels) => {
+    const decoded = JSON.parse(formatComponentPropertyCode(context));
+    decoded.appearance.foreground = channels;
+    expect(
+      parseComponentPropertyCode(JSON.stringify(decoded), context).ok,
+    ).toBe(false);
   });
 });

--- a/apps/editor/src/features/properties/component-property-code.ts
+++ b/apps/editor/src/features/properties/component-property-code.ts
@@ -190,20 +190,29 @@ export function serializeComponentPropertyCode(
   value: ComponentPropertyCodeValue,
 ): string {
   const source = JSON.stringify(
-    value,
-    (key, item: unknown) =>
-      (key === "foreground" || key === "background") &&
-      typeof item === "string" &&
-      item !== "auto"
-        ? colorToRgb(item)
-        : item,
+    {
+      ...value,
+      appearance: {
+        foreground:
+          value.appearance.foreground === "auto"
+            ? "auto"
+            : colorToRgb(value.appearance.foreground),
+        background:
+          value.appearance.background === "auto"
+            ? "auto"
+            : colorToRgb(value.appearance.background),
+      },
+    },
+    null,
     2,
   );
   // Keep coordinate and RGB tuples readable on one line; this remains strict JSON.
   return source.replace(
-    /\[\s*(-?\d+(?:\.\d+)?(?:e[+-]?\d+)?)\s*,\s*(-?\d+(?:\.\d+)?(?:e[+-]?\d+)?)(?:\s*,\s*(\d+))?\s*\]/giu,
-    (_match, first: string, second: string, third?: string) =>
-      `[${first}, ${second}${third === undefined ? "" : `, ${third}`}]`,
+    /"(?:\\.|[^"\\])*"|\[\s*(-?\d+(?:\.\d+)?(?:e[+-]?\d+)?)\s*,\s*(-?\d+(?:\.\d+)?(?:e[+-]?\d+)?)(?:\s*,\s*(\d+))?\s*\]/giu,
+    (match, first?: string, second?: string, third?: string) =>
+      first === undefined
+        ? match
+        : `[${first}, ${second}${third === undefined ? "" : `, ${third}`}]`,
   );
 }
 

--- a/apps/editor/src/features/properties/component-property-code.ts
+++ b/apps/editor/src/features/properties/component-property-code.ts
@@ -1,4 +1,17 @@
 import type { SchematicDocument } from "@icm/model";
+import {
+  componentPropertyDetailsValue,
+  parseComponentPropertyDetails,
+  type ComponentPropertyDetailsContext,
+  type ComponentPropertyDetailsValue,
+} from "./component-property-details";
+import {
+  CANVAS_PROPERTY_FIELDS,
+  ROTATION_OPTIONS,
+  MIRROR_OPTIONS,
+  colorToRgb,
+  parseCanvasColor,
+} from "./component-property-fields";
 
 type Instance = SchematicDocument["instances"][number];
 
@@ -15,7 +28,7 @@ export interface ComponentPropertyDisplayCode {
   value?: boolean;
 }
 
-export interface ComponentPropertyCodeValue {
+export interface ComponentPropertyCodeValue extends ComponentPropertyDetailsValue {
   placement: ComponentPropertyPlacementCode | null;
   display?: ComponentPropertyDisplayCode;
   appearance: {
@@ -28,16 +41,31 @@ export interface ComponentPropertyCodeContext {
   instance: Instance;
   referenceVisible: boolean | null;
   valueVisible: boolean | null;
+  details?: ComponentPropertyDetailsContext;
 }
 
 export type ComponentPropertyCodeParseResult =
   | { ok: true; value: ComponentPropertyCodeValue }
   | { ok: false; message: string };
 
-const COLOR_PATTERN = /^#[0-9A-Fa-f]{6}$/u;
-const ROOT_KEYS = new Set(["placement", "display", "appearance"]);
-const PLACEMENT_KEYS = new Set(["at", "rotation", "mirror"]);
-const APPEARANCE_KEYS = new Set(["foreground", "background"]);
+const ROOT_KEYS = new Set([
+  "placement",
+  "display",
+  "appearance",
+  "reference",
+  "parameters",
+  "netlistTarget",
+  "symbol",
+  "signalFlow",
+]);
+const fieldKeys = (group: string) =>
+  new Set(
+    CANVAS_PROPERTY_FIELDS.filter((field) =>
+      field.path.startsWith(`${group}.`),
+    ).map((field) => field.path.split(".")[1]!),
+  );
+const PLACEMENT_KEYS = fieldKeys("placement");
+const APPEARANCE_KEYS = fieldKeys("appearance");
 
 function formattedColor(value: string | undefined): ComponentPropertyColor {
   return (value ?? "auto") as ComponentPropertyColor;
@@ -56,27 +84,20 @@ function unexpectedKey(
   return key ? `${path}.${key} is not a supported property` : null;
 }
 
-function parseColor(value: unknown, path: string): ComponentPropertyColor {
-  if (value === "auto") return value;
-  if (typeof value === "string" && COLOR_PATTERN.test(value)) {
-    return value as `#${string}`;
-  }
-  throw new Error(`${path} must be "auto" or a #RRGGBB color`);
-}
-
 function parsePlacement(
   value: unknown,
   currentlyPlaced: boolean,
+  editableLifecycle = false,
 ): ComponentPropertyPlacementCode | null {
   if (value === null) {
-    if (currentlyPlaced) {
+    if (currentlyPlaced && !editableLifecycle) {
       throw new Error(
         "placement cannot be changed to null here; use Return to tray",
       );
     }
     return null;
   }
-  if (!currentlyPlaced) {
+  if (!currentlyPlaced && !editableLifecycle) {
     throw new Error(
       "placement is read-only while this component is in the Placement Tray",
     );
@@ -95,17 +116,21 @@ function parsePlacement(
     throw new Error("placement.at must be a finite [x, y] coordinate");
   }
   const rotation = value.rotation;
-  if (![0, 90, 180, 270].includes(rotation as number)) {
-    throw new Error("placement.rotation must be 0, 90, 180, or 270");
+  if (!ROTATION_OPTIONS.some((option) => option.value === rotation)) {
+    throw new Error(
+      `placement.rotation must be ${ROTATION_OPTIONS.map((option) => option.value).join(", ")}`,
+    );
   }
   const mirror = value.mirror;
-  if (mirror !== "none" && mirror !== "x") {
-    throw new Error('placement.mirror must be "none" or "x"');
+  if (!MIRROR_OPTIONS.some((option) => option.value === mirror)) {
+    throw new Error(
+      `placement.mirror must be ${MIRROR_OPTIONS.map((option) => JSON.stringify(option.value)).join(" or ")}`,
+    );
   }
   return {
     at: [at[0] as number, at[1] as number],
     rotation: rotation as 0 | 90 | 180 | 270,
-    mirror,
+    mirror: mirror as ComponentPropertyPlacementCode["mirror"],
   };
 }
 
@@ -145,6 +170,7 @@ export function componentPropertyCodeValue(
   }
   if (context.valueVisible !== null) display.value = context.valueVisible;
   return {
+    ...componentPropertyDetailsValue(instance, context.details),
     placement: instance.placement
       ? {
           at: [instance.placement.position.x, instance.placement.position.y],
@@ -163,7 +189,22 @@ export function componentPropertyCodeValue(
 export function serializeComponentPropertyCode(
   value: ComponentPropertyCodeValue,
 ): string {
-  return JSON.stringify(value, null, 2);
+  const source = JSON.stringify(
+    value,
+    (key, item: unknown) =>
+      (key === "foreground" || key === "background") &&
+      typeof item === "string" &&
+      item !== "auto"
+        ? colorToRgb(item)
+        : item,
+    2,
+  );
+  // Keep coordinate and RGB tuples readable on one line; this remains strict JSON.
+  return source.replace(
+    /\[\s*(-?\d+(?:\.\d+)?(?:e[+-]?\d+)?)\s*,\s*(-?\d+(?:\.\d+)?(?:e[+-]?\d+)?)(?:\s*,\s*(\d+))?\s*\]/giu,
+    (_match, first: string, second: string, third?: string) =>
+      `[${first}, ${second}${third === undefined ? "" : `, ${third}`}]`,
+  );
 }
 
 export function formatComponentPropertyCode(
@@ -205,17 +246,23 @@ export function parseComponentPropertyCode(
     return {
       ok: true,
       value: {
+        ...parseComponentPropertyDetails(
+          decoded,
+          context.instance,
+          context.details,
+        ),
         placement: parsePlacement(
           decoded.placement,
           context.instance.placement !== null,
+          context.details !== undefined,
         ),
         ...(display ? { display } : {}),
         appearance: {
-          foreground: parseColor(
+          foreground: parseCanvasColor(
             decoded.appearance.foreground,
             "appearance.foreground",
           ),
-          background: parseColor(
+          background: parseCanvasColor(
             decoded.appearance.background,
             "appearance.background",
           ),
@@ -229,4 +276,21 @@ export function parseComponentPropertyCode(
         error instanceof Error ? error.message : "Property code is invalid",
     };
   }
+}
+
+/** Reset authored defaults in the draft without moving, renaming, or rebinding the device. */
+export function defaultComponentPropertyCode(
+  context: ComponentPropertyCodeContext,
+): string {
+  const value = componentPropertyCodeValue(context);
+  if (value.placement)
+    value.placement = { ...value.placement, rotation: 0, mirror: "none" };
+  value.appearance = { foreground: "auto", background: "auto" };
+  if (value.parameters && context.details) {
+    // Preserve unknown model overrides; only descriptor-owned defaults are known.
+    for (const parameter of context.details.parameters)
+      value.parameters[parameter.key] = parameter.defaultValue ?? "";
+  }
+  if (value.signalFlow) value.signalFlow = {};
+  return serializeComponentPropertyCode(value);
 }

--- a/apps/editor/src/features/properties/component-property-details.test.ts
+++ b/apps/editor/src/features/properties/component-property-details.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import type { Instance } from "@icm/model";
+import { componentParameters } from "../component-insert/component-parameters";
+import {
+  defaultComponentPropertyCode,
+  formatComponentPropertyCode,
+  parseComponentPropertyCode,
+} from "./component-property-code";
+import { planComponentPropertyCodeEdits } from "./component-property-code-edits";
+import { createEmptyDocument } from "@icm/model";
+import { componentSymbolOptions } from "./component-property-details";
+
+const instance: Instance = {
+  id: "M1",
+  reference: "M1",
+  symbolId: "nmos",
+  placement: { position: { x: 200, y: 160 }, rotation: 90, mirror: "x" },
+  netlist: {
+    parameters: { w: "EV", l: "L", nf: "2", m: "1", custom: "{x+1}" },
+  },
+};
+const context = {
+  instance,
+  referenceVisible: true,
+  valueVisible: true,
+  details: {
+    parameters: componentParameters("nmos"),
+    modelTarget: { defaultValue: "model_a", suggestions: ["model_a"] },
+  },
+};
+
+describe("unified component property details", () => {
+  it("round-trips authored strings, overrides, and model target without unit conversion", () => {
+    const source = formatComponentPropertyCode(context);
+    expect(JSON.parse(source)).toMatchObject({
+      reference: "M1",
+      parameters: instance.netlist!.parameters,
+      netlistTarget: "model_a",
+    });
+    expect(parseComponentPropertyCode(source, context)).toMatchObject({
+      ok: true,
+      value: { parameters: instance.netlist!.parameters },
+    });
+  });
+  it("plans parameter set/unset, identity and placement as ordinary atomic edits", () => {
+    const decoded = JSON.parse(formatComponentPropertyCode(context));
+    decoded.reference = "M2";
+    decoded.parameters.w = "3u";
+    decoded.parameters.custom = "";
+    delete decoded.parameters.nf;
+    decoded.placement.rotation = 180;
+    const parsed = parseComponentPropertyCode(JSON.stringify(decoded), context);
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    const doc = createEmptyDocument("doc", "doc");
+    const edits = planComponentPropertyCodeEdits(doc, instance, parsed.value);
+    expect(edits).toContainEqual({
+      kind: "set_instance_reference",
+      instanceId: "M1",
+      reference: "M2",
+    });
+    expect(edits).toContainEqual({
+      kind: "patch_instance_netlist_parameters",
+      instanceId: "M1",
+      set: { w: "3u" },
+      unset: ["nf", "custom"],
+    });
+    expect(edits).toContainEqual({
+      kind: "rotate_instance",
+      instanceId: "M1",
+      rotation: 180,
+    });
+  });
+  it.each([{ w: 3 }, { w: "1u", W: "2u" }, { w: null }])(
+    "rejects invalid or ambiguous raw parameter values %j",
+    (parameters) => {
+      const decoded = JSON.parse(formatComponentPropertyCode(context));
+      decoded.parameters = parameters;
+      expect(
+        parseComponentPropertyCode(JSON.stringify(decoded), context).ok,
+      ).toBe(false);
+    },
+  );
+  it("loads real descriptor defaults but preserves placement coordinates, identity, target and unknown overrides", () => {
+    const defaults = JSON.parse(defaultComponentPropertyCode(context));
+    expect(defaults).toMatchObject({
+      reference: "M1",
+      netlistTarget: "model_a",
+      placement: { at: [200, 160], rotation: 0, mirror: "none" },
+      parameters: { custom: "{x+1}" },
+    });
+    for (const parameter of componentParameters("nmos"))
+      expect(defaults.parameters[parameter.key]).toBe(
+        parameter.defaultValue ?? "",
+      );
+    expect(
+      parseComponentPropertyCode(JSON.stringify(defaults), context).ok,
+    ).toBe(true);
+  });
+  it("only offers pin-compatible drawing variants, including combined input/output swaps", () => {
+    expect(componentSymbolOptions("opamp-differential")).toEqual(
+      expect.arrayContaining([
+        "opamp-differential",
+        "opamp-differential-inputs-swapped",
+        "opamp-differential-crossed",
+        "opamp-differential-crossed-inputs-swapped",
+      ]),
+    );
+    expect(componentSymbolOptions("nmos")).toEqual(["nmos"]);
+  });
+});

--- a/apps/editor/src/features/properties/component-property-details.test.ts
+++ b/apps/editor/src/features/properties/component-property-details.test.ts
@@ -42,6 +42,23 @@ describe("unified component property details", () => {
       value: { parameters: instance.netlist!.parameters },
     });
   });
+
+  it("never color-converts parameter names or reformats tuples inside raw strings", () => {
+    const raw = {
+      ...instance,
+      netlist: {
+        parameters: {
+          foreground: "EV",
+          background: "[1,2]",
+          custom: 'say "[3,4]"',
+        },
+      },
+    };
+    const rawContext = { ...context, instance: raw };
+    expect(
+      JSON.parse(formatComponentPropertyCode(rawContext)).parameters,
+    ).toMatchObject(raw.netlist.parameters);
+  });
   it("plans parameter set/unset, identity and placement as ordinary atomic edits", () => {
     const decoded = JSON.parse(formatComponentPropertyCode(context));
     decoded.reference = "M2";
@@ -107,5 +124,41 @@ describe("unified component property details", () => {
       ]),
     );
     expect(componentSymbolOptions("nmos")).toEqual(["nmos"]);
+  });
+
+  it("keeps Digital Clock primary controls connected to its compatibility pulse values", () => {
+    const clock = {
+      ...instance,
+      symbolId: "pulse-voltage-source",
+      reference: "V1",
+      netlist: {
+        parameters: {
+          period: "10ns",
+          dutyCycle: "50",
+          initial: "0",
+          low: "0",
+          high: "1",
+          width: "5ns",
+          delay: "5ns",
+        },
+      },
+    };
+    const clockContext = {
+      ...context,
+      instance: clock,
+      details: { parameters: componentParameters(clock.symbolId) },
+    };
+    const source = JSON.parse(formatComponentPropertyCode(clockContext));
+    source.parameters.dutyCycle = "25";
+    const parsed = parseComponentPropertyCode(
+      JSON.stringify(source),
+      clockContext,
+    );
+    expect(parsed).toMatchObject({
+      ok: true,
+      value: {
+        parameters: { dutyCycle: "25", width: "2500ps", delay: "7500ps" },
+      },
+    });
   });
 });

--- a/apps/editor/src/features/properties/component-property-details.ts
+++ b/apps/editor/src/features/properties/component-property-details.ts
@@ -5,6 +5,10 @@ import {
 } from "@icm/model";
 import type { Instance } from "@icm/model";
 import type { ComponentParameter } from "../component-insert/component-parameters";
+import {
+  effectiveComponentParameterValue,
+  updateComponentParameterValues,
+} from "../component-insert/component-parameters";
 import { differentialInputSibling } from "../editor-shell/differential-input-swap";
 import { differentialOutputSibling } from "../editor-shell/differential-output-swap";
 import { switchContactStyleSibling } from "../editor-shell/switch-contact-style";
@@ -51,7 +55,10 @@ export function componentPropertyDetailsValue(
             ...Object.fromEntries(
               context.parameters
                 .filter((parameter) => !parameter.compatibilityOnly)
-                .map((parameter) => [parameter.key, ""]),
+                .map((parameter) => [
+                  parameter.key,
+                  effectiveComponentParameterValue(instance, parameter),
+                ]),
             ),
             ...instance.netlist.parameters,
           },
@@ -115,6 +122,21 @@ export function parseComponentPropertyDetails(
         entries.push([name, raw]);
       }
       result.parameters = Object.fromEntries(entries);
+      // The Digital Clock's primary timing controls still own its legacy
+      // pulse-source projection. Reuse that policy rather than leaving the
+      // displayed duty cycle disconnected from the waveform sent to SPICE.
+      if (instance.symbolId === "pulse-voltage-source") {
+        for (const key of ["period", "dutyCycle", "initial"]) {
+          const raw = result.parameters[key];
+          if (raw !== undefined && raw !== baseline.parameters?.[key])
+            result.parameters = updateComponentParameterValues(
+              instance.symbolId,
+              result.parameters,
+              key,
+              raw,
+            );
+        }
+      }
     } else if (key === "signalFlow") {
       const parsed = SignalFlowParametersSchema.safeParse(value);
       if (!parsed.success)

--- a/apps/editor/src/features/properties/component-property-details.ts
+++ b/apps/editor/src/features/properties/component-property-details.ts
@@ -1,0 +1,203 @@
+import {
+  NetlistParameterNameSchema,
+  NetlistParameterValueSchema,
+  SignalFlowParametersSchema,
+} from "@icm/model";
+import type { Instance } from "@icm/model";
+import type { ComponentParameter } from "../component-insert/component-parameters";
+import { differentialInputSibling } from "../editor-shell/differential-input-swap";
+import { differentialOutputSibling } from "../editor-shell/differential-output-swap";
+import { switchContactStyleSibling } from "../editor-shell/switch-contact-style";
+import type { CanvasPropertyField } from "./component-property-fields";
+
+export interface ComponentPropertyDetailsContext {
+  parameters: readonly ComponentParameter[];
+  modelTarget?: { defaultValue: string; suggestions: readonly string[] };
+  signalFlow?: boolean;
+}
+
+export interface ComponentPropertyDetailsValue {
+  reference?: string;
+  parameters?: Record<string, string>;
+  netlistTarget?: string;
+  symbol?: string;
+  signalFlow?: NonNullable<Instance["signalFlowParameters"]>;
+}
+
+/** Only the existing pin-compatible drawing variants are interchangeable. */
+export function componentSymbolOptions(symbolId: string): string[] {
+  const options = new Set([symbolId]);
+  for (const candidate of options) {
+    for (const sibling of [
+      differentialInputSibling(candidate),
+      differentialOutputSibling(candidate),
+      switchContactStyleSibling(candidate),
+    ])
+      if (sibling) options.add(sibling);
+  }
+  return [...options];
+}
+
+export function componentPropertyDetailsValue(
+  instance: Instance,
+  context?: ComponentPropertyDetailsContext,
+): ComponentPropertyDetailsValue {
+  if (!context) return {};
+  return {
+    ...(instance.reference ? { reference: instance.reference } : {}),
+    ...(instance.netlist
+      ? {
+          parameters: {
+            ...Object.fromEntries(
+              context.parameters
+                .filter((parameter) => !parameter.compatibilityOnly)
+                .map((parameter) => [parameter.key, ""]),
+            ),
+            ...instance.netlist.parameters,
+          },
+        }
+      : {}),
+    ...(context.modelTarget
+      ? { netlistTarget: context.modelTarget.defaultValue }
+      : {}),
+    ...(componentSymbolOptions(instance.symbolId).length > 1
+      ? { symbol: instance.symbolId }
+      : {}),
+    ...(context.signalFlow
+      ? { signalFlow: instance.signalFlowParameters ?? {} }
+      : {}),
+  };
+}
+
+export function parseComponentPropertyDetails(
+  decoded: Record<string, unknown>,
+  instance: Instance,
+  context?: ComponentPropertyDetailsContext,
+): ComponentPropertyDetailsValue {
+  const baseline = componentPropertyDetailsValue(instance, context);
+  const result: ComponentPropertyDetailsValue = {};
+  for (const key of [
+    "reference",
+    "parameters",
+    "netlistTarget",
+    "symbol",
+    "signalFlow",
+  ] as const) {
+    if (!(key in baseline)) {
+      if (key in decoded)
+        throw new Error(`${key} is not available for this component`);
+      continue;
+    }
+    const value = decoded[key];
+    if (key === "parameters") {
+      if (typeof value !== "object" || value === null || Array.isArray(value))
+        throw new Error("parameters must be an object of raw string values");
+      if (Object.keys(value).length > 128)
+        throw new Error("parameters may contain at most 128 entries");
+      const names = new Set<string>();
+      const entries: [string, string][] = [];
+      for (const [name, raw] of Object.entries(value)) {
+        if (
+          !NetlistParameterNameSchema.safeParse(name).success ||
+          name !== name.trim()
+        )
+          throw new Error(`Invalid parameter name: ${name}`);
+        if (names.has(name.toLowerCase()))
+          throw new Error(`Duplicate parameter name: ${name}`);
+        names.add(name.toLowerCase());
+        if (
+          typeof raw !== "string" ||
+          (raw !== "" && !NetlistParameterValueSchema.safeParse(raw).success)
+        )
+          throw new Error(
+            `parameters.${name} must be a raw string (empty removes it)`,
+          );
+        entries.push([name, raw]);
+      }
+      result.parameters = Object.fromEntries(entries);
+    } else if (key === "signalFlow") {
+      const parsed = SignalFlowParametersSchema.safeParse(value);
+      if (!parsed.success)
+        throw new Error(`signalFlow: ${parsed.error.issues[0]?.message}`);
+      result.signalFlow = parsed.data;
+    } else {
+      if (
+        typeof value !== "string" ||
+        value.length > 128 ||
+        (key !== "netlistTarget" && !value.trim())
+      )
+        throw new Error(
+          `${key} must be ${key === "netlistTarget" ? "a" : "a nonempty"} string of at most 128 characters`,
+        );
+      if (
+        key === "symbol" &&
+        !componentSymbolOptions(instance.symbolId).includes(value)
+      )
+        throw new Error(
+          "symbol must be one of this component's compatible drawing variants",
+        );
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+export function componentDetailFields(
+  instance: Instance,
+  context?: ComponentPropertyDetailsContext,
+): CanvasPropertyField[] {
+  if (!context) return [];
+  return [
+    {
+      path: "placement",
+      label: "Placement",
+      kind: "text",
+      description:
+        'Set null to return to the Placement Tray without deleting the component; set {at: [x, y], rotation: 0, mirror: "none"} to place it.',
+    },
+    {
+      path: "reference",
+      label: "Reference",
+      kind: "text",
+      description: "Authored netlist reference; must be unique in this Cell.",
+    },
+    {
+      path: "parameters",
+      label: "Parameters",
+      kind: "text",
+      description:
+        "Raw strings, including W/L/NF/M and netlist overrides. Add keys here; empty strings or removed keys clear values. Units are never appended.",
+    },
+    ...context.parameters.map((parameter) => ({
+      path: `parameters.${parameter.key}`,
+      label: parameter.label,
+      kind: parameter.options ? ("choice" as const) : ("text" as const),
+      ...(parameter.options ? { options: parameter.options } : {}),
+      description: `${parameter.help}${parameter.defaultValue ? ` Default: ${parameter.defaultValue}.` : ""} Enter any unit suffix yourself.`,
+    })),
+    {
+      path: "netlistTarget",
+      label: "Netlist target",
+      kind: "text",
+      description: `Model name; "" clears it. ${context.modelTarget?.suggestions.length ? `Suggestions: ${context.modelTarget.suggestions.join(", ")}. ` : ""}Reviewed external models use an X reference.`,
+    },
+    {
+      path: "symbol",
+      label: "Drawing variant",
+      kind: "choice",
+      options: componentSymbolOptions(instance.symbolId).map((value) => ({
+        value,
+        label: value,
+      })),
+      description:
+        "Pin-compatible drawing variants: swap input/output polarity or switch contact circles without losing connections.",
+    },
+    {
+      path: "signalFlow",
+      label: "Signal flow",
+      kind: "text",
+      description:
+        "Presentation only: formula, coefficient, bodyWidth (20–1000), bodyHeight (20–500); dimensions are multiples of 10. {} uses symbol defaults.",
+    },
+  ];
+}

--- a/apps/editor/src/features/properties/component-property-details.ts
+++ b/apps/editor/src/features/properties/component-property-details.ts
@@ -195,7 +195,7 @@ export function componentDetailFields(
       label: parameter.label,
       kind: parameter.options ? ("choice" as const) : ("text" as const),
       ...(parameter.options ? { options: parameter.options } : {}),
-      description: `${parameter.help}${parameter.defaultValue ? ` Default: ${parameter.defaultValue}.` : ""} Enter any unit suffix yourself.`,
+      description: `${parameter.help}${parameter.defaultValue ? ` Default: ${parameter.defaultValue}.` : ""}${parameter.unit ? " Enter any unit suffix yourself." : ""}`,
     })),
     {
       path: "netlistTarget",

--- a/apps/editor/src/features/properties/component-property-fields.ts
+++ b/apps/editor/src/features/properties/component-property-fields.ts
@@ -1,0 +1,107 @@
+/** Canvas-layer authoring metadata shared by validation and inline assistance. */
+export const ROTATION_OPTIONS = [
+  { value: 0, label: "0°" },
+  { value: 90, label: "90°" },
+  { value: 180, label: "180°" },
+  { value: 270, label: "270°" },
+] as const;
+
+export const MIRROR_OPTIONS = [
+  { value: "none", label: "No mirror" },
+  { value: "x", label: "Local X flip" },
+] as const;
+
+export const RGB_CHANNEL_MAX = 255;
+export const HEX_COLOR_PATTERN = /^#[0-9A-Fa-f]{6}$/u;
+
+export interface CanvasPropertyField {
+  path: string;
+  label: string;
+  kind:
+    | "coordinate"
+    | "rotation"
+    | "mirror"
+    | "boolean"
+    | "color"
+    | "text"
+    | "choice";
+  options?: readonly { value: string; label: string }[];
+  description: string;
+}
+
+export const CANVAS_PROPERTY_FIELDS: readonly CanvasPropertyField[] = [
+  {
+    path: "placement.at",
+    label: "Position",
+    kind: "coordinate",
+    description: "[x, y] · canvas coordinates; snapped to the grid on Apply.",
+  },
+  {
+    path: "placement.rotation",
+    label: "Rotation",
+    kind: "rotation",
+    description: `Clockwise · ${ROTATION_OPTIONS.map((option) => option.label).join(" / ")}.`,
+  },
+  {
+    path: "placement.mirror",
+    label: "Mirror",
+    kind: "mirror",
+    description:
+      '"none": unchanged; "x": local X flip before rotation. Buttons flip in canvas directions.',
+  },
+  {
+    path: "display.reference",
+    label: "Reference",
+    kind: "boolean",
+    description: "Show or hide the component name (for example, M1).",
+  },
+  {
+    path: "display.value",
+    label: "Value",
+    kind: "boolean",
+    description: "Show or hide the value / W/L label.",
+  },
+  {
+    path: "appearance.foreground",
+    label: "Foreground",
+    kind: "color",
+    description: `[R, G, B] · each 0–${RGB_CHANNEL_MAX}; #RRGGBB also accepted. Auto follows global ink.`,
+  },
+  {
+    path: "appearance.background",
+    label: "Background",
+    kind: "color",
+    description: `[R, G, B] · each 0–${RGB_CHANNEL_MAX}; #RRGGBB also accepted. Auto adds no independent fill.`,
+  },
+];
+
+export function colorToRgb(value: string): [number, number, number] {
+  return [1, 3, 5].map((offset) =>
+    Number.parseInt(value.slice(offset, offset + 2), 16),
+  ) as [number, number, number];
+}
+
+/** RGB is an editor notation; persisted instance colors stay #RRGGBB. */
+export function parseCanvasColor(
+  value: unknown,
+  path: string,
+): "auto" | `#${string}` {
+  if (value === "auto") return value;
+  if (typeof value === "string" && HEX_COLOR_PATTERN.test(value))
+    return value as `#${string}`;
+  if (
+    Array.isArray(value) &&
+    value.length === 3 &&
+    value.every(
+      (channel) =>
+        typeof channel === "number" &&
+        Number.isInteger(channel) &&
+        channel >= 0 &&
+        channel <= RGB_CHANNEL_MAX,
+    )
+  )
+    return `#${value.map((channel: number) => channel.toString(16).padStart(2, "0")).join("")}`;
+  throw new Error(
+    `${path} must be "auto", #RRGGBB, or [R, G, B] with integer channels 0–${RGB_CHANNEL_MAX}`,
+  );
+}

--- a/apps/editor/src/features/properties/component-property-json-editor.tsx
+++ b/apps/editor/src/features/properties/component-property-json-editor.tsx
@@ -47,6 +47,7 @@ interface Props {
   historyKey: string;
   context: ComponentPropertyCodeContext;
   defaultForeground: string;
+  focusRequest: number;
   onChange(source: string): void;
   onApply(): void;
 }
@@ -142,6 +143,10 @@ export default function ComponentPropertyJsonEditor(props: Props) {
       });
     } else view.dispatch({ effects: refreshAssists.of(null) });
   }, [props.value, props.historyKey, props.context, props.defaultForeground]);
+
+  useLayoutEffect(() => {
+    if (props.focusRequest > 0) viewRef.current?.focus();
+  }, [props.focusRequest]);
 
   return <div className="component-json-editor" ref={parent} />;
 }

--- a/apps/editor/src/features/properties/component-property-json-editor.tsx
+++ b/apps/editor/src/features/properties/component-property-json-editor.tsx
@@ -1,0 +1,351 @@
+import { useLayoutEffect, useRef } from "react";
+import {
+  EditorState,
+  StateEffect,
+  StateField,
+  Transaction,
+  type Range,
+} from "@codemirror/state";
+import {
+  Decoration,
+  EditorView,
+  WidgetType,
+  keymap,
+  drawSelection,
+  type DecorationSet,
+} from "@codemirror/view";
+import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
+import {
+  bracketMatching,
+  defaultHighlightStyle,
+  syntaxHighlighting,
+  syntaxTree,
+  indentUnit,
+} from "@codemirror/language";
+import { json, jsonParseLinter } from "@codemirror/lang-json";
+import { closeBrackets, closeBracketsKeymap } from "@codemirror/autocomplete";
+import { linter } from "@codemirror/lint";
+import {
+  parseComponentPropertyCode,
+  type ComponentPropertyCodeContext,
+} from "./component-property-code";
+import {
+  colorToRgb,
+  parseCanvasColor,
+  MIRROR_OPTIONS,
+  ROTATION_OPTIONS,
+} from "./component-property-fields";
+import {
+  propertyCodeSpans,
+  propertyCodeChanges,
+  reflectedPropertyCode,
+  type PropertyCodeSpan,
+} from "./component-property-code-assists";
+
+interface Props {
+  value: string;
+  historyKey: string;
+  context: ComponentPropertyCodeContext;
+  defaultForeground: string;
+  onChange(source: string): void;
+  onApply(): void;
+}
+const refreshAssists = StateEffect.define<null>();
+
+/** Lazy loaded: selecting a component does not make the canvas shell depend on CodeMirror. */
+export default function ComponentPropertyJsonEditor(props: Props) {
+  const parent = useRef<HTMLDivElement>(null);
+  const viewRef = useRef<EditorView | null>(null);
+  const latest = useRef(props);
+  latest.current = props;
+  const historyKey = useRef(props.historyKey);
+  const createState = useRef<(source: string) => EditorState>(() =>
+    EditorState.create(),
+  );
+
+  useLayoutEffect(() => {
+    if (!parent.current) return;
+    const read = () => latest.current;
+    const assistField = StateField.define<DecorationSet>({
+      create: (state) => decorations(state, read),
+      update: (value, transaction) =>
+        transaction.docChanged ||
+        transaction.effects.some((effect) => effect.is(refreshAssists)) ||
+        syntaxTree(transaction.startState) !== syntaxTree(transaction.state)
+          ? decorations(transaction.state, read)
+          : value,
+      provide: (field) => EditorView.decorations.from(field),
+    });
+    createState.current = (source) =>
+      EditorState.create({
+        doc: source,
+        extensions: [
+          json(),
+          indentUnit.of("  "),
+          history(),
+          drawSelection(),
+          bracketMatching(),
+          closeBrackets(),
+          syntaxHighlighting(defaultHighlightStyle),
+          linter(jsonParseLinter()),
+          assistField,
+          EditorView.lineWrapping,
+          EditorView.contentAttributes.of({
+            "aria-label": "Editable Canvas property code",
+            spellcheck: "false",
+          }),
+          keymap.of([
+            {
+              key: "Mod-Enter",
+              run: () => {
+                read().onApply();
+                return true;
+              },
+            },
+            {
+              key: "Ctrl-Enter",
+              run: () => {
+                read().onApply();
+                return true;
+              },
+            },
+            ...historyKeymap,
+            ...closeBracketsKeymap,
+            ...defaultKeymap,
+          ]),
+          EditorView.updateListener.of((update) => {
+            if (update.docChanged) read().onChange(update.state.doc.toString());
+          }),
+        ],
+      });
+    const view = new EditorView({
+      parent: parent.current,
+      state: createState.current(read().value),
+    });
+    viewRef.current = view;
+    return () => {
+      viewRef.current = null;
+      view.destroy();
+    };
+  }, []);
+
+  useLayoutEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+    if (historyKey.current !== props.historyKey) {
+      historyKey.current = props.historyKey;
+      view.setState(createState.current(props.value));
+    } else if (view.state.doc.toString() !== props.value) {
+      view.dispatch({
+        changes: { from: 0, to: view.state.doc.length, insert: props.value },
+        annotations: Transaction.addToHistory.of(false),
+      });
+    } else view.dispatch({ effects: refreshAssists.of(null) });
+  }, [props.value, props.historyKey, props.context, props.defaultForeground]);
+
+  return <div className="component-json-editor" ref={parent} />;
+}
+
+function decorations(state: EditorState, read: () => Props): DecorationSet {
+  const ranges: Range<Decoration>[] = [];
+  // Give stable, themeable classes to JSON tokens; assistance is never part of the document.
+  const classes: Record<string, string> = {
+    PropertyName: "key",
+    String: "string",
+    Number: "number",
+    True: "boolean",
+    False: "boolean",
+    Null: "boolean",
+    "{": "bracket",
+    "}": "bracket",
+    "[": "bracket",
+    "]": "bracket",
+  };
+  syntaxTree(state).iterate({
+    enter(node) {
+      const token = classes[node.name];
+      if (token && node.to > node.from)
+        ranges.push(
+          Decoration.mark({ class: `cm-json-${token}` }).range(
+            node.from,
+            node.to,
+          ),
+        );
+    },
+  });
+  const source = state.doc.toString();
+  const enabled = parseComponentPropertyCode(source, read().context).ok;
+  for (const span of propertyCodeSpans(source, read().context)) {
+    ranges.push(
+      Decoration.widget({
+        widget: new PropertyAssist(
+          span,
+          enabled,
+          read().defaultForeground,
+          read,
+        ),
+        side: 1,
+      }).range(state.doc.lineAt(span.to).to),
+    );
+  }
+  return Decoration.set(ranges, true);
+}
+
+class PropertyAssist extends WidgetType {
+  constructor(
+    readonly span: PropertyCodeSpan,
+    readonly enabled: boolean,
+    readonly foreground: string,
+    readonly read: () => Props,
+  ) {
+    super();
+  }
+  override eq(other: PropertyAssist) {
+    return (
+      JSON.stringify(this.span.field) === JSON.stringify(other.span.field) &&
+      this.span.from === other.span.from &&
+      this.span.to === other.span.to &&
+      JSON.stringify(this.span.value) === JSON.stringify(other.span.value) &&
+      this.enabled === other.enabled &&
+      this.foreground === other.foreground
+    );
+  }
+  override ignoreEvent() {
+    return true;
+  }
+  toDOM(view: EditorView) {
+    const { field, value } = this.span;
+    const dom = document.createElement("span");
+    dom.className = "cm-property-assist";
+    dom.setAttribute("data-property-assist", field.path);
+    dom.contentEditable = "false";
+    dom.addEventListener("keydown", (event) => {
+      if ((event.ctrlKey || event.metaKey) && event.key === "Enter") {
+        event.preventDefault();
+        this.read().onApply();
+      }
+      event.stopPropagation();
+    });
+    const change = (values: Record<string, unknown>) => {
+      const changes = propertyCodeChanges(
+        view.state.doc.toString(),
+        this.read().context,
+        values,
+      );
+      if (changes.length)
+        view.dispatch({ changes, userEvent: "input.property-control" });
+    };
+    const button = (label: string, text: string, run: () => void) => {
+      const control = document.createElement("button");
+      control.type = "button";
+      control.setAttribute("aria-label", label);
+      control.title = label;
+      control.textContent = text;
+      control.disabled = !this.enabled;
+      control.onclick = run;
+      dom.append(control);
+      return control;
+    };
+    if (field.kind === "boolean" && typeof value === "boolean") {
+      const toggle = button(
+        `Show ${field.label.toLowerCase()}`,
+        value ? "On" : "Off",
+        () => change({ [field.path]: !value }),
+      );
+      toggle.setAttribute("role", "switch");
+      toggle.setAttribute("aria-checked", String(value));
+      toggle.className = "cm-property-toggle";
+    }
+    if (
+      field.kind === "rotation" ||
+      field.kind === "mirror" ||
+      field.kind === "choice"
+    ) {
+      const select = document.createElement("select");
+      select.setAttribute("aria-label", `${field.label} options`);
+      select.title = field.description;
+      select.disabled = !this.enabled;
+      const options =
+        field.kind === "rotation"
+          ? ROTATION_OPTIONS
+          : field.kind === "mirror"
+            ? MIRROR_OPTIONS
+            : (field.options ?? []);
+      for (const option of options) {
+        const element = document.createElement("option");
+        element.value = String(option.value);
+        element.textContent = option.label;
+        select.append(element);
+      }
+      select.value = String(value);
+      select.onchange = () =>
+        change({
+          [field.path]:
+            field.kind === "rotation" ? Number(select.value) : select.value,
+        });
+      dom.append(select);
+      if (field.kind === "mirror")
+        for (const [direction, label] of [
+          ["left-right", "Flip left/right"],
+          ["top-bottom", "Flip top/bottom"],
+        ] as const) {
+          button(label, direction === "left-right" ? "↔" : "↕", () => {
+            const changes = reflectedPropertyCode(
+              view.state.doc.toString(),
+              this.read().context,
+              direction,
+            );
+            if (changes.length)
+              view.dispatch({ changes, userEvent: "input.property-control" });
+          });
+        }
+    }
+    if (field.kind === "color") {
+      let color: string;
+      try {
+        color = parseCanvasColor(value, field.path);
+      } catch {
+        color = "auto";
+      }
+      const inherited = color === "auto";
+      const isForeground = field.path === "appearance.foreground";
+      const effective = inherited
+        ? isForeground
+          ? this.foreground
+          : "#ffffff"
+        : color;
+      const picker = document.createElement("input");
+      picker.type = "color";
+      picker.value = effective;
+      picker.setAttribute("aria-label", `${field.label} color picker`);
+      picker.title = inherited
+        ? isForeground
+          ? `Global RGB: ${JSON.stringify(colorToRgb(effective))}`
+          : "No independent background fill"
+        : `RGB: ${JSON.stringify(colorToRgb(effective))}`;
+      picker.disabled = !this.enabled;
+      picker.onchange = () =>
+        change({ [field.path]: colorToRgb(picker.value) });
+      dom.append(picker);
+      const reset = button(
+        isForeground ? "Use global foreground" : "Use no background fill",
+        isForeground ? "Global" : "No fill",
+        () => change({ [field.path]: "auto" }),
+      );
+      reset.disabled = !this.enabled || inherited;
+      if (inherited) {
+        const resolved = document.createElement("span");
+        resolved.className = "cm-property-inherited";
+        resolved.textContent = isForeground
+          ? `RGB ${JSON.stringify(colorToRgb(effective))}`
+          : "No independent fill";
+        dom.append(resolved);
+      }
+    }
+    const hint = document.createElement("span");
+    hint.className = "cm-property-hint";
+    hint.textContent = field.description;
+    dom.append(hint);
+    return dom;
+  }
+}

--- a/apps/editor/src/styles/editor-properties.css
+++ b/apps/editor/src/styles/editor-properties.css
@@ -487,8 +487,8 @@
 
 .component-property-code-status {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
+  flex-direction: column;
+  align-items: stretch;
   gap: var(--icm-space-2);
   min-width: 0;
 }
@@ -502,7 +502,8 @@
 
 .component-property-code-status > div {
   display: flex;
-  flex: none;
+  flex-wrap: wrap;
+  justify-content: flex-end;
   gap: var(--icm-space-1);
 }
 

--- a/apps/editor/src/styles/editor-properties.css
+++ b/apps/editor/src/styles/editor-properties.css
@@ -374,28 +374,115 @@
   white-space: nowrap;
 }
 
-.component-property-code-editor > textarea {
+.component-property-code-editor textarea,
+.component-json-editor {
   box-sizing: border-box;
   width: 100%;
   min-width: 0;
   min-height: 15.5rem;
-  resize: vertical;
-  padding: 0.65rem 0.75rem;
   border: 1px solid var(--icm-border);
   border-radius: var(--icm-radius-sm);
   color: var(--icm-text);
   background: var(--icm-surface);
   font-family: var(--icm-font-mono, ui-monospace, monospace);
-  font-size: 12px;
+  font-size: 13px;
   line-height: 1.5;
   tab-size: 2;
   white-space: pre;
 }
 
-.component-property-code-editor > textarea:focus {
+.component-json-editor:focus-within {
   border-color: var(--icm-accent);
   outline: 2px solid var(--icm-accent-soft);
   outline-offset: 0;
+}
+
+.component-json-editor .cm-editor {
+  min-height: 15.5rem;
+  border-radius: inherit;
+}
+.component-json-editor .cm-editor.cm-focused {
+  outline: none;
+}
+.component-json-editor .cm-scroller {
+  max-height: 34rem;
+  overflow: auto;
+  font-family: inherit;
+  line-height: 1.6;
+}
+.component-json-editor .cm-content {
+  padding: 0.65rem;
+  caret-color: var(--icm-text);
+}
+.component-json-editor .cm-line {
+  padding: 0;
+}
+.component-json-editor .cm-json-key {
+  color: #0550ae;
+}
+.component-json-editor .cm-json-string {
+  color: #116329;
+}
+.component-json-editor .cm-json-number {
+  color: #953800;
+}
+.component-json-editor .cm-json-boolean {
+  color: #8250df;
+  font-weight: 600;
+}
+.component-json-editor .cm-json-bracket {
+  color: #6e40a6;
+}
+.component-json-editor .cm-property-assist {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.3rem;
+  max-width: 100%;
+  margin: 0.2rem 0 0.35rem 0.4rem;
+  font-family: var(--icm-font-sans, sans-serif);
+  font-size: 12px;
+  line-height: 1.4;
+  vertical-align: middle;
+  white-space: normal;
+}
+.component-json-editor .cm-property-assist button,
+.component-json-editor .cm-property-assist select {
+  width: auto;
+  min-height: 1.6rem;
+  padding: 0.1rem 0.4rem;
+  border: 1px solid var(--icm-border-strong);
+  border-radius: 4px;
+  background: var(--icm-surface);
+  color: var(--icm-text);
+  font: inherit;
+  cursor: pointer;
+}
+.component-json-editor .cm-property-assist :disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+.component-json-editor .cm-property-toggle[aria-checked="true"] {
+  background: var(--icm-accent);
+  border-color: var(--icm-accent);
+  color: white;
+}
+.component-json-editor .cm-property-assist input[type="color"] {
+  width: 1.8rem;
+  height: 1.6rem;
+  padding: 1px;
+  border: 1px solid var(--icm-border-strong);
+  border-radius: 4px;
+  background: var(--icm-surface);
+  cursor: pointer;
+}
+.component-json-editor .cm-property-hint {
+  flex: 1 1 100%;
+  color: var(--icm-text-muted);
+  overflow-wrap: anywhere;
+}
+.component-json-editor .cm-property-inherited {
+  color: var(--icm-text-muted);
 }
 
 .component-property-code-status {

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -63,11 +63,14 @@ is appended only by the Project transaction.
 
 ## Component property code
 
-Selecting a placed component and opening **Properties** presents its canvas
-properties first as strict, editable JSON:
+Selecting a component and opening **Properties** presents its instance
+properties together as strict, editable JSON. For example, a resistor:
 
 ```json
 {
+  "reference": "R1",
+  "parameters": { "value": "10k", "tc": "0.1" },
+  "netlistTarget": "",
   "placement": {
     "at": [360, 240],
     "rotation": 90,
@@ -90,11 +93,22 @@ annotations supported by that Symbol. Fixed colors are displayed as compact
 `[R, G, B]` tuples with integer channels 0–255; six-digit hex input remains
 accepted and persisted instance colors remain hex. `"auto"` inherits global
 ink for foreground and adds no independent background fill; it does not mean
-fixed black or white. Applying valid code plans the existing typed placement, annotation,
-and style edits and submits them as one transaction. Unknown keys and invalid
-values are rejected without changing the Document. Connectivity, pins, Netlist
-identity, and Placement Tray lifecycle are intentionally absent from this
-surface; their dedicated typed commands remain authoritative.
+fixed black or white. Applying valid code plans the existing typed placement,
+annotation, parameter, identity, and style edits as one transaction. Unknown
+root keys and invalid values are rejected without changing the Document.
+`parameters` contains descriptor-owned values and arbitrary model/dialect
+overrides as raw strings; empty values or removed keys unset a parameter.
+`netlistTarget` accepts model names, including reviewed external targets, and
+an empty string clears it. A target switch composes the existing structural
+planner with the rest of the draft into one project transaction. No new
+project format or parallel netlist authority is introduced.
+
+The optional `symbol` enum exposes only the existing pin-compatible input,
+output, or switch-contact variants. `signalFlow` owns formula presentation
+overrides. Setting `placement` to null uses the retained-instance unplacement
+planner; coordinates re-place the retained instance. Electrical connectivity
+and Cell-level interface/layout operations retain their existing typed
+authoring surfaces; removing a component remains an explicit Delete action.
 
 The lazy JSON editor provides syntax highlighting, bracket matching, JSON
 diagnostics and local text undo. Canvas-layer field metadata owns the rotation
@@ -104,13 +118,18 @@ they never apply implicitly. Left/right and top/bottom actions compose the
 current draft orientation in canvas coordinates, updating rotation and the one
 local mirror bit together. Invalid drafts disable assistance, not text editing.
 Hints and widgets are editor decorations, never JSON comments or persisted data.
-Apply is one document transaction; Revert discards the draft, and switching
-components cannot carry an old draft or its local history into a new selection.
+**Discard draft** restores the last applied state without changing the circuit.
+**Defaults** loads known parameter, orientation, color, and formula defaults
+into the draft; it preserves coordinates, reference, model target, display
+flags, and unknown overrides. It still requires Apply. **Copy JSON** copies
+the complete raw draft without decorations. Switching components cannot carry
+an old draft or its local history into a new selection.
 
 The old component placement, display, and appearance button grids are not
-mounted in the composed Properties dock. Electrical parameters, Reference,
-model bindings, Symbol-specific actions, and the exact read-only SPICE card
-remain in their focused sections below the canvas code. The left edge of
+mounted in the composed Properties dock. Parameters, Netlist Overrides,
+Actions, and Netlist Target no longer have duplicate forms below the JSON.
+Specialized electrical terminal and Cell interface/layout controls retain
+their distinct connectivity/definition ownership. The left edge of
 Properties is draggable and keyboard-adjustable in both docked and compact
 overlay layouts; its independent width is retained locally without becoming
 Project data.
@@ -471,8 +490,9 @@ in the Project, so hiding is recoverable and a missing label can be re-created
 from the same toggle. Component value display is the paired `Value` toggle on
 the same control row: MOS devices project `W/L` as a stacked fraction with a
 fraction bar, passives and independent sources project their scalar parameter,
-and every projected value is upright bold text carrying its engineering unit
-(`150n` displays as `150nm`, `10k` as `10kΩ`). The toggle's availability
+and every projected value is upright bold text preserving authored spelling
+(`150n` stays `150n`, `EV` stays `EV`; `150nm` stays `150nm` when explicitly
+entered). No unit suffix is invented. The toggle's availability
 follows the live property draft — typing a value enables it without
 reopening the panel — and checking it commits the typed parameters and shows
 the projected value in one transaction. Showing a value re-projects its text

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -86,12 +86,26 @@ properties first as strict, editable JSON:
 
 `placement.at` is the `[x, y]` grid coordinate, rotation is restricted to
 quarter turns, and mirror is `"none"` or `"x"`. Display keys appear only for
-annotations supported by that Symbol. Colors are `"auto"` or six-digit hex
-values. Applying valid code plans the existing typed placement, annotation,
+annotations supported by that Symbol. Fixed colors are displayed as compact
+`[R, G, B]` tuples with integer channels 0–255; six-digit hex input remains
+accepted and persisted instance colors remain hex. `"auto"` inherits global
+ink for foreground and adds no independent background fill; it does not mean
+fixed black or white. Applying valid code plans the existing typed placement, annotation,
 and style edits and submits them as one transaction. Unknown keys and invalid
 values are rejected without changing the Document. Connectivity, pins, Netlist
 identity, and Placement Tray lifecycle are intentionally absent from this
 surface; their dedicated typed commands remain authoritative.
+
+The lazy JSON editor provides syntax highlighting, bracket matching, JSON
+diagnostics and local text undo. Canvas-layer field metadata owns the rotation
+and mirror options, color channel limits and per-field guidance. Inline switches,
+enum menus, color pickers and global/no-fill resets edit the same draft as typing;
+they never apply implicitly. Left/right and top/bottom actions compose the
+current draft orientation in canvas coordinates, updating rotation and the one
+local mirror bit together. Invalid drafts disable assistance, not text editing.
+Hints and widgets are editor decorations, never JSON comments or persisted data.
+Apply is one document transaction; Revert discards the draft, and switching
+components cannot carry an old draft or its local history into a new selection.
 
 The old component placement, display, and appearance button grids are not
 mounted in the composed Properties dock. Electrical parameters, Reference,

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -41,8 +41,12 @@ palette-first manual authoring; no Project file needs to be opened first.
   only the drawn route.
 - Select a component and press `Q` to open **Properties**. Its editable
   **Canvas properties** JSON keeps position as `"at": [x, y]`, plus quarter-turn
-  rotation, mirror, supported Reference/Value visibility, and automatic or hex
-  foreground/background colors. Edit the code and choose **Apply code** (or
+  rotation, mirror, supported Reference/Value visibility, and foreground/background
+  colors. Use the inline switches, angle/mirror menus, color swatches and field
+  hints, or type JSON directly. Fixed colors display as `[R, G, B]` (0–255);
+  hex input also works. **Global** inherits ink and **No fill** removes the
+  independent background override. Flip arrows work in canvas directions.
+  These controls change the draft: choose **Apply code** (or
   press `Ctrl`/`Cmd`+`Enter`); invalid or unknown properties are reported
   without changing the drawing. Electrical parameters and the read-only SPICE
   card remain below it. Drag the panel's left edge to set a comfortable width.

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -40,7 +40,9 @@ palette-first manual authoring; no Project file needs to be opened first.
   **Remove route geometry** action to keep logical membership while deleting
   only the drawn route.
 - Select a component and press `Q` to open **Properties**. Its editable
-  **Canvas properties** JSON keeps position as `"at": [x, y]`, plus quarter-turn
+  **Component properties** JSON keeps raw parameters (W/L/NF/M and additional
+  netlist overrides), reference and model target together with position as
+  `"at": [x, y]`, plus quarter-turn
   rotation, mirror, supported Reference/Value visibility, and foreground/background
   colors. Use the inline switches, angle/mirror menus, color swatches and field
   hints, or type JSON directly. Fixed colors display as `[R, G, B]` (0–255);
@@ -48,8 +50,14 @@ palette-first manual authoring; no Project file needs to be opened first.
   independent background override. Flip arrows work in canvas directions.
   These controls change the draft: choose **Apply code** (or
   press `Ctrl`/`Cmd`+`Enter`); invalid or unknown properties are reported
-  without changing the drawing. Electrical parameters and the read-only SPICE
-  card remain below it. Drag the panel's left edge to set a comfortable width.
+  without changing the drawing. Parameter values are strings: type unit suffixes
+  yourself; `EV` remains `EV`, and `2u` is not changed to `2um`.
+  **Discard draft** cancels unapplied edits. **Defaults** loads known defaults
+  into the draft without moving, renaming or rebinding the component; Apply
+  commits them. **Copy JSON** excludes hints and controls. Compatible drawing
+  variants and formula overrides are in the same editor, with no duplicate
+  Parameters/Actions/Netlist Target forms. Drag the panel's left edge to set a
+  comfortable width.
 - Right-click an endpoint for the distinct **Disconnect endpoint** and
   **Delete connection** actions.
 - `Delete` on a connected component now removes the component while preserving

--- a/packages/derived/src/instance-value.test.ts
+++ b/packages/derived/src/instance-value.test.ts
@@ -36,7 +36,7 @@ const bold = (value: string) => ({
 });
 
 describe("displayableInstanceValue", () => {
-  it("projects MOS dimensions as a stacked fraction with units", () => {
+  it("projects authored MOS dimensions without adding unit suffixes", () => {
     const result = displayableInstanceValue(
       instance("nmos", { w: "10u", l: "150n" }),
     );
@@ -46,8 +46,8 @@ describe("displayableInstanceValue", () => {
         runs: [
           {
             kind: "fraction",
-            numerator: { runs: [bold("10um")] },
-            denominator: { runs: [bold("150nm")] },
+            numerator: { runs: [bold("10u")] },
+            denominator: { runs: [bold("150n")] },
           },
         ],
       },
@@ -64,8 +64,8 @@ describe("displayableInstanceValue", () => {
         runs: [
           {
             kind: "fraction",
-            numerator: { runs: [bold("2um")] },
-            denominator: { runs: [bold("600nm")] },
+            numerator: { runs: [bold("2u")] },
+            denominator: { runs: [bold("600n")] },
           },
           {
             kind: "span",
@@ -86,39 +86,39 @@ describe("displayableInstanceValue", () => {
     );
   });
 
-  it("shows passive values bold with their engineering unit", () => {
+  it("shows passive values exactly as authored, in bold", () => {
     expect(
       displayableInstanceValue(instance("resistor", { value: "10k" })),
     ).toEqual({
       kind: "displayable",
-      content: { runs: [bold("10kΩ")] },
+      content: { runs: [bold("10k")] },
     });
     expect(
       displayableInstanceValue(instance("capacitor", { value: "2p" })),
     ).toEqual({
       kind: "displayable",
-      content: { runs: [bold("2pF")] },
+      content: { runs: [bold("2p")] },
     });
     expect(
       displayableInstanceValue(instance("inductor", { value: "3n" })),
     ).toEqual({
       kind: "displayable",
-      content: { runs: [bold("3nH")] },
+      content: { runs: [bold("3n")] },
     });
   });
 
-  it("shows independent source dc values with their unit", () => {
+  it("does not invent units for independent source values", () => {
     expect(
       displayableInstanceValue(instance("voltage-source", { dc: "1.8" })),
     ).toEqual({
       kind: "displayable",
-      content: { runs: [bold("1.8V")] },
+      content: { runs: [bold("1.8")] },
     });
     expect(
       displayableInstanceValue(instance("current-source", { dc: "100u" })),
     ).toEqual({
       kind: "displayable",
-      content: { runs: [bold("100uA")] },
+      content: { runs: [bold("100u")] },
     });
   });
 
@@ -144,6 +144,27 @@ describe("displayableInstanceValue", () => {
       },
     });
   });
+
+  it.each(["EV", "W", "3", "3u", "3um", "{W_VAR}"])(
+    "does not modify a user-authored dimension %s",
+    (raw) => {
+      const result = displayableInstanceValue(
+        instance("pmos", { w: raw, l: "L" }),
+      );
+      expect(result).toMatchObject({
+        kind: "displayable",
+        content: {
+          runs: [
+            {
+              kind: "fraction",
+              numerator: { runs: [bold(raw)] },
+              denominator: { runs: [bold("L")] },
+            },
+          ],
+        },
+      });
+    },
+  );
 
   it("does not display a value when netlist parameters are absent", () => {
     expect(displayableInstanceValue(instance("inductor"))).toEqual({

--- a/packages/derived/src/instance-value.ts
+++ b/packages/derived/src/instance-value.ts
@@ -29,19 +29,6 @@ function effectiveParameterValue(
   return "";
 }
 
-function displayUnit(parameter: DeviceParameterDefinition): string {
-  // `Ohm` remains the form's familiar text hint, while the existing Razavi
-  // value annotation uses its conventional glyph. This is a general display
-  // spelling rule, not a second device registry.
-  return parameter.unitHint === "Ohm" ? "Ω" : (parameter.unitHint ?? "");
-}
-
-function withUnit(raw: string, unit: string): string {
-  // Values are typed as bare SPICE numbers; append the physical unit unless
-  // the author already ended with it.
-  return raw.endsWith(unit) ? raw : `${raw}${unit}`;
-}
-
 function boldText(value: string): RichTextDocument["runs"][number] {
   return {
     kind: "span",
@@ -58,8 +45,8 @@ function boldDocument(value: string): RichTextDocument {
  * One pure authority for the optional Value annotation beside an instance.
  * Electrical truth stays in the typed netlist parameters; this only projects
  * it to display text and never
- * writes back. Display is Razavi textbook style: upright bold text with the
- * engineering unit, and a stacked fraction bar for MOS W/L.
+ * writes back. Preserve authored spelling, including any explicit unit; never
+ * append a guessed suffix. Keep upright bold text and a stacked MOS W/L fraction.
  */
 /**
  * Whether this Symbol's device can ever annotate a value.
@@ -134,10 +121,8 @@ export function displayableInstanceValue(
         runs: [
           {
             kind: "fraction",
-            numerator: boldDocument(withUnit(widthValue, displayUnit(width))),
-            denominator: boldDocument(
-              withUnit(lengthValue, displayUnit(length)),
-            ),
+            numerator: boldDocument(widthValue),
+            denominator: boldDocument(lengthValue),
           },
           ...(showsMultiplier
             ? [
@@ -172,6 +157,6 @@ export function displayableInstanceValue(
   }
   return {
     kind: "displayable",
-    content: boldDocument(withUnit(valueText, displayUnit(value))),
+    content: boldDocument(valueText),
   };
 }


### PR DESCRIPTION
## Outcome

Replace the component's duplicate Parameters, Netlist Overrides, Actions and Netlist Target forms with one strict, guided JSON draft. Publish to **Preview only** after the normal required checks and merge queue; do not tag or dispatch Production.

- Lazy CodeMirror syntax highlighting, bracket matching, JSON diagnostics and local text history, with per-field help and inline boolean, orientation, drawing-variant and color controls.
- Fixed RGB triples with color picker; retain explicit global foreground / no independent background semantics, accept existing hex input, and keep persisted project colors unchanged.
- Raw string parameters, including W/L/NF/M and arbitrary netlist overrides, reference, model target and formula overrides share Apply. Model changes use the existing project structural planner in the same undo boundary. Compatible symbol swaps and retained-instance unplacement use existing typed edits.
- `Discard draft` means cancel unapplied changes. `Defaults` loads known defaults into the draft without moving, renaming or rebinding a component; Apply is still required. Copy JSON excludes decoration widgets and hints.
- Value labels preserve authored spelling: `EV` stays `EV`, `2u` stays `2u`, and an explicitly entered `2um` stays `2um`. Keep MOS fraction geometry; do not modify electrical values or invent units.
- Correct React queued baseline synchronization after model-target-induced reference changes; keep Digital Clock compatibility projection; never color-convert a similarly named raw parameter or reformat a tuple inside a raw string.

This intentionally migrates browser assertions from removed form controls/live field commits to the new explicit-draft interaction contract. Electrical terminal connectivity and Cell-level interface/layout editing keep their existing typed ownership; there is no project schema change, dependency addition, or second component registry.

## Validation

- Frozen-lockfile install; gate plan and preflight (shared value projection selects full delivery).
- Latest full unit run: 471 passed files, 3,176 passed tests (one file and four tests skipped by existing suite policy), including new raw-string and clock regression tests.
- Static contracts passed; build, performance, visual/export goldens, production-preview smoke, release packaging and packaged MCP smoke passed.
- 30 targeted browser journeys: 23 passed, seven failures fixed and all seven rerun green (including source-waveform preservation, stale draft after model changes, and explicit Apply adaptation).
- Atomic model/parameter/color Apply and unplacement/re-placement browser regressions: two passed. Updated Symbol body property/variant assertions: all 15 scenarios passed (the last commit message incorrectly says 17; the actual suite has 15).
- Full local gate was run once: static, unit, build and release checks passed. Its browser phase lost a reused local server during execution. Re-running all 47 browser failures on a dedicated server recovered 39; the remaining eight are existing simulation-editor tests using Linux Control shortcuts on macOS. No gate or simulation tests were weakened. Required remote Linux CI must be green before merge.
- Exact merge SHA must subsequently pass Deploy Preview, including numerical, Agent/MCP and source-GUI acceptance, plus hosted property-editor checks. No deployment is claimed by this local evidence.

## Delivery receipt

- Exact branch head `6efa646c97ed8c762f1c3afc7e5a9ff677ff5417`: all seven required checks passed in [CI 34645566629](https://github.com/cascode-ai/analog-canvas/actions/runs/34645566629), including all 392 browser scenarios (98 per shard).
- Normal merge queue passed all seven checks in [CI 34646298917](https://github.com/cascode-ai/analog-canvas/actions/runs/34646298917). Merged as `c18a397a874add03239e11b4161a5d1eff67564c`; its tree matches the verified branch exactly.
- That exact merge SHA passed [Deploy Preview 34646833988](https://github.com/cascode-ai/analog-canvas/actions/runs/34646833988), including numerical, public Agent/MCP, source workspace GUI and cross-Project acceptance.
- The deployed Preview passed all eight targeted property-editor browser journeys. Separate hosted screenshot verification reported no page errors, raw `EV` with no appended unit, and zero duplicate parameter forms. `/api/channel` returned `preview`.
- Production was not dispatched or tagged; its latest deployment remains `34624514937` at `b2b223086b10061084f29a808632a5e159458a7e`.

Production remains unchanged.
