### PR TITLE
feat(editor): live Properties edits and opt-in help

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -1117,12 +1117,11 @@ test("carries a manual Value through placement and Q property editing", async ({
   const draft = JSON.parse(await readComponentPropertyCode(page));
   draft.parameters.value = "10k";
   await propertyCode.fill(JSON.stringify(draft, null, 2));
-  await expect(page.getByTestId("revision")).toHaveText("1");
+  await expect(page.getByTestId("revision")).toHaveText("2");
   await expect(
     page.getByRole("button", { name: "Apply component properties" }),
   ).toHaveCount(0);
-  await page.getByRole("button", { name: "Discard draft" }).click();
-  await expect(page.getByTestId("revision")).toHaveText("1");
+  await clickCommand(page, "Edit", "Undo");
   await expectComponentCodeField(page, "parameters.value", "");
   // Electrical renaming and the shared visual editor are distinct actions;
   // there is no second, plain-text Label field or heavyweight Identity card.
@@ -1140,7 +1139,7 @@ test("carries a manual Value through placement and Q property editing", async ({
     code.reference = "R7";
     code.parameters.tc = "0.1";
   });
-  await expect(page.getByTestId("revision")).toHaveText("2");
+  await expect(page.getByTestId("revision")).toHaveText("4");
   await expectComponentCodeField(page, "reference", "R7");
   await expectComponentCodeField(page, "parameters.tc", "0.1");
 });
@@ -1166,7 +1165,6 @@ test("ordinary source Properties switch waveforms without erasing inactive value
   );
 
   await waveform.selectOption("pulse");
-  await page.getByRole("button", { name: "Apply code" }).click();
   await expectComponentCodeField(page, "parameters.high", "1");
   await setComponentParameter(page, "high", "2.5");
 
@@ -1174,7 +1172,6 @@ test("ordinary source Properties switch waveforms without erasing inactive value
     .getByLabel("Editable Canvas property code")
     .press("ControlOrMeta+Home");
   await waveform.selectOption("sin");
-  await page.getByRole("button", { name: "Apply code" }).click();
   await expectComponentCodeField(page, "parameters.amplitude", "1");
   await expectComponentCodeField(page, "parameters.high", "2.5");
 
@@ -1182,7 +1179,6 @@ test("ordinary source Properties switch waveforms without erasing inactive value
     .getByLabel("Editable Canvas property code")
     .press("ControlOrMeta+Home");
   await waveform.selectOption("pulse");
-  await page.getByRole("button", { name: "Apply code" }).click();
   await expectComponentCodeField(page, "parameters.high", "2.5");
   await expect
     .poll(() => recoveryProjectTexts(page))

--- a/apps/editor/e2e/editor-fixtures.ts
+++ b/apps/editor/e2e/editor-fixtures.ts
@@ -99,7 +99,7 @@ export async function chooseComponent(
   await dialog.getByTestId(`insert-component-${symbolId}`).click();
 }
 
-/** Edit the selected component's strict Canvas-property JSON and apply it. */
+/** Edit the selected component's strict JSON; valid changes update live. */
 export async function editComponentPropertyCode(
   page: Page,
   update: (value: Record<string, any>) => void,
@@ -111,7 +111,6 @@ export async function editComponentPropertyCode(
   >;
   update(value);
   await input.fill(JSON.stringify(value, null, 2));
-  await page.getByRole("button", { name: "Apply code" }).click();
 }
 
 /** Read rendered JSON lines only; the inline controls/help are not source text. */

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -25,7 +25,7 @@ import {
   recoveryProjectTexts,
 } from "./editor-fixtures.js";
 
-test("guided JSON properties keep controls in one draft and round-trip raw parameter strings", async ({
+test("live JSON properties update controls immediately and round-trip raw parameter strings", async ({
   page,
 }) => {
   await page.goto("/editor");
@@ -40,12 +40,25 @@ test("guided JSON properties keep controls in one draft and round-trip raw param
     0,
   );
   const revision = await page.getByTestId("revision").textContent();
+  await expect(panel.getByRole("button", { name: "Apply code" })).toHaveCount(
+    0,
+  );
+  await expect(panel.locator(".cm-property-hint")).toHaveCount(0);
+  await panel.getByRole("button", { name: "Need help?", exact: true }).click();
+  await expect(panel.locator(".cm-property-hint").first()).toBeVisible();
+  await panel.getByRole("button", { name: "Hide help", exact: true }).click();
+  await expect(panel.locator(".cm-property-hint")).toHaveCount(0);
   await panel.getByLabel("Rotation options").selectOption("90");
+  await expect(page.getByTestId("revision")).toHaveText(
+    String(Number(revision) + 1),
+  );
   await panel
     .getByRole("switch", { name: "Show reference", exact: true })
     .click();
   await panel.getByLabel("Foreground color picker").fill("#dc2626");
-  await expect(page.getByTestId("revision")).toHaveText(revision!);
+  await expect(page.getByTestId("revision")).toHaveText(
+    String(Number(revision) + 3),
+  );
   const draft = JSON.parse(await readComponentPropertyCode(page));
   expect(draft.placement.rotation).toBe(90);
   expect(draft.display.reference).toBe(false);
@@ -57,9 +70,8 @@ test("guided JSON properties keep controls in one draft and round-trip raw param
   await panel
     .getByLabel("Editable Canvas property code")
     .fill(JSON.stringify(draft, null, 2));
-  await panel.getByRole("button", { name: "Apply code" }).click();
   await expect(page.getByTestId("revision")).toHaveText(
-    String(Number(revision) + 1),
+    String(Number(revision) + 4),
   );
   const value = page.locator(
     '[data-layer="formal"] [data-object-id="instance-value-M1"]',
@@ -93,7 +105,7 @@ test("guided JSON properties keep controls in one draft and round-trip raw param
   await expectComponentCodeField(page, "parameters.w", "EV");
 });
 
-test("Defaults and Discard draft have distinct non-destructive behavior", async ({
+test("live Defaults are undoable and invalid drafts never change the canvas", async ({
   page,
 }) => {
   await page.goto("/editor");
@@ -103,16 +115,20 @@ test("Defaults and Discard draft have distinct non-destructive behavior", async 
   const revision = await page.getByTestId("revision").textContent();
   await page.getByRole("button", { name: "Defaults", exact: true }).click();
   await expectComponentCodeField(page, "parameters.w", "1u");
-  await expect(page.getByTestId("revision")).toHaveText(revision!);
-  await page
-    .getByRole("button", { name: "Discard draft", exact: true })
-    .click();
+  await expect(page.getByTestId("revision")).toHaveText(
+    String(Number(revision) + 1),
+  );
+  await clickCommand(page, "Edit", "Undo");
   await expectComponentCodeField(page, "parameters.w", "7u");
   const code = page.getByLabel("Editable Canvas property code");
   const invalid = JSON.parse(await readComponentPropertyCode(page));
+  const lastValidRevision = await page.getByTestId("revision").textContent();
   invalid.appearance.foreground = [256, 0, 0];
   await code.fill(JSON.stringify(invalid, null, 2));
-  await expect(page.getByRole("button", { name: "Apply code" })).toBeDisabled();
+  await expect(
+    page.getByText(/Canvas keeps the last valid edit/u),
+  ).toBeVisible();
+  await expect(page.getByTestId("revision")).toHaveText(lastValidRevision!);
   await expect(page.getByLabel("Rotation options")).toBeDisabled();
   await page.getByRole("button", { name: "Discard draft" }).click();
   await expectComponentCodeField(page, "parameters.w", "7u");
@@ -120,7 +136,7 @@ test("Defaults and Discard draft have distinct non-destructive behavior", async 
   await expect(page.locator(".cm-json-string").first()).toBeVisible();
 });
 
-test("one JSON Apply combines model, dimensions and appearance in one undo boundary", async ({
+test("one live JSON edit combines model, dimensions and appearance in one undo boundary", async ({
   page,
 }) => {
   await page.goto("/editor");
@@ -183,6 +199,116 @@ test("property placement null retains a wired instance and re-places it with gri
   await clickCommand(page, "Edit", "Undo");
   await expect(page.getByTestId("hit-R1")).toHaveCount(0);
 });
+
+test("live typing preserves the caret, local undo and incomplete JSON", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await placeComponent(page, "nmos", { x: 360, y: 220 });
+  await openSelectionShelf(page);
+  const code = page.getByLabel("Editable Canvas property code");
+  await editComponentPropertyCode(page, (value) => {
+    value.display.value = true;
+  });
+  // Locate the width string through the actual editable DOM, then type normally.
+  await code
+    .locator(".cm-line")
+    .filter({ hasText: '"w":' })
+    .evaluate((line) => {
+      const token = line.querySelector(".cm-json-string")!;
+      const text = document
+        .createTreeWalker(token, NodeFilter.SHOW_TEXT)
+        .nextNode()!;
+      const range = document.createRange();
+      range.setStart(text, 1);
+      range.setEnd(text, 3);
+      const selection = window.getSelection()!;
+      selection.removeAllRanges();
+      selection.addRange(range);
+      (line.closest('[contenteditable="true"]') as HTMLElement).focus();
+    });
+  await page.keyboard.type("EV", { delay: 80 });
+  const value = page.locator(
+    '[data-layer="formal"] [data-object-id="instance-value-M1"]',
+  );
+  await expect(value).toContainText("EV");
+  await page.keyboard.type("x", { delay: 80 });
+  await expect(value).toContainText("EVx");
+  await code.press("ControlOrMeta+z");
+  await expect(value).toContainText("1u");
+  await code.press("ControlOrMeta+Shift+z");
+  await expect(value).toContainText("EVx");
+  const raw = await readComponentPropertyCode(page);
+  const revision = await page.getByTestId("revision").textContent();
+  await code.fill(raw.slice(0, -1));
+  await expect(
+    page.getByText(/Canvas keeps the last valid edit/u),
+  ).toBeVisible();
+  await expect(value).toContainText("EVx");
+  await expect(page.getByTestId("revision")).toHaveText(revision!);
+  await code.press("ControlOrMeta+End");
+  await code.press("}");
+  await expect(page.getByText(/Live · valid edits/u)).toBeVisible();
+  await expect(page.getByTestId("revision")).toHaveText(revision!);
+});
+
+for (const width of [300, 540]) {
+  test(`property controls stay on their value line at ${width}px with optional help`, async ({
+    page,
+  }) => {
+    await page.addInitScript(
+      (size) =>
+        localStorage.setItem("icm.properties-panel-width.v1", String(size)),
+      width,
+    );
+    await page.goto("/editor");
+    await placeComponent(page, "pmos", { x: 360, y: 220 });
+    await openSelectionShelf(page);
+    const editor = page.getByTestId("component-property-code-editor");
+    await expect(page.getByLabel("Mirror options")).toBeAttached();
+    for (const help of [false, true]) {
+      if (help)
+        await page
+          .getByRole("button", { name: "Need help?", exact: true })
+          .click();
+      const layout = await editor.evaluate((section) => {
+        const assists = [...section.querySelectorAll(".cm-property-assist")];
+        return {
+          overflow: section.scrollWidth > section.clientWidth,
+          offsets: assists
+            .map((assist) => {
+              const line = assist.closest(".cm-line")!;
+              const tokens = [
+                ...line.querySelectorAll(
+                  ".cm-json-string, .cm-json-number, .cm-json-boolean",
+                ),
+              ];
+              const value = tokens.at(-1)!.getBoundingClientRect();
+              return [...assist.querySelectorAll("button, select, input")].map(
+                (control) => {
+                  const box = control.getBoundingClientRect();
+                  return Math.abs(
+                    (box.top + box.bottom - value.top - value.bottom) / 2,
+                  );
+                },
+              );
+            })
+            .flat(),
+        };
+      });
+      expect(layout.overflow).toBe(false);
+      expect(layout.offsets.length).toBeGreaterThan(5);
+      expect(Math.max(...layout.offsets)).toBeLessThan(4);
+    }
+    await expect(page.getByLabel("Foreground color picker")).toHaveValue(
+      "#000000",
+    );
+    await expect(page.getByLabel("Foreground color picker")).toHaveAttribute(
+      "title",
+      "Global RGB: [0,0,0]",
+    );
+  });
+}
 
 test("a directly connected device can move away and return with its wire, undo and redo", async ({
   page,
@@ -1009,7 +1135,6 @@ test("a switch changes contact style in place, keeping its wires", async ({
   );
 
   await toggle.selectOption("simple-spdt-switch");
-  await page.getByRole("button", { name: "Apply code" }).click();
   await expect(page.locator("[data-symbol-id]").first()).toHaveAttribute(
     "data-symbol-id",
     "simple-spdt-switch",
@@ -1020,7 +1145,6 @@ test("a switch changes contact style in place, keeping its wires", async ({
   await expect(page.locator('[data-layer="routes"] polyline')).toHaveCount(1);
 
   await toggle.selectOption("spdt-switch");
-  await page.getByRole("button", { name: "Apply code" }).click();
   await expect(page.locator("[data-symbol-id]").first()).toHaveAttribute(
     "data-symbol-id",
     "spdt-switch",
@@ -2384,7 +2508,7 @@ test("Q opens a text-first Properties editor with one-click exact draft copy", a
     });
   expect(positions.copyBottom).toBeLessThanOrEqual(positions.editorTop);
   expect(positions.editorHeight).toBeGreaterThan(positions.panelHeight * 0.65);
-  await page.getByRole("button", { name: "Discard draft" }).click();
+  await clickCommand(page, "Edit", "Undo");
   await expectComponentCodeField(page, "parameters.w", "1u");
 });
 
@@ -3660,7 +3784,6 @@ test("resizes Properties and applies component presentation as editable code", a
   edited.display.reference = false;
   edited.appearance.foreground = "#DC2626";
   await code.fill(JSON.stringify(edited, null, 2));
-  await properties.getByRole("button", { name: "Apply code" }).click();
 
   await expect(page.getByTestId("revision")).toHaveText("2");
   await expect(
@@ -4039,7 +4162,6 @@ test("reference and value code refreshes content after parameter edits", async (
   const missingValueCode = JSON.parse(await readComponentPropertyCode(page));
   missingValueCode.display.value = true;
   await propertyCode.fill(JSON.stringify(missingValueCode, null, 2));
-  await properties.getByRole("button", { name: "Apply code" }).click();
   await expect(
     properties.getByText(/Set a valid component value/u),
   ).toBeVisible();
@@ -5424,7 +5546,6 @@ test("edits a formula-capable Signal Flow block with undo, redo, and Reset defau
   await properties
     .getByRole("button", { name: "Defaults", exact: true })
     .click();
-  await properties.getByRole("button", { name: "Apply code" }).click();
   // Reset restores the Symbol's own formula as editable text, not an empty
   // box: the default is the starting point for the next edit.
   await expectComponentCodeField(page, "signalFlow", {});

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -246,6 +246,12 @@ test("live typing preserves the caret, local undo and incomplete JSON", async ({
   ).toBeVisible();
   await expect(value).toContainText("EVx");
   await expect(page.getByTestId("revision")).toHaveText(revision!);
+  await code.press("Escape");
+  await expect(code).not.toBeFocused();
+  await expect(
+    page.getByText(/Canvas keeps the last valid edit/u),
+  ).toBeVisible();
+  await expect(page.getByTestId("revision")).toHaveText(revision!);
   await code.press("ControlOrMeta+End");
   await code.press("}");
   await expect(page.getByText(/Live · valid edits/u)).toBeVisible();
@@ -4398,7 +4404,7 @@ test("drag value annotation keeps the user offset through rotation", async ({
   ).toBeGreaterThan(10);
 });
 
-test("applied property drafts survive blank click and Escape", async ({
+test("live property edits survive blank click and Escape without replaying legacy drafts", async ({
   page,
 }) => {
   await page.goto("/editor");
@@ -5562,6 +5568,9 @@ test("selects a reviewed SKY130 MOS through the existing Model field", async ({
   await openSelectionShelf(page);
   const properties = page.getByRole("complementary", { name: "Properties" });
 
+  await properties
+    .getByRole("button", { name: "Need help?", exact: true })
+    .click();
   await expect(properties).toContainText("sky130_fd_pr__nfet_01v8");
   await setComponentCodeField(page, "netlistTarget", "sky130_fd_pr__nfet_01v8");
 

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -200,63 +200,73 @@ test("property placement null retains a wired instance and re-places it with gri
   await expect(page.getByTestId("hit-R1")).toHaveCount(0);
 });
 
-test("live typing preserves the caret, local undo and incomplete JSON", async ({
-  page,
-}) => {
-  await page.goto("/editor");
-  await placeComponent(page, "nmos", { x: 360, y: 220 });
-  await openSelectionShelf(page);
-  const code = page.getByLabel("Editable Canvas property code");
-  await editComponentPropertyCode(page, (value) => {
-    value.display.value = true;
-  });
-  // Locate the width string through the actual editable DOM, then type normally.
-  await code
-    .locator(".cm-line")
-    .filter({ hasText: '"w":' })
-    .evaluate((line) => {
-      const token = line.querySelector(".cm-json-string")!;
-      const text = document
-        .createTreeWalker(token, NodeFilter.SHOW_TEXT)
-        .nextNode()!;
-      const range = document.createRange();
-      range.setStart(text, 1);
-      range.setEnd(text, 3);
-      const selection = window.getSelection()!;
-      selection.removeAllRanges();
-      selection.addRange(range);
-      (line.closest('[contenteditable="true"]') as HTMLElement).focus();
+for (const platform of ["native", "Win32", "Linux x86_64"])
+  test(`live typing preserves the caret, local undo and incomplete JSON (${platform})`, async ({
+    page,
+  }) => {
+    if (platform !== "native")
+      await page.addInitScript(
+        (name) =>
+          Object.defineProperty(navigator, "platform", { get: () => name }),
+        platform,
+      );
+    const modifier = platform === "native" ? "ControlOrMeta" : "Control";
+    await page.goto("/editor");
+    await placeComponent(page, "nmos", { x: 360, y: 220 });
+    await openSelectionShelf(page);
+    const code = page.getByLabel("Editable Canvas property code");
+    await editComponentPropertyCode(page, (value) => {
+      value.display.value = true;
     });
-  await page.keyboard.type("EV", { delay: 80 });
-  const value = page.locator(
-    '[data-layer="formal"] [data-object-id="instance-value-M1"]',
-  );
-  await expect(value).toContainText("EV");
-  await page.keyboard.type("x", { delay: 80 });
-  await expect(value).toContainText("EVx");
-  await code.press("ControlOrMeta+z");
-  await expect(value).toContainText("1u");
-  await code.press("ControlOrMeta+Shift+z");
-  await expect(value).toContainText("EVx");
-  const raw = await readComponentPropertyCode(page);
-  const revision = await page.getByTestId("revision").textContent();
-  await code.fill(raw.slice(0, -1));
-  await expect(
-    page.getByText(/Canvas keeps the last valid edit/u),
-  ).toBeVisible();
-  await expect(value).toContainText("EVx");
-  await expect(page.getByTestId("revision")).toHaveText(revision!);
-  await code.press("Escape");
-  await expect(code).not.toBeFocused();
-  await expect(
-    page.getByText(/Canvas keeps the last valid edit/u),
-  ).toBeVisible();
-  await expect(page.getByTestId("revision")).toHaveText(revision!);
-  await code.press("ControlOrMeta+End");
-  await code.press("}");
-  await expect(page.getByText(/Live · valid edits/u)).toBeVisible();
-  await expect(page.getByTestId("revision")).toHaveText(revision!);
-});
+    // Locate the width string through the actual editable DOM, then type normally.
+    await code
+      .locator(".cm-line")
+      .filter({ hasText: '"w":' })
+      .evaluate((line) => {
+        const token = line.querySelector(".cm-json-string")!;
+        const text = document
+          .createTreeWalker(token, NodeFilter.SHOW_TEXT)
+          .nextNode()!;
+        const range = document.createRange();
+        range.setStart(text, 1);
+        range.setEnd(text, 3);
+        const selection = window.getSelection()!;
+        selection.removeAllRanges();
+        selection.addRange(range);
+        (line.closest('[contenteditable="true"]') as HTMLElement).focus();
+      });
+    await page.keyboard.type("EV", { delay: 80 });
+    const value = page.locator(
+      '[data-layer="formal"] [data-object-id="instance-value-M1"]',
+    );
+    await expect(value).toContainText("EV");
+    await page.keyboard.type("x", { delay: 80 });
+    await expect(value).toContainText("EVx");
+    await code.press(`${modifier}+z`);
+    await expect(value).toContainText("1u");
+    // Emit the actual shifted letter, not lowercase z with Shift held: the
+    // latter is a synthetic layout event that CodeMirror interprets as Undo.
+    await code.press(`${modifier}+Shift+Z`);
+    await expect(value).toContainText("EVx");
+    const raw = await readComponentPropertyCode(page);
+    const revision = await page.getByTestId("revision").textContent();
+    await code.fill(raw.slice(0, -1));
+    await expect(
+      page.getByText(/Canvas keeps the last valid edit/u),
+    ).toBeVisible();
+    await expect(value).toContainText("EVx");
+    await expect(page.getByTestId("revision")).toHaveText(revision!);
+    await code.press("Escape");
+    await expect(code).not.toBeFocused();
+    await expect(
+      page.getByText(/Canvas keeps the last valid edit/u),
+    ).toBeVisible();
+    await expect(page.getByTestId("revision")).toHaveText(revision!);
+    await code.press(`${modifier}+End`);
+    await code.press("}");
+    await expect(page.getByText(/Live · valid edits/u)).toBeVisible();
+    await expect(page.getByTestId("revision")).toHaveText(revision!);
+  });
 
 for (const width of [300, 540]) {
   test(`property controls stay on their value line at ${width}px with optional help`, async ({

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -4086,11 +4086,14 @@ export function App({
         event.target instanceof Element &&
         event.target.closest(".selection-dock") !== null
       ) {
-        // Escape inside Properties commits pending drafts instead of losing
-        // them; a second Escape resumes normal canvas cancel behavior.
+        // JSON properties already commit live. Do not replay the legacy form
+        // draft over them when leaving the editor (or discard incomplete JSON).
+        // Other property forms retain their explicit Escape commit behavior.
         event.preventDefault();
-        commitInstancePropertyDraft();
-        commitPendingNetLabelDraft();
+        if (!event.target.closest(".component-property-code-editor")) {
+          commitInstancePropertyDraft();
+          commitPendingNetLabelDraft();
+        }
         if (event.target instanceof HTMLElement) event.target.blur();
         return;
       }

--- a/apps/editor/src/features/properties/component-property-code-editor.test.tsx
+++ b/apps/editor/src/features/properties/component-property-code-editor.test.tsx
@@ -25,7 +25,10 @@ describe("ComponentPropertyCodeEditor", () => {
     );
     expect(markup).toContain('aria-label="Loading Canvas property code"');
     expect(markup).toContain("&quot;at&quot;");
-    expect(markup).toContain("Apply code");
+    expect(markup).not.toContain("Apply code");
+    expect(markup).toContain("Need help?");
+    expect(markup).toContain('aria-expanded="false"');
+    expect(markup).toContain("valid edits update the canvas immediately");
     expect(markup).toContain('aria-label="Copy JSON"');
     expect(markup).toContain('title="Copy JSON"');
     expect(markup.indexOf('aria-label="Copy JSON"')).toBeLessThan(

--- a/apps/editor/src/features/properties/component-property-code-editor.tsx
+++ b/apps/editor/src/features/properties/component-property-code-editor.tsx
@@ -1,4 +1,11 @@
-import { lazy, Suspense, useEffect, useMemo, useRef, useState } from "react";
+import {
+  lazy,
+  Suspense,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import type { SchematicDocument } from "@icm/model";
 
@@ -54,16 +61,26 @@ export function ComponentPropertyCodeEditor({
     [context, revision],
   );
   const previousBaseline = useRef(baseline);
+  const appliedCode = useRef<string | null>(null);
+  const [historyKey, setHistoryKey] = useState(0);
   const [draft, setDraft] = useState(baseline);
   const [applyMessage, setApplyMessage] = useState<string | null>(null);
+  const [rejected, setRejected] = useState(false);
+  const [showHelp, setShowHelp] = useState(false);
 
-  useEffect(() => {
-    // Capture before enqueueing: React may run the updater after the ref has
-    // advanced. Reading the ref inside it leaves normalized target edits stale.
-    const previous = previousBaseline.current;
+  useLayoutEffect(() => {
+    const ownEdit = appliedCode.current;
+    appliedCode.current = null;
+    if (previousBaseline.current === baseline && ownEdit === null) return;
     previousBaseline.current = baseline;
-    setDraft((current) => (current === previous ? baseline : current));
-  }, [baseline]);
+    // Preserve the user's whitespace, caret and local undo history on a live
+    // acknowledgement. Only planner normalization or an external edit replaces
+    // text; external undo/redo must never be replayed back into the model.
+    if (ownEdit !== baseline) setDraft(baseline);
+    if (ownEdit === null) setHistoryKey((key) => key + 1);
+    setApplyMessage(null);
+    setRejected(false);
+  }, [baseline, draft]);
 
   const parsed = useMemo(
     () => parseComponentPropertyCode(draft, context),
@@ -80,20 +97,21 @@ export function ComponentPropertyCodeEditor({
     }
   };
 
-  const apply = (): void => {
-    if (!parsed.ok) {
-      setApplyMessage(parsed.message);
-      return;
-    }
-    const result = onApply(parsed.value);
+  const change = (source: string): void => {
+    setDraft(source);
+    setApplyMessage(null);
+    setRejected(false);
+    const next = parseComponentPropertyCode(source, context);
+    if (!next.ok) return;
+    const normalized = serializeComponentPropertyCode(next.value);
+    if (normalized === baseline) return;
+    const result = onApply(next.value);
     if (!result.ok) {
       setApplyMessage(result.message);
+      setRejected(true);
       return;
     }
-    const normalized = serializeComponentPropertyCode(parsed.value);
-    previousBaseline.current = normalized;
-    setDraft(normalized);
-    setApplyMessage("Applied");
+    appliedCode.current = normalized;
   };
 
   return (
@@ -104,6 +122,14 @@ export function ComponentPropertyCodeEditor({
     >
       <header>
         <strong>Component properties</strong>
+        <button
+          type="button"
+          className="component-property-help"
+          aria-expanded={showHelp}
+          onClick={() => setShowHelp((visible) => !visible)}
+        >
+          {showHelp ? "Hide help" : "Need help?"}
+        </button>
         <button
           type="button"
           className="component-property-copy"
@@ -135,54 +161,42 @@ export function ComponentPropertyCodeEditor({
       >
         <PropertyJsonEditor
           value={draft}
-          historyKey={baseline}
+          historyKey={historyKey}
           context={context}
           defaultForeground={defaultForeground}
           focusRequest={focusRequest}
-          onChange={(source) => {
-            setDraft(source);
-            setApplyMessage(null);
-          }}
-          onApply={apply}
+          showHelp={showHelp}
+          onChange={change}
         />
       </Suspense>
       <div className="component-property-code-status" aria-live="polite">
         <span>
           {parsed.ok
             ? (applyMessage ??
-              (changed
-                ? "Changes pending · Apply or Ctrl/⌘ + Enter"
-                : "JSON · hints and controls are not saved"))
-            : parsed.message}
+              "Live · valid edits update the canvas immediately")
+            : `${parsed.message} · Canvas keeps the last valid edit`}
         </span>
         <div>
           <button
             type="button"
-            title="Reset parameter and appearance defaults in the draft; keep position, identity, target, display flags, and unknown overrides. Apply to commit."
-            onClick={() => {
-              setDraft(defaultComponentPropertyCode(context));
-              setApplyMessage("Defaults loaded into draft · Apply to commit");
-            }}
+            title="Reset parameter and appearance defaults immediately; keep position, identity, target, display flags, and unknown overrides. Undo restores the previous values."
+            onClick={() => change(defaultComponentPropertyCode(context))}
           >
             Defaults
           </button>
-          <button
-            type="button"
-            disabled={!changed}
-            onClick={() => {
-              setDraft(baseline);
-              setApplyMessage(null);
-            }}
-          >
-            Discard draft
-          </button>
-          <button
-            type="button"
-            disabled={!changed || !parsed.ok}
-            onClick={apply}
-          >
-            Apply code
-          </button>
+          {(!parsed.ok || rejected) && (
+            <button
+              type="button"
+              disabled={!changed}
+              onClick={() => {
+                setDraft(baseline);
+                setApplyMessage(null);
+                setRejected(false);
+              }}
+            >
+              Discard draft
+            </button>
+          )}
         </div>
       </div>
     </section>

--- a/apps/editor/src/features/properties/component-property-fields.test.ts
+++ b/apps/editor/src/features/properties/component-property-fields.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { colorToRgb } from "./component-property-fields";
+
+describe("inherited property colors", () => {
+  it.each([
+    ["#000", [0, 0, 0]],
+    ["#fff", [255, 255, 255]],
+    ["#aBc", [170, 187, 204]],
+    ["#dc2626", [220, 38, 38]],
+  ])("resolves %s to finite RGB channels", (color, channels) => {
+    expect(colorToRgb(color)).toEqual(channels);
+  });
+});

--- a/apps/editor/src/features/properties/component-property-fields.ts
+++ b/apps/editor/src/features/properties/component-property-fields.ts
@@ -34,7 +34,8 @@ export const CANVAS_PROPERTY_FIELDS: readonly CanvasPropertyField[] = [
     path: "placement.at",
     label: "Position",
     kind: "coordinate",
-    description: "[x, y] · canvas coordinates; snapped to the grid on Apply.",
+    description:
+      "[x, y] · canvas coordinates; snapped to the grid when updated.",
   },
   {
     path: "placement.rotation",
@@ -76,8 +77,11 @@ export const CANVAS_PROPERTY_FIELDS: readonly CanvasPropertyField[] = [
 ];
 
 export function colorToRgb(value: string): [number, number, number] {
+  const expanded = /^#[0-9a-f]{3}$/iu.test(value)
+    ? `#${[...value.slice(1)].map((channel) => channel + channel).join("")}`
+    : value;
   return [1, 3, 5].map((offset) =>
-    Number.parseInt(value.slice(offset, offset + 2), 16),
+    Number.parseInt(expanded.slice(offset, offset + 2), 16),
   ) as [number, number, number];
 }
 

--- a/apps/editor/src/features/properties/component-property-json-editor.tsx
+++ b/apps/editor/src/features/properties/component-property-json-editor.tsx
@@ -1,6 +1,7 @@
 import { useLayoutEffect, useRef } from "react";
 import {
   EditorState,
+  Annotation,
   StateEffect,
   StateField,
   Transaction,
@@ -44,14 +45,15 @@ import {
 
 interface Props {
   value: string;
-  historyKey: string;
+  historyKey: number;
   context: ComponentPropertyCodeContext;
   defaultForeground: string;
   focusRequest: number;
+  showHelp: boolean;
   onChange(source: string): void;
-  onApply(): void;
 }
 const refreshAssists = StateEffect.define<null>();
+const externalUpdate = Annotation.define<boolean>();
 
 /** Lazy loaded: selecting a component does not make the canvas shell depend on CodeMirror. */
 export default function ComponentPropertyJsonEditor(props: Props) {
@@ -90,32 +92,23 @@ export default function ComponentPropertyJsonEditor(props: Props) {
           syntaxHighlighting(defaultHighlightStyle),
           linter(jsonParseLinter()),
           assistField,
-          EditorView.lineWrapping,
           EditorView.contentAttributes.of({
             "aria-label": "Editable Canvas property code",
             spellcheck: "false",
           }),
           keymap.of([
-            {
-              key: "Mod-Enter",
-              run: () => {
-                read().onApply();
-                return true;
-              },
-            },
-            {
-              key: "Ctrl-Enter",
-              run: () => {
-                read().onApply();
-                return true;
-              },
-            },
             ...historyKeymap,
             ...closeBracketsKeymap,
             ...defaultKeymap,
           ]),
           EditorView.updateListener.of((update) => {
-            if (update.docChanged) read().onChange(update.state.doc.toString());
+            if (
+              update.docChanged &&
+              !update.transactions.some((transaction) =>
+                transaction.annotation(externalUpdate),
+              )
+            )
+              read().onChange(update.state.doc.toString());
           }),
         ],
       });
@@ -137,12 +130,39 @@ export default function ComponentPropertyJsonEditor(props: Props) {
       historyKey.current = props.historyKey;
       view.setState(createState.current(props.value));
     } else if (view.state.doc.toString() !== props.value) {
+      const current = view.state.doc.toString();
+      let from = 0;
+      let suffix = 0;
+      while (
+        from < Math.min(current.length, props.value.length) &&
+        current[from] === props.value[from]
+      )
+        from++;
+      while (
+        suffix < Math.min(current.length, props.value.length) - from &&
+        current[current.length - 1 - suffix] ===
+          props.value[props.value.length - 1 - suffix]
+      )
+        suffix++;
       view.dispatch({
-        changes: { from: 0, to: view.state.doc.length, insert: props.value },
-        annotations: Transaction.addToHistory.of(false),
+        changes: {
+          from,
+          to: current.length - suffix,
+          insert: props.value.slice(from, props.value.length - suffix),
+        },
+        annotations: [
+          Transaction.addToHistory.of(false),
+          externalUpdate.of(true),
+        ],
       });
     } else view.dispatch({ effects: refreshAssists.of(null) });
-  }, [props.value, props.historyKey, props.context, props.defaultForeground]);
+  }, [
+    props.value,
+    props.historyKey,
+    props.context,
+    props.defaultForeground,
+    props.showHelp,
+  ]);
 
   useLayoutEffect(() => {
     if (props.focusRequest > 0) viewRef.current?.focus();
@@ -181,19 +201,43 @@ function decorations(state: EditorState, read: () => Props): DecorationSet {
   const source = state.doc.toString();
   const enabled = parseComponentPropertyCode(source, read().context).ok;
   for (const span of propertyCodeSpans(source, read().context)) {
-    ranges.push(
-      Decoration.widget({
-        widget: new PropertyAssist(
-          span,
-          enabled,
-          read().defaultForeground,
-          read,
-        ),
-        side: 1,
-      }).range(state.doc.lineAt(span.to).to),
-    );
+    if (span.field.kind !== "text" && span.field.kind !== "coordinate")
+      ranges.push(
+        Decoration.widget({
+          widget: new PropertyAssist(
+            span,
+            enabled,
+            read().defaultForeground,
+            read,
+          ),
+          side: 1,
+        }).range(state.doc.lineAt(span.to).to),
+      );
+    if (read().showHelp)
+      ranges.push(
+        Decoration.widget({
+          widget: new PropertyHelp(span.field.description),
+          block: true,
+          side: 2,
+        }).range(state.doc.lineAt(span.to).to),
+      );
   }
   return Decoration.set(ranges, true);
+}
+
+class PropertyHelp extends WidgetType {
+  constructor(readonly description: string) {
+    super();
+  }
+  override eq(other: PropertyHelp) {
+    return this.description === other.description;
+  }
+  toDOM() {
+    const dom = document.createElement("div");
+    dom.className = "cm-property-hint";
+    dom.textContent = this.description;
+    return dom;
+  }
 }
 
 class PropertyAssist extends WidgetType {
@@ -225,10 +269,6 @@ class PropertyAssist extends WidgetType {
     dom.setAttribute("data-property-assist", field.path);
     dom.contentEditable = "false";
     dom.addEventListener("keydown", (event) => {
-      if ((event.ctrlKey || event.metaKey) && event.key === "Enter") {
-        event.preventDefault();
-        this.read().onApply();
-      }
       event.stopPropagation();
     });
     const change = (values: Record<string, unknown>) => {
@@ -321,7 +361,7 @@ class PropertyAssist extends WidgetType {
         : color;
       const picker = document.createElement("input");
       picker.type = "color";
-      picker.value = effective;
+      picker.value = parseCanvasColor(colorToRgb(effective), field.path);
       picker.setAttribute("aria-label", `${field.label} color picker`);
       picker.title = inherited
         ? isForeground
@@ -338,19 +378,7 @@ class PropertyAssist extends WidgetType {
         () => change({ [field.path]: "auto" }),
       );
       reset.disabled = !this.enabled || inherited;
-      if (inherited) {
-        const resolved = document.createElement("span");
-        resolved.className = "cm-property-inherited";
-        resolved.textContent = isForeground
-          ? `RGB ${JSON.stringify(colorToRgb(effective))}`
-          : "No independent fill";
-        dom.append(resolved);
-      }
     }
-    const hint = document.createElement("span");
-    hint.className = "cm-property-hint";
-    hint.textContent = field.description;
-    dom.append(hint);
     return dom;
   }
 }

--- a/apps/editor/src/features/properties/component-property-json-editor.tsx
+++ b/apps/editor/src/features/properties/component-property-json-editor.tsx
@@ -15,7 +15,12 @@ import {
   drawSelection,
   type DecorationSet,
 } from "@codemirror/view";
-import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
+import {
+  defaultKeymap,
+  history,
+  historyKeymap,
+  redo,
+} from "@codemirror/commands";
 import {
   bracketMatching,
   defaultHighlightStyle,
@@ -97,6 +102,9 @@ export default function ComponentPropertyJsonEditor(props: Props) {
             spellcheck: "false",
           }),
           keymap.of([
+            // Match the canvas redo chord on Windows too (CodeMirror defaults
+            // to Ctrl+Y there). Ctrl+Y remains available through historyKeymap.
+            { key: "Mod-Shift-z", run: redo, preventDefault: true },
             ...historyKeymap,
             ...closeBracketsKeymap,
             ...defaultKeymap,

--- a/apps/editor/src/styles/editor-properties.css
+++ b/apps/editor/src/styles/editor-properties.css
@@ -353,6 +353,15 @@
 
 .component-property-code-editor > header strong {
   font-size: var(--icm-font-sm);
+  margin-right: auto;
+}
+
+.component-property-help {
+  flex: 0 0 auto;
+  padding: 0.2rem 0.4rem;
+  min-height: 2rem;
+  font-size: var(--icm-font-xs);
+  white-space: nowrap;
 }
 
 .component-property-copy {
@@ -459,6 +468,11 @@
   outline-offset: 0;
 }
 
+.component-json-editor {
+  container-type: inline-size;
+  overflow: hidden;
+}
+
 .component-json-editor .cm-editor {
   min-height: 15.5rem;
   border-radius: inherit;
@@ -497,16 +511,15 @@
 }
 .component-json-editor .cm-property-assist {
   display: inline-flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   align-items: center;
   gap: 0.3rem;
-  max-width: 100%;
-  margin: 0.2rem 0 0.35rem 0.4rem;
+  margin: 0.1rem 0 0.1rem 0.65rem;
   font-family: var(--icm-font-sans, sans-serif);
   font-size: 12px;
   line-height: 1.4;
   vertical-align: middle;
-  white-space: normal;
+  white-space: nowrap;
 }
 .component-json-editor .cm-property-assist button,
 .component-json-editor .cm-property-assist select {
@@ -539,12 +552,15 @@
   cursor: pointer;
 }
 .component-json-editor .cm-property-hint {
-  flex: 1 1 100%;
+  box-sizing: border-box;
+  width: calc(100cqw - 2rem);
+  margin: 0.15rem 0 0.5rem 1rem;
+  padding-left: 0.6rem;
+  border-left: 2px solid var(--icm-border);
+  font: 12px/1.5 var(--icm-font-sans, sans-serif);
+  white-space: normal;
   color: var(--icm-text-muted);
   overflow-wrap: anywhere;
-}
-.component-json-editor .cm-property-inherited {
-  color: var(--icm-text-muted);
 }
 
 .component-property-code-status {

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -113,15 +113,22 @@ authoring surfaces; removing a component remains an explicit Delete action.
 The lazy JSON editor provides syntax highlighting, bracket matching, JSON
 diagnostics and local text undo. Canvas-layer field metadata owns the rotation
 and mirror options, color channel limits and per-field guidance. Inline switches,
-enum menus, color pickers and global/no-fill resets edit the same draft as typing;
-they never apply implicitly. Left/right and top/bottom actions compose the
+enum menus, color pickers and global/no-fill resets edit the same source as typing;
+valid changes update the canvas immediately, with no Apply step. Left/right and top/bottom actions compose the
 current draft orientation in canvas coordinates, updating rotation and the one
 local mirror bit together. Invalid drafts disable assistance, not text editing.
-Hints and widgets are editor decorations, never JSON comments or persisted data.
-**Discard draft** restores the last applied state without changing the circuit.
-**Defaults** loads known parameter, orientation, color, and formula defaults
-into the draft; it preserves coordinates, reference, model target, display
-flags, and unknown overrides. It still requires Apply. **Copy JSON** copies
+Hints are hidden by default and expand through **Need help?**. Hints and widgets
+are editor decorations, never JSON comments or persisted data. Controls stay
+on their value line; a narrow text area scrolls horizontally without wrapping
+button groups. Help occupies separate, wrapping rows.
+**Discard draft** clears invalid or rejected source back to the last accepted
+state without changing the circuit. **Defaults** immediately restores known
+parameter, orientation, color, and formula defaults; it preserves coordinates,
+reference, model target, display flags, and unknown overrides and remains undoable.
+Live acknowledgements preserve source formatting, caret, and local text history;
+external undo/redo synchronizes without replaying edits. Escape leaves the JSON
+editor without committing legacy form drafts or dropping incomplete source.
+**Copy JSON** copies
 the complete raw draft without decorations from the copy icon at the editor's
 top right, including unapplied whitespace and invalid drafts. The text area
 is the dominant, viewport-sized surface; instance identity stays in the dock

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -48,13 +48,15 @@ palette-first manual authoring; no Project file needs to be opened first.
   hints, or type JSON directly. Fixed colors display as `[R, G, B]` (0–255);
   hex input also works. **Global** inherits ink and **No fill** removes the
   independent background override. Flip arrows work in canvas directions.
-  These controls change the draft: choose **Apply code** (or
-  press `Ctrl`/`Cmd`+`Enter`); invalid or unknown properties are reported
-  without changing the drawing. Parameter values are strings: type unit suffixes
+  Valid edits update the drawing immediately, with no Apply step. **Need help?**
+  expands field explanations; they are hidden by default. Controls stay on the
+  same line as their values; narrow panels scroll horizontally instead of splitting
+  buttons across lines. Invalid or unknown properties are reported while the
+  drawing keeps its last valid state. Parameter values are strings: type unit suffixes
   yourself; `EV` remains `EV`, and `2u` is not changed to `2um`.
-  **Discard draft** cancels unapplied edits. **Defaults** loads known defaults
-  into the draft without moving, renaming or rebinding the component; Apply
-  commits them. The small **Copy JSON** icon at the text area's top right copies
+  **Discard draft** clears an invalid or rejected edit. **Defaults** restores known
+  defaults immediately without moving, renaming or rebinding the component;
+  use Undo to restore previous values. The small **Copy JSON** icon at the text area's top right copies
   the whole draft, excluding hints and controls. Compatible drawing
   variants and formula overrides are in the same editor, with no duplicate
   Parameters/Actions/Netlist Target forms. Drag the panel's left edge to set a


### PR DESCRIPTION
## Summary

- Apply valid Properties JSON and inline controls immediately, without an Apply button. Invalid/rejected drafts keep the last accepted canvas and can be discarded; Defaults updates live and is undoable.
- Preserve text formatting, caret and local undo on live acknowledgements. Reconcile planner normalization and external undo without replaying edits.
- Hide explanatory comments by default behind Need help?; render expanded help separately from same-line controls. Narrow editors scroll locally instead of wrapping buttons onto unrelated rows.
- Fix inherited short-hex foreground colors producing invalid RGB channels.

## Validation

- Frozen dependency install and preflight/static/type contracts passed.
- Nine focused units passed. Eleven focused browser scenarios passed across the initial run and corrected text-range fixture rerun (ten plus one).
- Final affected gate passed on 4bfdd7b5: 472 unit files / 3,187 tests, 34 component-insert browser cases and 153 manual-editor browser cases. Preflight/static/type checks passed.
- Regression review found and fixed the legacy capture-phase Escape handler replaying stale form values over live JSON; exact revision assertions and invalid-source Escape behavior pass. Model suggestions are verified after opening opt-in help.
- Required CI passed on exact head 4bfdd7b5: [34666023073](https://github.com/cascode-ai/analog-canvas/actions/runs/34666023073). Merge-queue full CI passed: [34666426741](https://github.com/cascode-ai/analog-canvas/actions/runs/34666426741).
- Cross-platform follow-up: CI's synthetic lowercase-z-with-Shift redo event was dispatched as Undo by CodeMirror. The test now emits physical shifted Z and covers native, Win32 and Linux keymap branches. Explicit Mod-Shift-Z also adds the canvas redo chord on Windows, retaining Ctrl-Y. All three focused keyboard scenarios and final local gates pass; the formerly failing remote browser shard is green.
- Existing atomic model changes, placement lifecycle, raw EV strings, copy, undo, rejected electrical references and narrow layouts remain covered.

## Delivery

Merged as `12279022e827dfa259f9a02b530ab420a773afc5`.
[Deploy Preview 34666769931](https://github.com/cascode-ai/analog-canvas/actions/runs/34666769931) succeeded on that exact SHA, including the public Agent/MCP, source-workspace GUI and cross-Project simulation acceptance journeys.

All 18 targeted hosted browser acceptance scenarios passed on https://analog-canvas-preview.tokenzhang.com/editor. Fresh isolated browser screenshots checked at 300px and 540px widths, with help collapsed and expanded; no page errors. `/api/channel` confirms `preview`.

Preview only. No production tag or deployment dispatch. Latest Production deploy remains run 34624514937 at `b2b223086b10061084f29a808632a5e159458a7e` (read-only verified).
