### PR TITLE
refactor(simulation): compact file tree and context downloads

### DIFF
--- a/apps/editor/e2e/simulation-batch.spec.ts
+++ b/apps/editor/e2e/simulation-batch.spec.ts
@@ -109,12 +109,12 @@ test("a saved-folder batch prepares first and exposes each ordinary run", async 
   });
   await clickNetlistWorkflowCommand(page, "open-analog-simulation");
   const panel = page.getByRole("region", { name: "Analog simulation" });
-  await panel.getByRole("button", { name: "Folder TT", exact: true }).click();
+  await panel.getByRole("treeitem", { name: "Folder TT", exact: true }).click();
   await panel
-    .getByRole("button", { name: "Folder FF", exact: true })
+    .getByRole("treeitem", { name: "Folder FF", exact: true })
     .click({ modifiers: ["Control"] });
   await panel
-    .getByRole("button", { name: "Folder FF", exact: true })
+    .getByRole("treeitem", { name: "Folder FF", exact: true })
     .click({ button: "right" });
   await page
     .getByRole("menuitem", { name: "Run selected folders (2)" })
@@ -131,8 +131,11 @@ test("a saved-folder batch prepares first and exposes each ordinary run", async 
   expect(executions).toBe(2);
   await batch.getByRole("button", { name: /FF finished/ }).click();
   await expect(
-    panel.getByRole("button", { name: "Folder FF", exact: true }),
-  ).toHaveClass(/is-active/);
+    panel.getByRole("treeitem", { name: "Folder FF", exact: true }),
+  ).toBeVisible();
+  await expect(
+    panel.getByRole("button", { name: "Run", exact: true }),
+  ).toHaveAttribute("title", "Run FF");
   await expect(panel.getByRole("status").first()).toContainText(
     "Batch finished",
   );

