### PR TITLE
fix(simulation): keep Helper save and Canvas picking continuous

### DIFF
--- a/apps/editor/e2e/simulation-code-editor.spec.ts
+++ b/apps/editor/e2e/simulation-code-editor.spec.ts
@@ -85,7 +85,7 @@ test("flat Helper finds an analysis by purpose and ghost arguments never enter s
     name: "Simulation source editor",
   });
   await editor.fill("* test\n.control\n");
-  await page.getByRole("button", { name: /Helper.*Ctrl\+Space/ }).click();
+  await page.getByRole("button", { name: "Helper", exact: true }).click();
   await page
     .getByRole("textbox", { name: "Search commands or purpose" })
     .fill("频响");

--- a/apps/editor/e2e/simulation-setup.spec.ts
+++ b/apps/editor/e2e/simulation-setup.spec.ts
@@ -100,7 +100,7 @@ test("the qualified OTA folder opens unchanged and preserves all root and hierar
   const panel = page.getByRole("region", { name: "Analog simulation" });
   // Ordinary picks write native save text; current instrumentation keeps its owner.
   const helper = async (name: string) => {
-    await panel.getByRole("button", { name: /Helper.*Ctrl\+Space/ }).click();
+    await panel.getByRole("button", { name: "Helper", exact: true }).click();
     await panel.getByRole("option", { name, exact: true }).click();
   };
   await helper("Pick Net on Canvas");
@@ -114,6 +114,22 @@ test("the qualified OTA folder opens unchanged and preserves all root and hierar
     page.getByTestId("terminal-VINP-+-current-pick-marker"),
   ).toHaveClass(/origin/u);
   await page.getByTestId("terminal-VINP--").click();
+  await expect(page.getByTestId("schematic-canvas")).toHaveClass(
+    /simulation-terminal-pick-active/,
+  );
+  await expect(
+    panel.getByRole("textbox", { name: "Simulation source editor" }),
+  ).not.toBeFocused();
+  // Repeated current picks stay active without duplicating instrumentation.
+  await page.getByTestId("terminal-VINP-+").click();
+  await page.getByTestId("terminal-VINP--").click();
+  await expect(page.getByTestId("schematic-canvas")).toHaveClass(
+    /simulation-terminal-pick-active/,
+  );
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("schematic-canvas")).not.toHaveClass(
+    /simulation-terminal-pick-active/,
+  );
   await helper("Save voltage…");
   const observe = panel.getByRole("dialog", { name: "Save signal" });
   await observe.getByRole("textbox", { name: "Search signal" }).fill("v(out)");

