### PR TITLE
release(mcp): publish source-workspace adapter 0.7.0

### DIFF
--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -18,7 +18,7 @@ import {
 import type { McpServerHandler, McpServerInfo } from "./protocol.js";
 
 export const MCP_SERVER_NAME = "analog-canvas";
-export const MCP_SERVER_VERSION = "0.5.0";
+export const MCP_SERVER_VERSION = "0.7.0";
 
 export interface McpServerConfig {
   apiBaseUrl: string;

--- a/config/agent-mcp-distribution.json
+++ b/config/agent-mcp-distribution.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "name": "analog-canvas",
-  "version": "0.5.0",
+  "version": "0.7.0",
   "node": ">=24.0.0",
   "packageName": "@analog-canvas/mcp-server",
   "binaryName": "analog-canvas-mcp",
@@ -9,8 +9,8 @@
   "release": {
     "buildPlatform": "linux",
     "repository": "cascode-ai/analog-canvas",
-    "tag": "mcp-v0.5.0",
-    "asset": "analog-canvas-mcp-server-0.5.0.tgz",
-    "sha256": "a27d20b86123a07816d280bc7b104030b13f25164e2ca0c1571f58f9d807c05c"
+    "tag": "mcp-v0.7.0",
+    "asset": "analog-canvas-mcp-server-0.7.0.tgz",
+    "sha256": "a285a2c107b2909996627eb117c60d3ff98133a1264e4427a6ddb8127071464f"
   }
 }


### PR DESCRIPTION
## Purpose

Publish the current source-workspace MCP adapter as 0.7.0, align its initialize handshake, and move Preview's installation manifest off the obsolete 0.5.0 setup/workspace contracts. Production site promotion is deliberately excluded.

## Release identity

- Tag: `mcp-v0.7.0` (new immutable release; no existing assets replaced).
- Canonical build: Linux, Node 24.20.0, pnpm 11.16.0.
- SHA-256: `a285a2c107b2909996627eb117c60d3ff98133a1264e4427a6ddb8127071464f`.
- Changes are limited to the distribution declaration and MCP handshake version. Existing source-folder, native-code and shared File/Run tools ship unchanged.

## Validation and delivery

- Frozen dependency install, 30 focused MCP tests, and reproducible Linux packaging with declared digest verification passed.
- Final preflight passed. The selected affected gate covers all unit tests, web Agent/simulation browser contracts, and complete release/performance verification; results will be recorded before merge.
- Publish the immutable asset before merging the manifest so the installation URL is live at rollout.
- Require all GitHub checks, Preview acceptance, and a simulation journey using the downloaded published tarball (not just the source-built adapter).

Test-Impact: no-test-change — only release identity/digest change; existing protocol, simulation, browser and packaged release contracts cover the unchanged runtime implementation.
