### PR TITLE
refactor(simulation): unify files in the code explorer

### DIFF
--- a/apps/editor/e2e/simulation-batch.spec.ts
+++ b/apps/editor/e2e/simulation-batch.spec.ts
@@ -265,7 +265,7 @@ test("a saved Run Plan prepares without executing and Run starts its ordinary ba
   await expect(panel.locator(".simulation-batch-menu-popover")).toContainText(
     "Batch · prepared",
   );
-  await expect(panel.getByLabel("Prepare files")).toBeVisible();
+  await expect(panel.getByLabel("Prepare temporary files")).toBeVisible();
   expect(executions).toBe(0);
   await panel.getByRole("button", { name: "Run", exact: true }).click();
   await expect(panel.locator(".simulation-batch-menu-popover")).toContainText(

--- a/apps/editor/e2e/simulation-code-editor.spec.ts
+++ b/apps/editor/e2e/simulation-code-editor.spec.ts
@@ -153,7 +153,7 @@ test.beforeEach(async ({ page }) => {
   ).toBeVisible();
 });
 
-test("Files opens sideways, configuration is advanced, and results maximize/restore without a new fixed panel", async ({
+test("Explorer opens sideways, configuration is advanced, and results maximize/restore without a new fixed panel", async ({
   page,
 }) => {
   const editor = page.getByRole("textbox", {
@@ -161,7 +161,7 @@ test("Files opens sideways, configuration is advanced, and results maximize/rest
   });
   const before = await editor.boundingBox();
   await expect(page.getByRole("tab", { name: "Configuration" })).toHaveCount(0);
-  await page.getByRole("button", { name: "Files", exact: true }).click();
+  await page.getByRole("button", { name: "Explorer", exact: true }).click();
   await expect(
     page.getByRole("complementary", { name: "Simulation files" }),
   ).toBeVisible();

--- a/apps/editor/e2e/simulation-setup.spec.ts
+++ b/apps/editor/e2e/simulation-setup.spec.ts
@@ -178,10 +178,10 @@ test("the qualified OTA folder opens unchanged and preserves all root and hierar
   );
   await panel.getByRole("button", { name: "More code actions" }).click();
   await page.getByRole("menuitem", { name: "View final deck" }).click();
-  await expect(panel.getByLabel("Prepare files")).toBeVisible();
-  await panel
-    .getByRole("button", { name: "prepared.cir", exact: true })
-    .click();
+  const prepareFiles = panel.getByLabel("Prepare temporary files");
+  await expect(prepareFiles).toBeVisible();
+  await prepareFiles.locator("summary").click();
+  await panel.getByRole("button", { name: /prepared\.cir/ }).click();
   const preview = panel.getByRole("region", { name: "File preview" });
   const download = page.waitForEvent("download");
   await preview.getByRole("button", { name: "Download", exact: true }).click();
@@ -345,7 +345,7 @@ test("one Testbench persists several independently named folders", async ({
       exact: true,
     }),
   ).toBeVisible();
-  await folders.getByRole("button", { name: "+ New folder…" }).click();
+  await folders.getByRole("button", { name: "+ New experiment" }).click();
   await folders.getByLabel("New simulation folder name").fill("Bias sweep");
   await folders.getByLabel("New simulation folder name").press("Enter");
   await expect(
@@ -375,7 +375,7 @@ test("one Testbench persists several independently named folders", async ({
     saved.simulationFolders.find(
       (folder: { name: string }) => folder.name === "Bias sweep",
     )?.input.circuitBindings[0]?.documentId,
-  ).toBeUndefined();
+  ).toBe("document-ota-5t-testbench");
   expect(
     new Set(
       saved.simulationFolders.map(
@@ -384,11 +384,7 @@ test("one Testbench persists several independently named folders", async ({
       ),
     ),
   ).toEqual(
-    new Set([
-      "document-ota-5t-testbench",
-      "document-ota-5t-testbench-sin",
-      undefined,
-    ]),
+    new Set(["document-ota-5t-testbench", "document-ota-5t-testbench-sin"]),
   );
 
   await folders

--- a/apps/editor/e2e/simulation-workspace.spec.ts
+++ b/apps/editor/e2e/simulation-workspace.spec.ts
@@ -418,7 +418,7 @@ test("human simulation uses saved folder, survives minimizing, recovers a bad in
   ).toBeVisible();
   await expect(panel.locator(".simulation-results-header")).toHaveCount(0);
   // A completed run belongs to its folder, not whichever folder is currently visible.
-  await panel.getByRole("button", { name: "+ New folder…" }).click();
+  await panel.getByRole("button", { name: "+ New experiment" }).click();
   await panel.getByLabel("New simulation folder name").fill("Second folder");
   await panel.getByLabel("New simulation folder name").press("Enter");
   await expect(panel.getByRole("status")).not.toHaveText(
@@ -857,7 +857,7 @@ test("human simulation uses saved folder, survives minimizing, recovers a bad in
   await ranges.getByRole("button", { name: "Apply ranges" }).click();
   await expect(ranges).toHaveCount(0);
   const savedTicks = await rightTimeLabel.textContent();
-  await panel.getByRole("tab", { name: "Files" }).click();
+  await panel.getByRole("tab", { name: "Console" }).click();
   await panel.getByRole("tab", { name: "Plot" }).click();
   await expect(rightTimeLabel).toHaveText(savedTicks ?? "");
   await expect(fixedReadout).toHaveText(markersBeforeRemount ?? "");
@@ -865,7 +865,7 @@ test("human simulation uses saved folder, survives minimizing, recovers a bad in
   await transientOutputs
     .getByRole("button", { name: "Hide first-output" })
     .click();
-  await panel.getByRole("tab", { name: "Files" }).click();
+  await panel.getByRole("tab", { name: "Console" }).click();
   await panel.getByRole("tab", { name: "Plot" }).click();
   await expect(
     transientOutputs.getByRole("button", { name: "Show first-output" }),
@@ -904,36 +904,44 @@ test("human simulation uses saved folder, survives minimizing, recovers a bad in
     path: test.info().outputPath("waveform-tools.png"),
   });
   await waveformDialog.getByRole("button", { name: "Close plot" }).click();
-  await panel.getByRole("tab", { name: "Files" }).click();
-  await panel.getByLabel("Run Evidence").locator("summary").click();
+  await panel.getByRole("button", { name: "Restore results" }).click();
+  const runFiles = panel.getByLabel("Run temporary files");
+  await runFiles.locator("summary").click();
   await expect(
     panel.getByRole("button", {
-      name: "evidence-manifest.json",
-      exact: true,
+      name: /evidence-manifest\.json/,
     }),
   ).toBeVisible();
   const download = page.waitForEvent("download");
-  await panel
-    .getByRole("button", { name: /Download .*\.csv$/ })
+  await runFiles
+    .locator('button[data-tree-row="artifact"]')
+    .filter({ hasText: /\.csv/ })
     .first()
     .click();
+  await panel
+    .getByLabel("File preview")
+    .getByRole("button", { name: "Download", exact: true })
+    .click();
   expect((await download).suggestedFilename()).toMatch(/\.csv$/);
-  await expect(panel.getByLabel("Run Results")).toBeVisible();
+  await expect(runFiles).toBeVisible();
+  await runFiles
+    .getByRole("button", { name: /evidence-manifest\.json/ })
+    .click({ modifiers: ["Control"] });
   const bundleDownload = page.waitForEvent("download");
   await panel
-    .getByLabel("Run files")
-    .getByRole("button", { name: "Download ZIP" })
+    .getByRole("button", { name: "Download selected files (2)" })
     .click();
-  expect((await bundleDownload).suggestedFilename()).toBe("simulation-run.zip");
+  expect((await bundleDownload).suggestedFilename()).toMatch(
+    /-selected-files\.zip$/,
+  );
   await panel.getByRole("button", { name: "More code actions" }).click();
   await page.getByRole("menuitem", { name: "View final deck" }).click();
-  await expect(panel.getByLabel("Prepare Netlist")).toBeVisible();
-  await expect(panel.getByLabel("Run Results")).toBeVisible();
+  await expect(panel.getByLabel("Prepare temporary files")).toBeVisible();
+  await expect(panel.getByLabel("Run temporary files")).toBeVisible();
   await expect(panel.getByText("Input identity", { exact: true })).toHaveCount(
     0,
   );
   expect(executions).toBe(1);
-  await panel.getByRole("button", { name: "Restore results" }).click();
   config.outputs[0]!.label = "new-output";
   await editSimulationFile(
     page,
@@ -1173,7 +1181,7 @@ test("human simulation uses saved folder, survives minimizing, recovers a bad in
   expect(executions).toBe(3);
 });
 
-test("Simulation creates an ordinary testbench and offers the current Cell at the cursor", async ({
+test("Simulation creates an ordinary testbench and defaults a new experiment to the current Cell", async ({
   page,
 }) => {
   await page.goto("/editor");
@@ -1206,8 +1214,16 @@ test("Simulation creates an ordinary testbench and offers the current Cell at th
   await expect(page.getByLabel("Testbench Cell")).toHaveCount(0);
   await page.getByRole("button", { name: "Set up", exact: true }).click();
   await page.getByLabel("New simulation folder name").fill("Main experiment");
-  await page.getByLabel("Folder source").selectOption("Current Canvas Cell");
+  await expect(page.getByLabel("Folder template")).toHaveCount(0);
+  await expect(page.getByLabel("Folder source")).toHaveCount(0);
   await page.getByLabel("New simulation folder name").press("Enter");
+  await page
+    .getByRole("button", { name: "run.cir", exact: true })
+    .first()
+    .click();
+  await expect(page.getByLabel("Analysis examples")).toContainText(
+    "ac dec 20 1 1G",
+  );
   const configured = JSON.parse(
     (await downloadBytes(page, "File", "Export Project File…")).toString(),
   );
@@ -1360,7 +1376,7 @@ test("workspace menus, selection, empty editors and resizing share non-destructi
   await handle.press("ArrowRight");
   await expect(handle).toHaveAttribute("aria-valuenow", String(original + 10));
   await handle.dblclick();
-  await expect(handle).toHaveAttribute("aria-valuenow", "170");
+  await expect(handle).toHaveAttribute("aria-valuenow", "240");
   await alpha.click({ button: "right" });
   await page.keyboard.press("Escape");
   await expect(page.getByRole("menu")).toHaveCount(0);
@@ -1396,13 +1412,12 @@ test("inline naming commits once on blur, cancels on Escape, and deletion uses a
     void dialog.dismiss();
   });
   await workspace
-    .getByRole("button", { name: "+ New folder…", exact: true })
+    .getByRole("button", { name: "+ New experiment", exact: true })
     .click();
   const input = workspace.getByRole("textbox", {
     name: "New simulation folder name",
   });
   await input.fill("Gamma");
-  await workspace.getByLabel("Folder template").selectOption("AC");
   // The destination click is not eaten by the naming transaction.
   await workspace
     .getByRole("button", { name: "Folder Beta", exact: true })
@@ -1412,9 +1427,9 @@ test("inline naming commits once on blur, cancels on Escape, and deletion uses a
   ).toHaveCount(1);
   await expect(
     workspace.getByRole("textbox", { name: "Simulation source editor" }),
-  ).toContainText("ac ");
+  ).toContainText("op");
   await workspace
-    .getByRole("button", { name: "+ New folder…", exact: true })
+    .getByRole("button", { name: "+ New experiment", exact: true })
     .click();
   await workspace
     .getByRole("textbox", { name: "New simulation folder name" })

--- a/apps/editor/e2e/simulation-workspace.spec.ts
+++ b/apps/editor/e2e/simulation-workspace.spec.ts
@@ -13,7 +13,7 @@ import {
   replaceSimulationExperimentConfig,
 } from "@icm/model";
 import { parseProject } from "@icm/project-protocol";
-import { generateCircuitSource } from "@icm/netlist";
+import { generateCircuitSource, simulationSignals } from "@icm/netlist";
 
 import {
   clickNetlistWorkflowCommand,
@@ -22,6 +22,65 @@ import {
 import { ota, profile, editSimulationFile } from "./simulation-e2e-fixtures.js";
 
 const loadModule = createRequire(import.meta.url);
+test("native save completion previews its mapped Net on the real Canvas", async ({
+  page,
+}) => {
+  const project = parseProject(JSON.stringify(ota));
+  const folder = createSimulationFolder({
+    id: "completion-preview-folder",
+    name: "Completion preview",
+    documentId: project.topDocumentId,
+    profileId: profile.id,
+  });
+  project.simulationFolders = [folder];
+  const mapped = Object.entries(simulationSignals(project, folder.input)).find(
+    ([, signal]) =>
+      signal.targets.some(
+        (target) =>
+          target.documentId === project.topDocumentId &&
+          target.netId === "tb-vout-net",
+      ),
+  );
+  if (!mapped)
+    throw Error("Expected the OTA output Net to have a native vector");
+  const [vector, signal] = mapped;
+  const target = signal.targets.find(
+    (candidate) =>
+      candidate.documentId === project.topDocumentId &&
+      candidate.netId === "tb-vout-net",
+  )!;
+  await page.route("**/api/simulate", (route) =>
+    route.fulfill({
+      status: 503,
+      json: { error: "Offline authoring fixture" },
+    }),
+  );
+  await page.goto("/editor");
+  await page.getByTestId("project-file").setInputFiles({
+    name: "completion-preview.icproj.json",
+    mimeType: "application/json",
+    buffer: Buffer.from(JSON.stringify(project)),
+  });
+  await page.getByTestId("open-analog-simulation").click();
+  const editor = page.getByRole("textbox", {
+    name: "Simulation source editor",
+  });
+  const source = folder.input.files.find(
+    (file) => file.path === folder.input.entry,
+  )!.text;
+  await editor.fill(`${source.slice(0, source.indexOf(".endc"))}save`);
+  await page.keyboard.type(" ");
+  const option = page.getByRole("option").filter({ hasText: vector });
+  await expect(option).toBeVisible();
+  await option.hover();
+  await expect(page.getByTestId("net-highlight-overlay")).toHaveAttribute(
+    "data-net-id",
+    target.netId,
+  );
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("net-highlight-overlay")).toHaveCount(0);
+});
+
 test("incomplete circuit opens Code and saves invalid parameter drafts across reload and folder duplication", async ({
   page,
 }) => {

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -1763,7 +1763,7 @@ export function App({
   );
   const codeNetHighlight = useMemo(
     () =>
-      simulationWindowOpen &&
+      analogSimulationOpen &&
       codeNetPreview &&
       codeNetPreview.documentId === document.id &&
       JSON.stringify(codeNetPreview.hierarchyPath) ===
@@ -1777,7 +1777,7 @@ export function App({
           )
         : undefined,
     [
-      simulationWindowOpen,
+      analogSimulationOpen,
       codeNetPreview,
       document.id,
       documentStack,

--- a/apps/editor/src/features/simulation/code-editor.tsx
+++ b/apps/editor/src/features/simulation/code-editor.tsx
@@ -93,6 +93,7 @@ export interface SimulationCodeEditorProps {
   onHistoryBoundary?(direction: "undo" | "redo"): void;
   onCursor?(sourceOffset: number): void;
   helperActions?: readonly CodeHelperAction[];
+  ghostHints?: readonly string[];
   relatedSources?: readonly string[];
   signalNames?: (() => Readonly<Record<string, string>>) | undefined;
   onFocusSignal?: ((vector: string | null) => void) | undefined;
@@ -491,6 +492,17 @@ export default function SimulationCodeEditor(props: SimulationCodeEditorProps) {
         }}
         onKeyDown={(event) => event.stopPropagation()}
       />
+      {props.ghostHints?.length && !props.readOnly ? (
+        <div
+          className="simulation-code-ghost-hints"
+          aria-label="Analysis examples"
+        >
+          <span>Try another analysis</span>
+          {props.ghostHints.map((hint) => (
+            <code key={hint}>{hint}</code>
+          ))}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/editor/src/features/simulation/code-workspace.css
+++ b/apps/editor/src/features/simulation/code-workspace.css
@@ -192,6 +192,25 @@
 .workspace-folder-row > button[data-tree-row] {
   flex: 1;
   min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.workspace-folder-row > button[data-tree-row] > span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.simulation-run-target-badge,
+.simulation-temporary-badge {
+  margin-left: auto;
+  padding: 1px 5px;
+  border-radius: 8px;
+  font-size: 9px;
+  line-height: 1.4;
+  letter-spacing: 0.02em;
+  color: var(--icm-text-muted);
+  background: color-mix(in srgb, var(--icm-border) 72%, transparent);
 }
 .workspace-editor-content {
   height: 100%;
@@ -224,6 +243,28 @@
   overflow: auto;
   background: var(--icm-surface-muted);
 }
+.simulation-explorer-header {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  height: 30px;
+  box-sizing: border-box;
+  padding: 0 6px 0 10px;
+  border-bottom: 1px solid var(--icm-border);
+  background: var(--icm-surface-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 10px;
+}
+.simulation-code-files .simulation-explorer-header button {
+  width: auto;
+  margin-left: auto;
+  padding: 4px 7px;
+  text-align: center;
+  border-radius: 3px;
+}
 .simulation-code-files ul {
   list-style: none;
   padding: 6px 0;
@@ -231,6 +272,7 @@
 }
 .simulation-folder-tree {
   min-height: 100%;
+  padding: 4px 0 8px;
 }
 .simulation-code-files input {
   width: 100%;
@@ -239,10 +281,6 @@
 }
 .simulation-folder-tree ul {
   padding-left: 12px;
-}
-.simulation-folder-tree button[aria-pressed="true"] {
-  outline: 1px solid var(--icm-accent);
-  outline-offset: -1px;
 }
 .simulation-code-files button {
   width: 100%;
@@ -256,9 +294,91 @@
   font: inherit;
   padding: 3px 6px;
 }
-.simulation-code-files button.is-active {
-  background: #eaf2f8;
-  color: #155782;
+.simulation-code-files button[data-tree-row].is-selected {
+  background: color-mix(in srgb, var(--icm-accent) 14%, transparent);
+  color: var(--icm-text);
+}
+.simulation-code-files button[data-tree-row].is-active {
+  position: relative;
+  background: color-mix(in srgb, var(--icm-accent) 21%, var(--icm-surface));
+  color: var(--icm-text);
+  font-weight: 600;
+}
+.simulation-code-files button[data-tree-row].is-active::before {
+  content: "";
+  position: absolute;
+  inset: 2px auto 2px 0;
+  width: 2px;
+  background: var(--icm-accent);
+}
+.simulation-folder-tree button[aria-pressed="true"]:not(.is-active),
+.simulation-code-files button[data-tree-row].is-selected:not(.is-active) {
+  box-shadow: inset 0 0 0 1px
+    color-mix(in srgb, var(--icm-accent) 55%, transparent);
+}
+.simulation-explorer-sections {
+  padding-left: 12px;
+}
+.simulation-explorer-section {
+  min-width: 0;
+}
+.simulation-explorer-section > summary {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 26px;
+  padding: 0 7px 0 3px;
+  cursor: pointer;
+  color: var(--icm-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 10px;
+  user-select: none;
+}
+.simulation-explorer-section > summary:hover {
+  background: color-mix(in srgb, var(--icm-border) 45%, transparent);
+}
+.simulation-explorer-section > summary > small:last-child {
+  margin-left: auto;
+  font-variant-numeric: tabular-nums;
+}
+.simulation-explorer-section > p {
+  margin: 0;
+  padding: 0 8px 3px 19px;
+  color: var(--icm-text-muted);
+  font-size: 10px;
+}
+.simulation-explorer-section > ul {
+  padding: 0 0 4px 8px;
+}
+.simulation-explorer-section button[data-tree-row] {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+.simulation-file-icon {
+  flex: none;
+  width: 13px;
+  color: var(--icm-text-muted);
+  text-align: center;
+}
+.simulation-file-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.simulation-file-state {
+  flex: none;
+  color: var(--icm-text-muted);
+}
+.simulation-file-state.is-dirty {
+  color: var(--icm-accent);
+}
+.simulation-explorer-section button[data-tree-row] > small {
+  flex: none;
+  color: var(--icm-text-muted);
+  font-size: 9px;
 }
 .simulation-code-document {
   display: flex;
@@ -279,10 +399,51 @@
   background: var(--icm-surface);
   box-shadow: inset 0 2px var(--icm-accent);
 }
+.simulation-artifact-tab > button[role="tab"] > span {
+  margin-left: 6px;
+  color: var(--icm-text-muted);
+  font-size: 9px;
+  text-transform: uppercase;
+}
 .simulation-code-document-content {
   flex: 1;
   min-height: 0;
   overflow: hidden;
+}
+.simulation-artifact-editor {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  background: var(--icm-surface);
+}
+.simulation-artifact-editor > header {
+  display: flex;
+  align-items: center;
+  min-height: 30px;
+  padding: 0 8px 0 12px;
+  border-bottom: 1px solid var(--icm-border);
+  color: var(--icm-text-muted);
+}
+.simulation-artifact-editor > header button {
+  margin-left: auto;
+  border: 1px solid var(--icm-border);
+  border-radius: 3px;
+  background: var(--icm-surface);
+  color: var(--icm-text);
+  padding: 4px 9px;
+}
+.simulation-artifact-editor > pre {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  margin: 0;
+  padding: 12px 14px;
+  font:
+    12px/1.6 "Google Sans Code Variable",
+    Consolas,
+    monospace;
+  white-space: pre-wrap;
 }
 .simulation-code-editor,
 .simulation-code-editor .cm-editor {
@@ -304,7 +465,7 @@
 }
 .simulation-code-editor .cm-activeLine,
 .simulation-code-editor .cm-activeLineGutter {
-  background: #f3f7fa;
+  background: color-mix(in srgb, var(--icm-accent) 7%, transparent);
 }
 .simulation-code-editor .cm-focused {
   outline: none;
@@ -365,6 +526,36 @@
   font-size: 11px;
   color: var(--icm-text-muted);
 }
+.simulation-code-actions [data-workspace-save] {
+  min-width: 68px;
+  border-radius: 3px;
+  transition:
+    background 120ms ease,
+    color 120ms ease,
+    box-shadow 120ms ease;
+}
+.simulation-code-actions [data-workspace-save][data-save-state="dirty"] {
+  background: var(--icm-accent);
+  color: white;
+  box-shadow: 0 1px 2px #0002;
+}
+.simulation-code-actions [data-workspace-save][data-save-state="saving"] {
+  opacity: 1;
+  background: color-mix(in srgb, var(--icm-accent) 16%, var(--icm-surface));
+  color: var(--icm-text);
+}
+.simulation-code-actions [data-workspace-save][data-save-state="saved"],
+.simulation-code-actions
+  [data-workspace-save][data-save-state="saved"]:disabled {
+  opacity: 1;
+  color: #26734d;
+  background: color-mix(in srgb, #38a169 12%, var(--icm-surface));
+}
+.simulation-code-actions [data-workspace-save][data-save-state="failed"] {
+  opacity: 1;
+  color: #b42318;
+  background: color-mix(in srgb, #b42318 10%, var(--icm-surface));
+}
 .simulation-code-workspace.is-maximized .simulation-code-source-area,
 .simulation-code-workspace.is-maximized .simulation-code-output-resizer {
   display: none;
@@ -400,6 +591,26 @@
 .simulation-code-editor-shell > .simulation-code-editor {
   min-height: 0;
   flex: 1;
+}
+.simulation-code-ghost-hints {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 26px;
+  padding: 3px 9px;
+  overflow-x: auto;
+  border-top: 1px solid var(--icm-border);
+  color: var(--icm-text-muted);
+  background: color-mix(in srgb, var(--icm-surface-muted) 78%, transparent);
+  white-space: nowrap;
+}
+.simulation-code-ghost-hints code {
+  opacity: 0.72;
+  font:
+    10px "Google Sans Code Variable",
+    Consolas,
+    monospace;
 }
 .simulation-code-helper-toolbar {
   height: 28px;

--- a/apps/editor/src/features/simulation/code-workspace.test.tsx
+++ b/apps/editor/src/features/simulation/code-workspace.test.tsx
@@ -4,7 +4,7 @@ import { SimulationCodeWorkspace } from "./code-workspace";
 import { WorkspaceInteractions } from "./workspace-interactions";
 
 describe("approved simulation Code layout", () => {
-  it("presents execution folders beside code without a Setup selector", () => {
+  it("presents experiments and source beside code without a Setup selector", () => {
     const markup = renderToStaticMarkup(
       <WorkspaceInteractions>
         <SimulationCodeWorkspace
@@ -36,6 +36,9 @@ describe("approved simulation Code layout", () => {
     expect(markup).toContain("OTA AC");
     expect(markup).toContain("OTA transient");
     expect(markup).toContain('data-workspace-new-folder="true"');
+    expect(markup).toContain("+ New experiment");
+    expect(markup).toContain("Source");
+    expect(markup).toContain("Run target");
     expect(markup).not.toContain("New file");
     expect(markup).not.toContain("Setup");
   });
@@ -73,7 +76,59 @@ describe("approved simulation Code layout", () => {
     expect(markup).not.toContain("Settings");
     expect(markup).toContain(">Compare</button>");
     expect(markup).toContain(">OP</button>");
+    expect(markup).not.toContain(">Files</button>");
     expect(markup).not.toContain(">Results</button>");
     expect(markup).toContain('aria-label="Close run.cir"');
+  });
+  it("defaults Source open and temporary Prepare/Run files closed in Explorer", () => {
+    const artifact = {
+      id: "artifact-1",
+      name: "prepared.cir",
+      mediaType: "text/plain",
+      byteLength: 12,
+      sha256: "0".repeat(64),
+    };
+    const markup = renderToStaticMarkup(
+      <WorkspaceInteractions>
+        <SimulationCodeWorkspace
+          workspaceKey="a"
+          entryPath="run.cir"
+          configPath="experiment.json"
+          activePath="run.cir"
+          files={[{ path: "run.cir", kind: "authored" }]}
+          artifactGroups={[
+            {
+              key: "prepare",
+              label: "Prepare",
+              description: "Compiled input",
+              artifacts: [artifact],
+            },
+          ]}
+          onSelectFile={() => {}}
+          folders={{
+            folders: [{ id: "a", name: "Untitled" }],
+            activeId: "a",
+            onSelect: () => {},
+            onAction: () => {},
+          }}
+          actions={null}
+          console={null}
+          results={null}
+          outputPane="console"
+          onSelectOutputPane={() => {}}
+        >
+          Code
+        </SimulationCodeWorkspace>
+      </WorkspaceInteractions>,
+    );
+    expect(markup).toMatch(
+      /class="simulation-explorer-section is-source" open=""/,
+    );
+    expect(markup).toContain(
+      'class="simulation-explorer-section is-temporary" aria-label="Prepare temporary files"',
+    );
+    expect(markup).toContain("Temporary");
+    expect(markup).toContain("prepared.cir");
+    expect(markup).toContain('aria-label="Download selected files"');
   });
 });

--- a/apps/editor/src/features/simulation/code-workspace.tsx
+++ b/apps/editor/src/features/simulation/code-workspace.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useId, useState, type ReactNode } from "react";
+import {
+  useEffect,
+  useId,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+  type ReactNode,
+} from "react";
+import type { ArtifactRef } from "@icm/simulation-service/contract";
 import {
   SimulationFolderTree,
   type SimulationFolderTreeProps,
@@ -8,6 +15,11 @@ import {
   WorkspaceNameInput,
   type WorkspaceMenuItem,
 } from "./workspace-interactions";
+import {
+  formatSimulationArtifactPreview,
+  simulationArtifactCategory,
+  type SimulationArtifactContent,
+} from "./simulation-artifact-files";
 
 export interface SimulationCodeFile {
   path: string;
@@ -15,6 +27,15 @@ export interface SimulationCodeFile {
   dirty?: boolean;
   draft?: boolean;
 }
+export interface SimulationExplorerArtifactGroup {
+  key: "prepare" | "run";
+  label: string;
+  description: string;
+  artifacts: readonly ArtifactRef[];
+}
+export type SimulationExplorerSelection =
+  | { kind: "source"; folderId: string; path: string }
+  | { kind: "artifact"; groupKey: "prepare" | "run"; artifact: ArtifactRef };
 export interface SimulationCodeWorkspaceProps {
   workspaceKey: string;
   files: readonly SimulationCodeFile[];
@@ -30,6 +51,13 @@ export interface SimulationCodeWorkspaceProps {
     path: string,
     folderId?: string,
   ): void;
+  artifactGroups?: readonly SimulationExplorerArtifactGroup[];
+  artifactPreview?: SimulationArtifactContent | undefined;
+  artifactBusy?: string | undefined;
+  onSelectArtifact?(artifact: ArtifactRef): void;
+  onCloseArtifact?(): void;
+  onDownloadArtifact?(artifact: ArtifactRef): void;
+  onDownloadSelection?(selection: readonly SimulationExplorerSelection[]): void;
   folders?:
     Omit<SimulationFolderTreeProps, "renderFiles" | "onNewFile"> | undefined;
   additionalActions?: WorkspaceMenuItem[];
@@ -39,7 +67,7 @@ export interface SimulationCodeWorkspaceProps {
   console: ReactNode;
   results: ReactNode;
   outputActions?: ReactNode;
-  outputPane: "console" | "plot" | "operating-point" | "compare" | "files";
+  outputPane: "console" | "plot" | "operating-point" | "compare";
   onSelectOutputPane(pane: SimulationCodeWorkspaceProps["outputPane"]): void;
   maximized?: boolean;
   onToggleMaximize?(): void;
@@ -70,15 +98,17 @@ export function SimulationCodeWorkspace(props: SimulationCodeWorkspaceProps) {
         110,
         Math.min(
           420,
-          Number(localStorage.getItem("icm.code.files-width")) || 170,
+          Number(localStorage.getItem("icm.code.files-width")) || 240,
         ),
       );
     } catch {
-      return 170;
+      return 240;
     }
   });
   const [resultsHeight, setResultsHeight] = useState(38);
   const [collapsed, setCollapsed] = useState(false);
+  const [selected, setSelected] = useState<string[]>([]);
+  const [sectionOpen, setSectionOpen] = useState<Record<string, boolean>>({});
   useEffect(() => {
     if (props.activePath)
       setOpened((paths) =>
@@ -108,6 +138,33 @@ export function SimulationCodeWorkspace(props: SimulationCodeWorkspaceProps) {
     const next = tabs.filter((item) => item !== path);
     setOpened(next);
     if (props.activePath === path) props.onSelectFile(next.at(-1) ?? "");
+  };
+  const sourceKey = (folderId: string, path: string) =>
+    `source\u0000${folderId}\u0000${path}`;
+  const artifactKey = (groupKey: string, artifactId: string) =>
+    `artifact\u0000${groupKey}\u0000${artifactId}`;
+  const select = (key: string, event: ReactMouseEvent) =>
+    setSelected((current) =>
+      event.ctrlKey || event.metaKey
+        ? current.includes(key)
+          ? current.filter((item) => item !== key)
+          : [...current, key]
+        : [key],
+    );
+  const selection = (): SimulationExplorerSelection[] => {
+    const result: SimulationExplorerSelection[] = [];
+    for (const key of selected) {
+      const [kind, owner, value] = key.split("\u0000");
+      if (kind === "source" && owner && value)
+        result.push({ kind, folderId: owner, path: value });
+      if (kind === "artifact" && (owner === "prepare" || owner === "run")) {
+        const artifact = props.artifactGroups
+          ?.find((group) => group.key === owner)
+          ?.artifacts.find((item) => item.id === value);
+        if (artifact) result.push({ kind, groupKey: owner, artifact });
+      }
+    }
+    return result;
   };
   const fileMenu = (
     file: SimulationCodeFile,
@@ -150,86 +207,191 @@ export function SimulationCodeWorkspace(props: SimulationCodeWorkspaceProps) {
     const current = !folderId || folderId === props.folders?.activeId;
     const folder = props.folders?.folders.find((f) => f.id === folderId);
     const files = current ? props.files : (folder?.files ?? []);
+    const visibleFiles = files.filter(
+      (file) => file.path !== (current ? props.configPath : folder?.configPath),
+    );
     const editing =
       ui.edit?.kind === "file" &&
       ui.edit.folderId === (folderId ?? props.folders?.activeId);
+    const resolvedFolderId = folderId ?? props.folders?.activeId ?? "workspace";
+    const sourceSectionKey = `${resolvedFolderId}:source`;
+    const groups = current ? (props.artifactGroups ?? []) : [];
     return (
-      <ul>
-        {editing && !ui.edit?.path ? (
-          <li>
-            <WorkspaceNameInput key="new-file" />
-          </li>
-        ) : null}
-        {files
-          .filter(
-            (file) =>
-              file.path !== (current ? props.configPath : folder?.configPath),
-          )
-          .map((file) => (
-            <li
-              key={file.path}
-              onContextMenu={(event) => {
-                event.preventDefault();
-                event.stopPropagation();
-                fileMenu(file, folderId, event.clientX, event.clientY);
-              }}
-              onKeyDown={(event) => {
-                if (event.target instanceof HTMLInputElement) return;
-                if (
-                  (event.key === "F2" || event.key === "Delete") &&
-                  file.kind === "authored"
-                ) {
+      <div className="simulation-explorer-sections">
+        <details
+          className="simulation-explorer-section is-source"
+          open={sectionOpen[sourceSectionKey] ?? true}
+          onToggle={(event) => {
+            const open = event.currentTarget.open;
+            setSectionOpen((state) => ({
+              ...state,
+              [sourceSectionKey]: open,
+            }));
+          }}
+        >
+          <summary>
+            <span>Source</span>
+            <small>{visibleFiles.length}</small>
+          </summary>
+          <ul>
+            {editing && !ui.edit?.path ? (
+              <li>
+                <WorkspaceNameInput key="new-file" />
+              </li>
+            ) : null}
+            {visibleFiles.map((file) => (
+              <li
+                key={file.path}
+                onContextMenu={(event) => {
                   event.preventDefault();
-                  props.onFileAction?.(
-                    event.key === "F2" ? "rename" : "delete",
-                    file.path,
-                    folderId,
-                  );
-                }
-                if (
-                  event.key === "ContextMenu" ||
-                  (event.shiftKey && event.key === "F10")
-                ) {
-                  event.preventDefault();
-                  const rect = event.currentTarget.getBoundingClientRect();
-                  fileMenu(file, folderId, rect.left, rect.bottom);
-                }
+                  event.stopPropagation();
+                  fileMenu(file, folderId, event.clientX, event.clientY);
+                }}
+                onKeyDown={(event) => {
+                  if (event.target instanceof HTMLInputElement) return;
+                  if (
+                    (event.key === "F2" || event.key === "Delete") &&
+                    file.kind === "authored"
+                  ) {
+                    event.preventDefault();
+                    props.onFileAction?.(
+                      event.key === "F2" ? "rename" : "delete",
+                      file.path,
+                      folderId,
+                    );
+                  }
+                  if (
+                    event.key === "ContextMenu" ||
+                    (event.shiftKey && event.key === "F10")
+                  ) {
+                    event.preventDefault();
+                    const rect = event.currentTarget.getBoundingClientRect();
+                    fileMenu(file, folderId, rect.left, rect.bottom);
+                  }
+                }}
+              >
+                {editing && ui.edit?.path === file.path ? (
+                  <WorkspaceNameInput key={file.path} />
+                ) : (
+                  <button
+                    type="button"
+                    data-tree-row="file"
+                    data-folder-id={folderId ?? props.folders?.activeId}
+                    data-file-path={file.path}
+                    className={[
+                      current &&
+                      !props.artifactPreview &&
+                      file.path === props.activePath
+                        ? "is-active"
+                        : "",
+                      selected.includes(sourceKey(resolvedFolderId, file.path))
+                        ? "is-selected"
+                        : "",
+                    ]
+                      .filter(Boolean)
+                      .join(" ")}
+                    aria-pressed={selected.includes(
+                      sourceKey(resolvedFolderId, file.path),
+                    )}
+                    title={file.path}
+                    onClick={(event) => {
+                      select(sourceKey(resolvedFolderId, file.path), event);
+                      props.onCloseArtifact?.();
+                      openFile(file.path, folderId);
+                    }}
+                  >
+                    <span className="simulation-file-icon" aria-hidden="true">
+                      {file.kind === "generated"
+                        ? "◇"
+                        : file.kind === "prepared"
+                          ? "▧"
+                          : "·"}
+                    </span>
+                    <span className="simulation-file-name">{file.path}</span>
+                    {file.dirty ? (
+                      <span
+                        className="simulation-file-state is-dirty"
+                        title="Unsaved"
+                      >
+                        ●
+                      </span>
+                    ) : file.draft ? (
+                      <span
+                        className="simulation-file-state"
+                        title="Saved draft"
+                      >
+                        ◌
+                      </span>
+                    ) : null}
+                  </button>
+                )}
+              </li>
+            ))}
+          </ul>
+        </details>
+        {groups.map((group) => {
+          const groupSectionKey = `${resolvedFolderId}:${group.key}`;
+          return (
+            <details
+              key={group.key}
+              className="simulation-explorer-section is-temporary"
+              aria-label={`${group.label} temporary files`}
+              open={sectionOpen[groupSectionKey] ?? false}
+              onToggle={(event) => {
+                const open = event.currentTarget.open;
+                setSectionOpen((state) => ({
+                  ...state,
+                  [groupSectionKey]: open,
+                }));
               }}
             >
-              {editing && ui.edit?.path === file.path ? (
-                <WorkspaceNameInput key={file.path} />
-              ) : (
-                <button
-                  type="button"
-                  data-tree-row="file"
-                  data-folder-id={folderId ?? props.folders?.activeId}
-                  data-file-path={file.path}
-                  className={
-                    current && file.path === props.activePath ? "is-active" : ""
-                  }
-                  title={file.path}
-                  onClick={() => openFile(file.path, folderId)}
-                >
-                  <span aria-hidden="true">
-                    {file.kind === "generated"
-                      ? "◇"
-                      : file.kind === "prepared"
-                        ? "▧"
-                        : "·"}
-                  </span>{" "}
-                  {file.path}
-                  {"dirty" in file && file.dirty
-                    ? " ●"
-                    : "draft" in file && file.draft
-                      ? " ◌"
-                      : ""}
-                </button>
-              )}
-            </li>
-          ))}
-      </ul>
+              <summary>
+                <span>{group.label}</span>
+                <span className="simulation-temporary-badge">Temporary</span>
+                <small>{group.artifacts.length}</small>
+              </summary>
+              <p>{group.description}</p>
+              <ul>
+                {group.artifacts.map((artifact) => {
+                  const key = artifactKey(group.key, artifact.id);
+                  const active =
+                    props.artifactPreview?.artifact.id === artifact.id;
+                  return (
+                    <li key={artifact.id}>
+                      <button
+                        type="button"
+                        data-tree-row="artifact"
+                        className={`${active ? "is-active" : ""}${selected.includes(key) ? " is-selected" : ""}`.trim()}
+                        aria-pressed={selected.includes(key)}
+                        title={`${simulationArtifactCategory(artifact)} · ${artifact.name}`}
+                        disabled={props.artifactBusy !== undefined}
+                        onClick={(event) => {
+                          select(key, event);
+                          props.onSelectArtifact?.(artifact);
+                        }}
+                      >
+                        <span
+                          className="simulation-file-icon"
+                          aria-hidden="true"
+                        >
+                          ▧
+                        </span>
+                        <span className="simulation-file-name">
+                          {artifact.name}
+                        </span>
+                        <small>{simulationArtifactCategory(artifact)}</small>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            </details>
+          );
+        })}
+      </div>
     );
   };
+  const selectedItems = selection();
   return (
     <section
       className={`simulation-code-workspace${props.maximized ? " is-maximized" : ""}`}
@@ -263,7 +425,7 @@ export function SimulationCodeWorkspace(props: SimulationCodeWorkspaceProps) {
           aria-controls={filesId}
           onClick={() => setFilesOpen(!filesOpen)}
         >
-          Files
+          Explorer
         </button>
         <div className="simulation-code-actions">{props.actions}</div>
         <div className="simulation-code-more">
@@ -315,6 +477,18 @@ export function SimulationCodeWorkspace(props: SimulationCodeWorkspaceProps) {
             style={{ width: filesWidth }}
             aria-label="Simulation files"
           >
+            <header className="simulation-explorer-header">
+              <strong>Explorer</strong>
+              <button
+                type="button"
+                disabled={!selectedItems.length || !props.onDownloadSelection}
+                onClick={() => props.onDownloadSelection?.(selectedItems)}
+                title="Download selected files"
+                aria-label={`Download selected files${selectedItems.length ? ` (${selectedItems.length})` : ""}`}
+              >
+                ↓ {selectedItems.length || ""}
+              </button>
+            </header>
             {props.folders ? (
               <SimulationFolderTree
                 {...props.folders}
@@ -336,7 +510,7 @@ export function SimulationCodeWorkspace(props: SimulationCodeWorkspaceProps) {
             aria-valuemin={110}
             aria-valuemax={420}
             aria-valuenow={filesWidth}
-            onDoubleClick={() => setFilesWidth(170)}
+            onDoubleClick={() => setFilesWidth(240)}
             onKeyDown={(event) => {
               if (event.key === "ArrowLeft" || event.key === "ArrowRight") {
                 event.preventDefault();
@@ -380,6 +554,21 @@ export function SimulationCodeWorkspace(props: SimulationCodeWorkspaceProps) {
             role="tablist"
             aria-label="Open simulation files"
           >
+            {props.artifactPreview ? (
+              <div className="simulation-code-tab simulation-artifact-tab">
+                <button type="button" role="tab" aria-selected="true">
+                  {props.artifactPreview.artifact.name}
+                  <span> Temporary</span>
+                </button>
+                <button
+                  type="button"
+                  aria-label={`Close ${props.artifactPreview.artifact.name}`}
+                  onClick={props.onCloseArtifact}
+                >
+                  ×
+                </button>
+              </div>
+            ) : null}
             {tabs.map((path) => {
               const file = props.files.find((f) => f.path === path)!;
               return (
@@ -387,8 +576,13 @@ export function SimulationCodeWorkspace(props: SimulationCodeWorkspaceProps) {
                   <button
                     type="button"
                     role="tab"
-                    aria-selected={props.activePath === path}
-                    onClick={() => props.onSelectFile(path)}
+                    aria-selected={
+                      !props.artifactPreview && props.activePath === path
+                    }
+                    onClick={() => {
+                      props.onCloseArtifact?.();
+                      props.onSelectFile(path);
+                    }}
                     title={path}
                   >
                     {path === props.configPath
@@ -412,12 +606,38 @@ export function SimulationCodeWorkspace(props: SimulationCodeWorkspaceProps) {
           </div>
           <div className="simulation-code-document-content">
             <div
-              hidden={!props.activePath}
+              hidden={!props.activePath || Boolean(props.artifactPreview)}
               className="workspace-editor-content"
             >
               {props.children}
             </div>
-            {!props.activePath ? (
+            {props.artifactPreview ? (
+              <section
+                className="simulation-artifact-editor"
+                aria-label="File preview"
+              >
+                <header>
+                  <span>
+                    Read-only preview · Temporary run file
+                    {props.artifactPreview.truncated ? " · First 64 KB" : ""}
+                  </span>
+                  <button
+                    type="button"
+                    disabled={props.artifactBusy !== undefined}
+                    onClick={() =>
+                      props.onDownloadArtifact?.(
+                        props.artifactPreview!.artifact,
+                      )
+                    }
+                  >
+                    Download
+                  </button>
+                </header>
+                <pre>
+                  {formatSimulationArtifactPreview(props.artifactPreview)}
+                </pre>
+              </section>
+            ) : !props.activePath ? (
               <p className="workspace-empty-editor">
                 Select a file to edit. Closing tabs does not delete files.
               </p>
@@ -486,39 +706,32 @@ export function SimulationCodeWorkspace(props: SimulationCodeWorkspaceProps) {
       >
         <header className="simulation-code-output-tabs">
           <div role="tablist" aria-label="Code output view">
-            {(
-              [
-                "console",
-                "plot",
-                "operating-point",
-                "compare",
-                "files",
-              ] as const
-            ).map((pane) => (
-              <button
-                key={pane}
-                type="button"
-                role="tab"
-                aria-selected={pane === props.outputPane}
-                aria-label={
-                  pane === "operating-point" ? "Operating Point" : undefined
-                }
-                onClick={() => {
-                  props.onSelectOutputPane(pane);
-                  setCollapsed(false);
-                }}
-              >
-                {
+            {(["console", "plot", "operating-point", "compare"] as const).map(
+              (pane) => (
+                <button
+                  key={pane}
+                  type="button"
+                  role="tab"
+                  aria-selected={pane === props.outputPane}
+                  aria-label={
+                    pane === "operating-point" ? "Operating Point" : undefined
+                  }
+                  onClick={() => {
+                    props.onSelectOutputPane(pane);
+                    setCollapsed(false);
+                  }}
+                >
                   {
-                    console: "Console",
-                    plot: "Plot",
-                    "operating-point": "OP",
-                    compare: "Compare",
-                    files: "Files",
-                  }[pane]
-                }
-              </button>
-            ))}
+                    {
+                      console: "Console",
+                      plot: "Plot",
+                      "operating-point": "OP",
+                      compare: "Compare",
+                    }[pane]
+                  }
+                </button>
+              ),
+            )}
           </div>
           <span className="simulation-code-output-spacer" />
           {props.outputActions}

--- a/apps/editor/src/features/simulation/simulation-artifact-files.test.ts
+++ b/apps/editor/src/features/simulation/simulation-artifact-files.test.ts
@@ -4,6 +4,7 @@ import { SimulationFiles } from "@icm/simulation-service/files";
 
 import {
   buildSimulationArtifactArchive,
+  buildSimulationWorkspaceArchive,
   formatSimulationArtifactPreview,
   readSimulationArtifactPreview,
   simulationArtifactCategory,
@@ -51,5 +52,23 @@ describe("simulation artifact files", () => {
     );
     expect(simulationArtifactCategory(deck)).toBe("Netlist");
     expect(simulationArtifactCategory(csv)).toBe("Results");
+  });
+
+  it("packages selected source and temporary artifacts into one hierarchy", async () => {
+    const files = new SimulationFiles();
+    const log = await files.put("run.log", "text/plain", "finished\n");
+    const archive = await buildSimulationWorkspaceArchive(files, [
+      {
+        kind: "text",
+        path: "Untitled/source/run.cir",
+        text: "op\n",
+      },
+      { kind: "artifact", path: "run/log/run.log", artifact: log },
+    ]);
+    expect(archive.ok).toBe(true);
+    if (!archive.ok) return;
+    const entries = unzipSync(archive.bytes);
+    expect(strFromU8(entries["Untitled/source/run.cir"]!)).toBe("op\n");
+    expect(strFromU8(entries["run/log/run.log"]!)).toBe("finished\n");
   });
 });

--- a/apps/editor/src/features/simulation/simulation-artifact-files.ts
+++ b/apps/editor/src/features/simulation/simulation-artifact-files.ts
@@ -10,6 +10,14 @@ export interface SimulationArtifactContent {
   readonly truncated: boolean;
 }
 
+export type SimulationWorkspaceArchiveEntry =
+  | { readonly kind: "text"; readonly path: string; readonly text: string }
+  | {
+      readonly kind: "artifact";
+      readonly path: string;
+      readonly artifact: ArtifactRef;
+    };
+
 type ArtifactReadResult =
   | { readonly ok: true; readonly content: SimulationArtifactContent }
   | { readonly ok: false; readonly error: Problem };
@@ -114,6 +122,58 @@ export async function buildSimulationArtifactArchive(
       },
     };
   }
+}
+
+export async function buildSimulationWorkspaceArchive(
+  files: SimulationFiles,
+  items: readonly SimulationWorkspaceArchiveEntry[],
+): Promise<
+  | { readonly ok: true; readonly bytes: Uint8Array }
+  | { readonly ok: false; readonly error: Problem }
+> {
+  try {
+    const entries: Record<string, Uint8Array> = {};
+    for (const item of items) {
+      let text: string;
+      if (item.kind === "text") text = item.text;
+      else {
+        const result = await readSimulationArtifact(files, item.artifact);
+        if (!result.ok) return result;
+        text = result.content.text;
+      }
+      entries[archivePath(item.path)] = strToU8(text);
+    }
+    return {
+      ok: true,
+      bytes: await new Promise<Uint8Array>((resolve, reject) =>
+        zip(
+          entries,
+          { level: 6, mtime: new Date("1980-01-01T00:00:00.000Z") },
+          (error, bytes) => (error ? reject(error) : resolve(bytes)),
+        ),
+      ),
+    };
+  } catch {
+    return {
+      ok: false,
+      error: {
+        code: "ARTIFACT_ARCHIVE_FAILED",
+        message:
+          "The selected file bundle could not be created in this browser",
+        stage: "export",
+        recovery: "retry-after",
+      },
+    };
+  }
+}
+
+function archivePath(path: string): string {
+  const safe = path
+    .replaceAll("\\", "/")
+    .split("/")
+    .filter((part) => part && part !== "." && part !== "..")
+    .join("/");
+  return safe || "file.txt";
 }
 
 export function simulationArtifactCategory(artifact: ArtifactRef): string {

--- a/apps/editor/src/features/simulation/simulation-file-tree.tsx
+++ b/apps/editor/src/features/simulation/simulation-file-tree.tsx
@@ -42,7 +42,7 @@ export function SimulationFolderTree(props: SimulationFolderTreeProps) {
     setSelected(ids);
     const target = id ?? props.activeId;
     const items: WorkspaceMenuItem[] = [
-      { label: "New folder…", run: () => action("new", []) },
+      { label: "New experiment…", run: () => action("new", []) },
       {
         label: "New file…",
         disabled: !target,
@@ -130,7 +130,7 @@ export function SimulationFolderTree(props: SimulationFolderTreeProps) {
         data-workspace-new-folder="true"
         onClick={() => action("new", [])}
       >
-        + New folder…
+        + New experiment
       </button>
       {naming && !ui.edit?.folderId ? (
         <WorkspaceNameInput key="new-folder" />
@@ -211,7 +211,12 @@ export function SimulationFolderTree(props: SimulationFolderTreeProps) {
                   }
                 }}
               >
-                {folder.name}
+                <span>{folder.name}</span>
+                {folder.id === props.activeId ? (
+                  <small className="simulation-run-target-badge">
+                    Run target
+                  </small>
+                ) : null}
               </button>
             </div>
           )}

--- a/apps/editor/src/features/simulation/source-code-pane.tsx
+++ b/apps/editor/src/features/simulation/source-code-pane.tsx
@@ -40,7 +40,12 @@ import { useWorkspaceInteractions } from "./workspace-interactions";
 import {
   SimulationCodeWorkspace,
   type SimulationCodeWorkspaceProps,
+  type SimulationExplorerSelection,
 } from "./code-workspace";
+import {
+  buildSimulationWorkspaceArchive,
+  simulationArtifactCategory,
+} from "./simulation-artifact-files";
 import { sourceProbeChoices } from "./source-probe-choices";
 import { SourceProbePicker } from "./source-probe-picker";
 
@@ -74,6 +79,12 @@ interface Props extends Pick<
   console: ReactNode;
   results: ReactNode;
   outputActions?: ReactNode;
+  artifactGroups?: SimulationCodeWorkspaceProps["artifactGroups"];
+  artifactPreview?: SimulationCodeWorkspaceProps["artifactPreview"];
+  artifactBusy?: string | undefined;
+  onSelectArtifact?: SimulationCodeWorkspaceProps["onSelectArtifact"];
+  onCloseArtifact?: SimulationCodeWorkspaceProps["onCloseArtifact"];
+  onDownloadArtifact?: SimulationCodeWorkspaceProps["onDownloadArtifact"];
   status?: ReactNode;
   outputPane: SimulationCodeWorkspaceProps["outputPane"];
   onSelectOutputPane: SimulationCodeWorkspaceProps["onSelectOutputPane"];
@@ -750,6 +761,55 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
         setSaveRequested(false);
       }
     };
+    const downloadSelection = async (
+      selection: readonly SimulationExplorerSelection[],
+    ) => {
+      if (selection.length === 1) {
+        const item = selection[0]!;
+        if (item.kind === "source") {
+          const result = downloadTextArtifact(
+            fileText(item.folderId, item.path),
+            item.path.split("/").at(-1)!,
+          );
+          if (result.status === "failed")
+            props.onProblem(
+              inputProblem("SOURCE_EXPORT_FAILED", result.message),
+            );
+        } else props.onDownloadArtifact?.(item.artifact);
+        return;
+      }
+      const archive = await buildSimulationWorkspaceArchive(
+        props.files,
+        selection.map((item) => {
+          if (item.kind === "artifact")
+            return {
+              kind: "artifact" as const,
+              path: `${item.groupKey}/${simulationArtifactCategory(item.artifact).toLowerCase()}/${item.artifact.name}`,
+              artifact: item.artifact,
+            };
+          const folder = props.project.simulationFolders.find(
+            (candidate) => candidate.id === item.folderId,
+          );
+          return {
+            kind: "text" as const,
+            path: `${folder?.name ?? item.folderId}/source/${item.path}`,
+            text: fileText(item.folderId, item.path),
+          };
+        }),
+      );
+      if (!archive.ok) {
+        props.onProblem(archive.error);
+        return;
+      }
+      const url = URL.createObjectURL(
+        new Blob([archive.bytes as BlobPart], { type: "application/zip" }),
+      );
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = `${props.folder.name}-selected-files.zip`;
+      anchor.click();
+      setTimeout(() => URL.revokeObjectURL(url), 0);
+    };
     return (
       <SimulationCodeWorkspace
         workspaceKey={props.folder.id}
@@ -800,6 +860,23 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
         additionalActions={[
           { label: "View final deck", run: () => props.onPrepare?.() },
         ]}
+        {...(props.artifactGroups
+          ? { artifactGroups: props.artifactGroups }
+          : {})}
+        {...(props.artifactPreview
+          ? { artifactPreview: props.artifactPreview }
+          : {})}
+        {...(props.artifactBusy ? { artifactBusy: props.artifactBusy } : {})}
+        {...(props.onSelectArtifact
+          ? { onSelectArtifact: props.onSelectArtifact }
+          : {})}
+        {...(props.onCloseArtifact
+          ? { onCloseArtifact: props.onCloseArtifact }
+          : {})}
+        {...(props.onDownloadArtifact
+          ? { onDownloadArtifact: props.onDownloadArtifact }
+          : {})}
+        onDownloadSelection={(selection) => void downloadSelection(selection)}
         files={ownFiles.map((filePath) => ({
           path: filePath,
           kind: input.circuitBindings.some((b) => b.path === filePath)
@@ -988,6 +1065,16 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
           <>
             <button
               data-workspace-save="true"
+              data-save-state={
+                saveRequested || saving || props.projectSaveState === "saving"
+                  ? "saving"
+                  : props.projectSaveState === "failed" ||
+                      props.projectSaveState === "offline"
+                    ? "failed"
+                    : props.projectSaveState === "clean" && !dirty
+                      ? "saved"
+                      : "dirty"
+              }
               aria-label="Save project"
               title={
                 props.projectSaveState === "failed" ||
@@ -1009,7 +1096,7 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
               {saveRequested || saving || props.projectSaveState === "saving"
                 ? "Saving…"
                 : props.projectSaveState === "clean" && !dirty
-                  ? "Saved"
+                  ? "✓ Saved"
                   : props.projectSaveState === "failed" ||
                       props.projectSaveState === "offline"
                     ? "Retry save"
@@ -1084,6 +1171,15 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
               drafts.current.get(`${props.folder.id}\u0000${file.path}`)
                 ?.text ?? file.text,
           )}
+          {...(selected?.path === input.entry
+            ? {
+                ghostHints: [
+                  "ac dec 20 1 1G",
+                  "tran 1n 1u",
+                  "dc VIN 0 1.8 0.01",
+                ],
+              }
+            : {})}
           helperActions={[
             {
               id: "save-voltage",

--- a/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
@@ -50,7 +50,8 @@ describe("source workspace default cutover", () => {
   it("projects the Project save lifecycle instead of claiming a buffer flush saved to cloud", () => {
     expect(render(true, false, "saving")).toContain("Saving…");
     expect(render(true, false, "saving")).toContain('aria-busy="true"');
-    expect(render(true, false, "clean")).toContain(">Saved</button>");
+    expect(render(true, false, "clean")).toContain(">✓ Saved</button>");
+    expect(render(true, false, "clean")).toContain('data-save-state="saved"');
     expect(render(true, false, "failed")).toContain("Retry save");
   });
   it("offers creation without restoring the retired Settings form", () => {

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -56,10 +56,8 @@ import { DeviceOperatingPointResults } from "./device-operating-point-results";
 
 import {
   buildSimulationArtifactArchive,
-  formatSimulationArtifactPreview,
   readSimulationArtifact,
   readSimulationArtifactPreview,
-  simulationArtifactCategory,
   type SimulationArtifactContent,
 } from "./simulation-artifact-files";
 import {
@@ -315,7 +313,7 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
       setPrepared(reply.prepared);
       setProblem(undefined);
       setArtifactPreview(undefined);
-      setResultTab("files");
+      setResultTab("console");
     } else if ("capabilities" in reply) {
       setCapabilities(reply.capabilities);
       setProblem(undefined);
@@ -556,7 +554,7 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
       setRun(undefined);
       setProblem(undefined);
       setArtifactPreview(undefined);
-      setResultTab("files");
+      setResultTab("console");
       if (presentation)
         folderResults.current.set(item.folderId, { prepared: item.prepared });
       return;
@@ -880,34 +878,26 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
       ];
     });
   };
-  const artifactCategories = ["Netlist", "Results", "Evidence", "Log", "Other"];
   const runPreparedArtifactIds = new Set(
     runPresentation?.prepared.artifacts.map((artifact) => artifact.id) ?? [],
   );
   const artifactGroups = [
-    ...(prepared
-      ? [
-          {
-            key: "prepare" as const,
-            label: "Prepare",
-            description: "Compiled input",
-            artifacts: prepared.artifacts,
-          },
-        ]
-      : []),
-    ...(run
-      ? [
-          {
-            key: "run" as const,
-            label: "Run",
-            description: "Execution output",
-            artifacts: run.artifacts.filter(
-              (artifact) => !runPreparedArtifactIds.has(artifact.id),
-            ),
-          },
-        ]
-      : []),
-  ].filter((group) => group.artifacts.length > 0);
+    {
+      key: "prepare" as const,
+      label: "Prepare",
+      description: "Compiled input",
+      artifacts: prepared?.artifacts ?? [],
+    },
+    {
+      key: "run" as const,
+      label: "Run",
+      description: "Execution output",
+      artifacts:
+        run?.artifacts.filter(
+          (artifact) => !runPreparedArtifactIds.has(artifact.id),
+        ) ?? [],
+    },
+  ];
   const resultCsvArtifacts = run
     ? (() => {
         const csv = run.artifacts.filter((artifact) =>
@@ -981,8 +971,6 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
       );
       return;
     }
-    let template = ids[0] === "ac" ? "AC" : ids[0] === "tran" ? "TRAN" : "OP";
-    let starter = "Text only";
     const name = await interaction.name({
       kind: "folder",
       ...(action === "rename" && current ? { folderId: current.id } : {}),
@@ -998,28 +986,6 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
           )
           ? `Simulation folder name already exists: ${value}`
           : undefined,
-      ...(action === "new"
-        ? {
-            template: {
-              value: template,
-              options: ["OP", "AC", "TRAN"],
-              onChange: (value: string) => {
-                template = value;
-              },
-            },
-            starter: {
-              value: starter,
-              options: [
-                "Text only",
-                "Current Canvas Cell",
-                "Text TB for current Cell",
-              ],
-              onChange: (value: string) => {
-                starter = value;
-              },
-            },
-          }
-        : {}),
       initial:
         action === "rename"
           ? (current?.name ?? "")
@@ -1047,17 +1013,11 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
     else {
       const result = createSimulationStarter(namingProject, {
         ...identity,
-        mode:
-          starter === "Current Canvas Cell"
-            ? "circuit"
-            : starter === "Text TB for current Cell"
-              ? "dut"
-              : "text",
+        mode: "circuit",
         documentId:
           props.draftContext?.rootDocumentId ?? props.activeDocumentId,
         profileId: capabilities?.profiles[0]?.id ?? authoringProfile.id,
-        template:
-          template === "AC" ? "ac" : template === "TRAN" ? "tran" : "op",
+        template: "op",
       });
       if (!result.ok) {
         setProblem(uiProblem("SIMULATION_STARTER_INVALID", result.message));
@@ -1567,138 +1527,6 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
             ) : null}
           </div>
         ) : null}
-
-        {resultTab === "files" ? (
-          <div
-            className={`simulation-files-view${artifactPreview ? " preview-open" : ""}`}
-          >
-            <div className="simulation-file-browser">
-              {artifactGroups.map((group) => (
-                <section
-                  key={group.key}
-                  className="simulation-artifact-group"
-                  aria-label={`${group.label} files`}
-                >
-                  <header>
-                    <span>
-                      <strong>{group.label}</strong>
-                      <small>{group.description}</small>
-                    </span>
-                    <button
-                      type="button"
-                      disabled={artifactBusy !== undefined}
-                      onClick={() =>
-                        void downloadBundle(group.key, group.artifacts)
-                      }
-                    >
-                      {artifactBusy === `bundle:${group.key}`
-                        ? "Packing…"
-                        : "Download ZIP"}
-                    </button>
-                  </header>
-                  {artifactCategories.map((category) => {
-                    const artifacts = group.artifacts.filter(
-                      (artifact) =>
-                        simulationArtifactCategory(artifact) === category,
-                    );
-                    return artifacts.length ? (
-                      <details
-                        key={category}
-                        className="simulation-artifact-category"
-                        aria-label={`${group.label} ${category}`}
-                        open={category === "Results" || category === "Netlist"}
-                      >
-                        <summary>
-                          <strong>{category}</strong>
-                          <small>{artifacts.length}</small>
-                        </summary>
-                        <ul className="simulation-artifact-list">
-                          {artifacts.map((artifact) => (
-                            <li
-                              key={artifact.id}
-                              className={
-                                artifactPreview?.artifact.id === artifact.id
-                                  ? "selected"
-                                  : undefined
-                              }
-                            >
-                              <button
-                                type="button"
-                                title={`Preview ${artifact.name}`}
-                                disabled={artifactBusy !== undefined}
-                                onClick={() => void preview(artifact)}
-                              >
-                                {artifactBusy === `preview:${artifact.id}`
-                                  ? "Opening…"
-                                  : artifact.name}
-                              </button>
-                              <small>
-                                {formatArtifactSize(artifact.byteLength)}
-                              </small>
-                              <button
-                                type="button"
-                                className="simulation-artifact-download"
-                                aria-label={`Download ${artifact.name}`}
-                                title={`Download ${artifact.name}`}
-                                disabled={artifactBusy !== undefined}
-                                onClick={() => void download(artifact)}
-                              >
-                                ↓
-                              </button>
-                            </li>
-                          ))}
-                        </ul>
-                      </details>
-                    ) : null;
-                  })}
-                </section>
-              ))}
-            </div>
-            {artifactPreview ? (
-              <section
-                className="simulation-artifact-preview"
-                aria-label="File preview"
-              >
-                <header>
-                  <span>
-                    <strong>{artifactPreview.artifact.name}</strong>
-                    <small>
-                      {formatArtifactSize(artifactPreview.artifact.byteLength)}
-                    </small>
-                  </span>
-                  <span>
-                    <button
-                      type="button"
-                      disabled={artifactBusy !== undefined}
-                      onClick={() => void download(artifactPreview.artifact)}
-                    >
-                      Download
-                    </button>
-                    <button
-                      type="button"
-                      aria-label="Close file preview"
-                      onClick={() => setArtifactPreview(undefined)}
-                    >
-                      ×
-                    </button>
-                  </span>
-                </header>
-                <pre>{formatSimulationArtifactPreview(artifactPreview)}</pre>
-                {artifactPreview.truncated ? (
-                  <footer>
-                    Preview limited to the first 64 KB. Download for the
-                    complete file.
-                  </footer>
-                ) : null}
-              </section>
-            ) : null}
-            {artifactGroups.length === 0 ? (
-              <p className="simulation-empty-result">
-                Prepare a deck or run the simulation to create files.
-              </p>
-            ) : null}
-          </div>
-        ) : null}
       </div>
     </section>
   );
@@ -1901,6 +1729,12 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
           console={resultContent}
           results={resultContent}
           outputActions={outputActions}
+          artifactGroups={artifactGroups}
+          artifactPreview={artifactPreview}
+          artifactBusy={artifactBusy}
+          onSelectArtifact={(artifact) => void preview(artifact)}
+          onCloseArtifact={() => setArtifactPreview(undefined)}
+          onDownloadArtifact={(artifact) => void download(artifact)}
           outputPane={resultTab}
           onSelectOutputPane={setResultTab}
           maximized={resultsMaximized}
@@ -1938,9 +1772,4 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
       )}
     </section>
   );
-}
-
-function formatArtifactSize(byteLength: number): string {
-  if (byteLength < 1024) return `${byteLength} B`;
-  return `${(byteLength / 1024).toFixed(byteLength < 10_240 ? 1 : 0)} KB`;
 }

--- a/apps/editor/src/features/simulation/workspace-interactions.tsx
+++ b/apps/editor/src/features/simulation/workspace-interactions.tsx
@@ -21,16 +21,6 @@ interface NameRequest {
   label: string;
   initial: string;
   validate?(name: string): string | undefined;
-  template?: {
-    value: string;
-    options: string[];
-    onChange(value: string): void;
-  };
-  starter?: {
-    value: string;
-    options: string[];
-    onChange(value: string): void;
-  };
 }
 interface Confirmation {
   title: string;
@@ -326,40 +316,6 @@ function NameInput() {
           }
         }}
       />
-      {request.template ? (
-        <select
-          aria-label="Folder template"
-          defaultValue={request.template.value}
-          onChange={(event) =>
-            request.template?.onChange(event.currentTarget.value)
-          }
-          onKeyDown={(event) => {
-            event.stopPropagation();
-            if (event.key === "Escape") finish(true);
-          }}
-        >
-          {request.template.options.map((value) => (
-            <option key={value}>{value}</option>
-          ))}
-        </select>
-      ) : null}
-      {request.starter ? (
-        <select
-          aria-label="Folder source"
-          defaultValue={request.starter.value}
-          onChange={(event) =>
-            request.starter?.onChange(event.currentTarget.value)
-          }
-          onKeyDown={(event) => {
-            event.stopPropagation();
-            if (event.key === "Escape") finish(true);
-          }}
-        >
-          {request.starter.options.map((value) => (
-            <option key={value}>{value}</option>
-          ))}
-        </select>
-      ) : null}
       {error ? <small role="status">{error}</small> : null}
     </div>
   );

--- a/docs/specs/simulation-code-workspace.md
+++ b/docs/specs/simulation-code-workspace.md
@@ -20,9 +20,10 @@ The execution and numeric contracts remain in
 [execution](simulation-execution.md) and [results](simulation-results.md).
 Only the changes explicitly identified here amend those boundaries.
 
-The goal is ordinary Canvas editing plus a right-hand code dock, with flat
-Console/Plot/OP/Compare/Files tabs beneath code. It is not a general IDE, a second circuit model,
-a new executor, or unrestricted remote shell access. Timing/Digital Simulation,
+The goal is ordinary Canvas editing plus a right-hand code dock, with a unified
+Explorer beside code and flat Console/Plot/OP/Compare tabs beneath it. It is not
+a general IDE, a second circuit model, a new executor, or unrestricted remote
+shell access. Timing/Digital Simulation,
 new model qualification, live cross-Project libraries, and Production promotion
 are outside this work.
 
@@ -98,13 +99,16 @@ IDs and exact files. Older data is read only at that compatibility boundary.
   otherwise retain the now-unresolved entry/reference for diagnosis. Deleting
   a binding is explicit, not a side effect of editing its displayed filename.
 
-New folders default to text-only input without a questionnaire. Optional templates
-run the current Cell directly (top-level binding) or write a text TB around the
-current DUT (subcircuit binding and an authored call using exported port order).
-None creates a TB Cell or guesses stimuli.
-The empty workspace uses the top **Set up** action for templates. Folder and file
-creation live in tree context menus (also available with Shift+F10), not permanent
-New buttons. Archive and Export share the output tab bar with Console/Plot/OP.
+New experiments require only a name. They bind the current Cell as the top-level
+circuit and create a small `op` starter; they do not ask for OP/AC/TRAN or source
+mode. AC, TRAN and DC examples appear as non-persisted editor hints, and helpers
+can insert them without making another form state authoritative. The source API
+retains text-only and text-DUT creation for import, Agent and compatibility flows,
+but those are not choices in the normal new-experiment interaction. No starter
+creates a TB Cell or guesses stimuli.
+The empty workspace uses the top **Set up** action. Explorer also keeps a permanent
+**New experiment** command; file and folder context commands remain available with
+Shift+F10. Archive and Export share the output tab bar with Console/Plot/OP.
 Existing experiments reopen unchanged; duplication is an explicit action.
 `circuit.spice`, `testbench.spice`, and `run.cir` are conventions, not mandatory
 file counts. A drawn TB does not need an additional authored TB file.
@@ -129,7 +133,8 @@ save list is never silently widened to `all` by that instrumentation.
 Discovery and completion use the compiler's authored call-path mapping; they
 show the Canvas name alongside the executable native vector. Native vectors
 remain available for text-only or statically unresolvable scopes.
-`experiment.json` is available through Files, not a compulsory fourth panel.
+`experiment.json` is available through the Explorer's advanced configuration
+command, not a compulsory fourth panel.
 
 Folder expansion is independent of active execution and batch selection. New
 files/folders and renames use inline text input (Enter accepts, Escape cancels),
@@ -461,11 +466,15 @@ the declared runtime/Profile and retain a minimal reproducible test.
 Existing application navigation / editing toolbar
 ---------------------------------------------------------------
 Ordinary Canvas                 | Code | Properties           x
-                                | Files / entry    Run Stop ...
-                                | Circuit / TB / Run file tabs
+                                | Explorer          Run Stop ...
+                                | Experiment
+                                |   Source (open) / files
+                                |   Prepare · Temporary (closed)
+                                |   Run · Temporary (closed)
+                                | Circuit / TB / Run / artifact tabs
                                 |   code editor with line numbers
                                 |------------------------------
-                                | Console | Plot | OP | Compare | Files    expand
+                                | Console | Plot | OP | Compare          expand
                                 | selected run / plot / OP
                                 | history, compare, export on demand
 ```
@@ -475,9 +484,14 @@ Ordinary Canvas                 | Code | Properties           x
 - Simulation has its own top-level command, outside Netlist. Missing circuit
   parameters do not prevent opening Code. An authoring-only IR keeps device
   cards with explicit missing-value slots; export and execution stay strict.
-- Files displays execution folders. Right-click offers creation from OP/AC/TRAN
-  templates, duplicate, rename, delete, export and Run. Multi-select runs a Batch.
-  File actions use the shared File Resource; generated topology remains locked.
+- Explorer displays every experiment and its source files. The active experiment
+  also exposes Prepare and Run artifact groups, each explicitly marked Temporary.
+  Source starts expanded; artifact groups start collapsed. Right-click offers
+  duplicate, rename, delete, export and Run. Multi-select runs a Batch. File
+  actions use the shared File Resource; generated topology remains locked.
+- Source and artifact rows support Ctrl/Cmd multi-selection. One selected file
+  downloads directly; multiple authored/generated/temporary files download as one
+  hierarchy-preserving ZIP. Selecting a temporary artifact opens a read-only tab.
 - There is no permanent Prepare or Pick toolbar. Run prepares automatically;
   final-deck inspection and Canvas observation helpers are available on demand.
   Observation helpers reveal the configuration they change rather than silently
@@ -487,9 +501,9 @@ Ordinary Canvas                 | Code | Properties           x
   around 40% and 22% respectively, not hard-coded accepted dimensions. Narrow
   windows use a temporary overlay/maximized view instead of crushing Canvas.
 - No permanent Setup/Settings/AC-response selection bar. Multiple experiments
-  retain IDs and lifecycle under Files. Run always targets the explicit entry
+  retain IDs and lifecycle under Explorer. Run always targets the explicit entry
   of the active experiment; viewing its Circuit or TB does not change entry.
-- Console/Plot/OP/Compare/Files occupy one tab row below the code editor;
+- Console/Plot/OP/Compare occupy one tab row below the code editor;
   measurements, history and export remain within these views. Maximize
   temporarily uses the main workspace, then restores the exact previous split.
 - Canvas selection highlights related code without forcibly opening Properties.
@@ -527,12 +541,12 @@ never execute Canvas editing commands.
 
 New/rename uses one inline naming interaction: Enter and valid blur commit exactly
 once; Escape or empty blur cancels. Invalid names show local feedback without
-trapping focus. New folders offer OP/AC/TRAN templates and the existing text-only,
-Canvas Cell or text-DUT starters in this same row. Delete
+trapping focus. New experiments ask only for a name and create the current-Cell OP
+starter described above. Delete
 uses the product's small modal confirmation with Cancel initially focused and
 Escape cancelling. File/Project transactions remain the mutation and Undo owner.
 
-Files has a bounded draggable/keyboard-adjustable splitter; double-click restores
+Explorer has a bounded draggable/keyboard-adjustable splitter; double-click restores
 the default. Width is an optional local preference, not Project data. Buttons
 share hover, pressed, focus-visible, disabled and in-flight styling. Save reflects
 the existing Project persistence lifecycle, not merely buffer flush. An unsaved
@@ -643,7 +657,9 @@ captures, invalid config, concurrent drafts, structural paste, changed DUT
 interfaces, two DUT calls and unbound input. A screenshot or HTTP 200 is not
 electrical evidence.
 
-The user approved the disposable layout prototype: Files expands beside code,
+The user approved the disposable layout prototype and subsequent Explorer
+consolidation: files expand beside code, Source opens by default, temporary
+Prepare/Run groups start collapsed,
 configuration stays hidden by default, Code/Properties have independent widths,
 and Console/Results stay beneath code with reversible maximization. Browser
 regressions verify those interactions. That approval does not replace language,

--- a/docs/user/analog-simulation.md
+++ b/docs/user/analog-simulation.md
@@ -7,10 +7,11 @@ workspace is separate from the development-only Digital tool.
 ## Circuit, source and files
 
 Code and Properties share the right dock but remember independent widths.
-**Files** opens a narrow list beside the code, not another horizontal panel.
-Choose an experiment from the experiment menu, or create, clone, rename or
-delete one there. Multiple experiments can use the same drawn Testbench; a
-different topology is an ordinary separate Cell.
+**Explorer** opens a narrow project tree beside the code. Each experiment puts
+Source first, expanded by default. Prepared and Run artifacts appear beneath it,
+marked **Temporary** and collapsed by default. Choose an experiment there, or
+create, clone, rename or delete one. Multiple experiments can use the same drawn
+Testbench; a different topology is an ordinary separate Cell.
 
 A generated Circuit file is marked with a diamond. Its topology and device
 identity belong to Canvas. You can edit mapped numeric parameters, but changing
@@ -22,6 +23,10 @@ Other SPICE files are authored source. You or an authorized Agent can edit
 them directly, use completion/hover help, or insert a template. The entry file
 is the Run target even while viewing another file. Invalid SPICE or JSON can
 be saved; preparation reports what needs repair rather than losing the draft.
+
+**New experiment** asks only for a name. It uses the current Canvas Cell and an
+OP starter. Muted AC, TRAN and DC examples below the editor show what to try next;
+they are hints and never enter the saved file until you type or insert them.
 
 **More code actions** opens advanced configuration, copies/exports the current
 file, or creates a source file. Configuration is not a default tab. It owns
@@ -121,7 +126,7 @@ refuse a run with a repairable explanation.
 
 ## Results, history and exports
 
-Console, Plot, OP, Compare and Files share one tab row below code. Measurements,
+Console, Plot, OP and Compare share one tab row below code. Measurements,
 history and exports stay inside these views. Maximize results temporarily uses the workspace;
 Restore returns to the previous dock size. Maximize Code keeps the editor.
 
@@ -139,8 +144,10 @@ Automatic summaries are separate from authored rules. Both export through
 `measurements.csv`.
 
 **Export** downloads visible plots as SVG or PNG, complete output CSV, or a
-complete run ZIP. Files exposes authored/generated input, prepared deck,
-rawfile and existing result artifacts. Image export follows the visible plot;
+complete run ZIP. Explorer exposes authored/generated input, prepared deck,
+rawfile and existing result artifacts. Ctrl/Cmd-select any combination of rows,
+then use the Explorer download control; one file downloads directly and several
+download as a hierarchy-preserving ZIP. Image export follows the visible plot;
 CSV retains full collected numbers. Restricted model data is not bundled.
 
 **Compare** keeps completed results within the session and overlays compatible


### PR DESCRIPTION
## Summary
- move source, prepared, and run files into one Explorer hierarchy
- default Source open and temporary Prepare/Run groups closed
- support source/artifact multi-selection, preview, and ZIP download
- simplify new experiments to name-only Current Cell + OP with AC/TRAN/DC hints
- strengthen file selection and Project save feedback
- include the follow-up fix restoring mapped Code Net preview on Canvas

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm test:local (471 files passed, 2 skipped; 3165 passed, 28 skipped)
- affected analog-simulation browser gate (22 passed)
- pnpm build
- affected manual-editor gate: 151/153 passed; NPN timeout passed on focused rerun; Properties exact clipboard copy remains a Windows-only LF/CRLF mismatch in the existing #766 path