--- a/apps/editor/e2e/simulation-workspace.spec.ts
+++ b/apps/editor/e2e/simulation-workspace.spec.ts
@@ -22,6 +22,91 @@ import {
 import { ota, profile, editSimulationFile } from "./simulation-e2e-fixtures.js";
 
 const loadModule = createRequire(import.meta.url);
+test("Helper keeps signal selection continuous and shares the file row without stealing focus", async ({
+  page,
+}) => {
+  const project = parseProject(JSON.stringify(ota));
+  const folder = createSimulationFolder({
+    id: "continuous-signals",
+    name: "Continuous signals",
+    documentId: project.topDocumentId,
+    profileId: profile.id,
+  });
+  project.simulationFolders = [folder];
+  await page.route("**/api/simulate", (route) =>
+    route.fulfill({
+      status: 503,
+      json: { error: "Offline authoring fixture" },
+    }),
+  );
+  await page.goto("/editor");
+  await page.getByTestId("project-file").setInputFiles({
+    name: "continuous.icproj.json",
+    mimeType: "application/json",
+    buffer: Buffer.from(JSON.stringify(project)),
+  });
+  await page.getByTestId("open-analog-simulation").click();
+  await page.getByRole("button", { name: "Explorer", exact: true }).click();
+  const editor = page.getByRole("textbox", {
+    name: "Simulation source editor",
+  });
+  const helper = page.getByRole("button", { name: "Helper", exact: true });
+  const tab = page.getByRole("tab", { name: /run.cir/ });
+  const helperBox = (await helper.boundingBox())!;
+  const tabBox = (await tab.boundingBox())!;
+  expect(Math.abs(helperBox.y - tabBox.y)).toBeLessThan(10);
+  expect(helperBox.x).toBeGreaterThan(tabBox.x + tabBox.width);
+  await expect(
+    page.getByText("Try another analysis", { exact: true }),
+  ).toHaveCount(0);
+  await helper.click();
+  const helperPopup = page.getByRole("dialog", { name: "Insert / Helper" });
+  const popupBox = (await helperPopup.boundingBox())!;
+  await page
+    .getByRole("option", { name: "Save voltage…", exact: true })
+    .click();
+  const picker = page.getByRole("dialog", { name: "Save signal" });
+  const search = picker.getByRole("textbox", { name: "Search signal" });
+  await expect(search).toBeFocused();
+  const pickerBox = (await picker.boundingBox())!;
+  expect(Math.abs(pickerBox.x - popupBox.x)).toBeLessThan(2);
+  expect(Math.abs(pickerBox.height - popupBox.height)).toBeLessThan(2);
+  const output = picker.getByRole("button", { name: /— v\(vout\)/ });
+  await output.click();
+  await expect(search).toBeFocused();
+  await expect(output).toContainText("Added");
+  await picker.getByRole("button", { name: /— v\(vinp\)/ }).click();
+  await expect(search).toBeFocused();
+  await expect(editor).toContainText("save v(vout) v(vinp)");
+  await expect(output).toBeDisabled();
+  await output.click({ force: true });
+  expect((await editor.innerText()).match(/v\(vout\)/g)).toHaveLength(1);
+  await search.press("Escape");
+  await expect(picker).toHaveCount(0);
+  // Dismissing the helper by clicking code must leave focus at that click.
+  await helper.click();
+  await editor.click({ position: { x: 2, y: 8 } });
+  await expect(helperPopup).toHaveCount(0);
+  await expect(editor).toBeFocused();
+  await editor.fill(
+    folder.input.files.find((file) => file.path === folder.input.entry)!.text,
+  );
+  await helper.click();
+  await page
+    .getByRole("option", { name: "Pick Net on Canvas", exact: true })
+    .click();
+  const canvas = page.getByTestId("schematic-canvas");
+  await page.getByTestId("route-hit-tb-vinp-route").click({ force: true });
+  await expect(canvas).toHaveClass(/simulation-net-pick-active/);
+  await expect(editor).not.toBeFocused();
+  await page.getByTestId("route-hit-tb-vout-route").click({ force: true });
+  await expect(editor).toContainText("save v(vinp) v(vout)");
+  await expect(canvas).toHaveClass(/simulation-net-pick-active/);
+  await expect(editor).not.toBeFocused();
+  await page.getByRole("button", { name: "Done", exact: true }).click();
+  await expect(canvas).not.toHaveClass(/simulation-net-pick-active/);
+});
+
 test("native save completion previews its mapped Net on the real Canvas", async ({
   page,
 }) => {
@@ -441,7 +526,7 @@ test("human simulation uses saved folder, survives minimizing, recovers a bad in
     .getByRole("textbox", { name: "Relative file path" })
     .press("Enter");
   await expect(panel.getByRole("tab", { name: /bias.spice/ })).toBeVisible();
-  await panel.getByRole("button", { name: /Helper.*Ctrl\+Space/ }).click();
+  await panel.getByRole("button", { name: "Helper", exact: true }).click();
   await panel
     .getByRole("textbox", { name: "Search commands or purpose" })
     .fill("Save voltage");
@@ -1221,9 +1306,7 @@ test("Simulation creates an ordinary testbench and defaults a new experiment to 
     .getByRole("button", { name: "run.cir", exact: true })
     .first()
     .click();
-  await expect(page.getByLabel("Analysis examples")).toContainText(
-    "ac dec 20 1 1G",
-  );
+  await expect(page.getByLabel("Analysis examples")).toHaveCount(0);
   const configured = JSON.parse(
     (await downloadBytes(page, "File", "Export Project File…")).toString(),
   );

--- a/apps/editor/src/features/simulation/code-editor.tsx
+++ b/apps/editor/src/features/simulation/code-editor.tsx
@@ -1,4 +1,13 @@
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import {
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+import { CodeDocumentActions } from "./code-workspace";
 import {
   Annotation,
   Compartment,
@@ -93,11 +102,13 @@ export interface SimulationCodeEditorProps {
   onHistoryBoundary?(direction: "undo" | "redo"): void;
   onCursor?(sourceOffset: number): void;
   helperActions?: readonly CodeHelperAction[];
-  ghostHints?: readonly string[];
+  helperContent?: ReactNode;
+  onCloseHelperContent?(): void;
+  picking?: { label: string; onStop(): void } | undefined;
   relatedSources?: readonly string[];
   signalNames?: (() => Readonly<Record<string, string>>) | undefined;
   onFocusSignal?: ((vector: string | null) => void) | undefined;
-  saveRequest?: { id: string; vectors: string[] } | undefined;
+  saveRequest?: { id: string; session: string; vectors: string[] } | undefined;
   reveal?:
     { sourceOffset: number; requestId: string; focus?: boolean } | undefined;
 }
@@ -105,9 +116,19 @@ export interface SimulationCodeEditorProps {
 const externalChange = Annotation.define<boolean>();
 /** Loaded only by the Code workspace. It owns local text history, never Project/Run state. */
 export default function SimulationCodeEditor(props: SimulationCodeEditorProps) {
+  const documentActions = useContext(CodeDocumentActions);
+  const saveAnchor = useRef<{
+    session: string;
+    path: string;
+    offset: number;
+  } | null>(null);
   const [helperOpen, setHelperOpen] = useState(false);
   const [unknownCommand, setUnknownCommand] = useState(false);
   const [argumentHint, setArgumentHint] = useState("");
+  useEffect(() => {
+    setHelperOpen(false);
+    saveAnchor.current = null;
+  }, [props.path, props.historyKey]);
   const parent = useRef<HTMLDivElement>(null);
   const view = useRef<EditorView | null>(null);
   const callbacks = useRef(props);
@@ -205,6 +226,13 @@ export default function SimulationCodeEditor(props: SimulationCodeEditorProps) {
             return !callbacks.current.readOnly;
           }),
           EditorView.updateListener.of((update) => {
+            if (
+              saveAnchor.current?.path === callbacks.current.path &&
+              update.docChanged
+            )
+              saveAnchor.current.offset = update.changes.mapPos(
+                saveAnchor.current.offset,
+              );
             if (update.docChanged) {
               exact.current = update.state.field(exactSourceField);
               if (
@@ -352,98 +380,127 @@ export default function SimulationCodeEditor(props: SimulationCodeEditorProps) {
       return;
     const edit = nativeSaveEdit(
       editor.state.doc.toString(),
-      editor.state.selection.main.head,
+      saveAnchor.current?.session === props.saveRequest.session &&
+        saveAnchor.current.path === props.path
+        ? saveAnchor.current.offset
+        : editor.state.selection.main.head,
       props.saveRequest.vectors,
       !!props.entry,
     );
+    const anchor = edit.from + edit.insert.replace(/[\r\n]+$/u, "").length;
     editor.dispatch({
       changes: { from: edit.from, insert: edit.insert },
-      selection: { anchor: edit.from + edit.insert.length },
+      selection: { anchor },
       scrollIntoView: true,
     });
-    editor.focus();
+    saveAnchor.current = {
+      session: props.saveRequest.session,
+      path: props.path,
+      offset: anchor,
+    };
   }, [props.saveRequest?.id]);
 
+  const toolbar = (
+    <div
+      className="simulation-code-helper-toolbar"
+      style={
+        props.mode === "json" && !props.helperActions?.length
+          ? { visibility: "hidden" }
+          : undefined
+      }
+    >
+      <button
+        type="button"
+        title="Insert / Helper · Ctrl+Space"
+        data-simulation-helper-trigger
+        aria-expanded={helperOpen || Boolean(props.helperContent)}
+        onClick={() => {
+          if (props.helperContent) props.onCloseHelperContent?.();
+          else setHelperOpen((open) => !open);
+        }}
+      >
+        Helper
+      </button>
+      {unknownCommand && !helperOpen && !props.helperContent && (
+        <button
+          className="simulation-find-helper"
+          onClick={() => setHelperOpen(true)}
+        >
+          Find a helper…
+        </button>
+      )}
+      {props.picking && (
+        <>
+          <small>{props.picking.label}</small>
+          <button onClick={props.picking.onStop}>Done</button>
+        </>
+      )}
+    </div>
+  );
   return (
     <div className="simulation-code-editor-shell">
-      <div
-        className="simulation-code-helper-toolbar"
-        style={
-          props.mode === "json" && !props.helperActions?.length
-            ? { visibility: "hidden" }
-            : undefined
-        }
-      >
-        <button
-          type="button"
-          title="Insert / Helper · Ctrl+Space"
-          data-simulation-helper-trigger
-          aria-expanded={helperOpen}
-          onClick={() => setHelperOpen((open) => !open)}
-        >
-          Helper <kbd>Ctrl+Space</kbd>
-        </button>
-        {unknownCommand && !helperOpen && (
-          <button
-            className="simulation-find-helper"
-            onClick={() => setHelperOpen(true)}
-          >
-            Find a helper…
-          </button>
-        )}
-        {argumentHint && (
-          <small aria-live="polite">{argumentHint} · Tab / Shift+Tab</small>
-        )}
-      </div>
-      {helperOpen && (
-        <CodeHelperList
-          language={props.mode ?? "spice"}
-          control={controlContext(
-            view.current?.state.doc.sliceString(
-              0,
-              view.current.state.selection.main.head,
-            ) ?? "",
-          )}
-          actions={props.helperActions}
-          onClose={() => {
-            setHelperOpen(false);
-            view.current?.focus();
-          }}
-          onChoose={(rule) => {
-            const editor = view.current;
-            if (!editor || props.readOnly || props.mode === "json") return;
-            const line = editor.state.doc.lineAt(
-              editor.state.selection.main.head,
-            );
-            if (
-              /^(PULSE|SIN|PWL)$/u.test(rule.name) &&
-              /^[VI]\S*\s/iu.test(line.text.trim())
-            ) {
-              insertSpiceHelp(
-                editor,
-                rule,
-                editor.state.selection.main.from,
-                editor.state.selection.main.to,
-              );
-              return;
-            }
-            // Replace an unfinished command only. Existing populated code is preserved.
-            if (/^\s*[.\p{L}\w]*$/u.test(line.text))
-              insertSpiceHelp(editor, rule);
-            else {
-              editor.dispatch({
-                changes: { from: line.to, insert: "\n" },
-                selection: { anchor: line.to + 1 },
-              });
-              insertSpiceHelp(editor, rule);
-            }
-          }}
-        />
+      {documentActions ? createPortal(toolbar, documentActions) : toolbar}
+      {argumentHint && (
+        <small className="simulation-code-argument-hint" aria-live="polite">
+          {argumentHint}
+        </small>
       )}
+      {props.helperContent ??
+        (helperOpen && (
+          <CodeHelperList
+            language={props.mode ?? "spice"}
+            control={controlContext(
+              view.current?.state.doc.sliceString(
+                0,
+                view.current.state.selection.main.head,
+              ) ?? "",
+            )}
+            actions={props.helperActions}
+            onClose={(restoreFocus = true) => {
+              setHelperOpen(false);
+              if (restoreFocus) view.current?.focus();
+            }}
+            onChoose={(rule) => {
+              const editor = view.current;
+              if (!editor || props.readOnly || props.mode === "json") return;
+              const line = editor.state.doc.lineAt(
+                editor.state.selection.main.head,
+              );
+              if (
+                /^(PULSE|SIN|PWL)$/u.test(rule.name) &&
+                /^[VI]\S*\s/iu.test(line.text.trim())
+              ) {
+                insertSpiceHelp(
+                  editor,
+                  rule,
+                  editor.state.selection.main.from,
+                  editor.state.selection.main.to,
+                );
+                return;
+              }
+              // Replace an unfinished command only. Existing populated code is preserved.
+              if (/^\s*[.\p{L}\w]*$/u.test(line.text))
+                insertSpiceHelp(editor, rule);
+              else {
+                editor.dispatch({
+                  changes: { from: line.to, insert: "\n" },
+                  selection: { anchor: line.to + 1 },
+                });
+                insertSpiceHelp(editor, rule);
+              }
+            }}
+          />
+        ))}
       <div
         ref={parent}
         className="simulation-code-editor"
         onKeyDownCapture={(event) => {
+          if (event.key === "Escape" && props.picking) {
+            event.preventDefault();
+            event.stopPropagation();
+            props.picking.onStop();
+            return;
+          }
           if (
             event.key === "Escape" &&
             props.mode !== "json" &&
@@ -492,17 +549,6 @@ export default function SimulationCodeEditor(props: SimulationCodeEditorProps) {
         }}
         onKeyDown={(event) => event.stopPropagation()}
       />
-      {props.ghostHints?.length && !props.readOnly ? (
-        <div
-          className="simulation-code-ghost-hints"
-          aria-label="Analysis examples"
-        >
-          <span>Try another analysis</span>
-          {props.ghostHints.map((hint) => (
-            <code key={hint}>{hint}</code>
-          ))}
-        </div>
-      ) : null}
     </div>
   );
 }

--- a/apps/editor/src/features/simulation/code-helper-list.tsx
+++ b/apps/editor/src/features/simulation/code-helper-list.tsx
@@ -21,7 +21,7 @@ export function CodeHelperList({
   language?: "spice" | "json";
   actions?: readonly CodeHelperAction[] | undefined;
   onChoose(rule: SimulationLanguageHelp): void;
-  onClose(): void;
+  onClose(restoreFocus?: boolean): void;
 }) {
   const [query, setQuery] = useState("");
   const [selected, select] = useState(0);
@@ -58,7 +58,7 @@ export function CodeHelperList({
         !root.current?.contains(event.target as Node) &&
         !(event.target as Element).closest?.("[data-simulation-helper-trigger]")
       )
-        onClose();
+        onClose(false);
     };
     document.addEventListener("pointerdown", close);
     return () => document.removeEventListener("pointerdown", close);
@@ -66,7 +66,7 @@ export function CodeHelperList({
   const choose = (index: number) => {
     if (!entries[index]) return;
     entries[index].run();
-    onClose();
+    onClose(false);
   };
   useEffect(() => {
     root.current

--- a/apps/editor/src/features/simulation/code-workspace.css
+++ b/apps/editor/src/features/simulation/code-workspace.css
@@ -389,6 +389,19 @@
 .simulation-code-tabs {
   overflow-x: auto;
   align-items: stretch;
+  min-width: 0;
+  flex: 1;
+}
+.simulation-code-document-header {
+  display: flex;
+  align-items: stretch;
+  min-width: 0;
+  flex: none;
+  border-bottom: 1px solid var(--icm-border);
+}
+.simulation-code-document-actions {
+  flex: none;
+  align-self: center;
 }
 .simulation-code-tab {
   display: flex;
@@ -592,26 +605,6 @@
   min-height: 0;
   flex: 1;
 }
-.simulation-code-ghost-hints {
-  flex: none;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  min-height: 26px;
-  padding: 3px 9px;
-  overflow-x: auto;
-  border-top: 1px solid var(--icm-border);
-  color: var(--icm-text-muted);
-  background: color-mix(in srgb, var(--icm-surface-muted) 78%, transparent);
-  white-space: nowrap;
-}
-.simulation-code-ghost-hints code {
-  opacity: 0.72;
-  font:
-    10px "Google Sans Code Variable",
-    Consolas,
-    monospace;
-}
 .simulation-code-helper-toolbar {
   height: 28px;
   box-sizing: border-box;
@@ -622,7 +615,16 @@
   display: flex;
   gap: 12px;
   padding: 3px 8px;
-  border-bottom: 1px solid var(--icm-border);
+}
+.simulation-code-argument-hint {
+  position: absolute;
+  bottom: 4px;
+  right: 12px;
+  max-width: calc(100% - 24px);
+  background: var(--icm-surface);
+  color: var(--icm-text-muted);
+  z-index: 2;
+  pointer-events: none;
 }
 .simulation-code-helper-toolbar button {
   background: transparent;
@@ -637,10 +639,12 @@
 }
 .simulation-helper-list {
   position: absolute;
-  top: 32px;
-  left: 8px;
+  top: 4px;
+  right: 8px;
   width: min(380px, calc(100% - 16px));
-  max-height: 80%;
+  height: 320px;
+  max-height: calc(100% - 8px);
+  box-sizing: border-box;
   display: flex;
   flex-direction: column;
   z-index: 30;
@@ -704,15 +708,13 @@
   }
 }
 .simulation-probe-picker {
-  position: absolute;
-  z-index: 40;
-  inset: 45px 12px auto;
-  max-height: 70%;
-  display: flex;
-  flex-direction: column;
   gap: 8px;
-  padding: 12px;
-  background: var(--icm-surface);
-  border: 1px solid var(--icm-border);
-  box-shadow: 0 8px 24px #0002;
+}
+.simulation-probe-picker-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.simulation-helper-options {
+  flex: 1;
 }

--- a/apps/editor/src/features/simulation/code-workspace.tsx
+++ b/apps/editor/src/features/simulation/code-workspace.tsx
@@ -1,4 +1,5 @@
 import {
+  createContext,
   useEffect,
   useId,
   useState,
@@ -20,6 +21,8 @@ import {
   simulationArtifactCategory,
   type SimulationArtifactContent,
 } from "./simulation-artifact-files";
+
+export const CodeDocumentActions = createContext<HTMLElement | null>(null);
 
 export interface SimulationCodeFile {
   path: string;
@@ -75,6 +78,9 @@ export interface SimulationCodeWorkspaceProps {
 
 /** Approved Code layout only; Project, drafts and Run ownership remain in their controllers. */
 export function SimulationCodeWorkspace(props: SimulationCodeWorkspaceProps) {
+  const [documentActions, setDocumentActions] = useState<HTMLDivElement | null>(
+    null,
+  );
   const ui = useWorkspaceInteractions();
   const filesId = useId();
   const defaults = () =>
@@ -549,67 +555,76 @@ export function SimulationCodeWorkspace(props: SimulationCodeWorkspaceProps) {
           />
         ) : null}
         <div className="simulation-code-document">
-          <div
-            className="simulation-code-tabs"
-            role="tablist"
-            aria-label="Open simulation files"
-          >
-            {props.artifactPreview ? (
-              <div className="simulation-code-tab simulation-artifact-tab">
-                <button type="button" role="tab" aria-selected="true">
-                  {props.artifactPreview.artifact.name}
-                  <span> Temporary</span>
-                </button>
-                <button
-                  type="button"
-                  aria-label={`Close ${props.artifactPreview.artifact.name}`}
-                  onClick={props.onCloseArtifact}
-                >
-                  ×
-                </button>
-              </div>
-            ) : null}
-            {tabs.map((path) => {
-              const file = props.files.find((f) => f.path === path)!;
-              return (
-                <div className="simulation-code-tab" key={path}>
+          <div className="simulation-code-document-header">
+            <div
+              className="simulation-code-tabs"
+              role="tablist"
+              aria-label="Open simulation files"
+            >
+              {props.artifactPreview ? (
+                <div className="simulation-code-tab simulation-artifact-tab">
+                  <button type="button" role="tab" aria-selected="true">
+                    {props.artifactPreview.artifact.name}
+                    <span> Temporary</span>
+                  </button>
                   <button
                     type="button"
-                    role="tab"
-                    aria-selected={
-                      !props.artifactPreview && props.activePath === path
-                    }
-                    onClick={() => {
-                      props.onCloseArtifact?.();
-                      props.onSelectFile(path);
-                    }}
-                    title={path}
+                    aria-label={`Close ${props.artifactPreview.artifact.name}`}
+                    onClick={props.onCloseArtifact}
                   >
-                    {path === props.configPath
-                      ? "Configuration"
-                      : path.split("/").at(-1)}
-                    {file.kind === "generated" ? " ◇" : ""}
-                    {file.dirty ? " ●" : file.draft ? " ◌" : ""}
+                    ×
                   </button>
-                  {
+                </div>
+              ) : null}
+              {tabs.map((path) => {
+                const file = props.files.find((f) => f.path === path)!;
+                return (
+                  <div className="simulation-code-tab" key={path}>
                     <button
                       type="button"
-                      aria-label={`Close ${path}`}
-                      onClick={() => closeFile(path)}
+                      role="tab"
+                      aria-selected={
+                        !props.artifactPreview && props.activePath === path
+                      }
+                      onClick={() => {
+                        props.onCloseArtifact?.();
+                        props.onSelectFile(path);
+                      }}
+                      title={path}
                     >
-                      ×
+                      {path === props.configPath
+                        ? "Configuration"
+                        : path.split("/").at(-1)}
+                      {file.kind === "generated" ? " ◇" : ""}
+                      {file.dirty ? " ●" : file.draft ? " ◌" : ""}
                     </button>
-                  }
-                </div>
-              );
-            })}
+                    {
+                      <button
+                        type="button"
+                        aria-label={`Close ${path}`}
+                        onClick={() => closeFile(path)}
+                      >
+                        ×
+                      </button>
+                    }
+                  </div>
+                );
+              })}
+            </div>
+            <div
+              className="simulation-code-document-actions"
+              hidden={!props.activePath || Boolean(props.artifactPreview)}
+              ref={setDocumentActions}
+            />
           </div>
           <div className="simulation-code-document-content">
             <div
               hidden={!props.activePath || Boolean(props.artifactPreview)}
               className="workspace-editor-content"
             >
-              {props.children}
+              <CodeDocumentActions.Provider value={documentActions}>
+                {props.children}
+              </CodeDocumentActions.Provider>
             </div>
             {props.artifactPreview ? (
               <section

--- a/apps/editor/src/features/simulation/source-code-pane.tsx
+++ b/apps/editor/src/features/simulation/source-code-pane.tsx
@@ -161,8 +161,16 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
     const [sourceDigest, setSourceDigest] = useState("");
     const [saveRequest, setSaveRequest] = useState<{
       id: string;
+      session: string;
       vectors: string[];
     }>();
+    const saveSession = useRef(crypto.randomUUID());
+    const beginSignalSelection = () => {
+      saveSession.current = crypto.randomUUID();
+      if (props.pickNetsActive) props.onPickNetsChange?.(false);
+      if (props.pickTerminalsActive) props.onPickTerminalsChange?.(false);
+      setProbePicker(undefined);
+    };
     const savingRef = useRef(false);
     const picked = useRef({
       net: props.pickedNet?.sequence,
@@ -211,14 +219,18 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
     const saveSignal = (
       label: string,
       expression: SimulationSourceExpression,
-    ) => {
+    ): boolean => {
       const insert = (vectors: string[]) => {
         if (
           input.circuitBindings.some((b) => b.path === path) ||
           path.endsWith(".json")
         )
           setPath(input.entry);
-        setSaveRequest({ id: crypto.randomUUID(), vectors });
+        setSaveRequest({
+          id: crypto.randomUUID(),
+          session: saveSession.current,
+          vectors,
+        });
       };
       if (expression.kind === "vector") {
         if (/[\r\n;]/u.test(expression.vector)) {
@@ -228,10 +240,10 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
               "Enter a vector, not a command.",
             ),
           );
-          return;
+          return false;
         }
         insert([expression.vector]);
-        return;
+        return true;
       }
       const file = props.folder.input.files.find(
           (f) => f.path === input.configPath,
@@ -256,8 +268,7 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
             `${parsed.path}: ${parsed.message}`,
           ),
         );
-        setPath(input.configPath);
-        return;
+        return false;
       }
       const previousOutputs = [...parsed.config.outputs];
       parsed.config.outputs.push({
@@ -288,7 +299,7 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
             resolved.diagnostics.map((d) => d.message).join("; "),
           ),
         );
-        return;
+        return false;
       }
       const output = resolved.outputs.at(-1)!;
       const acquisitionIds = new Set<string>();
@@ -324,13 +335,17 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
       }
       insert(nativeVectors.length ? nativeVectors : ["v(0)"]);
       render((v) => v + 1);
+      return true;
     };
     const addPicked = (matches: readonly SimulationProbeOption[]) => {
       if (!binding) return;
-      props.onPickNetsChange?.(false);
-      props.onPickTerminalsChange?.(false);
       if (matches.length !== 1) {
-        setProbePicker(props.pickTerminalsActive ? "current" : "voltage");
+        props.onProblem(
+          inputProblem(
+            "SIMULATION_SIGNAL_UNRESOLVED",
+            "This pick has no unique signal. Choose a mapped Net or terminal, or select the signal from Helper.",
+          ),
+        );
         return;
       }
       const match = matches[0]!;
@@ -377,6 +392,8 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
     );
     useEffect(() => {
       setReveal(undefined);
+      setProbePicker(undefined);
+      saveSession.current = crypto.randomUUID();
     }, [props.folder.id]);
     const lastCanvasSelection = useRef<string | undefined>(undefined);
     useEffect(() => {
@@ -1141,15 +1158,32 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
           </>
         }
       >
-        {probePicker && (
-          <SourceProbePicker
-            choices={probeChoices}
-            kind={probePicker}
-            onAdd={saveSignal}
-            onClose={() => setProbePicker(undefined)}
-          />
-        )}
         <SimulationCodeEditor
+          helperContent={
+            probePicker ? (
+              <SourceProbePicker
+                key={`${props.folder.id}:${probePicker}`}
+                choices={probeChoices}
+                kind={probePicker}
+                onAdd={saveSignal}
+                onClose={() => setProbePicker(undefined)}
+              />
+            ) : undefined
+          }
+          onCloseHelperContent={() => setProbePicker(undefined)}
+          picking={
+            props.pickNetsActive || props.pickTerminalsActive
+              ? {
+                  label: props.pickNetsActive
+                    ? "Picking voltage"
+                    : "Picking current",
+                  onStop: () => {
+                    props.onPickNetsChange?.(false);
+                    props.onPickTerminalsChange?.(false);
+                  },
+                }
+              : undefined
+          }
           signalNames={() =>
             Object.fromEntries(
               Object.entries(signals).map(([vector, signal]) => [
@@ -1171,27 +1205,24 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
               drafts.current.get(`${props.folder.id}\u0000${file.path}`)
                 ?.text ?? file.text,
           )}
-          {...(selected?.path === input.entry
-            ? {
-                ghostHints: [
-                  "ac dec 20 1 1G",
-                  "tran 1n 1u",
-                  "dc VIN 0 1.8 0.01",
-                ],
-              }
-            : {})}
           helperActions={[
             {
               id: "save-voltage",
               label: "Save voltage…",
               keywords: "probe voltage 电压 信号 看输出",
-              run: () => setProbePicker("voltage"),
+              run: () => {
+                beginSignalSelection();
+                setProbePicker("voltage");
+              },
             },
             {
               id: "save-current",
               label: "Save terminal current…",
               keywords: "probe current 电流 MOS 端口",
-              run: () => setProbePicker("current"),
+              run: () => {
+                beginSignalSelection();
+                setProbePicker("current");
+              },
             },
             ...(binding
               ? [
@@ -1201,7 +1232,10 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
                       ? "Stop picking Nets"
                       : "Pick Net on Canvas",
                     keywords: "probe 电压 画布",
-                    run: () => props.onPickNetsChange?.(!props.pickNetsActive),
+                    run: () => {
+                      beginSignalSelection();
+                      props.onPickNetsChange?.(!props.pickNetsActive);
+                    },
                   },
                   {
                     id: "pick-current",
@@ -1209,8 +1243,10 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
                       ? "Stop picking current"
                       : "Pick current on Canvas",
                     keywords: "probe 电流 画布",
-                    run: () =>
-                      props.onPickTerminalsChange?.(!props.pickTerminalsActive),
+                    run: () => {
+                      beginSignalSelection();
+                      props.onPickTerminalsChange?.(!props.pickTerminalsActive);
+                    },
                   },
                 ]
               : []),

--- a/apps/editor/src/features/simulation/source-probe-picker.tsx
+++ b/apps/editor/src/features/simulation/source-probe-picker.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { SimulationSourceExpression } from "@icm/model";
 import type { SourceProbeChoice } from "./source-probe-choices";
 
@@ -10,30 +10,59 @@ export function SourceProbePicker({
 }: {
   choices: readonly SourceProbeChoice[];
   kind: "voltage" | "current";
-  onAdd(label: string, expression: SimulationSourceExpression): void;
+  onAdd(label: string, expression: SimulationSourceExpression): boolean;
   onClose(): void;
 }) {
   const [query, setQuery] = useState("");
+  const [added, setAdded] = useState<string[]>([]);
+  const root = useRef<HTMLDivElement>(null);
+  const finish = () => {
+    const trigger = root.current
+      ?.closest(".simulation-code-document")
+      ?.querySelector<HTMLButtonElement>("[data-simulation-helper-trigger]");
+    onClose();
+    trigger?.focus();
+  };
+  useEffect(() => {
+    const close = (event: PointerEvent) => {
+      if (
+        !root.current?.contains(event.target as Node) &&
+        !(event.target as Element).closest?.("[data-simulation-helper-trigger]")
+      )
+        onClose();
+    };
+    document.addEventListener("pointerdown", close);
+    return () => document.removeEventListener("pointerdown", close);
+  }, [onClose]);
   const filtered = choices.filter(
     (c) =>
       c.kind === (kind === "current" ? "current" : "voltage") &&
       c.label.toLowerCase().includes(query.toLowerCase()),
   );
   const add = (choice: SourceProbeChoice) => {
-    onAdd(choice.label, choice.expression);
-    onClose();
+    const key = JSON.stringify(choice.expression);
+    if (added.includes(key)) return;
+    if (onAdd(choice.label, choice.expression))
+      setAdded((current) => [...current, key]);
   };
   return (
     <div
-      className="simulation-probe-picker"
+      ref={root}
+      className="simulation-helper-list simulation-probe-picker"
       role="dialog"
       aria-label="Save signal"
       onKeyDown={(e) => {
         e.stopPropagation();
-        if (e.key === "Escape") onClose();
+        if (e.key === "Escape") {
+          e.preventDefault();
+          finish();
+        }
       }}
     >
-      <strong>Save {kind}</strong>
+      <header className="simulation-probe-picker-header">
+        <strong>Save {kind}</strong>
+        <button onClick={finish}>Done</button>
+      </header>
       <input
         autoFocus
         value={query}
@@ -43,13 +72,22 @@ export function SourceProbePicker({
       />
       <div className="simulation-helper-options">
         {filtered.map((choice, index) => (
-          <button key={index} onClick={() => add(choice)}>
+          <button
+            key={index}
+            aria-disabled={added.includes(JSON.stringify(choice.expression))}
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={() => add(choice)}
+          >
             {choice.label}
+            {added.includes(JSON.stringify(choice.expression)) && (
+              <small>Added</small>
+            )}
           </button>
         ))}
       </div>
       {query.trim() && (
         <button
+          onMouseDown={(event) => event.preventDefault()}
           onClick={() =>
             add({
               label: query.trim(),
@@ -61,11 +99,6 @@ export function SourceProbePicker({
           Use native vector: {query.trim()}
         </button>
       )}
-      <small>
-        Inserts a native save statement. Terminal currents may require generated
-        measurement wiring.
-      </small>
-      <button onClick={onClose}>Cancel</button>
     </div>
   );
 }

--- a/docs/specs/simulation-code-workspace.md
+++ b/docs/specs/simulation-code-workspace.md
@@ -101,8 +101,8 @@ IDs and exact files. Older data is read only at that compatibility boundary.
 
 New experiments require only a name. They bind the current Cell as the top-level
 circuit and create a small `op` starter; they do not ask for OP/AC/TRAN or source
-mode. AC, TRAN and DC examples appear as non-persisted editor hints, and helpers
-can insert them without making another form state authoritative. The source API
+mode. Helpers can insert AC, TRAN and DC commands without making another form
+state authoritative; the editor has no permanent analysis-example footer. The source API
 retains text-only and text-DUT creation for import, Agent and compatibility flows,
 but those are not choices in the normal new-experiment interaction. No starter
 creates a TB Cell or guesses stimuli.
@@ -113,8 +113,11 @@ Existing experiments reopen unchanged; duplication is an explicit action.
 `circuit.spice`, `testbench.spice`, and `run.cir` are conventions, not mandatory
 file counts. A drawn TB does not need an additional authored TB file.
 
-The flat **Helper** list and Ctrl+Space share the ngspice help catalog. Search
-accepts command names and purpose keywords; contextual typing completion is
+The flat **Helper** list and Ctrl+Space share the ngspice help catalog. The
+Helper button stays fixed at the right of the open-file tab row.
+Helper and signal selection use the same anchored popup footprint without resizing
+the editor. Closing by clicking outside preserves focus at the clicked destination.
+Search accepts command names and purpose keywords; contextual typing completion is
 limited to commands and relevant arguments, not comments or arbitrary text.
 Argument completion opens after the space in `save`/`dc`; native vector names stay
 unchanged. Candidate selection and hover can locate mapped Canvas Nets through
@@ -125,10 +128,16 @@ Choosing a command inserts its name and presents missing arguments as display-on
 ghosts. Tab/Shift+Tab navigate arguments, Escape dismisses guidance, and no ghost
 or implicit default enters saved/exported/executed text. Parameter guidance is
 advisory: users and Agents may continue writing native syntax beyond the catalog.
+Parameter descriptions remain visible without a permanent Tab/Shift+Tab legend.
 
 Helper signal actions insert native `save`/`.save` statements, not a parallel
-voltage-output configuration. Terminal-current picks retain their existing
-configuration owner when generated measurement wiring is required. An explicit
+voltage-output configuration. Signal selection stays open for successive additions;
+added choices are marked and cannot insert duplicates within that selection session.
+Canvas picking continues until Done or Escape. Successive picks extend the session's
+save statement without focusing the editor; the file row exposes picking status
+and Done. Failed additions keep the selection available and report their cause.
+Terminal-current picks retain their existing configuration owner when generated
+measurement wiring is required. An explicit
 save list is never silently widened to `all` by that instrumentation.
 Discovery and completion use the compiler's authored call-path mapping; they
 show the Canvas name alongside the executable native vector. Native vectors


### PR DESCRIPTION
Helper previously closed signal selection after every addition, ended Canvas picking after one click, and forced focus back into the editor. Signal lists now stay open, mark added choices, and preserve search focus. Canvas voltage/current picking continues until Done or Escape, appending to the same native save statement without focusing the editor.

Helper now sits at the right of the open-file row. Commands and signal selection share an anchored popup size; outside clicks retain their destination focus. The permanent Tab/Shift+Tab legend and analysis-example footer are removed. Parameter descriptions remain available. Quick start is deferred.

Validation: `pnpm gate:preflight -- --base origin/main` and `pnpm gate:affected -- --base origin/main` passed. Workspace unit contracts: 3169 passed, 28 skipped. Analog Simulation browser group: 23 passed, including continuous list and Canvas picks, current instrumentation deduplication, focus, exit, and file-row layout. Regression assertions for the removed analysis footer now require its absence. The gate plan selected these bounded checks without a full fallback.

Test-Impact: tests-updated
