### PR TITLE
feat(editor): streamline Properties and Bulk connection layout

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -2426,9 +2426,15 @@ test("initializes NMOS bulk from the first explicitly placed Ground", async ({
 
   await page.getByTestId("hit-M1").click();
   await openSelectionShelf(page);
-  await expect(page.getByLabel("MOS bulk connection")).toContainText(
-    "M1.B → 0 · cell-default",
+  const bulk = page.getByLabel("MOS bulk connection");
+  await expect(bulk.locator(".mos-bulk-status")).toHaveText("0");
+  await expect(bulk.locator(".mos-bulk-status")).toHaveAttribute(
+    "title",
+    "M1.B → 0 · Cell default",
   );
+  await expect(
+    bulk.getByRole("button", { name: "Draw bulk connection" }),
+  ).toHaveText("Draw");
 
   const saved = JSON.parse(
     (await downloadBytes(page, "File", "Export Project File…")).toString(

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -2297,22 +2297,31 @@ test("keeps a selected MOS in its fixed Razavi three-terminal view", async ({
   ).toHaveCount(0);
 });
 
-test("leads the Bulk section with its draw action", async ({ page }) => {
+test("keeps Bulk status and its prominent draw action on one compact row", async ({
+  page,
+}) => {
   await page.goto("/editor");
   await placeComponent(page, "nmos", { x: 360, y: 220 });
   await page.getByTestId("hit-M1").click();
   await openSelectionShelf(page);
 
   const bulk = page.getByLabel("MOS bulk connection");
-  await expect(bulk.getByTestId("draw-bulk-connection")).toBeVisible();
-  // The action is the reason the section is open, so it must precede the
-  // default-Net selects rather than trail them.
-  const order = await bulk.evaluate((section) =>
-    [...section.querySelectorAll("button, select")].map(
-      (element) => element.getAttribute("data-testid") ?? element.tagName,
-    ),
-  );
-  expect(order[0]).toBe("draw-bulk-connection");
+  const draw = bulk.getByRole("button", { name: "Draw bulk connection" });
+  await expect(draw).toBeVisible();
+  await expect(draw).toHaveText("Connect");
+  await expect(bulk.locator(".mos-bulk-status")).toHaveText("Unconnected");
+  await expect(bulk).not.toContainText("unresolved");
+  const layout = await bulk.evaluate((section) => {
+    const heading = section.querySelector("h2")!.getBoundingClientRect();
+    const action = section.querySelector("button")!.getBoundingClientRect();
+    return {
+      height: section.getBoundingClientRect().height,
+      headingY: heading.y + heading.height / 2,
+      actionY: action.y + action.height / 2,
+    };
+  });
+  expect(layout.height).toBeLessThan(58);
+  expect(Math.abs(layout.headingY - layout.actionY)).toBeLessThan(2);
 
   // Bulk is the first section in the panel, not buried under the tray.
   const firstSection = await page
@@ -2320,6 +2329,63 @@ test("leads the Bulk section with its draw action", async ({ page }) => {
     .first()
     .getAttribute("aria-label");
   expect(firstSection).toBe("MOS bulk connection");
+  await draw.click();
+  await expect(page.getByTestId("status")).toContainText(
+    "Drawing M1.B bulk connection",
+  );
+  await expect(page.getByTestId("terminal-M1-B")).toBeVisible();
+});
+
+test("Q opens a text-first Properties editor with one-click exact draft copy", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await placeComponent(page, "pmos", { x: 360, y: 220 });
+  const shelf = page.getByTestId("selection-shelf");
+  if ((await shelf.getAttribute("aria-expanded")) === "true")
+    await shelf.click();
+  await page.keyboard.press("q");
+  const code = page.getByLabel("Editable Canvas property code");
+  await expect(code).toBeVisible();
+  await page.keyboard.press("q");
+  await expect(code).not.toBeVisible();
+  await page.keyboard.press("q");
+  await expect(code).toBeVisible();
+  const draft = JSON.parse(await readComponentPropertyCode(page));
+  draft.parameters.w = "EV";
+  const raw = JSON.stringify(draft, null, 2) + "\n\n";
+  await code.fill(raw);
+  await code.press("ControlOrMeta+End");
+  const copy = page.getByRole("button", { name: "Copy JSON", exact: true });
+  await expect(copy).toHaveCount(1);
+  await expect(copy.locator("svg")).toBeVisible();
+  await copy.click();
+  expect(await page.evaluate(() => navigator.clipboard.readText())).toBe(raw);
+  await expect(
+    page.getByText("JSON copied · hints and controls excluded", {
+      exact: true,
+    }),
+  ).toBeVisible();
+  const positions = await page
+    .getByTestId("component-property-code-editor")
+    .evaluate((section) => {
+      const copy = section
+        .querySelector(".component-property-copy")!
+        .getBoundingClientRect();
+      const editor = section
+        .querySelector(".cm-scroller")!
+        .getBoundingClientRect();
+      return {
+        copyBottom: copy.bottom,
+        editorTop: editor.top,
+        editorHeight: editor.height,
+        panelHeight: section.getBoundingClientRect().height,
+      };
+    });
+  expect(positions.copyBottom).toBeLessThanOrEqual(positions.editorTop);
+  expect(positions.editorHeight).toBeGreaterThan(positions.panelHeight * 0.65);
+  await page.getByRole("button", { name: "Discard draft" }).click();
+  await expectComponentCodeField(page, "parameters.w", "1u");
 });
 
 test("keeps DMOS bulk hidden until drawing an explicit bulk route", async ({

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -5611,15 +5611,18 @@ export function App({
               mosBulk={{
                 connection:
                   selectedInstance && selectedBulkResolution
-                    ? `${selectedInstance.id}.B → ${
-                        selectedBulkResolution.net
+                    ? {
+                        terminal: `${selectedInstance.reference ?? selectedInstance.id}.B`,
+                        netName: selectedBulkResolution.net
                           ? (logicalNets.byBaseNetId.get(
                               selectedBulkResolution.net.id,
                             )?.name ?? selectedBulkResolution.net.id)
-                          : "unresolved"
-                      } · ${selectedBulkResolution.status}`
+                          : null,
+                        status: selectedBulkResolution.status,
+                      }
                     : null,
                 explicitRouteVisible: Boolean(selectedHiddenBulkNet),
+                canDraw: Boolean(selectedInstance?.placement),
                 onDraw: drawSelectedMosBulk,
               }}
               routingGuidance={{

--- a/apps/editor/src/features/properties/component-property-code-editor.test.tsx
+++ b/apps/editor/src/features/properties/component-property-code-editor.test.tsx
@@ -26,6 +26,11 @@ describe("ComponentPropertyCodeEditor", () => {
     expect(markup).toContain('aria-label="Loading Canvas property code"');
     expect(markup).toContain("&quot;at&quot;");
     expect(markup).toContain("Apply code");
+    expect(markup).toContain('aria-label="Copy JSON"');
+    expect(markup).toContain('title="Copy JSON"');
+    expect(markup.indexOf('aria-label="Copy JSON"')).toBeLessThan(
+      markup.indexOf('aria-label="Loading Canvas property code"'),
+    );
     expect(markup).not.toContain('inputMode="decimal"');
     expect(markup).not.toContain("mirror-horizontal");
   });

--- a/apps/editor/src/features/properties/component-property-code-editor.tsx
+++ b/apps/editor/src/features/properties/component-property-code-editor.tsx
@@ -71,6 +71,15 @@ export function ComponentPropertyCodeEditor({
   );
   const changed = draft !== baseline;
 
+  const copy = async (): Promise<void> => {
+    try {
+      await navigator.clipboard.writeText(draft);
+      setApplyMessage("JSON copied · hints and controls excluded");
+    } catch {
+      setApplyMessage("Clipboard unavailable; select the code and copy it");
+    }
+  };
+
   const apply = (): void => {
     if (!parsed.ok) {
       setApplyMessage(parsed.message);
@@ -94,11 +103,25 @@ export function ComponentPropertyCodeEditor({
       data-testid="component-property-code-editor"
     >
       <header>
-        <div>
-          <strong>Component properties</strong>
-          <span>{instance.reference ?? instance.id}</span>
-        </div>
-        <code>{instance.symbolId}</code>
+        <strong>Component properties</strong>
+        <button
+          type="button"
+          className="component-property-copy"
+          aria-label="Copy JSON"
+          title="Copy JSON"
+          onClick={() => void copy()}
+        >
+          <svg
+            viewBox="0 0 20 20"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.6"
+            aria-hidden="true"
+          >
+            <rect x="7" y="7" width="10" height="10" rx="1.5" />
+            <path d="M13 7V4.5A1.5 1.5 0 0 0 11.5 3h-7A1.5 1.5 0 0 0 3 4.5v7A1.5 1.5 0 0 0 4.5 13H7" />
+          </svg>
+        </button>
       </header>
       <Suspense
         fallback={
@@ -133,21 +156,6 @@ export function ComponentPropertyCodeEditor({
             : parsed.message}
         </span>
         <div>
-          <button
-            type="button"
-            onClick={() => {
-              void navigator.clipboard.writeText(draft).then(
-                () =>
-                  setApplyMessage("JSON copied · hints and controls excluded"),
-                () =>
-                  setApplyMessage(
-                    "Clipboard unavailable; select the code and copy it",
-                  ),
-              );
-            }}
-          >
-            Copy JSON
-          </button>
           <button
             type="button"
             title="Reset parameter and appearance defaults in the draft; keep position, identity, target, display flags, and unknown overrides. Apply to commit."

--- a/apps/editor/src/features/selection/selection-context-actions.test.tsx
+++ b/apps/editor/src/features/selection/selection-context-actions.test.tsx
@@ -4,11 +4,60 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   EndpointActionsSection,
+  MosBulkConnectionSection,
   RouteActionsSection,
   RoutingGuidanceSection,
 } from "./selection-context-actions";
 
 describe("selection context actions", () => {
+  it.each([
+    ["unresolved", null, "Unconnected", "Choose a net"],
+    ["no-connect", null, "No Connect", "Intentionally left unconnected"],
+    ["cell-default", "VDD", "VDD", "Cell default"],
+    ["supply-default", "0", "0", "Supply default"],
+    ["instance-override", "VB", "VB", "Instance override"],
+    ["explicit", "VSS", "VSS", "Explicit connection"],
+  ] as const)(
+    "explains %s bulk state without repeating unresolved text",
+    (status, netName, label, origin) => {
+      const markup = renderToStaticMarkup(
+        <MosBulkConnectionSection
+          connection={{ terminal: "M1.B", netName, status }}
+          explicitRouteVisible={status === "explicit"}
+          canDraw
+          onDraw={vi.fn()}
+        />,
+      );
+      expect(markup).toContain(`>${label}</span>`);
+      expect(markup).toContain(origin);
+      expect(markup).toContain('aria-label="Draw bulk connection"');
+      expect(markup).not.toContain("→ unresolved");
+      if (status === "explicit")
+        expect(markup).toContain("Dashed bulk route shown");
+    },
+  );
+
+  it("keeps unplaced bulk routing disabled and hides the bar for non-MOS selections", () => {
+    const props = {
+      explicitRouteVisible: false,
+      canDraw: false,
+      onDraw: vi.fn(),
+    };
+    expect(
+      renderToStaticMarkup(
+        <MosBulkConnectionSection connection={null} {...props} />,
+      ),
+    ).toBe("");
+    const markup = renderToStaticMarkup(
+      <MosBulkConnectionSection
+        connection={{ terminal: "M1.B", netName: null, status: "unresolved" }}
+        {...props}
+      />,
+    );
+    expect(markup).toContain('disabled=""');
+    expect(markup).toContain("Place the component on the canvas");
+  });
+
   it("renders route label and highlight actions", () => {
     const markup = renderToStaticMarkup(
       <RouteActionsSection

--- a/apps/editor/src/features/selection/selection-context-actions.tsx
+++ b/apps/editor/src/features/selection/selection-context-actions.tsx
@@ -1,34 +1,71 @@
 import type { Ref } from "react";
+import type { MosBulkResolution } from "@icm/derived";
 
 import { ColorOverrideControl } from "../properties/color-override-control";
+import { ToolIcon } from "../editor-shell/tool-icon";
 
 import { DisplayToggle } from "../component-insert/display-toggle";
 
 export function MosBulkConnectionSection({
   connection,
   explicitRouteVisible,
+  canDraw,
   onDraw,
 }: {
-  connection: string | null;
+  connection: {
+    terminal: string;
+    netName: string | null;
+    status: MosBulkResolution["status"];
+  } | null;
   explicitRouteVisible: boolean;
+  canDraw: boolean;
   onDraw: () => void;
 }) {
   if (connection === null) return null;
+  const { terminal, netName, status } = connection;
+  const label =
+    netName ?? (status === "no-connect" ? "No Connect" : "Unconnected");
+  const origin = {
+    explicit: "Explicit connection",
+    "cell-default": "Cell default",
+    "instance-override": "Instance override",
+    "supply-default": "Supply default",
+    "no-connect": "Intentionally left unconnected",
+    unresolved: "Choose a net for the bulk terminal",
+  }[status];
+  const description = `${terminal} → ${label} · ${origin}${
+    explicitRouteVisible ? " · Dashed bulk route shown" : ""
+  }`;
   return (
-    <section className="context-actions" aria-label="MOS bulk connection">
+    <section
+      className="mos-bulk-bar"
+      aria-label="MOS bulk connection"
+      data-state={status}
+    >
       <h2>Bulk</h2>
+      <span
+        className="mos-bulk-status"
+        title={description}
+        aria-label={description}
+      >
+        {label}
+      </span>
       <button
         type="button"
         className="bulk-draw-action"
         data-testid="draw-bulk-connection"
+        aria-label="Draw bulk connection"
+        disabled={!canDraw}
+        title={
+          canDraw
+            ? `Draw a connection from ${terminal} on the canvas`
+            : "Place the component on the canvas before drawing its bulk connection"
+        }
         onClick={onDraw}
       >
-        Draw bulk connection
+        <ToolIcon name="wire" />
+        {status === "unresolved" ? "Connect" : "Draw"}
       </button>
-      <p>{connection}</p>
-      {explicitRouteVisible ? (
-        <p>Explicit bulk is shown with a Razavi dashed route.</p>
-      ) : null}
     </section>
   );
 }

--- a/apps/editor/src/styles/editor-canvas.css
+++ b/apps/editor/src/styles/editor-canvas.css
@@ -1090,19 +1090,6 @@
   box-shadow: none;
 }
 
-/* Drawing the bulk connection is the reason this section is open, so it
-   leads the section as an accented action instead of trailing its defaults. */
-.context-actions button.bulk-draw-action {
-  margin-top: 0.5rem;
-  border-color: var(--icm-accent);
-  color: var(--icm-accent);
-  font-weight: 600;
-}
-
-.context-actions button.bulk-draw-action:hover {
-  background: color-mix(in srgb, var(--icm-accent) 12%, transparent);
-}
-
 .placement-tray {
   display: block;
   padding-top: 0;

--- a/apps/editor/src/styles/editor-properties.css
+++ b/apps/editor/src/styles/editor-properties.css
@@ -341,23 +341,13 @@
   display: grid;
   gap: 0.5rem;
   min-width: 0;
-  padding: 0.65rem;
-  border: 1px solid var(--icm-border-strong);
-  border-radius: var(--icm-radius-md);
-  background: var(--icm-surface-muted);
+  padding: 0;
 }
 
 .component-property-code-editor > header {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   justify-content: space-between;
-  gap: var(--icm-space-2);
-}
-
-.component-property-code-editor > header > div {
-  display: flex;
-  align-items: baseline;
-  min-width: 0;
   gap: var(--icm-space-2);
 }
 
@@ -365,13 +355,85 @@
   font-size: var(--icm-font-sm);
 }
 
-.component-property-code-editor > header span,
-.component-property-code-editor > header code {
+.component-property-copy {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  min-height: 2rem;
+  padding: 0.35rem;
+  border-color: transparent;
+  background: transparent;
+  color: var(--icm-text-muted);
+  box-shadow: none;
+}
+
+.component-property-copy:hover {
+  border-color: var(--icm-border);
+  background: var(--icm-surface-muted);
+  color: var(--icm-text);
+}
+
+.component-property-copy svg {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.mos-bulk-bar {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.6rem;
+  min-width: 0;
+  margin-bottom: 0.7rem;
+  padding: 0.4rem 0.5rem 0.4rem 0.65rem;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  background: var(--icm-surface-muted);
+}
+
+.selection-panel .mos-bulk-bar h2 {
+  margin: 0;
+  font-size: var(--icm-font-sm);
+}
+
+.mos-bulk-status {
+  min-width: 0;
   overflow: hidden;
   color: var(--icm-text-muted);
-  font-size: var(--icm-font-xs);
+  font-size: var(--icm-font-sm);
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.mos-bulk-bar[data-state="unresolved"] .mos-bulk-status {
+  color: #946200;
+}
+
+.mos-bulk-bar .bulk-draw-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+  min-height: 2rem;
+  padding: 0.25rem 0.6rem;
+  border-color: var(--icm-accent);
+  background: var(--icm-accent);
+  color: white;
+  font-size: var(--icm-font-sm);
+  font-weight: 600;
+  white-space: nowrap;
+  box-shadow: none;
+}
+
+.mos-bulk-bar .bulk-draw-action:hover {
+  background: color-mix(in srgb, var(--icm-accent) 85%, black);
+}
+
+.mos-bulk-bar .bulk-draw-action .tool-icon {
+  width: 1rem;
+  height: 1rem;
 }
 
 .component-property-code-editor textarea,
@@ -405,7 +467,7 @@
   outline: none;
 }
 .component-json-editor .cm-scroller {
-  max-height: 34rem;
+  height: clamp(18rem, calc(100dvh - 22rem), 48rem);
   overflow: auto;
   font-family: inherit;
   line-height: 1.6;

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -122,7 +122,10 @@ Hints and widgets are editor decorations, never JSON comments or persisted data.
 **Defaults** loads known parameter, orientation, color, and formula defaults
 into the draft; it preserves coordinates, reference, model target, display
 flags, and unknown overrides. It still requires Apply. **Copy JSON** copies
-the complete raw draft without decorations. Switching components cannot carry
+the complete raw draft without decorations from the copy icon at the editor's
+top right, including unapplied whitespace and invalid drafts. The text area
+is the dominant, viewport-sized surface; instance identity stays in the dock
+header rather than being repeated around the code. Switching components cannot carry
 an old draft or its local history into a new selection.
 
 The old component placement, display, and appearance button grids are not
@@ -151,6 +154,11 @@ membership first, then an explicitly configured cell default; otherwise bulk
 remains unresolved. Drawing the visible `bulk-dashed` connection clears that
 default binding and connects B to the selected Net in the same transaction.
 Imported MOS instances do not receive a guessed fourth node.
+Properties shows Bulk as one compact row: its current Net or an explicit
+Unconnected/No Connect state sits beside the draw action. Hovering the status
+reveals the terminal and binding source; a drawn route's dashed presentation
+is described there too. Unresolved bulk is not repeated as a second message.
+Drawing is disabled for retained-unplaced instances until they are placed.
 
 ## Formula-capable behavioral blocks
 

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -54,10 +54,16 @@ palette-first manual authoring; no Project file needs to be opened first.
   yourself; `EV` remains `EV`, and `2u` is not changed to `2um`.
   **Discard draft** cancels unapplied edits. **Defaults** loads known defaults
   into the draft without moving, renaming or rebinding the component; Apply
-  commits them. **Copy JSON** excludes hints and controls. Compatible drawing
+  commits them. The small **Copy JSON** icon at the text area's top right copies
+  the whole draft, excluding hints and controls. Compatible drawing
   variants and formula overrides are in the same editor, with no duplicate
   Parameters/Actions/Netlist Target forms. Drag the panel's left edge to set a
   comfortable width.
+- For a MOS device, the compact **Bulk** row shows its current Net or
+  **Unconnected** beside **Connect**. Click the button to draw from the bulk
+  terminal on the canvas. Hover the status for the terminal name and connection
+  source. A configured default connection shows its Net rather than a warning;
+  **Draw** lets you make an explicit route. Place an unplaced device first.
 - Right-click an endpoint for the distinct **Disconnect endpoint** and
   **Delete connection** actions.
 - `Delete` on a connected component now removes the component while preserving


### PR DESCRIPTION
## Outcome

Make the Properties dock a text-first editing surface, with one accessible Copy JSON icon at the top right and a compact MOS Bulk status/action row. Preview only; do not tag or dispatch Production.

- Remove the nested card frame and repeated instance identity. Give the JSON surface viewport-sized height, keeping existing syntax assistance, Q toggling, explicit Apply and local draft history.
- Copy the exact full draft, including unapplied whitespace; do not include hints or widgets. Report clipboard failure without throwing.
- Keep Bulk title, concise state/Net and a filled-blue Connect/Draw action on one row. Show terminal, binding source and explicit dashed-route detail in the status tooltip instead of multiple paragraphs. Preserve No Connect as a distinct state and disable routing for retained-unplaced instances.
- Reuse existing derived electrical state and wire-start behavior. No electrical changes, persisted schema changes, dependencies, or gate-policy changes.

## Validation

- Frozen-lockfile install; actual gate plan selects affected unit/editor/commands/selection checks, not full fallback. Preflight passed.
- 11 focused unit tests passed; 5 focused browser scenarios passed (Q/exact-copy, compact Bulk/action, DMOS route, guided JSON, Defaults/Discard).
- Local visual inspection at 540 px and 300 px sidebar widths: Bulk remains a single 38.4 px row, button stays visible/clickable, no horizontal overflow, no page errors.
- All affected local gates passed: 3,183 unit tests; 148 editor, 14 command and 13 selection browser scenarios (175 browser scenarios total). One file and four unit cases are skipped by existing suite policy.

## Delivery receipt

- Exact head `963fee1a68cc4f0002d712101da729f871a5290b` passed all seven required checks in [CI 34648459882](https://github.com/cascode-ai/analog-canvas/actions/runs/34648459882).
- Normal merge queue passed all seven checks in [CI 34649064951](https://github.com/cascode-ai/analog-canvas/actions/runs/34649064951), merging as `933676192ec88e58a31d924ebbbd8b1b0bf4c367`. Its source tree matches the verified branch.
- That exact merge SHA passed [Deploy Preview 34649696890](https://github.com/cascode-ai/analog-canvas/actions/runs/34649696890), including numerical, public Agent/MCP, source GUI and cross-Project acceptance.
- Eight targeted browser scenarios passed against the deployed Preview. Hosted visual checks at 540 px and 300 px panel widths reported no page errors or horizontal overflow; the Bulk row is 38.4 px high with a visible/clickable action. `/api/channel` returned `preview`.
- Production was not dispatched or tagged; its deployment record remains `34624514937` at `b2b223086b10061084f29a808632a5e159458a7e`.

Test-Impact: tests-updated