--- a/apps/editor/e2e/simulation-setup.spec.ts
+++ b/apps/editor/e2e/simulation-setup.spec.ts
@@ -180,8 +180,13 @@ test("the qualified OTA folder opens unchanged and preserves all root and hierar
   await page.getByRole("menuitem", { name: "View final deck" }).click();
   const prepareFiles = panel.getByLabel("Prepare temporary files");
   await expect(prepareFiles).toBeVisible();
-  await prepareFiles.locator("summary").click();
-  await panel.getByRole("button", { name: /prepared\.cir/ }).click();
+  await prepareFiles
+    .getByRole("button", { name: "Toggle Prepare", exact: true })
+    .click();
+  await prepareFiles
+    .getByRole("button", { name: "Toggle Netlist", exact: true })
+    .click();
+  await panel.getByRole("treeitem", { name: /prepared\.cir/ }).click();
   const preview = panel.getByRole("region", { name: "File preview" });
   const download = page.waitForEvent("download");
   await preview.getByRole("button", { name: "Download", exact: true }).click();
@@ -340,7 +345,7 @@ test("one Testbench persists several independently named folders", async ({
   const panel = page.getByRole("region", { name: "Analog simulation" });
   const folders = panel.getByLabel("Simulation folders", { exact: true });
   await expect(
-    folders.getByRole("button", {
+    folders.getByRole("treeitem", {
       name: "Folder OTA OP, DC, AC, and TRAN",
       exact: true,
     }),
@@ -349,10 +354,10 @@ test("one Testbench persists several independently named folders", async ({
   await folders.getByLabel("New simulation folder name").fill("Bias sweep");
   await folders.getByLabel("New simulation folder name").press("Enter");
   await expect(
-    folders.getByRole("button", { name: "Folder Bias sweep", exact: true }),
+    folders.getByRole("treeitem", { name: "Folder Bias sweep", exact: true }),
   ).toBeVisible();
   await folders
-    .getByRole("button", { name: "Folder Bias sweep", exact: true })
+    .getByRole("treeitem", { name: "Folder Bias sweep", exact: true })
     .click({ button: "right" });
   await page.getByRole("menuitem", { name: "Rename…" }).click();
   await folders
@@ -388,7 +393,7 @@ test("one Testbench persists several independently named folders", async ({
   );
 
   await folders
-    .getByRole("button", { name: "Folder Bias sweep", exact: true })
+    .getByRole("treeitem", { name: "Folder Bias sweep", exact: true })
     .click({ button: "right" });
   await page.getByRole("menuitem", { name: "Delete…" }).click();
   await page
@@ -396,10 +401,10 @@ test("one Testbench persists several independently named folders", async ({
     .getByRole("button", { name: "Cancel" })
     .click();
   await expect(
-    folders.getByRole("button", { name: "Folder Bias sweep", exact: true }),
+    folders.getByRole("treeitem", { name: "Folder Bias sweep", exact: true }),
   ).toBeVisible();
   await folders
-    .getByRole("button", { name: "Folder Bias sweep", exact: true })
+    .getByRole("treeitem", { name: "Folder Bias sweep", exact: true })
     .click({ button: "right" });
   await page.getByRole("menuitem", { name: "Delete…" }).click();
   await page
@@ -407,7 +412,7 @@ test("one Testbench persists several independently named folders", async ({
     .getByRole("button", { name: "Delete", exact: true })
     .click();
   await expect(
-    folders.getByRole("button", { name: "Folder Bias sweep", exact: true }),
+    folders.getByRole("treeitem", { name: "Folder Bias sweep", exact: true }),
   ).toHaveCount(0);
   const afterDelete = JSON.parse(
     (await downloadBytes(page, "File", "Export Project File…")).toString(),

--- a/apps/editor/e2e/simulation-workspace.spec.ts
+++ b/apps/editor/e2e/simulation-workspace.spec.ts
@@ -69,6 +69,11 @@ test("native save completion previews its mapped Net on the real Canvas", async 
     (file) => file.path === folder.input.entry,
   )!.text;
   await editor.fill(`${source.slice(0, source.indexOf(".endc"))}save`);
+  await expect(page.locator(".simulation-code-status")).toHaveCount(0);
+  await expect(
+    page.getByRole("button", { name: "Save project", exact: true }),
+  ).toBeEnabled();
+  await expect(page.getByRole("tab", { name: /run\.cir/ })).toContainText("●");
   await page.keyboard.type(" ");
   const option = page.getByRole("option").filter({ hasText: vector });
   await expect(option).toBeVisible();
@@ -1218,6 +1223,11 @@ test("Simulation creates an ordinary testbench and defaults a new experiment to 
   await clickNetlistWorkflowCommand(page, "open-analog-simulation");
   await expect(page.getByLabel("Testbench Cell")).toHaveCount(0);
   const taskbar = page.locator(".simulation-taskbar");
+  await expect(taskbar).toHaveCount(1);
+  await expect(
+    page.getByRole("button", { name: "Sim Code", exact: true }),
+  ).toBeVisible();
+  await expect(page.locator(".simulation-brand")).toHaveCount(0);
   const setupBox = await page
     .getByRole("button", { name: "Set up", exact: true })
     .boundingBox();
@@ -1236,6 +1246,15 @@ test("Simulation creates an ordinary testbench and defaults a new experiment to 
   expect(runBox!.height).toBe(setupBox!.height);
   expect(statusBox!.x).toBeGreaterThanOrEqual(runBox!.x + runBox!.width);
   expect(Math.abs(statusBox!.y - runBox!.y)).toBeLessThanOrEqual(2);
+  await expect(taskbar).toHaveCount(1);
+  for (const name of ["Explorer", "Save project"]) {
+    const box = await taskbar
+      .getByRole("button", { name, exact: true })
+      .boundingBox();
+    expect(Math.abs(box!.y - runBox!.y)).toBeLessThanOrEqual(2);
+    expect(box!.height).toBeLessThanOrEqual(24);
+  }
+  expect((await taskbar.boundingBox())!.height).toBeLessThanOrEqual(32);
   await page
     .getByRole("treeitem", { name: "run.cir", exact: true })
     .first()

--- a/apps/editor/e2e/simulation-workspace.spec.ts
+++ b/apps/editor/e2e/simulation-workspace.spec.ts
@@ -153,13 +153,13 @@ test("incomplete circuit opens Code and saves invalid parameter drafts across re
   await panel.getByRole("tab", { name: "circuit.spice", exact: false }).click();
   await expect(editor).toContainText("bad-value");
   await panel
-    .getByRole("button", { name: "Folder Draft", exact: true })
+    .getByRole("treeitem", { name: "Folder Draft", exact: true })
     .click({ button: "right" });
   await page.getByRole("menuitem", { name: "Duplicate…" }).click();
   await panel.getByLabel("New simulation folder name").fill("Draft copy");
   await panel.getByLabel("New simulation folder name").press("Enter");
   await expect(
-    panel.getByRole("button", { name: "Folder Draft copy", exact: true }),
+    panel.getByRole("treeitem", { name: "Folder Draft copy", exact: true }),
   ).toBeVisible();
 });
 
@@ -410,7 +410,7 @@ test("human simulation uses saved folder, survives minimizing, recovers a bad in
   expect(cancellations).toBe(0);
   release();
   await clickNetlistWorkflowCommand(page, "open-analog-simulation");
-  await expect(panel.getByRole("status")).toHaveText("finished · completed");
+  await expect(panel.getByRole("status")).toHaveText("completed");
   await expect(
     panel
       .locator(".simulation-code-output-tabs")
@@ -421,9 +421,7 @@ test("human simulation uses saved folder, survives minimizing, recovers a bad in
   await panel.getByRole("button", { name: "+ New experiment" }).click();
   await panel.getByLabel("New simulation folder name").fill("Second folder");
   await panel.getByLabel("New simulation folder name").press("Enter");
-  await expect(panel.getByRole("status")).not.toHaveText(
-    "finished · completed",
-  );
+  await expect(panel.getByRole("status")).not.toHaveText("completed");
   await expect(
     panel.getByRole("button", { name: "Toggle E2E folder" }),
   ).toHaveAttribute("aria-expanded", "true");
@@ -431,7 +429,7 @@ test("human simulation uses saved folder, survives minimizing, recovers a bad in
     panel.getByRole("button", { name: "Toggle Second folder" }),
   ).toHaveAttribute("aria-expanded", "true");
   await panel
-    .getByRole("button", { name: "Folder Second folder", exact: true })
+    .getByRole("treeitem", { name: "Folder Second folder", exact: true })
     .click({ button: "right" });
   await page.getByRole("menuitem", { name: "New file…", exact: true }).click();
   await panel
@@ -454,18 +452,16 @@ test("human simulation uses saved folder, survives minimizing, recovers a bad in
     panel.getByRole("textbox", { name: "Simulation source editor" }),
   ).toContainText(".save v(out)");
   await panel
-    .getByRole("button", { name: "Folder E2E folder", exact: true })
+    .getByRole("treeitem", { name: "Folder E2E folder", exact: true })
     .locator("..")
     .locator("..")
-    .getByRole("button", { name: "run.cir", exact: true })
+    .getByRole("treeitem", { name: "run.cir", exact: true })
     .click();
-  await expect(panel.getByRole("status")).toHaveText("finished · completed");
+  await expect(panel.getByRole("status")).toHaveText("completed");
   expect(executions).toBe(1);
   await expect(panel.getByRole("tab", { name: "Summary" })).toHaveCount(0);
   await panel.getByRole("tab", { name: "Console" }).click();
-  await expect(panel.locator(".simulation-console-summary")).toContainText(
-    "finished · completed",
-  );
+  await expect(panel.locator(".simulation-console-summary")).toHaveCount(0);
   await expect(panel.locator(".simulation-console-view > pre")).toBeVisible();
   await panel.getByRole("tab", { name: "Plot", exact: true }).click();
   await panel.getByRole("tab", { name: "Operating Point" }).click();
@@ -906,9 +902,17 @@ test("human simulation uses saved folder, survives minimizing, recovers a bad in
   await waveformDialog.getByRole("button", { name: "Close plot" }).click();
   await panel.getByRole("button", { name: "Restore results" }).click();
   const runFiles = panel.getByLabel("Run temporary files");
-  await runFiles.locator("summary").click();
+  await runFiles
+    .getByRole("button", { name: "Toggle Run", exact: true })
+    .click();
+  await runFiles
+    .getByRole("button", { name: "Toggle Results", exact: true })
+    .click();
+  await runFiles
+    .getByRole("button", { name: "Toggle Evidence", exact: true })
+    .click();
   await expect(
-    panel.getByRole("button", {
+    panel.getByRole("treeitem", {
       name: /evidence-manifest\.json/,
     }),
   ).toBeVisible();
@@ -925,12 +929,13 @@ test("human simulation uses saved folder, survives minimizing, recovers a bad in
   expect((await download).suggestedFilename()).toMatch(/\.csv$/);
   await expect(runFiles).toBeVisible();
   await runFiles
-    .getByRole("button", { name: /evidence-manifest\.json/ })
+    .getByRole("treeitem", { name: /evidence-manifest\.json/ })
     .click({ modifiers: ["Control"] });
+  await runFiles
+    .getByRole("treeitem", { name: /evidence-manifest\.json/ })
+    .click({ button: "right" });
   const bundleDownload = page.waitForEvent("download");
-  await panel
-    .getByRole("button", { name: "Download selected files (2)" })
-    .click();
+  await page.getByRole("menuitem", { name: "Download selected (2)…" }).click();
   expect((await bundleDownload).suggestedFilename()).toMatch(
     /-selected-files\.zip$/,
   );
@@ -968,7 +973,7 @@ test("human simulation uses saved folder, survives minimizing, recovers a bad in
   ).toHaveCount(0);
   await panel.getByRole("button", { name: "Run", exact: true }).click();
   await expect.poll(() => executions).toBe(2);
-  await expect(panel.getByRole("status")).toHaveText("finished · completed");
+  await expect(panel.getByRole("status")).toHaveText("completed");
   await panel.getByRole("tab", { name: "Plot" }).click();
   await expect(panel.locator(".ac-cursor-readout")).toHaveCount(0);
   await transientToolbar.hover();
@@ -1177,7 +1182,7 @@ test("human simulation uses saved folder, survives minimizing, recovers a bad in
   });
   await expect(savedArchives).toContainText("E2E folder");
   await savedArchives.getByRole("button", { name: "Open" }).click();
-  await expect(panel.getByRole("status")).toHaveText("finished · completed");
+  await expect(panel.getByRole("status")).toHaveText("completed");
   expect(executions).toBe(3);
 });
 
@@ -1212,13 +1217,27 @@ test("Simulation creates an ordinary testbench and defaults a new experiment to 
   expect(saved.simulationFolders).toEqual([]);
   await clickNetlistWorkflowCommand(page, "open-analog-simulation");
   await expect(page.getByLabel("Testbench Cell")).toHaveCount(0);
+  const taskbar = page.locator(".simulation-taskbar");
+  const setupBox = await page
+    .getByRole("button", { name: "Set up", exact: true })
+    .boundingBox();
+  const initialBar = await taskbar.boundingBox();
+  expect(setupBox!.height).toBeLessThanOrEqual(24);
+  expect(initialBar!.height).toBeLessThanOrEqual(36);
   await page.getByRole("button", { name: "Set up", exact: true }).click();
   await page.getByLabel("New simulation folder name").fill("Main experiment");
   await expect(page.getByLabel("Folder template")).toHaveCount(0);
   await expect(page.getByLabel("Folder source")).toHaveCount(0);
   await page.getByLabel("New simulation folder name").press("Enter");
+  const runBox = await page
+    .getByRole("button", { name: "Run", exact: true })
+    .boundingBox();
+  const statusBox = await taskbar.getByRole("status").boundingBox();
+  expect(runBox!.height).toBe(setupBox!.height);
+  expect(statusBox!.x).toBeGreaterThanOrEqual(runBox!.x + runBox!.width);
+  expect(Math.abs(statusBox!.y - runBox!.y)).toBeLessThanOrEqual(2);
   await page
-    .getByRole("button", { name: "run.cir", exact: true })
+    .getByRole("treeitem", { name: "run.cir", exact: true })
     .first()
     .click();
   await expect(page.getByLabel("Analysis examples")).toContainText(
@@ -1310,17 +1329,20 @@ test("workspace menus, selection, empty editors and resizing share non-destructi
   const files = workspace.getByRole("complementary", {
     name: "Simulation files",
   });
-  const alpha = files.getByRole("button", {
+  const alpha = files.getByRole("treeitem", {
     name: "Folder Alpha",
     exact: true,
   });
-  const beta = files.getByRole("button", { name: "Folder Beta", exact: true });
+  const beta = files.getByRole("treeitem", {
+    name: "Folder Beta",
+    exact: true,
+  });
   await expect(
     workspace.getByRole("tab", { name: "run.cir", exact: true }),
   ).toHaveAttribute("aria-selected", "true");
   const before = await files.boundingBox();
   await files
-    .getByRole("button", { name: "circuit.spice", exact: true })
+    .getByRole("treeitem", { name: "circuit.spice", exact: true })
     .first()
     .click({ button: "right" });
   await expect(
@@ -1333,7 +1355,7 @@ test("workspace menus, selection, empty editors and resizing share non-destructi
   // One outside click both dismisses the menu and activates its intended target.
   await beta.click({ position: { x: 2, y: 2 } });
   await expect(page.getByRole("menu")).toHaveCount(0);
-  await expect(beta).toHaveAttribute("aria-pressed", "true");
+  await expect(beta).toHaveAttribute("aria-selected", "true");
   await expect(
     page.getByRole("button", { name: "Run", exact: true }),
   ).toHaveAttribute("title", "Run Alpha");
@@ -1358,11 +1380,9 @@ test("workspace menus, selection, empty editors and resizing share non-destructi
   await expect(
     workspace.getByText("Select a file to edit.", { exact: false }),
   ).toBeVisible();
+  await alpha.press("ArrowRight");
   await files
-    .getByRole("button", { name: "Toggle Alpha", exact: true })
-    .click();
-  await files
-    .getByRole("button", { name: "run.cir", exact: true })
+    .getByRole("treeitem", { name: "run.cir", exact: true })
     .first()
     .click();
   await expect(
@@ -1389,10 +1409,11 @@ test("workspace menus, selection, empty editors and resizing share non-destructi
   await expect(
     workspace.getByRole("tab", { name: /circuit\.spice/ }),
   ).toHaveAttribute("aria-selected", "true");
+  await files.getByRole("button", { name: "Toggle Beta", exact: true }).click();
   await beta
     .locator("..")
     .locator("..")
-    .getByRole("button", { name: "run.cir", exact: true })
+    .getByRole("treeitem", { name: "run.cir", exact: true })
     .click();
   await expect(
     workspace.getByRole("tab", { name: "run.cir", exact: true }),
@@ -1400,6 +1421,113 @@ test("workspace menus, selection, empty editors and resizing share non-destructi
   await expect(
     page.getByRole("button", { name: "Run", exact: true }),
   ).toHaveAttribute("title", "Run Beta");
+});
+
+test("Explorer context downloads preserve multi-selection and directory contents without resizing rename rows", async ({
+  page,
+}) => {
+  const workspace = await openWorkspace(page);
+  const tree = workspace.getByRole("tree", { name: "Simulation folders" });
+  const alpha = tree.getByRole("treeitem", {
+    name: "Folder Alpha",
+    exact: true,
+  });
+  const beta = tree.getByRole("treeitem", { name: "Folder Beta", exact: true });
+  const alphaFiles = alpha.locator("../..");
+  const circuit = alphaFiles.getByRole("treeitem", {
+    name: "circuit.spice",
+    exact: true,
+  });
+  const run = alphaFiles.getByRole("treeitem", {
+    name: "run.cir",
+    exact: true,
+  });
+  await expect(
+    workspace.getByRole("button", { name: "Explorer", exact: true }),
+  ).toHaveCount(1);
+  await expect(
+    workspace.getByRole("button", { name: /Download selected/ }),
+  ).toHaveCount(0);
+  await expect(
+    alphaFiles.getByRole("treeitem", { name: "Source", exact: true }),
+  ).toHaveAttribute("aria-expanded", "true");
+  await run.click();
+  await circuit.click({ modifiers: ["Control"] });
+  await expect(
+    workspace.getByRole("tab", { name: "run.cir", exact: true }),
+  ).toHaveAttribute("aria-selected", "true");
+  await run.click({ button: "right" });
+  const pending = page.waitForEvent("download");
+  await page.getByRole("menuitem", { name: "Download selected (2)…" }).click();
+  const stream = await (await pending).createReadStream();
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream!) chunks.push(Buffer.from(chunk));
+  expect(Object.keys(unzipSync(Buffer.concat(chunks))).sort()).toEqual([
+    "Alpha/source/circuit.spice",
+    "Alpha/source/run.cir",
+  ]);
+  await circuit.click();
+  await run.click({ modifiers: ["Shift"] });
+  await expect(
+    alphaFiles.getByRole("treeitem", { selected: true }),
+  ).toHaveCount(3);
+  await expect(
+    workspace.getByRole("tab", { name: /circuit\.spice/ }),
+  ).toHaveAttribute("aria-selected", "true");
+  await beta.click({ button: "right" });
+  await expect(
+    page.getByRole("menuitem", { name: "Download…", exact: true }),
+  ).toBeVisible();
+  await expect(run).toHaveAttribute("aria-selected", "false");
+  await page.keyboard.press("Escape");
+  const bounds = await run.locator("..").boundingBox();
+  await run.focus();
+  await run.press("F2");
+  const name = tree.getByRole("textbox", { name: "Relative file path" });
+  const editingBounds = await name.locator("../..").boundingBox();
+  expect(editingBounds!.height).toBe(bounds!.height);
+  expect(editingBounds!.width).toBe(bounds!.width);
+  await name.press("Escape");
+  await alpha.click({ button: "right" });
+  await page.getByRole("menuitem", { name: "New file…", exact: true }).click();
+  await name.fill("models/bias/local.cir");
+  await name.press("Enter");
+  const models = alphaFiles.getByRole("treeitem", {
+    name: "models",
+    exact: true,
+  });
+  await expect(models).toHaveAttribute("aria-expanded", "true");
+  await expect(
+    alphaFiles.getByRole("treeitem", { name: "local.cir", exact: true }),
+  ).toBeVisible();
+  await models.click();
+  await expect(
+    alphaFiles.getByRole("treeitem", { name: "local.cir", exact: true }),
+  ).toHaveCount(0);
+  await models.click({ button: "right" });
+  const nestedDownload = page.waitForEvent("download");
+  await page.getByRole("menuitem", { name: "Download…", exact: true }).click();
+  expect((await nestedDownload).suggestedFilename()).toMatch(/\.zip$/);
+  // Selecting the parent and one descendant must not duplicate ZIP entries.
+  await alpha.click({ modifiers: ["Control"] });
+  await alpha.click({ button: "right" });
+  const folderDownload = page.waitForEvent("download");
+  await page.getByRole("menuitem", { name: "Download selected (2)…" }).click();
+  const folderStream = await (await folderDownload).createReadStream();
+  const folderChunks: Buffer[] = [];
+  for await (const chunk of folderStream!)
+    folderChunks.push(Buffer.from(chunk));
+  const names = Object.keys(unzipSync(Buffer.concat(folderChunks)));
+  expect(
+    names.filter((path) => path.endsWith("models/bias/local.cir")),
+  ).toHaveLength(1);
+  expect(names).toContain("Alpha/source/experiment.json");
+  await workspace.screenshot({
+    path: test.info().outputPath("compact-explorer.png"),
+  });
+  await page.screenshot({
+    path: test.info().outputPath("simulation-header.png"),
+  });
 });
 
 test("inline naming commits once on blur, cancels on Escape, and deletion uses a local dialog", async ({
@@ -1420,10 +1548,10 @@ test("inline naming commits once on blur, cancels on Escape, and deletion uses a
   await input.fill("Gamma");
   // The destination click is not eaten by the naming transaction.
   await workspace
-    .getByRole("button", { name: "Folder Beta", exact: true })
+    .getByRole("treeitem", { name: "Folder Beta", exact: true })
     .click();
   await expect(
-    workspace.getByRole("button", { name: "Folder Gamma", exact: true }),
+    workspace.getByRole("treeitem", { name: "Folder Gamma", exact: true }),
   ).toHaveCount(1);
   await expect(
     workspace.getByRole("textbox", { name: "Simulation source editor" }),
@@ -1436,9 +1564,9 @@ test("inline naming commits once on blur, cancels on Escape, and deletion uses a
     .fill("Cancelled");
   await page.keyboard.press("Escape");
   await expect(
-    workspace.getByRole("button", { name: "Folder Cancelled", exact: true }),
+    workspace.getByRole("treeitem", { name: "Folder Cancelled", exact: true }),
   ).toHaveCount(0);
-  const gamma = workspace.getByRole("button", {
+  const gamma = workspace.getByRole("treeitem", {
     name: "Folder Gamma",
     exact: true,
   });
@@ -1448,7 +1576,7 @@ test("inline naming commits once on blur, cancels on Escape, and deletion uses a
     .getByRole("textbox", { name: "Folder name", exact: true })
     .fill("Renamed");
   await page.keyboard.press("Enter");
-  const renamed = workspace.getByRole("button", {
+  const renamed = workspace.getByRole("treeitem", {
     name: "Folder Renamed",
     exact: true,
   });
@@ -1490,7 +1618,7 @@ test("inline naming commits once on blur, cancels on Escape, and deletion uses a
   await renamed
     .locator("..")
     .locator("..")
-    .getByRole("button", { name: "stimulus.cir", exact: true })
+    .getByRole("treeitem", { name: "stimulus.cir", exact: true })
     .click();
   await expect(editor).toContainText("Editable new file");
   expect(nativeDialogs).toEqual([]);

--- a/apps/editor/e2e/simulation-workspace.spec.ts
+++ b/apps/editor/e2e/simulation-workspace.spec.ts
@@ -1528,6 +1528,16 @@ test("Explorer context downloads preserve multi-selection and directory contents
   await page.screenshot({
     path: test.info().outputPath("simulation-header.png"),
   });
+  // Workspace shortcuts still work while focus is in the file tree.
+  await run.focus();
+  await run.press("Control+w");
+  await expect(workspace.getByRole("tab", { name: /local\.cir/ })).toHaveCount(
+    0,
+  );
+  await models.press("ArrowRight");
+  await expect(
+    alphaFiles.getByRole("treeitem", { name: "local.cir", exact: true }),
+  ).toBeVisible();
 });
 
 test("inline naming commits once on blur, cancels on Escape, and deletion uses a local dialog", async ({

--- a/apps/editor/src/app/editor-right-dock.tsx
+++ b/apps/editor/src/app/editor-right-dock.tsx
@@ -22,7 +22,7 @@ export function EditorRightDock(props: {
             aria-pressed={showCode}
             onClick={() => props.onSelectProperties(false)}
           >
-            Code
+            Sim Code
           </button>
           <button
             type="button"

--- a/apps/editor/src/features/simulation/code-workspace.css
+++ b/apps/editor/src/features/simulation/code-workspace.css
@@ -80,6 +80,27 @@
 .simulation-code-more {
   position: relative;
 }
+.simulation-code-workspace .simulation-code-toolbar {
+  min-height: 30px;
+  gap: 4px;
+  padding: 2px 5px;
+}
+.simulation-code-workspace .simulation-code-toolbar > button,
+.simulation-code-workspace .simulation-code-actions > button,
+.simulation-code-workspace .simulation-task-actions > button,
+.simulation-code-workspace .simulation-code-more > button {
+  height: 22px;
+  min-height: 22px;
+  padding: 0 5px;
+  font-size: 11px;
+}
+.simulation-code-workspace .simulation-run-button {
+  width: 20px;
+}
+.simulation-code-toolbar .simulation-window-actions,
+.simulation-code-toolbar .simulation-code-more {
+  flex: none;
+}
 .workspace-context-menu {
   position: fixed;
   z-index: 1200;

--- a/apps/editor/src/features/simulation/code-workspace.css
+++ b/apps/editor/src/features/simulation/code-workspace.css
@@ -180,38 +180,6 @@
   margin-top: 4px;
   font: inherit;
 }
-.workspace-folder-row {
-  display: flex;
-  align-items: center;
-}
-.simulation-code-files .workspace-folder-toggle {
-  flex: none;
-  width: 24px;
-  padding-inline: 4px;
-}
-.workspace-folder-row > button[data-tree-row] {
-  flex: 1;
-  min-width: 0;
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-.workspace-folder-row > button[data-tree-row] > span {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.simulation-run-target-badge,
-.simulation-temporary-badge {
-  margin-left: auto;
-  padding: 1px 5px;
-  border-radius: 8px;
-  font-size: 9px;
-  line-height: 1.4;
-  letter-spacing: 0.02em;
-  color: var(--icm-text-muted);
-  background: color-mix(in srgb, var(--icm-border) 72%, transparent);
-}
 .workspace-editor-content {
   height: 100%;
 }
@@ -243,142 +211,131 @@
   overflow: auto;
   background: var(--icm-surface-muted);
 }
-.simulation-explorer-header {
-  position: sticky;
-  top: 0;
-  z-index: 2;
-  display: flex;
-  align-items: center;
-  height: 30px;
-  box-sizing: border-box;
-  padding: 0 6px 0 10px;
-  border-bottom: 1px solid var(--icm-border);
-  background: var(--icm-surface-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  font-size: 10px;
-}
-.simulation-code-files .simulation-explorer-header button {
-  width: auto;
-  margin-left: auto;
-  padding: 4px 7px;
-  text-align: center;
-  border-radius: 3px;
-}
-.simulation-code-files ul {
-  list-style: none;
-  padding: 6px 0;
-  margin: 0;
-}
+
 .simulation-folder-tree {
   min-height: 100%;
-  padding: 4px 0 8px;
-}
-.simulation-code-files input {
-  width: 100%;
-  min-width: 0;
+  padding: 3px 0 8px;
   box-sizing: border-box;
 }
-.simulation-folder-tree ul {
-  padding-left: 12px;
+.simulation-code-files {
+  overflow-x: hidden;
 }
-.simulation-code-files button {
+.simulation-code-files .simulation-folder-tree > button {
+  display: block;
   width: 100%;
+  height: 24px;
+  min-height: 24px;
+  padding: 0 8px;
   text-align: left;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  border: 0;
+  border-radius: 0;
+  font-size: 11px;
+  color: var(--icm-text-muted);
+}
+.simulation-tree-row {
+  display: flex;
+  align-items: center;
+  height: 24px;
+  min-width: 0;
+  padding-left: calc(4px + var(--tree-depth) * 12px);
+  padding-right: 5px;
+  box-sizing: border-box;
+}
+.simulation-tree-row:hover {
+  background: color-mix(in srgb, var(--icm-text) 4%, transparent);
+}
+.simulation-code-files .simulation-tree-row button {
+  display: flex;
+  align-items: center;
+  min-height: 24px;
+  height: 24px;
+  min-width: 0;
+  padding: 0;
   border: 0;
   border-radius: 0;
   box-shadow: none;
   font: inherit;
-  padding: 3px 6px;
+  text-align: left;
+  background: transparent;
 }
-.simulation-code-files button[data-tree-row].is-selected {
-  background: color-mix(in srgb, var(--icm-accent) 14%, transparent);
-  color: var(--icm-text);
+.simulation-code-files .simulation-tree-row button:hover:not(:disabled) {
+  background: transparent;
 }
-.simulation-code-files button[data-tree-row].is-active {
-  position: relative;
-  background: color-mix(in srgb, var(--icm-accent) 21%, var(--icm-surface));
-  color: var(--icm-text);
-  font-weight: 600;
-}
-.simulation-code-files button[data-tree-row].is-active::before {
-  content: "";
-  position: absolute;
-  inset: 2px auto 2px 0;
-  width: 2px;
-  background: var(--icm-accent);
-}
-.simulation-folder-tree button[aria-pressed="true"]:not(.is-active),
-.simulation-code-files button[data-tree-row].is-selected:not(.is-active) {
-  box-shadow: inset 0 0 0 1px
-    color-mix(in srgb, var(--icm-accent) 55%, transparent);
-}
-.simulation-explorer-sections {
-  padding-left: 12px;
-}
-.simulation-explorer-section {
-  min-width: 0;
-}
-.simulation-explorer-section > summary {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  min-height: 26px;
-  padding: 0 7px 0 3px;
-  cursor: pointer;
-  color: var(--icm-text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  font-size: 10px;
-  user-select: none;
-}
-.simulation-explorer-section > summary:hover {
-  background: color-mix(in srgb, var(--icm-border) 45%, transparent);
-}
-.simulation-explorer-section > summary > small:last-child {
-  margin-left: auto;
-  font-variant-numeric: tabular-nums;
-}
-.simulation-explorer-section > p {
-  margin: 0;
-  padding: 0 8px 3px 19px;
-  color: var(--icm-text-muted);
-  font-size: 10px;
-}
-.simulation-explorer-section > ul {
-  padding: 0 0 4px 8px;
-}
-.simulation-explorer-section button[data-tree-row] {
-  display: flex;
-  align-items: center;
+.simulation-tree-row button[role="treeitem"] {
+  flex: 1;
   gap: 5px;
+  overflow: hidden;
 }
-.simulation-file-icon {
-  flex: none;
-  width: 13px;
+.simulation-tree-chevron {
+  display: flex;
+  flex: 0 0 16px;
+  width: 16px;
+  align-items: center;
+  justify-content: center;
   color: var(--icm-text-muted);
-  text-align: center;
+}
+.simulation-tree-icon {
+  flex: 0 0 14px;
+  display: flex;
+  color: var(--icm-text-muted);
+}
+.simulation-tree-row svg {
+  width: 14px;
+  height: 14px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+.simulation-tree-row.is-active {
+  background: color-mix(in srgb, var(--icm-text) 4%, transparent);
+}
+.simulation-tree-row.is-selected {
+  background: color-mix(in srgb, var(--icm-text) 7%, transparent);
+}
+.simulation-folder-tree:focus-within .simulation-tree-row.is-selected {
+  background: color-mix(in srgb, var(--icm-accent) 11%, transparent);
+}
+.simulation-code-files .simulation-tree-row button:focus-visible {
+  outline: 1px solid color-mix(in srgb, var(--icm-accent) 55%, transparent);
+  outline-offset: -1px;
 }
 .simulation-file-name {
   flex: 1;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }
+.simulation-tree-row small,
 .simulation-file-state {
   flex: none;
   color: var(--icm-text-muted);
+  font-size: 10px;
 }
-.simulation-file-state.is-dirty {
-  color: var(--icm-accent);
+.simulation-tree-row .workspace-inline-name {
+  flex: 1;
+  padding: 0 0 0 19px;
+  height: 24px;
+  position: relative;
+  box-sizing: border-box;
 }
-.simulation-explorer-section button[data-tree-row] > small {
-  flex: none;
-  color: var(--icm-text-muted);
-  font-size: 9px;
+.simulation-tree-row .workspace-inline-name input {
+  height: 24px;
+  padding: 0 3px;
+  border-radius: 0;
+  font-size: inherit;
+}
+.simulation-tree-row .workspace-inline-name small {
+  position: absolute;
+  top: 24px;
+  left: 19px;
+  right: 0;
+  z-index: 5;
+  padding: 3px;
+  background: var(--icm-surface);
+  border: 1px solid #b42318;
 }
 .simulation-code-document {
   display: flex;
@@ -525,6 +482,9 @@
   border-top: 1px solid var(--icm-border);
   font-size: 11px;
   color: var(--icm-text-muted);
+}
+.simulation-code-status:empty {
+  display: none;
 }
 .simulation-code-actions [data-workspace-save] {
   min-width: 68px;

--- a/apps/editor/src/features/simulation/code-workspace.test.tsx
+++ b/apps/editor/src/features/simulation/code-workspace.test.tsx
@@ -41,6 +41,7 @@ describe("approved simulation Code layout", () => {
     expect(markup).not.toContain("Run target");
     expect(markup).not.toContain("New file");
     expect(markup).not.toContain("Setup");
+    expect(markup).not.toContain('class="simulation-code-status"');
   });
   it("opens only circuit/run tabs by default, with output below the editor and configuration on demand", () => {
     const markup = renderToStaticMarkup(

--- a/apps/editor/src/features/simulation/code-workspace.test.tsx
+++ b/apps/editor/src/features/simulation/code-workspace.test.tsx
@@ -38,7 +38,7 @@ describe("approved simulation Code layout", () => {
     expect(markup).toContain('data-workspace-new-folder="true"');
     expect(markup).toContain("+ New experiment");
     expect(markup).toContain("Source");
-    expect(markup).toContain("Run target");
+    expect(markup).not.toContain("Run target");
     expect(markup).not.toContain("New file");
     expect(markup).not.toContain("Setup");
   });
@@ -121,14 +121,12 @@ describe("approved simulation Code layout", () => {
         </SimulationCodeWorkspace>
       </WorkspaceInteractions>,
     );
-    expect(markup).toMatch(
-      /class="simulation-explorer-section is-source" open=""/,
-    );
-    expect(markup).toContain(
-      'class="simulation-explorer-section is-temporary" aria-label="Prepare temporary files"',
-    );
-    expect(markup).toContain("Temporary");
-    expect(markup).toContain("prepared.cir");
-    expect(markup).toContain('aria-label="Download selected files"');
+    expect(markup).toContain('aria-label="Source"');
+    expect(markup).toContain('aria-expanded="true"');
+    expect(markup).toContain('aria-label="Prepare"');
+    expect(markup).toContain('aria-expanded="false"');
+    expect(markup).toContain(">tmp</small>");
+    expect(markup).not.toContain("prepared.cir");
+    expect(markup).not.toContain('aria-label="Download selected files"');
   });
 });

--- a/apps/editor/src/features/simulation/code-workspace.tsx
+++ b/apps/editor/src/features/simulation/code-workspace.tsx
@@ -1,23 +1,15 @@
-import {
-  useEffect,
-  useId,
-  useState,
-  type MouseEvent as ReactMouseEvent,
-  type ReactNode,
-} from "react";
+import { useEffect, useId, useState, type ReactNode } from "react";
 import type { ArtifactRef } from "@icm/simulation-service/contract";
 import {
-  SimulationFolderTree,
+  SimulationFileTree,
   type SimulationFolderTreeProps,
 } from "./simulation-file-tree";
 import {
   useWorkspaceInteractions,
-  WorkspaceNameInput,
   type WorkspaceMenuItem,
 } from "./workspace-interactions";
 import {
   formatSimulationArtifactPreview,
-  simulationArtifactCategory,
   type SimulationArtifactContent,
 } from "./simulation-artifact-files";
 
@@ -57,7 +49,10 @@ export interface SimulationCodeWorkspaceProps {
   onSelectArtifact?(artifact: ArtifactRef): void;
   onCloseArtifact?(): void;
   onDownloadArtifact?(artifact: ArtifactRef): void;
-  onDownloadSelection?(selection: readonly SimulationExplorerSelection[]): void;
+  onDownloadSelection?(
+    selection: readonly SimulationExplorerSelection[],
+    archive?: boolean,
+  ): void;
   folders?:
     Omit<SimulationFolderTreeProps, "renderFiles" | "onNewFile"> | undefined;
   additionalActions?: WorkspaceMenuItem[];
@@ -107,8 +102,6 @@ export function SimulationCodeWorkspace(props: SimulationCodeWorkspaceProps) {
   });
   const [resultsHeight, setResultsHeight] = useState(38);
   const [collapsed, setCollapsed] = useState(false);
-  const [selected, setSelected] = useState<string[]>([]);
-  const [sectionOpen, setSectionOpen] = useState<Record<string, boolean>>({});
   useEffect(() => {
     if (props.activePath)
       setOpened((paths) =>
@@ -131,6 +124,7 @@ export function SimulationCodeWorkspace(props: SimulationCodeWorkspaceProps) {
   const openFile = (path: string, folderId?: string) => {
     if (!folderId || folderId === props.folders?.activeId)
       setOpened((paths) => (paths.includes(path) ? paths : [...paths, path]));
+    props.onCloseArtifact?.();
     props.onSelectFile(path, folderId);
     ui.closeMenu();
   };
@@ -139,259 +133,6 @@ export function SimulationCodeWorkspace(props: SimulationCodeWorkspaceProps) {
     setOpened(next);
     if (props.activePath === path) props.onSelectFile(next.at(-1) ?? "");
   };
-  const sourceKey = (folderId: string, path: string) =>
-    `source\u0000${folderId}\u0000${path}`;
-  const artifactKey = (groupKey: string, artifactId: string) =>
-    `artifact\u0000${groupKey}\u0000${artifactId}`;
-  const select = (key: string, event: ReactMouseEvent) =>
-    setSelected((current) =>
-      event.ctrlKey || event.metaKey
-        ? current.includes(key)
-          ? current.filter((item) => item !== key)
-          : [...current, key]
-        : [key],
-    );
-  const selection = (): SimulationExplorerSelection[] => {
-    const result: SimulationExplorerSelection[] = [];
-    for (const key of selected) {
-      const [kind, owner, value] = key.split("\u0000");
-      if (kind === "source" && owner && value)
-        result.push({ kind, folderId: owner, path: value });
-      if (kind === "artifact" && (owner === "prepare" || owner === "run")) {
-        const artifact = props.artifactGroups
-          ?.find((group) => group.key === owner)
-          ?.artifacts.find((item) => item.id === value);
-        if (artifact) result.push({ kind, groupKey: owner, artifact });
-      }
-    }
-    return result;
-  };
-  const fileMenu = (
-    file: SimulationCodeFile,
-    folderId: string | undefined,
-    x: number,
-    y: number,
-  ) => {
-    const items: WorkspaceMenuItem[] = [
-      { label: "Open", run: () => openFile(file.path, folderId) },
-      {
-        label: "Copy contents",
-        run: () => props.onCopyFile?.(file.path, folderId),
-      },
-      {
-        label: "Export file…",
-        run: () => props.onExportFile?.(file.path, folderId),
-      },
-    ];
-    if (file.kind === "authored")
-      items.push(
-        ...(
-          [
-            ["rename", "Rename…"],
-            ["delete", "Delete…"],
-            ["entry", "Use as run entry"],
-          ] as const
-        ).map(([action, label]) => ({
-          label,
-          run: () => props.onFileAction?.(action, file.path, folderId),
-        })),
-      );
-    if (file.draft)
-      items.push({
-        label: "Discard draft",
-        run: () => props.onFileAction?.("discard", file.path, folderId),
-      });
-    ui.menu(x, y, items, `Actions for ${file.path}`);
-  };
-  const fileList = (folderId?: string) => {
-    const current = !folderId || folderId === props.folders?.activeId;
-    const folder = props.folders?.folders.find((f) => f.id === folderId);
-    const files = current ? props.files : (folder?.files ?? []);
-    const visibleFiles = files.filter(
-      (file) => file.path !== (current ? props.configPath : folder?.configPath),
-    );
-    const editing =
-      ui.edit?.kind === "file" &&
-      ui.edit.folderId === (folderId ?? props.folders?.activeId);
-    const resolvedFolderId = folderId ?? props.folders?.activeId ?? "workspace";
-    const sourceSectionKey = `${resolvedFolderId}:source`;
-    const groups = current ? (props.artifactGroups ?? []) : [];
-    return (
-      <div className="simulation-explorer-sections">
-        <details
-          className="simulation-explorer-section is-source"
-          open={sectionOpen[sourceSectionKey] ?? true}
-          onToggle={(event) => {
-            const open = event.currentTarget.open;
-            setSectionOpen((state) => ({
-              ...state,
-              [sourceSectionKey]: open,
-            }));
-          }}
-        >
-          <summary>
-            <span>Source</span>
-            <small>{visibleFiles.length}</small>
-          </summary>
-          <ul>
-            {editing && !ui.edit?.path ? (
-              <li>
-                <WorkspaceNameInput key="new-file" />
-              </li>
-            ) : null}
-            {visibleFiles.map((file) => (
-              <li
-                key={file.path}
-                onContextMenu={(event) => {
-                  event.preventDefault();
-                  event.stopPropagation();
-                  fileMenu(file, folderId, event.clientX, event.clientY);
-                }}
-                onKeyDown={(event) => {
-                  if (event.target instanceof HTMLInputElement) return;
-                  if (
-                    (event.key === "F2" || event.key === "Delete") &&
-                    file.kind === "authored"
-                  ) {
-                    event.preventDefault();
-                    props.onFileAction?.(
-                      event.key === "F2" ? "rename" : "delete",
-                      file.path,
-                      folderId,
-                    );
-                  }
-                  if (
-                    event.key === "ContextMenu" ||
-                    (event.shiftKey && event.key === "F10")
-                  ) {
-                    event.preventDefault();
-                    const rect = event.currentTarget.getBoundingClientRect();
-                    fileMenu(file, folderId, rect.left, rect.bottom);
-                  }
-                }}
-              >
-                {editing && ui.edit?.path === file.path ? (
-                  <WorkspaceNameInput key={file.path} />
-                ) : (
-                  <button
-                    type="button"
-                    data-tree-row="file"
-                    data-folder-id={folderId ?? props.folders?.activeId}
-                    data-file-path={file.path}
-                    className={[
-                      current &&
-                      !props.artifactPreview &&
-                      file.path === props.activePath
-                        ? "is-active"
-                        : "",
-                      selected.includes(sourceKey(resolvedFolderId, file.path))
-                        ? "is-selected"
-                        : "",
-                    ]
-                      .filter(Boolean)
-                      .join(" ")}
-                    aria-pressed={selected.includes(
-                      sourceKey(resolvedFolderId, file.path),
-                    )}
-                    title={file.path}
-                    onClick={(event) => {
-                      select(sourceKey(resolvedFolderId, file.path), event);
-                      props.onCloseArtifact?.();
-                      openFile(file.path, folderId);
-                    }}
-                  >
-                    <span className="simulation-file-icon" aria-hidden="true">
-                      {file.kind === "generated"
-                        ? "◇"
-                        : file.kind === "prepared"
-                          ? "▧"
-                          : "·"}
-                    </span>
-                    <span className="simulation-file-name">{file.path}</span>
-                    {file.dirty ? (
-                      <span
-                        className="simulation-file-state is-dirty"
-                        title="Unsaved"
-                      >
-                        ●
-                      </span>
-                    ) : file.draft ? (
-                      <span
-                        className="simulation-file-state"
-                        title="Saved draft"
-                      >
-                        ◌
-                      </span>
-                    ) : null}
-                  </button>
-                )}
-              </li>
-            ))}
-          </ul>
-        </details>
-        {groups.map((group) => {
-          const groupSectionKey = `${resolvedFolderId}:${group.key}`;
-          return (
-            <details
-              key={group.key}
-              className="simulation-explorer-section is-temporary"
-              aria-label={`${group.label} temporary files`}
-              open={sectionOpen[groupSectionKey] ?? false}
-              onToggle={(event) => {
-                const open = event.currentTarget.open;
-                setSectionOpen((state) => ({
-                  ...state,
-                  [groupSectionKey]: open,
-                }));
-              }}
-            >
-              <summary>
-                <span>{group.label}</span>
-                <span className="simulation-temporary-badge">Temporary</span>
-                <small>{group.artifacts.length}</small>
-              </summary>
-              <p>{group.description}</p>
-              <ul>
-                {group.artifacts.map((artifact) => {
-                  const key = artifactKey(group.key, artifact.id);
-                  const active =
-                    props.artifactPreview?.artifact.id === artifact.id;
-                  return (
-                    <li key={artifact.id}>
-                      <button
-                        type="button"
-                        data-tree-row="artifact"
-                        className={`${active ? "is-active" : ""}${selected.includes(key) ? " is-selected" : ""}`.trim()}
-                        aria-pressed={selected.includes(key)}
-                        title={`${simulationArtifactCategory(artifact)} · ${artifact.name}`}
-                        disabled={props.artifactBusy !== undefined}
-                        onClick={(event) => {
-                          select(key, event);
-                          props.onSelectArtifact?.(artifact);
-                        }}
-                      >
-                        <span
-                          className="simulation-file-icon"
-                          aria-hidden="true"
-                        >
-                          ▧
-                        </span>
-                        <span className="simulation-file-name">
-                          {artifact.name}
-                        </span>
-                        <small>{simulationArtifactCategory(artifact)}</small>
-                      </button>
-                    </li>
-                  );
-                })}
-              </ul>
-            </details>
-          );
-        })}
-      </div>
-    );
-  };
-  const selectedItems = selection();
   return (
     <section
       className={`simulation-code-workspace${props.maximized ? " is-maximized" : ""}`}
@@ -477,27 +218,7 @@ export function SimulationCodeWorkspace(props: SimulationCodeWorkspaceProps) {
             style={{ width: filesWidth }}
             aria-label="Simulation files"
           >
-            <header className="simulation-explorer-header">
-              <strong>Explorer</strong>
-              <button
-                type="button"
-                disabled={!selectedItems.length || !props.onDownloadSelection}
-                onClick={() => props.onDownloadSelection?.(selectedItems)}
-                title="Download selected files"
-                aria-label={`Download selected files${selectedItems.length ? ` (${selectedItems.length})` : ""}`}
-              >
-                ↓ {selectedItems.length || ""}
-              </button>
-            </header>
-            {props.folders ? (
-              <SimulationFolderTree
-                {...props.folders}
-                renderFiles={fileList}
-                onNewFile={(id) => props.onNewFile?.(id)}
-              />
-            ) : (
-              fileList()
-            )}
+            <SimulationFileTree {...props} onSelectFile={openFile} />
           </aside>
         ) : null}
         {filesOpen ? (
@@ -558,7 +279,7 @@ export function SimulationCodeWorkspace(props: SimulationCodeWorkspaceProps) {
               <div className="simulation-code-tab simulation-artifact-tab">
                 <button type="button" role="tab" aria-selected="true">
                   {props.artifactPreview.artifact.name}
-                  <span> Temporary</span>
+                  <span> tmp</span>
                 </button>
                 <button
                   type="button"
@@ -618,7 +339,7 @@ export function SimulationCodeWorkspace(props: SimulationCodeWorkspaceProps) {
               >
                 <header>
                   <span>
-                    Read-only preview · Temporary run file
+                    Read-only · tmp
                     {props.artifactPreview.truncated ? " · First 64 KB" : ""}
                   </span>
                   <button

--- a/apps/editor/src/features/simulation/code-workspace.tsx
+++ b/apps/editor/src/features/simulation/code-workspace.tsx
@@ -58,6 +58,7 @@ export interface SimulationCodeWorkspaceProps {
   additionalActions?: WorkspaceMenuItem[];
   children: ReactNode;
   actions: ReactNode;
+  toolbarEnd?: ReactNode;
   status?: ReactNode;
   console: ReactNode;
   results: ReactNode;
@@ -159,7 +160,7 @@ export function SimulationCodeWorkspace(props: SimulationCodeWorkspaceProps) {
         }
       }}
     >
-      <header className="simulation-code-toolbar">
+      <header className="simulation-code-toolbar simulation-taskbar">
         <button
           type="button"
           aria-expanded={filesOpen}
@@ -209,6 +210,7 @@ export function SimulationCodeWorkspace(props: SimulationCodeWorkspaceProps) {
             ···
           </button>
         </div>
+        {props.toolbarEnd}
       </header>
       <div className="simulation-code-source-area">
         {filesOpen ? (
@@ -486,7 +488,9 @@ export function SimulationCodeWorkspace(props: SimulationCodeWorkspaceProps) {
           </div>
         ) : null}
       </section>
-      <footer className="simulation-code-status">{props.status}</footer>
+      {props.status ? (
+        <footer className="simulation-code-status">{props.status}</footer>
+      ) : null}
     </section>
   );
 }

--- a/apps/editor/src/features/simulation/simulation-file-tree.tsx
+++ b/apps/editor/src/features/simulation/simulation-file-tree.tsx
@@ -1,4 +1,16 @@
-import { useState, type ReactNode } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
+import type {
+  SimulationCodeWorkspaceProps,
+  SimulationExplorerSelection,
+  SimulationCodeFile,
+} from "./code-workspace";
+import { simulationArtifactCategory } from "./simulation-artifact-files";
 import {
   useWorkspaceInteractions,
   WorkspaceNameInput,
@@ -26,89 +38,501 @@ export interface SimulationFolderTreeProps {
   onNewFile(id: string): void;
   busy?: boolean;
 }
-/** Selection and expansion do not change execution context. Opening a file does. */
-export function SimulationFolderTree(props: SimulationFolderTreeProps) {
+
+interface TreeNode {
+  id: string;
+  name: string;
+  folderId: string;
+  kind: "folder" | "directory" | "file" | "artifact";
+  children?: TreeNode[];
+  entry?: SimulationExplorerSelection;
+  file?: SimulationCodeFile;
+  expanded?: boolean;
+  tmp?: boolean;
+}
+const collect = (node: TreeNode): SimulationExplorerSelection[] =>
+  node.entry ? [node.entry] : (node.children ?? []).flatMap(collect);
+
+/** One selection owner for directories, source and immutable execution files. */
+export function SimulationFileTree(props: SimulationCodeWorkspaceProps) {
   const ui = useWorkspaceInteractions();
+  const anchor = useRef<string | undefined>(undefined);
   const [selected, setSelected] = useState<string[]>([]);
-  const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set());
-  const action = (name: FolderAction, ids: string[]) =>
-    props.onAction(name, ids);
-  const open = (x: number, y: number, id?: string) => {
-    const ids = id
-      ? selected.includes(id)
-        ? selected.filter((key) => props.folders.some((f) => f.id === key))
-        : [id]
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  const folders = props.folders?.folders ?? [
+    { id: props.workspaceKey, name: props.workspaceKey, files: props.files },
+  ];
+  const activeId = props.folders?.activeId ?? props.workspaceKey;
+  useEffect(() => {
+    if (!props.activePath) {
+      setSelected([]);
+      return;
+    }
+    setSelected([activeId + "/file/" + props.activePath]);
+    const parts = props.activePath.split("/").slice(0, -1);
+    setExpanded((state) => {
+      const next = { ...state, [activeId]: true, [activeId + "/source"]: true };
+      let path = activeId + "/source";
+      for (const part of parts) {
+        path += "/" + part;
+        next[path] = true;
+      }
+      return next;
+    });
+  }, [activeId, props.activePath]);
+  const nodes: TreeNode[] = folders.map((folder) => {
+    const files = folder.id === activeId ? props.files : (folder.files ?? []);
+    const source: TreeNode = {
+      id: folder.id + "/source",
+      name: "Source",
+      folderId: folder.id,
+      kind: "directory",
+      children: [],
+      expanded: true,
+    };
+    for (const file of files) {
+      let parent = source;
+      const parts = file.path.split("/");
+      for (const part of parts.slice(0, -1)) {
+        const id = parent.id + "/" + part;
+        let child = parent.children!.find(
+          (node) => node.id === id && node.children,
+        );
+        if (!child) {
+          child = {
+            id,
+            name: part,
+            folderId: folder.id,
+            kind: "directory",
+            children: [],
+          };
+          parent.children!.push(child);
+        }
+        parent = child;
+      }
+      parent.children!.push({
+        id: folder.id + "/file/" + file.path,
+        name: parts.at(-1)!,
+        folderId: folder.id,
+        kind: "file",
+        file,
+        entry: { kind: "source", folderId: folder.id, path: file.path },
+      });
+    }
+    const children = [source];
+    if (folder.id === activeId)
+      for (const group of props.artifactGroups ?? []) {
+        const directory: TreeNode = {
+          id: folder.id + "/" + group.key,
+          name: group.label,
+          folderId: folder.id,
+          kind: "directory",
+          children: [],
+          tmp: true,
+        };
+        for (const artifact of group.artifacts) {
+          const category = simulationArtifactCategory(artifact);
+          let categoryNode = directory.children!.find(
+            (node) => node.name === category,
+          );
+          if (!categoryNode) {
+            categoryNode = {
+              id: directory.id + "/" + category,
+              name: category,
+              folderId: folder.id,
+              kind: "directory",
+              children: [],
+            };
+            directory.children!.push(categoryNode);
+          }
+          categoryNode.children!.push({
+            id: folder.id + "/" + group.key + "/" + artifact.id,
+            name: artifact.name,
+            folderId: folder.id,
+            kind: "artifact",
+            entry: { kind: "artifact", groupKey: group.key, artifact },
+          });
+        }
+        children.push(directory);
+      }
+    return {
+      id: folder.id,
+      name: folder.name,
+      folderId: folder.id,
+      kind: "folder",
+      children,
+      expanded: true,
+    };
+  });
+  const all = new Map<string, TreeNode>();
+  const visit = (items: TreeNode[]) =>
+    items.forEach((node) => {
+      all.set(node.id, node);
+      if (node.children) {
+        if (node.kind !== "folder")
+          node.children.sort(
+            (a, b) =>
+              Number(Boolean(b.children)) - Number(Boolean(a.children)) ||
+              a.name.localeCompare(b.name),
+          );
+        visit(node.children);
+      }
+    });
+  visit(nodes);
+  const isOpen = (node: TreeNode) =>
+    expanded[node.id] ?? node.expanded ?? false;
+  const visible: TreeNode[] = [];
+  const flatten = (items: TreeNode[]) =>
+    items.forEach((node) => {
+      visible.push(node);
+      if (node.children && isOpen(node)) flatten(node.children);
+    });
+  flatten(nodes);
+  const validSelection = selected.filter((id) => all.has(id));
+  const choose = (
+    node: TreeNode,
+    event: { ctrlKey: boolean; metaKey: boolean; shiftKey: boolean },
+  ) => {
+    if (event.shiftKey && anchor.current) {
+      const start = visible.findIndex((item) => item.id === anchor.current);
+      const end = visible.indexOf(node);
+      if (start >= 0) {
+        const range = visible
+          .slice(Math.min(start, end), Math.max(start, end) + 1)
+          .map((item) => item.id);
+        setSelected(
+          event.ctrlKey || event.metaKey
+            ? [...new Set([...validSelection, ...range])]
+            : range,
+        );
+        return;
+      }
+    }
+    anchor.current = node.id;
+    setSelected(
+      event.ctrlKey || event.metaKey
+        ? validSelection.includes(node.id)
+          ? validSelection.filter((id) => id !== node.id)
+          : [...validSelection, node.id]
+        : [node.id],
+    );
+  };
+  const toggle = (node: TreeNode, open = !isOpen(node)) =>
+    setExpanded((state) => ({ ...state, [node.id]: open }));
+  const openFile = (node: TreeNode) => {
+    if (node.entry?.kind === "source") {
+      props.onCloseArtifact?.();
+      props.onSelectFile(node.entry.path, node.folderId);
+    } else if (node.entry?.kind === "artifact")
+      props.onSelectArtifact?.(node.entry.artifact);
+  };
+  const menu = (node: TreeNode | undefined, x: number, y: number) => {
+    const ids = node
+      ? validSelection.includes(node.id)
+        ? validSelection
+        : [node.id]
       : [];
     setSelected(ids);
-    const target = id ?? props.activeId;
-    const items: WorkspaceMenuItem[] = [
-      { label: "New experiment…", run: () => action("new", []) },
-      {
-        label: "New file…",
-        disabled: !target,
-        run: () => {
-          setCollapsed(
-            (set) => new Set([...set].filter((key) => key !== target)),
-          );
-          props.onNewFile(target);
-        },
-      },
+    const targets = ids.map((id) => all.get(id)!);
+    const entries = [
+      ...new Map(
+        targets
+          .flatMap(collect)
+          .map((entry) => [
+            entry.kind === "source"
+              ? "source/" + entry.folderId + "/" + entry.path
+              : "artifact/" + entry.artifact.id,
+            entry,
+          ]),
+      ).values(),
     ];
-    if (ids.length === 1)
-      items.push(
-        {
-          label: "Run folder",
-          disabled: props.busy,
-          run: () => action("run", ids),
-        },
-        { label: "Duplicate…", run: () => action("duplicate", ids) },
-        { label: "Rename…", run: () => action("rename", ids) },
-        { label: "Export folder…", run: () => action("export", ids) },
-        { label: "Delete…", run: () => action("delete", ids) },
-      );
-    if (ids.length > 1)
+    const items: WorkspaceMenuItem[] = [];
+    if (entries.length)
       items.push({
-        label: `Run selected folders (${ids.length})`,
-        disabled: props.busy,
-        run: () => action("batch", ids),
+        label:
+          targets.length > 1
+            ? "Download selected (" + targets.length + ")…"
+            : "Download…",
+        disabled: !props.onDownloadSelection,
+        run: () =>
+          props.onDownloadSelection?.(
+            entries,
+            targets.some((target) => Boolean(target.children)),
+          ),
       });
+    if (targets.length === 1 && node?.file) {
+      items.push(
+        { label: "Open", run: () => openFile(node) },
+        {
+          label: "Copy contents",
+          run: () => props.onCopyFile?.(node.file!.path, node.folderId),
+        },
+      );
+      if (node.file.kind === "authored")
+        for (const [action, label] of [
+          ["rename", "Rename…"],
+          ["delete", "Delete…"],
+          ["entry", "Use as run entry"],
+        ] as const)
+          items.push({
+            label,
+            run: () =>
+              props.onFileAction?.(action, node.file!.path, node.folderId),
+          });
+      if (node.file.draft)
+        items.push({
+          label: "Discard draft",
+          run: () =>
+            props.onFileAction?.("discard", node.file!.path, node.folderId),
+        });
+    }
+    if (props.folders) {
+      if (
+        targets.length <= 1 &&
+        (!node || node.kind === "folder" || node.id.includes("/source"))
+      ) {
+        items.push({
+          label: "New file…",
+          run: () => {
+            const id = node?.folderId ?? activeId;
+            setExpanded((state) => ({
+              ...state,
+              [id]: true,
+              [id + "/source"]: true,
+            }));
+            props.onNewFile?.(id);
+          },
+        });
+      }
+      if (targets.length === 1 && node?.kind === "folder")
+        for (const [action, label] of [
+          ["run", "Run folder"],
+          ["duplicate", "Duplicate…"],
+          ["rename", "Rename…"],
+          ["delete", "Delete…"],
+        ] as const)
+          items.push({
+            label,
+            disabled: action === "run" && props.folders.busy,
+            run: () => props.folders?.onAction(action, [node.folderId]),
+          });
+      if (targets.length > 1 && targets.every((item) => item.kind === "folder"))
+        items.push({
+          label: "Run selected folders (" + targets.length + ")",
+          disabled: props.folders.busy,
+          run: () => props.folders?.onAction("batch", ids),
+        });
+      items.push({
+        label: "New experiment…",
+        run: () => props.folders?.onAction("new", []),
+      });
+    }
     items.push({
       label: "Collapse all",
-      run: () => setCollapsed(new Set(props.folders.map((f) => f.id))),
+      run: () =>
+        setExpanded(
+          Object.fromEntries([...all.keys()].map((id) => [id, false])),
+        ),
     });
-    ui.menu(x, y, items, "Folder actions");
+    ui.menu(
+      x,
+      y,
+      items,
+      node?.file ? "Actions for " + node.file.path : "Folder actions",
+    );
   };
-  const naming = ui.edit?.kind === "folder";
+  const render = (node: TreeNode, level: number): ReactNode => {
+    const naming =
+      ui.edit?.folderId === node.folderId &&
+      (node.kind === "folder"
+        ? ui.edit.kind === "folder"
+        : node.file &&
+          ui.edit.kind === "file" &&
+          ui.edit.path === node.file.path);
+    const active =
+      node.entry?.kind === "source"
+        ? node.folderId === activeId &&
+          node.entry.path === props.activePath &&
+          !props.artifactPreview
+        : node.entry?.kind === "artifact" &&
+          node.entry.artifact.id === props.artifactPreview?.artifact.id;
+    return (
+      <div
+        key={node.id}
+        className="simulation-tree-node"
+        role="none"
+        aria-label={node.tmp ? node.name + " temporary files" : undefined}
+      >
+        <div
+          className={
+            "simulation-tree-row" +
+            (validSelection.includes(node.id) ? " is-selected" : "") +
+            (active ? " is-active" : "")
+          }
+          style={{ "--tree-depth": level } as CSSProperties}
+          onContextMenu={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            menu(node, event.clientX, event.clientY);
+          }}
+        >
+          {node.children ? (
+            <button
+              type="button"
+              className="simulation-tree-chevron"
+              tabIndex={-1}
+              aria-label={"Toggle " + node.name}
+              aria-expanded={isOpen(node)}
+              onClick={(event) => {
+                event.stopPropagation();
+                toggle(node);
+              }}
+            >
+              <svg viewBox="0 0 16 16" aria-hidden="true">
+                <path d={isOpen(node) ? "m4 6 4 4 4-4" : "m6 4 4 4-4 4"} />
+              </svg>
+            </button>
+          ) : (
+            <span className="simulation-tree-chevron" />
+          )}
+          {naming ? (
+            <WorkspaceNameInput />
+          ) : (
+            <button
+              type="button"
+              role="treeitem"
+              aria-level={level + 1}
+              aria-selected={validSelection.includes(node.id)}
+              aria-expanded={node.children ? isOpen(node) : undefined}
+              data-tree-row={node.kind}
+              data-node-id={node.id}
+              data-folder-id={node.folderId}
+              data-file-path={node.file?.path}
+              aria-label={
+                node.kind === "folder" ? "Folder " + node.name : node.name
+              }
+              aria-current={active ? "page" : undefined}
+              title={node.file?.path ?? node.name}
+              onClick={(event) => {
+                choose(node, event);
+                if (!event.ctrlKey && !event.metaKey && !event.shiftKey) {
+                  if (node.children) toggle(node);
+                  else openFile(node);
+                }
+              }}
+              onKeyDown={(event) => {
+                if (event.key === "ArrowLeft" || event.key === "ArrowRight") {
+                  event.preventDefault();
+                  if (node.children) toggle(node, event.key === "ArrowRight");
+                }
+                if (event.key === "F2" || event.key === "Delete") {
+                  event.preventDefault();
+                  if (node.kind === "folder")
+                    props.folders?.onAction(
+                      event.key === "F2" ? "rename" : "delete",
+                      [node.folderId],
+                    );
+                  else if (node.file?.kind === "authored")
+                    props.onFileAction?.(
+                      event.key === "F2" ? "rename" : "delete",
+                      node.file.path,
+                      node.folderId,
+                    );
+                }
+                if (
+                  event.key === "ContextMenu" ||
+                  (event.shiftKey && event.key === "F10")
+                ) {
+                  event.preventDefault();
+                  const rect = event.currentTarget.getBoundingClientRect();
+                  menu(node, rect.left, rect.bottom);
+                }
+              }}
+            >
+              <span className="simulation-tree-icon" aria-hidden="true">
+                <svg viewBox="0 0 16 16">
+                  <path
+                    d={
+                      node.children
+                        ? "M2 4h4l2 2h6v7H2z"
+                        : node.file?.kind === "generated"
+                          ? "m8 2 5 6-5 6-5-6z"
+                          : "M4 2h5l3 3v9H4z M9 2v4h3"
+                    }
+                  />
+                </svg>
+              </span>
+              <span className="simulation-file-name">{node.name}</span>
+              {node.tmp ? <small>tmp</small> : null}
+              {node.file?.dirty ? (
+                <span className="simulation-file-state" title="Unsaved">
+                  ●
+                </span>
+              ) : node.file?.draft ? (
+                <span className="simulation-file-state" title="Saved draft">
+                  ◌
+                </span>
+              ) : null}
+            </button>
+          )}
+        </div>
+        {node.children && isOpen(node) ? (
+          <div role="group" aria-label={node.name + " files"}>
+            {node.id.endsWith("/source") &&
+            ui.edit?.kind === "file" &&
+            ui.edit.folderId === node.folderId &&
+            !ui.edit.path ? (
+              <div
+                className="simulation-tree-row"
+                style={{ "--tree-depth": level + 1 } as CSSProperties}
+              >
+                <WorkspaceNameInput />
+              </div>
+            ) : null}
+            {node.children.map((child) => render(child, level + 1))}
+          </div>
+        ) : null}
+      </div>
+    );
+  };
   return (
     <div
       className="simulation-folder-tree"
+      role="tree"
       aria-label="Simulation folders"
-      onClick={(event) => {
-        if (
-          event.target === event.currentTarget ||
-          (event.target instanceof Element &&
-            event.target.closest('[data-tree-row="file"]'))
-        )
-          setSelected([]);
-      }}
+      aria-multiselectable="true"
       onContextMenu={(event) => {
         event.preventDefault();
-        event.stopPropagation();
-        open(event.clientX, event.clientY);
+        menu(undefined, event.clientX, event.clientY);
+      }}
+      onClick={(event) => {
+        if (event.target === event.currentTarget) setSelected([]);
       }}
       onKeyDown={(event) => {
         event.stopPropagation();
         if (event.target instanceof HTMLInputElement) return;
+        if (
+          (event.ctrlKey || event.metaKey) &&
+          event.key.toLowerCase() === "a"
+        ) {
+          event.preventDefault();
+          setSelected(visible.map((node) => node.id));
+        }
+        if (event.key === "Escape") {
+          event.preventDefault();
+          setSelected([]);
+        }
         if (["ArrowUp", "ArrowDown", "Home", "End"].includes(event.key)) {
+          event.preventDefault();
           const rows = [
             ...event.currentTarget.querySelectorAll<HTMLButtonElement>(
-              "button[data-tree-row]",
+              "[data-node-id]",
             ),
           ];
-          const current = rows.indexOf(
+          const index = rows.indexOf(
             document.activeElement as HTMLButtonElement,
           );
-          const index =
+          const next =
             event.key === "Home"
               ? 0
               : event.key === "End"
@@ -117,112 +541,28 @@ export function SimulationFolderTree(props: SimulationFolderTreeProps) {
                     0,
                     Math.min(
                       rows.length - 1,
-                      current + (event.key === "ArrowDown" ? 1 : -1),
+                      index + (event.key === "ArrowDown" ? 1 : -1),
                     ),
                   );
-          event.preventDefault();
-          rows[index]?.focus();
+          rows[next]?.focus();
+          const node = all.get(rows[next]?.dataset.nodeId ?? "");
+          if (node) choose(node, event);
         }
       }}
     >
-      <button
-        type="button"
-        data-workspace-new-folder="true"
-        onClick={() => action("new", [])}
-      >
-        + New experiment
-      </button>
-      {naming && !ui.edit?.folderId ? (
-        <WorkspaceNameInput key="new-folder" />
+      {props.folders ? (
+        <button
+          type="button"
+          data-workspace-new-folder="true"
+          onClick={() => props.folders?.onAction("new", [])}
+        >
+          + New experiment
+        </button>
       ) : null}
-      {props.folders.map((folder) => (
-        <div key={folder.id}>
-          {naming && ui.edit?.folderId === folder.id ? (
-            <WorkspaceNameInput key={folder.id} />
-          ) : (
-            <div
-              className="workspace-folder-row"
-              onContextMenu={(event) => {
-                event.preventDefault();
-                event.stopPropagation();
-                open(event.clientX, event.clientY, folder.id);
-              }}
-            >
-              <button
-                type="button"
-                className="workspace-folder-toggle"
-                aria-label={`Toggle ${folder.name}`}
-                aria-expanded={!collapsed.has(folder.id)}
-                onClick={() =>
-                  setCollapsed((set) => {
-                    const next = new Set(set);
-                    if (next.has(folder.id)) next.delete(folder.id);
-                    else next.add(folder.id);
-                    return next;
-                  })
-                }
-              >
-                {collapsed.has(folder.id) ? "▸" : "▾"}
-              </button>
-              <button
-                type="button"
-                data-tree-row="folder"
-                data-folder-id={folder.id}
-                aria-label={`Folder ${folder.name}`}
-                aria-pressed={selected.includes(folder.id)}
-                title={
-                  folder.id === props.activeId
-                    ? `${folder.name} · Run target`
-                    : folder.name
-                }
-                className={folder.id === props.activeId ? "is-active" : ""}
-                onClick={(event) =>
-                  setSelected((ids) =>
-                    event.ctrlKey || event.metaKey
-                      ? ids.includes(folder.id)
-                        ? ids.filter((id) => id !== folder.id)
-                        : [...ids, folder.id]
-                      : [folder.id],
-                  )
-                }
-                onKeyDown={(event) => {
-                  if (event.key === "ArrowLeft" || event.key === "ArrowRight") {
-                    event.preventDefault();
-                    setCollapsed((set) => {
-                      const next = new Set(set);
-                      if (event.key === "ArrowLeft") next.add(folder.id);
-                      else next.delete(folder.id);
-                      return next;
-                    });
-                  }
-                  if (event.key === "F2" || event.key === "Delete") {
-                    event.preventDefault();
-                    action(event.key === "F2" ? "rename" : "delete", [
-                      folder.id,
-                    ]);
-                  }
-                  if (
-                    event.key === "ContextMenu" ||
-                    (event.shiftKey && event.key === "F10")
-                  ) {
-                    event.preventDefault();
-                    const rect = event.currentTarget.getBoundingClientRect();
-                    open(rect.left, rect.bottom, folder.id);
-                  }
-                }}
-              >
-                <span>{folder.name}</span>
-                {folder.id === props.activeId ? (
-                  <small className="simulation-run-target-badge">
-                    Run target
-                  </small>
-                ) : null}
-              </button>
-            </div>
-          )}
-          {!collapsed.has(folder.id) ? props.renderFiles(folder.id) : null}
-        </div>
-      ))}
+      {ui.edit?.kind === "folder" && !ui.edit.folderId ? (
+        <WorkspaceNameInput />
+      ) : null}
+      {nodes.map((node) => render(node, 0))}
     </div>
   );
 }

--- a/apps/editor/src/features/simulation/simulation-file-tree.tsx
+++ b/apps/editor/src/features/simulation/simulation-file-tree.tsx
@@ -509,6 +509,11 @@ export function SimulationFileTree(props: SimulationCodeWorkspaceProps) {
         if (event.target === event.currentTarget) setSelected([]);
       }}
       onKeyDown={(event) => {
+        if (
+          (event.ctrlKey || event.metaKey) &&
+          ["s", "w"].includes(event.key.toLowerCase())
+        )
+          return;
         event.stopPropagation();
         if (event.target instanceof HTMLInputElement) return;
         if (

--- a/apps/editor/src/features/simulation/source-code-pane.tsx
+++ b/apps/editor/src/features/simulation/source-code-pane.tsx
@@ -763,8 +763,9 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
     };
     const downloadSelection = async (
       selection: readonly SimulationExplorerSelection[],
+      archive = false,
     ) => {
-      if (selection.length === 1) {
+      if (selection.length === 1 && !archive) {
         const item = selection[0]!;
         if (item.kind === "source") {
           const result = downloadTextArtifact(
@@ -778,7 +779,7 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
         } else props.onDownloadArtifact?.(item.artifact);
         return;
       }
-      const archive = await buildSimulationWorkspaceArchive(
+      const bundle = await buildSimulationWorkspaceArchive(
         props.files,
         selection.map((item) => {
           if (item.kind === "artifact")
@@ -797,12 +798,12 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
           };
         }),
       );
-      if (!archive.ok) {
-        props.onProblem(archive.error);
+      if (!bundle.ok) {
+        props.onProblem(bundle.error);
         return;
       }
       const url = URL.createObjectURL(
-        new Blob([archive.bytes as BlobPart], { type: "application/zip" }),
+        new Blob([bundle.bytes as BlobPart], { type: "application/zip" }),
       );
       const anchor = document.createElement("a");
       anchor.href = url;
@@ -876,7 +877,9 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
         {...(props.onDownloadArtifact
           ? { onDownloadArtifact: props.onDownloadArtifact }
           : {})}
-        onDownloadSelection={(selection) => void downloadSelection(selection)}
+        onDownloadSelection={(selection, archive) =>
+          void downloadSelection(selection, archive)
+        }
         files={ownFiles.map((filePath) => ({
           path: filePath,
           kind: input.circuitBindings.some((b) => b.path === filePath)

--- a/apps/editor/src/features/simulation/source-code-pane.tsx
+++ b/apps/editor/src/features/simulation/source-code-pane.tsx
@@ -74,6 +74,7 @@ interface Props extends Pick<
   folder: ProjectSimulationFolder;
   files: SimulationFiles;
   actions: ReactNode;
+  toolbarEnd?: ReactNode;
   folders?: SimulationCodeWorkspaceProps["folders"];
   onPrepare?(): void;
   console: ReactNode;
@@ -1108,6 +1109,7 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
             {props.actions}
           </>
         }
+        toolbarEnd={props.toolbarEnd}
         console={props.console}
         results={props.results}
         outputActions={props.outputActions}
@@ -1116,32 +1118,30 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
         maximized={props.maximized}
         onToggleMaximize={props.onToggleMaximize}
         status={
-          <>
-            {!recoveryAvailable ? (
-              <span role="alert">
-                Draft recovery unavailable — save or export before leaving.
-              </span>
-            ) : null}
-            {conflict ? (
-              <>
-                <span role="alert">Changed elsewhere — draft retained.</span>
-                <button
-                  onClick={() => {
-                    drafts.current.delete(key(path));
-                    render((value) => value + 1);
-                  }}
-                >
-                  Discard local draft
-                </button>
-              </>
-            ) : activeDirty ? (
-              "Unsaved source"
-            ) : buffer && buffer.text !== buffer.base ? (
-              "Draft saved · finish or discard before Run"
-            ) : (
-              props.status
-            )}
-          </>
+          !recoveryAvailable || conflict || props.status ? (
+            <>
+              {!recoveryAvailable ? (
+                <span role="alert">
+                  Draft recovery unavailable — save or export before leaving.
+                </span>
+              ) : null}
+              {conflict ? (
+                <>
+                  <span role="alert">Changed elsewhere — draft retained.</span>
+                  <button
+                    onClick={() => {
+                      drafts.current.delete(key(path));
+                      render((value) => value + 1);
+                    }}
+                  >
+                    Discard local draft
+                  </button>
+                </>
+              ) : (
+                props.status
+              )}
+            </>
+          ) : null
         }
       >
         {probePicker && (

--- a/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
@@ -67,7 +67,7 @@ describe("source workspace default cutover", () => {
     expect(markup).toContain('aria-label="Open simulation files"');
     expect(markup).toContain("circuit.spice");
     expect(markup).toContain("run.cir");
-    expect(markup).not.toContain("experiment.json");
+    expect(markup).toContain("experiment.json");
     expect(markup).toContain('aria-label="Simulation folders"');
     expect(markup).not.toContain('aria-label="Simulation setup"');
     expect(markup).not.toContain("Prepare deck");

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -1530,6 +1530,145 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
     </section>
   );
 
+  const simulationActions = (
+    <div className="simulation-task-actions">
+      {running ? (
+        <button
+          className="simulation-stop-button"
+          disabled={
+            batch?.state === "cancelling" || run?.state === "cancelling"
+          }
+          onClick={() => {
+            if (batchRunning)
+              void session
+                .handle({ operation: "cancel-batch", batchId: batch.id })
+                .then(receive);
+            else if (run)
+              void session
+                .handle({ operation: "cancel", runId: run.id })
+                .then(receive);
+          }}
+        >
+          {batchRunning ? "Cancel batch" : "Cancel run"}
+        </button>
+      ) : selectedFolder ? (
+        <button
+          className="simulation-primary-button simulation-run-button"
+          disabled={busy}
+          onClick={() => void execute(true)}
+          aria-label="Run"
+          title={`Run ${selectedFolder.name}`}
+        >
+          ▶
+        </button>
+      ) : (
+        <button
+          className="simulation-primary-button simulation-setup-button"
+          onClick={createFolder}
+        >
+          Set up
+        </button>
+      )}
+      <span
+        className={`simulation-status-chip simulation-status-${batch?.state ?? run?.state ?? (prepared ? "prepared" : "idle")}`}
+        role="status"
+      >
+        {activeDirty ? "Source changed" : statusLabel}
+      </span>
+      {batch ? (
+        <details
+          ref={batchMenuRef}
+          className="simulation-batch-menu"
+          onToggle={(event) => {
+            if (event.currentTarget.open) batchMenuRef.current?.focus();
+          }}
+        >
+          <summary
+            aria-label={`Batch queue: ${batch.state}, ${finishedBatchItems} of ${batch.items.length} finished`}
+            title="Batch queue"
+          >
+            <span aria-hidden="true">≡</span>
+          </summary>
+          <div className="simulation-batch-menu-popover">
+            <header>
+              <strong>Batch · {batch.state}</strong>
+              <span>
+                {finishedBatchItems}/{batch.items.length}
+              </span>
+            </header>
+            <div className="simulation-batch-menu-items">
+              {batch.items.map((item) => {
+                const folder = project.simulationFolders.find(
+                  (candidate) => candidate.id === item.folderId,
+                );
+                return (
+                  <button
+                    type="button"
+                    key={item.id}
+                    data-state={item.state}
+                    disabled={item.state === "queued"}
+                    onClick={() => void showBatchItem(item)}
+                  >
+                    <span>{item.label ?? folder?.name ?? item.folderId}</span>
+                    <small>{item.state}</small>
+                  </button>
+                );
+              })}
+            </div>
+            {!batchRunning ? (
+              <button type="button" onClick={() => setBatch(undefined)}>
+                Dismiss
+              </button>
+            ) : null}
+          </div>
+        </details>
+      ) : null}
+    </div>
+  );
+  const windowActions = (
+    <div className="simulation-window-actions">
+      <button
+        className="simulation-minimize-button"
+        onClick={props.onMinimize}
+        aria-label="Minimize simulation"
+        title="Minimize simulation"
+      >
+        <span className="simulation-minimize-glyph" aria-hidden="true" />
+      </button>
+      <button
+        className="simulation-maximize-button"
+        onClick={props.onToggleMaximized}
+        aria-label={
+          props.maximized ? "Restore simulation panel" : "Maximize simulation"
+        }
+        title={
+          props.maximized ? "Restore simulation panel" : "Maximize simulation"
+        }
+      >
+        {props.maximized ? "↙" : "□"}
+      </button>
+      <button
+        className="simulation-close-button"
+        onClick={async () => {
+          if (
+            await interaction.confirm({
+              title: "Exit Simulation?",
+              message:
+                "Unsaved source drafts and temporary run files will be discarded. An active run will be cancelled.",
+              acceptLabel: "Exit Simulation",
+            })
+          ) {
+            codeRef.current?.discard();
+            props.onExit();
+          }
+        }}
+        aria-label="Exit simulation"
+      >
+        ×
+      </button>
+    </div>
+  );
+
   return (
     <section
       hidden={!open}
@@ -1543,151 +1682,12 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
         }
       }}
     >
-      <header className="simulation-taskbar">
-        <div className="simulation-brand">
-          <strong>Simulation</strong>
-        </div>
-        <div className="simulation-task-actions">
-          {running ? (
-            <button
-              className="simulation-stop-button"
-              disabled={
-                batch?.state === "cancelling" || run?.state === "cancelling"
-              }
-              onClick={() => {
-                if (batchRunning)
-                  void session
-                    .handle({ operation: "cancel-batch", batchId: batch.id })
-                    .then(receive);
-                else if (run)
-                  void session
-                    .handle({ operation: "cancel", runId: run.id })
-                    .then(receive);
-              }}
-            >
-              {batchRunning ? "Cancel batch" : "Cancel run"}
-            </button>
-          ) : selectedFolder ? (
-            <button
-              className="simulation-primary-button simulation-run-button"
-              disabled={busy}
-              onClick={() => void execute(true)}
-              aria-label="Run"
-              title={`Run ${selectedFolder.name}`}
-            >
-              ▶
-            </button>
-          ) : (
-            <button
-              className="simulation-primary-button simulation-setup-button"
-              onClick={createFolder}
-            >
-              Set up
-            </button>
-          )}
-          <span
-            className={`simulation-status-chip simulation-status-${batch?.state ?? run?.state ?? (prepared ? "prepared" : "idle")}`}
-            role="status"
-          >
-            {activeDirty ? "Source changed" : statusLabel}
-          </span>
-          {batch ? (
-            <details
-              ref={batchMenuRef}
-              className="simulation-batch-menu"
-              onToggle={(event) => {
-                if (event.currentTarget.open) batchMenuRef.current?.focus();
-              }}
-            >
-              <summary
-                aria-label={`Batch queue: ${batch.state}, ${finishedBatchItems} of ${batch.items.length} finished`}
-                title="Batch queue"
-              >
-                <span aria-hidden="true">≡</span>
-              </summary>
-              <div className="simulation-batch-menu-popover">
-                <header>
-                  <strong>Batch · {batch.state}</strong>
-                  <span>
-                    {finishedBatchItems}/{batch.items.length}
-                  </span>
-                </header>
-                <div className="simulation-batch-menu-items">
-                  {batch.items.map((item) => {
-                    const folder = project.simulationFolders.find(
-                      (candidate) => candidate.id === item.folderId,
-                    );
-                    return (
-                      <button
-                        type="button"
-                        key={item.id}
-                        data-state={item.state}
-                        disabled={item.state === "queued"}
-                        onClick={() => void showBatchItem(item)}
-                      >
-                        <span>
-                          {item.label ?? folder?.name ?? item.folderId}
-                        </span>
-                        <small>{item.state}</small>
-                      </button>
-                    );
-                  })}
-                </div>
-                {!batchRunning ? (
-                  <button type="button" onClick={() => setBatch(undefined)}>
-                    Dismiss
-                  </button>
-                ) : null}
-              </div>
-            </details>
-          ) : null}
-        </div>
-        <div className="simulation-window-actions">
-          <button
-            className="simulation-minimize-button"
-            onClick={props.onMinimize}
-            aria-label="Minimize simulation"
-            title="Minimize simulation"
-          >
-            <span className="simulation-minimize-glyph" aria-hidden="true" />
-          </button>
-          <button
-            className="simulation-maximize-button"
-            onClick={props.onToggleMaximized}
-            aria-label={
-              props.maximized
-                ? "Restore simulation panel"
-                : "Maximize simulation"
-            }
-            title={
-              props.maximized
-                ? "Restore simulation panel"
-                : "Maximize simulation"
-            }
-          >
-            {props.maximized ? "↙" : "□"}
-          </button>
-          <button
-            className="simulation-close-button"
-            onClick={async () => {
-              if (
-                await interaction.confirm({
-                  title: "Exit Simulation?",
-                  message:
-                    "Unsaved source drafts and temporary run files will be discarded. An active run will be cancelled.",
-                  acceptLabel: "Exit Simulation",
-                })
-              ) {
-                codeRef.current?.discard();
-                props.onExit();
-              }
-            }}
-            aria-label="Exit simulation"
-          >
-            ×
-          </button>
-        </div>
-      </header>
+      {!selectedFolder ? (
+        <header className="simulation-taskbar">
+          {simulationActions}
+          {windowActions}
+        </header>
+      ) : null}
 
       {!selectedFolder && !hasDutInstance ? (
         <p className="simulation-context-hint">
@@ -1720,7 +1720,8 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
           onPickTerminalsChange={(active) =>
             props.onPickTerminalsChange?.(active)
           }
-          actions={null}
+          actions={simulationActions}
+          toolbarEnd={windowActions}
           status={staleMessage}
           onDirty={setDirty}
           onActiveDirty={setActiveDirty}

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -180,6 +180,14 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
   const [artifactPreview, setArtifactPreview] =
     useState<SimulationArtifactContent>();
   const [artifactBusy, setArtifactBusy] = useState<string>();
+  const artifactRequest = useRef(0);
+  const closeArtifact = () => {
+    artifactRequest.current += 1;
+    setArtifactPreview(undefined);
+    setArtifactBusy((busy) =>
+      busy?.startsWith("preview:") ? undefined : busy,
+    );
+  };
   const [canvasOpEnabled, setCanvasOpEnabled] = useState(false);
   const [opRecord, setOpRecord] = useState<{ runId: string; index: number }>();
   const [comparisonRecords, setComparisonRecords] = useState<
@@ -235,7 +243,7 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
     setPrepared(previous?.prepared);
     setRun(previous?.run);
     setProblem(undefined);
-    setArtifactPreview(undefined);
+    closeArtifact();
     props.onOperatingPointProjection?.(null);
   }, [props.selectedFolderId]);
   const lock = useRef(false);
@@ -312,7 +320,7 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
         });
       setPrepared(reply.prepared);
       setProblem(undefined);
-      setArtifactPreview(undefined);
+      closeArtifact();
       setResultTab("console");
     } else if ("capabilities" in reply) {
       setCapabilities(reply.capabilities);
@@ -553,7 +561,7 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
       setPrepared(item.prepared);
       setRun(undefined);
       setProblem(undefined);
-      setArtifactPreview(undefined);
+      closeArtifact();
       setResultTab("console");
       if (presentation)
         folderResults.current.set(item.folderId, { prepared: item.prepared });
@@ -597,9 +605,13 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
       setProblem(uiProblem("ARTIFACT_DOWNLOAD_FAILED", result.message));
   };
   const preview = async (artifact: ArtifactRef) => {
+    const request = ++artifactRequest.current;
     setArtifactBusy(`preview:${artifact.id}`);
     const result = await readSimulationArtifactPreview(session.files, artifact);
-    setArtifactBusy(undefined);
+    if (request !== artifactRequest.current) return;
+    setArtifactBusy((busy) =>
+      busy === `preview:${artifact.id}` ? undefined : busy,
+    );
     if (!result.ok) {
       setProblem(result.error);
       return;
@@ -787,7 +799,9 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
     : batch
       ? `Batch ${batch.state} · ${finishedBatchItems}/${batch.items.length}`
       : run
-        ? `${run.state}${run.result ? ` · ${run.result.outcome.status}` : ""}`
+        ? run.state === "finished"
+          ? (run.result?.outcome.status ?? run.state)
+          : run.state
         : prepared
           ? "Deck prepared"
           : "No run yet";
@@ -911,7 +925,6 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
         return evaluated.length ? evaluated : csv;
       })()
     : [];
-  const analysisLabel = runPresentation?.analysisLabel;
   const presentationProbes =
     runPresentation?.outputs.flatMap((output) => {
       const probe = focusTarget(output);
@@ -1470,20 +1483,6 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
 
         {resultTab === "console" ? (
           <div className="simulation-console-view">
-            <div className="simulation-console-summary">
-              <span>
-                <small>Run</small>
-                <strong>{statusLabel}</strong>
-              </span>
-              <span>
-                <small>Input</small>
-                <strong>{run?.inputStatus ?? "current"}</strong>
-              </span>
-              <span>
-                <small>Analyses</small>
-                <strong>{analysisLabel || "Not configured"}</strong>
-              </span>
-            </div>
             {run?.state === "lost" ? (
               <p>
                 The executor response is unknown. Inspect its evidence before
@@ -1547,12 +1546,6 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
       <header className="simulation-taskbar">
         <div className="simulation-brand">
           <strong>Simulation</strong>
-          <span
-            className={`simulation-status-chip simulation-status-${batch?.state ?? run?.state ?? (prepared ? "prepared" : "idle")}`}
-            role="status"
-          >
-            {activeDirty ? "Source changed" : statusLabel}
-          </span>
         </div>
         <div className="simulation-task-actions">
           {running ? (
@@ -1586,12 +1579,18 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
             </button>
           ) : (
             <button
-              className="simulation-primary-button"
+              className="simulation-primary-button simulation-setup-button"
               onClick={createFolder}
             >
               Set up
             </button>
           )}
+          <span
+            className={`simulation-status-chip simulation-status-${batch?.state ?? run?.state ?? (prepared ? "prepared" : "idle")}`}
+            role="status"
+          >
+            {activeDirty ? "Source changed" : statusLabel}
+          </span>
           {batch ? (
             <details
               ref={batchMenuRef}
@@ -1722,7 +1721,7 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
             props.onPickTerminalsChange?.(active)
           }
           actions={null}
-          status={staleMessage || statusLabel}
+          status={staleMessage}
           onDirty={setDirty}
           onActiveDirty={setActiveDirty}
           onProblem={setProblem}
@@ -1733,7 +1732,7 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
           artifactPreview={artifactPreview}
           artifactBusy={artifactBusy}
           onSelectArtifact={(artifact) => void preview(artifact)}
-          onCloseArtifact={() => setArtifactPreview(undefined)}
+          onCloseArtifact={closeArtifact}
           onDownloadArtifact={(artifact) => void download(artifact)}
           outputPane={resultTab}
           onSelectOutputPane={setResultTab}

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -45,17 +45,16 @@
   position: relative;
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
-  align-items: start;
+  align-items: center;
   gap: 6px;
-  min-height: 44px;
-  padding: 6px 7px;
+  min-height: 30px;
+  padding: 2px 7px;
   border-bottom: 1px solid var(--icm-border);
   background: var(--icm-surface);
 }
 .simulation-brand {
-  display: grid;
-  align-content: start;
-  gap: 2px;
+  display: flex;
+  align-items: center;
   min-width: 68px;
   line-height: 1.05;
 }
@@ -72,22 +71,23 @@
 .simulation-task-actions > button {
   flex: 0 0 auto;
   min-width: 0;
-  min-height: 28px;
-  padding: 3px 5px;
+  min-height: 22px;
+  height: 22px;
+  padding: 0 5px;
   border-color: var(--icm-border);
   font-size: var(--icm-font-xs);
 }
 .simulation-status-chip {
   justify-self: start;
-  max-width: 84px;
+  min-width: 0;
+  max-width: none;
   overflow: hidden;
-  padding: 2px 6px;
-  border-radius: 999px;
-  border: 1px solid var(--icm-border);
+  padding: 0 3px;
+  border: 0;
   color: var(--icm-text-muted);
-  background: var(--icm-surface-muted);
-  font-size: 9px;
-  line-height: 1.15;
+  background: transparent;
+  font-size: 10px;
+  line-height: 22px;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -211,7 +211,7 @@
 .simulation-status-finished {
   color: #067647;
   border-color: #75e0a7;
-  background: #ecfdf3;
+  background: transparent;
 }
 .simulation-batch-menu {
   position: relative;
@@ -301,7 +301,7 @@
   font-weight: 650;
 }
 .simulation-run-button {
-  width: 30px;
+  width: 22px;
   padding: 0 !important;
 }
 .simulation-stop-button {
@@ -345,8 +345,8 @@
 .spice-simulation-surface.maximized .simulation-taskbar {
   grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
-  gap: 24px;
-  padding: 10px 24px;
+  gap: 8px;
+  padding: 2px 12px;
 }
 
 .spice-simulation-surface.maximized .simulation-task-actions {
@@ -360,8 +360,8 @@
 }
 
 .spice-simulation-surface.maximized .simulation-task-actions > button {
-  min-height: 30px;
-  padding-inline: 10px;
+  min-height: 22px;
+  padding-inline: 5px;
 }
 
 .spice-simulation-surface.maximized .simulation-window-actions {

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -43,8 +43,8 @@
 
 .simulation-taskbar {
   position: relative;
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  display: flex;
+  flex: none;
   align-items: center;
   gap: 6px;
   min-height: 30px;
@@ -52,17 +52,9 @@
   border-bottom: 1px solid var(--icm-border);
   background: var(--icm-surface);
 }
-.simulation-brand {
-  display: flex;
-  align-items: center;
-  min-width: 68px;
-  line-height: 1.05;
-}
-.simulation-brand strong {
-  font-size: var(--icm-font-md);
-}
 .simulation-task-actions {
   display: flex;
+  flex: 1;
   align-items: center;
   gap: 4px;
   min-width: 0;
@@ -343,7 +335,6 @@
 }
 
 .spice-simulation-surface.maximized .simulation-taskbar {
-  grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
   gap: 8px;
   padding: 2px 12px;
@@ -351,7 +342,7 @@
 
 .spice-simulation-surface.maximized .simulation-task-actions {
   justify-self: stretch;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: 8px;
 }
 
@@ -2157,15 +2148,6 @@
 }
 
 @media (max-width: 700px) {
-  .simulation-taskbar {
-    grid-template-columns: auto minmax(0, 1fr) auto;
-  }
-  .simulation-brand {
-    min-width: 68px;
-  }
-  .simulation-brand strong {
-    font-size: var(--icm-font-sm);
-  }
   .simulation-plot-layout {
     grid-template-columns: 1fr;
   }

--- a/docs/user/analog-simulation.md
+++ b/docs/user/analog-simulation.md
@@ -9,7 +9,8 @@ workspace is separate from the development-only Digital tool.
 Code and Properties share the right dock but remember independent widths.
 **Explorer** opens a narrow project tree beside the code. Each experiment puts
 Source first, expanded by default. Prepared and Run artifacts appear beneath it,
-marked **Temporary** and collapsed by default. Choose an experiment there, or
+marked **tmp** and collapsed by default, with expandable artifact categories.
+Source paths also form expandable directories. Choose an experiment there, or
 create, clone, rename or delete one. Multiple experiments can use the same drawn
 Testbench; a different topology is an ordinary separate Cell.
 
@@ -145,9 +146,11 @@ Automatic summaries are separate from authored rules. Both export through
 
 **Export** downloads visible plots as SVG or PNG, complete output CSV, or a
 complete run ZIP. Explorer exposes authored/generated input, prepared deck,
-rawfile and existing result artifacts. Ctrl/Cmd-select any combination of rows,
-then use the Explorer download control; one file downloads directly and several
-download as a hierarchy-preserving ZIP. Image export follows the visible plot;
+rawfile and existing result artifacts. Ctrl/Cmd-select individual rows or use
+Shift for a range, then right-click and choose **Download**. Directories include
+their collapsed descendants; overlapping selections export each file once.
+One file downloads directly and several download as a hierarchy-preserving ZIP.
+Image export follows the visible plot;
 CSV retains full collected numbers. Restricted model data is not bundled.
 
 **Compare** keeps completed results within the session and overlays compatible

--- a/scripts/preview-source-gui-journey.mjs
+++ b/scripts/preview-source-gui-journey.mjs
@@ -145,22 +145,13 @@ async function downloadArtifactGroup(label, name) {
     exact: true,
   });
   await expect(group).toBeVisible();
-  if ((await group.getAttribute("open")) === null)
-    await group.locator("summary").click();
-  const artifacts = group.locator('button[data-tree-row="artifact"]');
-  const count = await artifacts.count();
-  assert(count > 1, `${label} must expose a downloadable artifact bundle`);
-  for (let index = 0; index < count; index += 1) {
-    const artifact = artifacts.nth(index);
-    await expect(artifact).toBeEnabled();
-    await artifact.click(index ? { modifiers: ["Control"] } : undefined);
-  }
+  // A directory context action includes its collapsed descendants.
+  await group
+    .getByRole("treeitem", { name: label, exact: true })
+    .click({ button: "right" });
   return unzipSync(
     await download(
-      explorer.getByRole("button", {
-        name: `Download selected files (${count})`,
-        exact: true,
-      }),
+      page.getByRole("menuitem", { name: "Download…", exact: true }),
       name,
     ),
   );
@@ -251,10 +242,6 @@ try {
   ).toHaveCount(0);
   const preparedEntries = await downloadArtifactGroup("Prepare", "prepare.zip");
   const runEntries = await downloadArtifactGroup("Run", "run.zip");
-  await panel
-    .locator(".simulation-artifact-tab")
-    .getByRole("button", { name: /^Close /u })
-    .click();
   await panel.getByRole("button", { name: "Maximize results" }).click();
   const input = JSON.parse(entryFromZip(preparedEntries, "prepared.json"));
   const result = JSON.parse(entryFromZip(runEntries, "result.json"));

--- a/scripts/preview-workflow.test.mjs
+++ b/scripts/preview-workflow.test.mjs
@@ -121,7 +121,9 @@ describe("the preview deploy", () => {
 
   it("exports GUI simulation evidence through the unified Explorer", () => {
     expect(sourceGuiJourney).toContain('name: "Simulation files"');
-    expect(sourceGuiJourney).toContain("Download selected files (${count})");
+    expect(sourceGuiJourney).toContain(
+      'getByRole("menuitem", { name: "Download…"',
+    );
     expect(sourceGuiJourney).toContain(
       'downloadArtifactGroup("Prepare", "prepare.zip")',
     );


### PR DESCRIPTION
Simulation files share a compact hierarchical tree and one selection state. Source paths and temporary artifact categories expand consistently; context downloads support individual files, Ctrl/Cmd or Shift selections, and folders including collapsed descendants. Overlapping selections export each file once; folder downloads retain ZIP hierarchy.

Remove the redundant Explorer heading and download control, use tmp labels and fixed-height rename rows. Rename the Properties sibling to Sim Code, remove the Simulation heading, and compose Explorer, Save, Run/status and window actions into a single compact toolbar. Set up remains compact before a folder exists. Remove routine source footer text while retaining exceptional recovery, conflict and stale-result notices. Console no longer repeats run state; cancellation stays distinguishable from completed results. Pending artifact reads cannot reopen a closed preview.

Integrated main PR #772 without losing its tab-row Helper host or continuous signal selection. Conflict resolution preserves the document-action context, compact tree, tmp labels and toolbar.

Validation: frozen install and static preflight passed. Original change passed 3169 unit tests, 23 analog and 153 editor browser tests. The integration delta passed all 3169 unit tests and 24 analog browser tests, including continuous Helper selection and compact layout. Remote checks rerun on the final head; merge queue provides full delivery coverage. Preview GUI acceptance uses directory context downloads and runs on the merged candidate.

Test-Impact: tests-updated