### PR TITLE
fix(preview): follow unified simulation explorer

### DIFF
--- a/scripts/preview-source-gui-journey.mjs
+++ b/scripts/preview-source-gui-journey.mjs
@@ -137,6 +137,34 @@ function entryFromZip(entries, name) {
   assert(value, `Missing exported ${name}`);
   return Buffer.from(value).toString();
 }
+async function downloadArtifactGroup(label, name) {
+  const explorer = panel.getByRole("complementary", {
+    name: "Simulation files",
+  });
+  const group = explorer.getByLabel(`${label} temporary files`, {
+    exact: true,
+  });
+  await expect(group).toBeVisible();
+  if ((await group.getAttribute("open")) === null)
+    await group.locator("summary").click();
+  const artifacts = group.locator('button[data-tree-row="artifact"]');
+  const count = await artifacts.count();
+  assert(count > 1, `${label} must expose a downloadable artifact bundle`);
+  for (let index = 0; index < count; index += 1) {
+    const artifact = artifacts.nth(index);
+    await expect(artifact).toBeEnabled();
+    await artifact.click(index ? { modifiers: ["Control"] } : undefined);
+  }
+  return unzipSync(
+    await download(
+      explorer.getByRole("button", {
+        name: `Download selected files (${count})`,
+        exact: true,
+      }),
+      name,
+    ),
+  );
+}
 try {
   report.candidate = await verifyPreviewCandidate(baseUrl);
   browser = await chromium.launch({ headless: true });
@@ -221,24 +249,13 @@ try {
   await expect(
     panel.getByRole("tab", { name: "Results", exact: true }),
   ).toHaveCount(0);
-  await panel.getByRole("tab", { name: "Files", exact: true }).click();
+  const preparedEntries = await downloadArtifactGroup("Prepare", "prepare.zip");
+  const runEntries = await downloadArtifactGroup("Run", "run.zip");
+  await panel
+    .locator(".simulation-artifact-tab")
+    .getByRole("button", { name: /^Close /u })
+    .click();
   await panel.getByRole("button", { name: "Maximize results" }).click();
-  const preparedEntries = unzipSync(
-    await download(
-      panel
-        .getByLabel("Prepare files", { exact: true })
-        .getByRole("button", { name: "Download ZIP" }),
-      "prepare.zip",
-    ),
-  );
-  const runEntries = unzipSync(
-    await download(
-      panel
-        .getByLabel("Run files", { exact: true })
-        .getByRole("button", { name: "Download ZIP" }),
-      "run.zip",
-    ),
-  );
   const input = JSON.parse(entryFromZip(preparedEntries, "prepared.json"));
   const result = JSON.parse(entryFromZip(runEntries, "result.json"));
   const outputs = JSON.parse(entryFromZip(runEntries, "outputs.json"));

--- a/scripts/preview-workflow.test.mjs
+++ b/scripts/preview-workflow.test.mjs
@@ -17,6 +17,10 @@ const crossProjectJourney = readFileSync(
   "scripts/preview-cross-project-simulation-journey.mjs",
   "utf8",
 );
+const sourceGuiJourney = readFileSync(
+  "scripts/preview-source-gui-journey.mjs",
+  "utf8",
+);
 
 describe("the preview deploy", () => {
   it("deploys the preview configuration file and nothing else", () => {
@@ -113,6 +117,18 @@ describe("the preview deploy", () => {
     expect(agentJourney).toContain("firstOutput.expression.anchor");
     expect(agentJourney).not.toContain("invalidSetup.input.probes");
     expect(agentJourney).not.toContain("invalidSetup.input.outputs");
+  });
+
+  it("exports GUI simulation evidence through the unified Explorer", () => {
+    expect(sourceGuiJourney).toContain('name: "Simulation files"');
+    expect(sourceGuiJourney).toContain("Download selected files (${count})");
+    expect(sourceGuiJourney).toContain(
+      'downloadArtifactGroup("Prepare", "prepare.zip")',
+    );
+    expect(sourceGuiJourney).toContain(
+      'downloadArtifactGroup("Run", "run.zip")',
+    );
+    expect(sourceGuiJourney).not.toContain('getByRole("tab", { name: "Files"');
   });
 
   it("imports a Cloud Project Cell before compiling the cross-Project Testbench", () => {


### PR DESCRIPTION
## Summary
- update the source GUI Preview journey for the unified left Explorer
- export Prepare and Run evidence through multi-select downloads
- close the read-only artifact preview before resuming source edits
- add a workflow contract test that rejects the retired Files tab selector

## Validation
- pnpm gate:preflight -- --base origin/main`n- pnpm gate:affected -- --base origin/main (471 files passed, 3166 tests passed)
- preview-configured editor build
- complete live preview-source-gui-journey.mjs against Preview (passed)