### PR TITLE
Fix composite wire landing and terminal-aware shortening

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -295,7 +295,9 @@ for (const width of [300, 540]) {
     const selected = await code.evaluate(() =>
       window.getSelection()?.toString(),
     );
-    expect(selected).toBe(raw);
+    // Selection serialization uses LF even when innerText uses the Windows
+    // CRLF convention. Compare all selected content, not OS line separators.
+    expect(selected?.replace(/\r\n/gu, "\n")).toBe(raw.replace(/\r\n/gu, "\n"));
 
     const layout = await editor.evaluate((section) => ({
       overflow: section.scrollWidth > section.clientWidth,

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -7345,9 +7345,11 @@ test("dragging a wire previews the orthogonal path it will commit", async ({
   );
   // While the pointer is down the preview used to close back at the old free
   // end, drawing a triangle the editor never commits.
-  expect(everyLegAxisAligned(await drawnPoints())).toBe(true);
+  const previewPoints = await drawnPoints();
+  expect(everyLegAxisAligned(previewPoints)).toBe(true);
   await page.mouse.up();
   expect(everyLegAxisAligned(await drawnPoints())).toBe(true);
+  expect(await drawnPoints()).toEqual(previewPoints);
 });
 
 test("the copy ghost shows the wires it is about to place", async ({

--- a/apps/editor/src/canvas/canvas-drag-visual.test.ts
+++ b/apps/editor/src/canvas/canvas-drag-visual.test.ts
@@ -25,6 +25,32 @@ class FakeElement {
 }
 
 describe("startCanvasDragVisual", () => {
+  it("moves a junction independently of its stretched incident wires and restores both", () => {
+    const junction = new FakeElement({
+      "data-object-id": "J",
+      transform: "translate(10 20)",
+    });
+    const route = new FakeElement({
+      "data-object-id": "R",
+      points: "10,20 100,20",
+    });
+    const root = {
+      querySelectorAll: () => [junction, route],
+    } as unknown as ParentNode;
+    const visual = startCanvasDragVisual(root, ["J", "R"]);
+    visual.translateObject("J", { x: 0, y: -10 });
+    visual.setObjectPolyline("R", [
+      { x: 10, y: 10 },
+      { x: 100, y: 10 },
+    ]);
+    expect(junction.getAttribute("transform")).toBe(
+      "translate(0 -10) translate(10 20)",
+    );
+    expect(route.getAttribute("transform")).toBeNull();
+    visual.restore();
+    expect(junction.getAttribute("transform")).toBe("translate(10 20)");
+    expect(route.getAttribute("points")).toBe("10,20 100,20");
+  });
   it("composes translation with existing transforms and restores exactly", () => {
     const formal = new FakeElement({
       "data-object-id": "M1",

--- a/apps/editor/src/canvas/canvas-drag-visual.ts
+++ b/apps/editor/src/canvas/canvas-drag-visual.ts
@@ -2,6 +2,7 @@ import type { Point } from "@icm/model";
 
 export interface CanvasDragVisual {
   translate(delta: Point): void;
+  translateObject(objectId: string, delta: Point): void;
   scale(pivot: Point, factor: number): void;
   setPolyline(points: readonly Point[]): void;
   setObjectPolyline(objectId: string, points: readonly Point[]): void;
@@ -49,6 +50,16 @@ export function startCanvasDragVisual(
   return {
     translate(delta) {
       for (const item of saved) {
+        const prefix = `translate(${delta.x} ${delta.y})`;
+        item.element.setAttribute(
+          "transform",
+          item.transform ? `${prefix} ${item.transform}` : prefix,
+        );
+      }
+    },
+    translateObject(objectId, delta) {
+      for (const item of saved) {
+        if (item.objectId !== objectId) continue;
         const prefix = `translate(${delta.x} ${delta.y})`;
         item.element.setAttribute(
           "transform",

--- a/apps/editor/src/features/wiring/use-wire-interaction.ts
+++ b/apps/editor/src/features/wiring/use-wire-interaction.ts
@@ -652,11 +652,42 @@ export function useWireInteraction(capabilities: UseWireInteractionOptions) {
           ? routeEndpointRouteIds
           : [routeId];
     let visual: ReturnType<typeof startCanvasDragVisual> | null = null;
+    const segmentJunctionIds = new Set(
+      [record.route.start, routeEnd(record.route)].flatMap((endpoint) =>
+        endpoint.kind === "junction" ? [endpoint.junctionId] : [],
+      ),
+    );
+    const segmentRouteIds = options.document.routes
+      .filter((route) =>
+        [route.start, routeEnd(route)].some(
+          (endpoint) =>
+            endpoint.kind === "junction" &&
+            segmentJunctionIds.has(endpoint.junctionId),
+        ),
+      )
+      .map((route) => route.id);
     const dragVisual = () =>
       (visual ??= startCanvasDragVisual(svg, [
         ...translatedRouteIds,
         ...anchorIds,
+        ...(intent === "stretch-segment"
+          ? [...segmentRouteIds, ...segmentJunctionIds]
+          : []),
       ]));
+    const previewJunctions = (
+      moves: readonly { junctionId: string; position: Point }[],
+    ) => {
+      for (const move of moves) {
+        const original = options.document.junctions.find(
+          (j) => j.id === move.junctionId,
+        );
+        if (!original) continue;
+        dragVisual().translateObject(move.junctionId, {
+          x: move.position.x - original.position.x,
+          y: move.position.y - original.position.y,
+        });
+      }
+    };
     const resizesRouteEnd =
       intent === "resize-route-start" || intent === "resize-route-end";
     const preview: RouteStretchPreview = {
@@ -755,18 +786,24 @@ export function useWireInteraction(capabilities: UseWireInteractionOptions) {
                 to,
               ]);
             }
+            previewJunctions(plan.preview?.junctions ?? []);
           } catch {
             // Keep the last valid endpoint preview; commit reports the error.
           }
           return;
         }
         try {
+          const grid = options.document.presentation.grid;
+          const snapped = {
+            x: snapCoordinate(point.x, grid),
+            y: snapCoordinate(point.y, grid),
+          };
           const plan = proposeWireSegmentMove(
             options.document,
             options.resolver,
             routeId,
             segmentIndex,
-            point,
+            snapped,
           );
           const proposal = plan.preview?.routes.find(
             (candidate) => candidate.routeId === routeId,
@@ -775,18 +812,29 @@ export function useWireInteraction(capabilities: UseWireInteractionOptions) {
           // Remember how far the drag actually planned. Releasing past that
           // point used to plan once more, fail, and snap the wire back to
           // where it started, discarding everything the preview had shown.
-          preview.point = point;
+          preview.point = snapped;
           // Draw what the plan will commit. Pinning the Route's original
           // endpoints here left a moved free end behind, so the closing leg
           // cut across at an angle and the drag read as a triangle.
-          dragVisual().setPolyline(
-            segmentDragPreviewPolyline(
-              record.route,
-              record.geometry.centerline,
-              proposal.waypoints,
-              plan.preview?.junctions ?? [],
-            ),
-          );
+          // Restore arms no longer affected by this plan (for example after
+          // returning from a carried Junction to a fixed-end dogleg).
+          dragVisual().restore();
+          for (const item of plan.preview?.routes ?? []) {
+            const affected = options.routeGeometryRecords.find(
+              (r) => r.route.id === item.routeId,
+            );
+            if (!affected) continue;
+            dragVisual().setObjectPolyline(
+              item.routeId,
+              segmentDragPreviewPolyline(
+                affected.route,
+                affected.geometry.centerline,
+                item.waypoints,
+                plan.preview?.junctions ?? [],
+              ),
+            );
+          }
+          previewJunctions(plan.preview?.junctions ?? []);
         } catch {
           // Keep the last valid preview; commit lands on it instead.
         }

--- a/packages/edit-engine/src/contact-planning-draft.ts
+++ b/packages/edit-engine/src/contact-planning-draft.ts
@@ -1,0 +1,57 @@
+import type { RouteEndpoint, SchematicDocument } from "@icm/model";
+import type { SymbolResolver } from "@icm/symbols";
+import type { SchematicEdit } from "./edit-schema.js";
+import { planDirectEndpointConnection } from "./direct-contact-planner.js";
+import { applyNetPowerEdit } from "./transaction-net-power.js";
+import { applyRouteTopologyEdit } from "./transaction-route-topology.js";
+import { applyPresentationLayoutEdit } from "./transaction-presentation-layout.js";
+
+/**
+ * The membership phase of a composite contact gesture. Use the transaction's
+ * mutations, without finalizing/pruning/normalizing between contacts: later
+ * contacts see surviving Net identities, and splits still address the authored
+ * Route legs. This transient draft is never saved or exposed as a Document.
+ */
+export function createContactPlanningDraft(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+) {
+  const draft = structuredClone(document);
+  const edits: SchematicEdit[] = [];
+  const context = {
+    draft,
+    resolver,
+    changedObjectIds: new Set<string>(),
+    explicitlyAuthoredRouteIds: new Set<string>(),
+    deferNetPrune: (_netId: string) => {},
+    reject: (_code: unknown, message: string): never => {
+      throw new Error(message);
+    },
+  };
+  return {
+    document: draft,
+    edits,
+    connect(from: RouteEndpoint, to: RouteEndpoint, newNetId: string) {
+      const connection = planDirectEndpointConnection(draft, {
+        from,
+        to,
+        newNetId,
+      });
+      if (!connection.ok) return connection;
+      for (const edit of connection.edits) {
+        if (edit.kind === "connect_endpoints")
+          applyRouteTopologyEdit(edit, context);
+        else if (
+          edit.kind === "merge_nets" ||
+          edit.kind === "remove_connectivity_evidence"
+        )
+          applyNetPowerEdit(edit, context);
+        else if (edit.kind === "remove_schematic_annotation")
+          applyPresentationLayoutEdit(edit, context);
+        else throw new Error(`Unexpected contact edit: ${edit.kind}`);
+        edits.push(edit);
+      }
+      return connection;
+    },
+  };
+}

--- a/packages/edit-engine/src/instance-contact-planner.ts
+++ b/packages/edit-engine/src/instance-contact-planner.ts
@@ -2,10 +2,7 @@ import {
   isEligibleSeriesInsertionPinPair,
   planSeriesInstanceSplice,
 } from "./series-splice-planner.js";
-import { planDirectEndpointConnection } from "./direct-contact-planner.js";
-import { applyNetPowerEdit } from "./transaction-net-power.js";
-import { applyRouteTopologyEdit } from "./transaction-route-topology.js";
-import { applyPresentationLayoutEdit } from "./transaction-presentation-layout.js";
+import { createContactPlanningDraft } from "./contact-planning-draft.js";
 import { planElectricalMarkerRename } from "./net-name-operation-planner.js";
 import { planEnsurePowerNet } from "./power-net-planner.js";
 import {
@@ -368,21 +365,12 @@ export function proposePlacementContact(
   // Fold all contact membership edits through the transaction's own mutations
   // before compiling any split. Later contacts must see prior Net merges, but
   // Route leg identities must remain unchanged until every split is planned.
-  const connected = structuredClone(document);
+  const contactDraft = createContactPlanningDraft(document, resolver);
+  const connected = contactDraft.document;
   for (const item of options.instances ?? [instance]) {
     connected.instances = connected.instances.filter((i) => i.id !== item.id);
     connected.instances.push(structuredClone(item));
   }
-  const mutationContext = {
-    draft: connected,
-    resolver,
-    changedObjectIds: new Set<string>(),
-    explicitlyAuthoredRouteIds: new Set<string>(),
-    deferNetPrune: (_netId: string) => {},
-    reject: (_code: unknown, message: string): never => {
-      throw new Error(message);
-    },
-  };
   const connections = new Map<
     WireSource,
     { netId: string; newNetId: string }
@@ -396,11 +384,7 @@ export function proposePlacementContact(
       const to =
         target.endpoint?.endpoint ??
         connected.routes.find((r) => r.id === target.route!.routeId)!.start;
-      const connection = planDirectEndpointConnection(connected, {
-        from: source.endpoint,
-        to,
-        newNetId,
-      });
+      const connection = contactDraft.connect(source.endpoint, to, newNetId);
       if (!connection.ok)
         return {
           edits: [],
@@ -408,19 +392,6 @@ export function proposePlacementContact(
           ambiguous: false,
           rejected: connection.message,
         };
-      for (const edit of connection.edits) {
-        if (edit.kind === "connect_endpoints")
-          applyRouteTopologyEdit(edit, mutationContext);
-        else if (
-          edit.kind === "merge_nets" ||
-          edit.kind === "remove_connectivity_evidence"
-        )
-          applyNetPowerEdit(edit, mutationContext);
-        else if (edit.kind === "remove_schematic_annotation")
-          applyPresentationLayoutEdit(edit, mutationContext);
-        else throw new Error(`Unexpected contact edit: ${edit.kind}`);
-        edits.push(edit);
-      }
       connections.set(source, { netId: connection.netId, newNetId });
     }
   } catch (error) {
@@ -431,6 +402,7 @@ export function proposePlacementContact(
       rejected: error instanceof Error ? error.message : String(error),
     };
   }
+  edits.push(...contactDraft.edits);
   let powerNetId: string | undefined;
   let powerCandidateState: "existing" | "pending-connection" | undefined;
   let powerEndpoint: RouteEndpoint | undefined;

--- a/packages/edit-engine/src/instance-contact-transform.ts
+++ b/packages/edit-engine/src/instance-contact-transform.ts
@@ -14,6 +14,7 @@ import {
   type RoutingOperationPlan,
 } from "./routing-operation-plan.js";
 import type { WireSource } from "./routing-planner.js";
+import { projectRoutingEditGeometry } from "./routing-geometry-projection.js";
 
 /** Transient geometry from the same typed plan, before transaction normalization.
  * This is not a committed Document and must never be persisted.
@@ -22,30 +23,7 @@ export function projectRoutingTransformGeometry(
   document: SchematicDocument,
   plan: RoutingOperationPlan,
 ): SchematicDocument {
-  const projected = structuredClone(document);
-  for (const edit of plan.edits) {
-    if (edit.kind === "move_instance") {
-      const instance = projected.instances.find(
-        (i) => i.id === edit.instanceId,
-      );
-      if (instance?.placement)
-        instance.placement.position = { ...edit.position };
-    } else if (edit.kind === "move_junction") {
-      const junction = projected.junctions.find(
-        (j) => j.id === edit.junctionId,
-      );
-      if (junction) junction.position = { ...edit.position };
-    } else if (edit.kind === "set_route_path") {
-      projected.routes = projected.routes.map((r) =>
-        r.id === edit.route.id ? structuredClone(edit.route) : r,
-      );
-    } else if (edit.kind === "remove_route_geometry") {
-      projected.routes = projected.routes.filter((r) => r.id !== edit.routeId);
-    } else {
-      throw new Error(`Not a transform geometry edit: ${edit.kind}`);
-    }
-  }
-  return projected;
+  return projectRoutingEditGeometry(document, plan.edits);
 }
 
 /** One final-position plan for moving geometry and an explicit snapped pin drop.

--- a/packages/edit-engine/src/route-drag-contacts.test.ts
+++ b/packages/edit-engine/src/route-drag-contacts.test.ts
@@ -183,6 +183,59 @@ describe("atomic endpoint landing", () => {
 });
 
 describe("terminal-aware shortening", () => {
+  it("preserves an existing opposite-side approach when dragging a two-pin crossbar", () => {
+    const d = createEmptyDocument("existing-detour", "Existing detour");
+    d.instances.push(
+      {
+        id: "R1",
+        symbolId: "resistor",
+        placement: {
+          position: { x: 270, y: 230 },
+          rotation: 0,
+          mirror: "none",
+        },
+      },
+      {
+        id: "R2",
+        symbolId: "resistor",
+        placement: {
+          position: { x: 530, y: 230 },
+          rotation: 0,
+          mirror: "none",
+        },
+      },
+    );
+    d.nets.push({
+      id: "n",
+      terminals: [
+        { instanceId: "R1", pinName: "2" },
+        { instanceId: "R2", pinName: "1" },
+      ],
+    });
+    d.routes.push(
+      createRoutePath({
+        id: "r",
+        netId: "n",
+        start: { kind: "terminal", instanceId: "R1", pinName: "2" },
+        end: { kind: "terminal", instanceId: "R2", pinName: "1" },
+        bends: [{ x: 530, y: 250 }],
+        modes: ["manual", "manual"],
+      }),
+    );
+    const p = proposeWireSegmentMove(d, resolver, "r", 0, { x: 400, y: 330 });
+    const final = commit(d, p.edits);
+    const points = resolveRouteGeometry(
+      final,
+      resolver,
+      final.routes[0]!,
+    )!.centerline;
+    expect(points).toEqual([
+      { x: 270, y: 250 },
+      { x: 270, y: 330 },
+      { x: 530, y: 330 },
+      { x: 530, y: 210 },
+    ]);
+  });
   it.each([0, 90, 180, 270] as const)(
     "does not fold wire over a Port lead at rotation %s",
     (rotation) => {

--- a/packages/edit-engine/src/route-drag-contacts.test.ts
+++ b/packages/edit-engine/src/route-drag-contacts.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it } from "vitest";
+import {
+  createEmptyDocument,
+  createRoutePath,
+  routeEnd,
+  transformPoint,
+  SchematicDocumentSchema,
+  type SchematicDocument,
+  type Point,
+} from "@icm/model";
+import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
+import { resolveEndpointConnection, resolveRouteGeometry } from "@icm/derived";
+import {
+  proposeLooseRouteTranslation,
+  proposeRouteEndpointMove,
+  proposeWireSegmentMove,
+} from "./routing-planner.js";
+import {
+  createRoutingOperationPlan,
+  gateRoutingOperationPlan,
+} from "./routing-operation-plan.js";
+import type { SchematicEdit } from "./edit-schema.js";
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
+function looseWires(): SchematicDocument {
+  const d = createEmptyDocument("drag-regression", "Drag regression");
+  d.presentation.grid = 10;
+  d.nets.push({ id: "n", terminals: [] }, { id: "m", terminals: [] });
+  for (const [id, netId, x, y] of [
+    ["A", "n", 0, 0],
+    ["B", "n", 100, 0],
+    ["X", "m", 50, 50],
+    ["Y", "m", 150, 50],
+  ] as const)
+    d.junctions.push({ id, netId, position: { x, y }, role: "route-anchor" });
+  for (const [id, netId, a, b] of [
+    ["r", "n", "A", "B"],
+    ["s", "m", "X", "Y"],
+  ] as const)
+    d.routes.push(
+      createRoutePath({
+        id,
+        netId,
+        start: { kind: "junction", junctionId: a },
+        end: { kind: "junction", junctionId: b },
+        bends: [],
+        modes: ["manual"],
+      }),
+    );
+  return d;
+}
+function port(
+  d: SchematicDocument,
+  id: string,
+  netId: string,
+  position: Point,
+) {
+  d.instances.push({
+    id,
+    symbolId: "port",
+    placement: { position, rotation: 0, mirror: "none" },
+  });
+  d.nets
+    .find((net) => net.id === netId)!
+    .terminals.push({ instanceId: id, pinName: "P" });
+  d.netlist!.terminals.push({
+    id: `cell-${id}`,
+    name: id,
+    netId,
+    direction: "passive",
+    interfaceInstanceIds: [id],
+  });
+}
+function commit(d: SchematicDocument, edits: readonly SchematicEdit[]) {
+  expect(SchematicDocumentSchema.safeParse(d).success).toBe(true);
+  const plan = createRoutingOperationPlan(d, {
+    intent: "route-geometry",
+    edits,
+    diagnostics: [],
+  });
+  const result = gateRoutingOperationPlan(d, plan, {
+    symbolResolver: resolver,
+  });
+  expect(result.ok, result.ok ? "" : result.message).toBe(true);
+  if (!result.ok) throw new Error(result.message);
+  return result.evaluated.finalDocument;
+}
+function conductorNets(d: SchematicDocument) {
+  return new Set(d.routes.map((r) => r.netId));
+}
+
+describe("atomic endpoint landing", () => {
+  it("merges a pair of Nets only once when both loose ends land on endpoints", () => {
+    const d = looseWires();
+    const before = structuredClone(d);
+    const p = proposeLooseRouteTranslation(
+      d,
+      "r",
+      { x: 50, y: 50 },
+      { resolver, suffix: "overlap" },
+    );
+    expect(p.edits.filter((e) => e.kind === "merge_nets")).toHaveLength(1);
+    const final = commit(d, p.edits);
+    expect(conductorNets(final).size).toBe(1);
+    expect(final.routes).toHaveLength(1);
+    expect(d).toEqual(before);
+  });
+  it("shares membership state between an endpoint landing and a span landing", () => {
+    const d = looseWires();
+    d.junctions.find((j) => j.id === "Y")!.position.x = 250;
+    const p = proposeLooseRouteTranslation(
+      d,
+      "r",
+      { x: 50, y: 50 },
+      { resolver, suffix: "mixed" },
+    );
+    expect(p.edits.filter((e) => e.kind === "merge_nets")).toHaveLength(1);
+    expect(conductorNets(commit(d, p.edits)).size).toBe(1);
+  });
+  it("joins three Nets when opposite ends land inside different conductors", () => {
+    const d = looseWires();
+    d.nets.push({ id: "third", terminals: [] });
+    d.junctions.find((j) => j.id === "Y")!.position = { x: 50, y: 150 };
+    d.junctions.push(
+      {
+        id: "T1",
+        netId: "third",
+        position: { x: 150, y: 50 },
+        role: "route-anchor",
+      },
+      {
+        id: "T2",
+        netId: "third",
+        position: { x: 150, y: 150 },
+        role: "route-anchor",
+      },
+    );
+    d.routes.push(
+      createRoutePath({
+        id: "third-wire",
+        netId: "third",
+        start: { kind: "junction", junctionId: "T1" },
+        end: { kind: "junction", junctionId: "T2" },
+        bends: [],
+        modes: ["manual"],
+      }),
+    );
+    const p = proposeLooseRouteTranslation(
+      d,
+      "r",
+      { x: 50, y: 100 },
+      { resolver, suffix: "two-spans" },
+    );
+    expect(conductorNets(commit(d, p.edits)).size).toBe(1);
+  });
+  it.each([false, true])(
+    "classifies coincident terminals as endpoints regardless of instance order (%s)",
+    (reverse) => {
+      const d = looseWires();
+      port(d, "P1", "n", { x: 40, y: 50 });
+      port(d, "P2", "m", { x: 40, y: 50 });
+      if (reverse) d.instances.reverse();
+      d.routes[1]!.start = { kind: "terminal", instanceId: "P2", pinName: "P" };
+      const p = proposeRouteEndpointMove(
+        d,
+        resolver,
+        "r",
+        "start",
+        { x: 50, y: 50 },
+        "coincident",
+      );
+      expect(p.edits.some((e) => e.kind === "attach_endpoint_to_route")).toBe(
+        false,
+      );
+      const final = commit(d, p.edits);
+      expect(conductorNets(final).size).toBe(1);
+      expect(
+        final.nets.find((n) => n.terminals.some((t) => t.instanceId === "P1"))
+          ?.terminals,
+      ).toContainEqual({ instanceId: "P2", pinName: "P" });
+    },
+  );
+});
+
+describe("terminal-aware shortening", () => {
+  it.each([0, 90, 180, 270] as const)(
+    "does not fold wire over a Port lead at rotation %s",
+    (rotation) => {
+      for (const mirror of ["none", "x"] as const) {
+        for (const reverse of [false, true]) {
+          const d = looseWires();
+          d.routes = [];
+          d.nets = d.nets.slice(0, 1);
+          d.junctions = d.junctions.filter((j) => j.id === "B");
+          port(d, "P1", "n", { x: 300, y: 300 });
+          d.instances[0]!.placement = {
+            position: { x: 300, y: 300 },
+            rotation,
+            mirror,
+          };
+          const at = (p: Point) =>
+            transformPoint(p, { x: 300, y: 300 }, { rotation, mirror });
+          d.junctions[0]!.position = at({ x: 200, y: 100 });
+          const ends = [
+            { kind: "terminal" as const, instanceId: "P1", pinName: "P" },
+            { kind: "junction" as const, junctionId: "B" },
+          ];
+          const bends = [at({ x: 100, y: 0 }), at({ x: 100, y: 100 })];
+          if (reverse) {
+            ends.reverse();
+            bends.reverse();
+          }
+          d.routes.push(
+            createRoutePath({
+              id: "p",
+              netId: "n",
+              start: ends[0]!,
+              end: ends[1]!,
+              bends,
+              modes: ["manual", "manual", "manual"],
+            }),
+          );
+          const p = proposeWireSegmentMove(
+            d,
+            resolver,
+            "p",
+            1,
+            at({ x: 0, y: 50 }),
+          );
+          const final = commit(d, p.edits);
+          const wire = final.routes.find((r) => r.id === "p")!;
+          let points = [
+            ...resolveRouteGeometry(final, resolver, wire)!.centerline,
+          ];
+          if (reverse) points.reverse();
+          expect(points).toEqual([
+            at({ x: 10, y: 0 }),
+            at({ x: 10, y: 100 }),
+            at({ x: 200, y: 100 }),
+          ]);
+          expect(final.instances).toEqual(d.instances);
+          expect(wire.start).toEqual(d.routes[0]!.start);
+          expect(routeEnd(wire)).toEqual(routeEnd(d.routes[0]!));
+          const pin = resolveEndpointConnection(final, resolver, {
+            kind: "terminal",
+            instanceId: "P1",
+            pinName: "P",
+          })!;
+          expect(points[0]).toEqual(pin.contactPoint);
+          const preview = p.preview!.routes[0]!;
+          expect(
+            reverse ? [...preview.waypoints].reverse() : preview.waypoints,
+          ).toEqual(points.slice(1, -1));
+        }
+      }
+    },
+  );
+});

--- a/packages/edit-engine/src/route-operations.ts
+++ b/packages/edit-engine/src/route-operations.ts
@@ -279,16 +279,13 @@ function normalizeProposal(
   };
 }
 
-/**
- * A rail must stay one straight axis-aligned conductor; a boundary stretch
- * that would bend it fails here with a named plan-time error instead of a
- * raw geometry rejection at commit.
- */
+/** Apply the same endpoint cleanup to every public stretch planner. */
 function tidyTerminalProposal(
   document: SchematicDocument,
   resolver: SymbolResolver,
   route: SchematicDocument["routes"][number],
   proposal: RouteStretchProposal,
+  originalDocument: SchematicDocument = document,
 ): RouteStretchProposal {
   if (proposal.collapsedToContact || route.presentation === "power-rail")
     return proposal;
@@ -301,6 +298,7 @@ function tidyTerminalProposal(
     route,
     [from.contactPoint, ...proposal.waypoints, to.contactPoint],
     proposal.segmentModes,
+    originalDocument,
   );
   return normalizeProposal(route.id, tidy.points, tidy.segmentModes);
 }
@@ -330,11 +328,12 @@ function tidyDragProposal(
       const route = document.routes.find(
         (candidate) => candidate.id === item.routeId,
       )!;
-      return tidyTerminalProposal(projected, resolver, route, item);
+      return tidyTerminalProposal(projected, resolver, route, item, document);
     }),
   };
 }
 
+/** A rail must stay straight; fail at plan time rather than during commit. */
 function assertPowerRailStaysStraight(
   route: SchematicDocument["routes"][number],
   first: Point,
@@ -356,6 +355,7 @@ function assertPowerRailStaysStraight(
  * transformed placement applied, plus the world bounds of the moved bodies.
  */
 interface BoundarySmoothing {
+  originalDocument: SchematicDocument;
   movedDocument: SchematicDocument;
   movedBodies: readonly Rect[];
 }
@@ -468,6 +468,7 @@ function smoothedBoundaryProposal(
     resolver,
     route,
     proposal,
+    smoothing.originalDocument,
   );
 }
 
@@ -1060,6 +1061,7 @@ export function proposeLocalStretch(
   )!;
   movedInstance.placement!.position = { ...newPosition };
   const smoothing: BoundarySmoothing = {
+    originalDocument: document,
     movedDocument,
     movedBodies: movedInstanceBodies(
       movedDocument,
@@ -1214,6 +1216,7 @@ export function proposeGroupMove(
     }
   }
   const smoothing: BoundarySmoothing = {
+    originalDocument: document,
     movedDocument,
     movedBodies: movedInstanceBodies(
       movedDocument,
@@ -1558,6 +1561,7 @@ function proposeRigidBodyMove(
     }
   }
   const smoothing: BoundarySmoothing = {
+    originalDocument: document,
     movedDocument,
     movedBodies: movedInstanceBodies(movedDocument, resolver, selected),
   };

--- a/packages/edit-engine/src/route-operations.ts
+++ b/packages/edit-engine/src/route-operations.ts
@@ -1,5 +1,6 @@
 import { cancelDoubledBackLegs } from "./routing-planner.js";
 import { stretchRouteEndpoint } from "./route-endpoint-stretch.js";
+import { tidyRouteTerminalApproaches } from "./route-terminal-approach.js";
 import {
   reflectOrientation,
   routeBends,
@@ -283,6 +284,57 @@ function normalizeProposal(
  * that would bend it fails here with a named plan-time error instead of a
  * raw geometry rejection at commit.
  */
+function tidyTerminalProposal(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+  route: SchematicDocument["routes"][number],
+  proposal: RouteStretchProposal,
+): RouteStretchProposal {
+  if (proposal.collapsedToContact || route.presentation === "power-rail")
+    return proposal;
+  const from = resolveEndpointConnection(document, resolver, route.start);
+  const to = resolveEndpointConnection(document, resolver, routeEnd(route));
+  if (!from || !to) return proposal;
+  const tidy = tidyRouteTerminalApproaches(
+    document,
+    resolver,
+    route,
+    [from.contactPoint, ...proposal.waypoints, to.contactPoint],
+    proposal.segmentModes,
+  );
+  return normalizeProposal(route.id, tidy.points, tidy.segmentModes);
+}
+
+function tidyDragProposal(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+  proposal: WireSegmentDragProposal,
+): WireSegmentDragProposal {
+  const moved = new Map(
+    proposal.junctions.map((junction) => [
+      junction.junctionId,
+      junction.position,
+    ]),
+  );
+  const projected = {
+    ...document,
+    junctions: document.junctions.map((junction) =>
+      moved.has(junction.id)
+        ? { ...junction, position: moved.get(junction.id)! }
+        : junction,
+    ),
+  };
+  return {
+    ...proposal,
+    routes: proposal.routes.map((item) => {
+      const route = document.routes.find(
+        (candidate) => candidate.id === item.routeId,
+      )!;
+      return tidyTerminalProposal(projected, resolver, route, item);
+    }),
+  };
+}
+
 function assertPowerRailStaysStraight(
   route: SchematicDocument["routes"][number],
   first: Point,
@@ -396,6 +448,30 @@ function axisOf(a: Point, b: Point): "x" | "y" | null {
  * identity never change: this is presentation geometry only.
  */
 function smoothedBoundaryProposal(
+  route: SchematicDocument["routes"][number],
+  originalBendCount: number,
+  stretched: RouteStretchProposal,
+  smoothing: BoundarySmoothing,
+  resolver: SymbolResolver,
+  stretchedRawBendCount: number = stretched.waypoints.length,
+): RouteStretchProposal {
+  const proposal = smoothedBoundaryGeometry(
+    route,
+    originalBendCount,
+    stretched,
+    smoothing,
+    resolver,
+    stretchedRawBendCount,
+  );
+  return tidyTerminalProposal(
+    smoothing.movedDocument,
+    resolver,
+    route,
+    proposal,
+  );
+}
+
+function smoothedBoundaryGeometry(
   route: SchematicDocument["routes"][number],
   originalBendCount: number,
   stretched: RouteStretchProposal,
@@ -565,6 +641,18 @@ export function proposeJunctionGroupTranslation(
   resolver: SymbolResolver,
   moves: readonly JunctionMoveProposal[],
 ): WireSegmentDragProposal {
+  return tidyDragProposal(
+    document,
+    resolver,
+    proposeJunctionTranslationGeometry(document, resolver, moves),
+  );
+}
+
+function proposeJunctionTranslationGeometry(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+  moves: readonly JunctionMoveProposal[],
+): WireSegmentDragProposal {
   const movedJunctions = new Map(
     moves.map((move) => [move.junctionId, move.position] as const),
   );
@@ -660,6 +748,26 @@ export function proposeJunctionGroupTranslation(
  * returned Junction and Route edits together in one transaction.
  */
 export function proposeWireSegmentDrag(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+  routeId: string,
+  segmentIndex: number,
+  target: Point,
+): WireSegmentDragProposal {
+  return tidyDragProposal(
+    document,
+    resolver,
+    proposeWireSegmentDragGeometry(
+      document,
+      resolver,
+      routeId,
+      segmentIndex,
+      target,
+    ),
+  );
+}
+
+function proposeWireSegmentDragGeometry(
   document: SchematicDocument,
   resolver: SymbolResolver,
   routeId: string,

--- a/packages/edit-engine/src/route-terminal-approach.ts
+++ b/packages/edit-engine/src/route-terminal-approach.ts
@@ -1,0 +1,84 @@
+import { resolveEndpointConnection, resolveRouteGeometry } from "@icm/derived";
+import {
+  routeEnd,
+  type Point,
+  type RouteBranch,
+  type SchematicDocument,
+  type SegmentMode,
+} from "@icm/model";
+import type { SymbolResolver } from "@icm/symbols";
+import { normalizeRouteGeometry, strongerMode } from "./route-geometry-edit.js";
+
+/**
+ * A shortened boundary must not retrace the terminal's artwork lead. Fold
+ * that local elbow onto the contact's perpendicular instead. No fixed escape
+ * length, symbol-specific rule, moved terminal, or global reroute is needed.
+ * A perpendicular departure is valid and deliberately remains unchanged.
+ */
+export function tidyRouteTerminalApproaches(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+  route: RouteBranch,
+  input: readonly Point[],
+  inputModes: readonly SegmentMode[],
+): { points: Point[]; segmentModes: SegmentMode[] } {
+  let points = input.map((point) => ({ ...point }));
+  let modes = [...inputModes];
+  if (modes.some((mode) => mode === "locked" || mode === "trunk"))
+    return { points, segmentModes: modes };
+  const original = resolveRouteGeometry(document, resolver, route)?.centerline;
+  for (const [endpoint, reverse] of [
+    [route.start, false],
+    [routeEnd(route), true],
+  ] as const) {
+    if (endpoint.kind !== "terminal") continue;
+    const connection = resolveEndpointConnection(document, resolver, endpoint);
+    if (!connection?.outward) continue;
+    const originalEnd = reverse ? original?.at(-1) : original?.[0];
+    const originalNeighbor = reverse ? original?.at(-2) : original?.[1];
+    // Explicit slanted-line repair is a different authoring intent: retain
+    // its dragged crossbar rather than replacing it with an unrelated L.
+    if (
+      originalEnd &&
+      originalNeighbor &&
+      originalEnd.x !== originalNeighbor.x &&
+      originalEnd.y !== originalNeighbor.y
+    )
+      continue;
+    if (reverse) {
+      points.reverse();
+      modes.reverse();
+    }
+    const [a, b, c] = points;
+    const outward = connection.outward;
+    // Only persist an elbow at an actual grid contact. Offset artwork leads
+    // remain owned by EndpointConnection, not rounded or copied into bends.
+    const gridContact =
+      a && a.x === connection.gridLanding.x && a.y === connection.gridLanding.y;
+    const horizontal = outward.x !== 0 && outward.y === 0;
+    const vertical = outward.y !== 0 && outward.x === 0;
+    const backwards =
+      a && b && (b.x - a.x) * outward.x + (b.y - a.y) * outward.y < 0;
+    const elbow =
+      a &&
+      b &&
+      c &&
+      ((horizontal && a.y === b.y && b.x === c.x && b.y !== c.y) ||
+        (vertical && a.x === b.x && b.y === c.y && b.x !== c.x));
+    if (gridContact && backwards && elbow && a && c) {
+      points[1] = horizontal ? { x: a.x, y: c.y } : { x: c.x, y: a.y };
+      if (points.length > 3) {
+        points.splice(2, 1);
+        modes.splice(0, 2, strongerMode(modes[0]!, modes[1]!));
+      }
+      const normalized = normalizeRouteGeometry(points, modes);
+      points = normalized.points;
+      modes = normalized.segmentModes;
+    }
+    if (reverse) {
+      points.reverse();
+      modes.reverse();
+    }
+  }
+  return { points, segmentModes: modes };
+}

--- a/packages/edit-engine/src/route-terminal-approach.ts
+++ b/packages/edit-engine/src/route-terminal-approach.ts
@@ -21,12 +21,17 @@ export function tidyRouteTerminalApproaches(
   route: RouteBranch,
   input: readonly Point[],
   inputModes: readonly SegmentMode[],
+  originalDocument: SchematicDocument = document,
 ): { points: Point[]; segmentModes: SegmentMode[] } {
   let points = input.map((point) => ({ ...point }));
   let modes = [...inputModes];
   if (modes.some((mode) => mode === "locked" || mode === "trunk"))
     return { points, segmentModes: modes };
-  const original = resolveRouteGeometry(document, resolver, route)?.centerline;
+  const original = resolveRouteGeometry(
+    originalDocument,
+    resolver,
+    route,
+  )?.centerline;
   for (const [endpoint, reverse] of [
     [route.start, false],
     [routeEnd(route), true],
@@ -34,6 +39,11 @@ export function tidyRouteTerminalApproaches(
     if (endpoint.kind !== "terminal") continue;
     const connection = resolveEndpointConnection(document, resolver, endpoint);
     if (!connection?.outward) continue;
+    const originalOutward = resolveEndpointConnection(
+      originalDocument,
+      resolver,
+      endpoint,
+    )?.outward;
     const originalEnd = reverse ? original?.at(-1) : original?.[0];
     const originalNeighbor = reverse ? original?.at(-2) : original?.[1];
     // Explicit slanted-line repair is a different authoring intent: retain
@@ -43,6 +53,19 @@ export function tidyRouteTerminalApproaches(
       originalNeighbor &&
       originalEnd.x !== originalNeighbor.x &&
       originalEnd.y !== originalNeighbor.y
+    )
+      continue;
+    // Repair a reversal introduced by THIS drag, not an authored approach
+    // that already came from the opposite side. Tidying that existing path
+    // can erase the dragged crossbar and even push a different arm through
+    // the other device. Use pre-transform geometry, including its orientation.
+    if (
+      originalEnd &&
+      originalNeighbor &&
+      originalOutward &&
+      (originalNeighbor.x - originalEnd.x) * originalOutward.x +
+        (originalNeighbor.y - originalEnd.y) * originalOutward.y <
+        0
     )
       continue;
     if (reverse) {

--- a/packages/edit-engine/src/routing-geometry-projection.ts
+++ b/packages/edit-engine/src/routing-geometry-projection.ts
@@ -1,0 +1,33 @@
+import type { SchematicDocument } from "@icm/model";
+import type { SchematicEdit } from "./edit-schema.js";
+
+/** Project only authored geometry. No normalization, Net pruning or persistence. */
+export function projectRoutingEditGeometry(
+  document: SchematicDocument,
+  edits: readonly SchematicEdit[],
+): SchematicDocument {
+  const projected = structuredClone(document);
+  for (const edit of edits) {
+    if (edit.kind === "move_instance") {
+      const instance = projected.instances.find(
+        (i) => i.id === edit.instanceId,
+      );
+      if (instance?.placement)
+        instance.placement.position = { ...edit.position };
+    } else if (edit.kind === "move_junction") {
+      const junction = projected.junctions.find(
+        (j) => j.id === edit.junctionId,
+      );
+      if (junction) junction.position = { ...edit.position };
+    } else if (edit.kind === "set_route_path") {
+      projected.routes = projected.routes.map((r) =>
+        r.id === edit.route.id ? structuredClone(edit.route) : r,
+      );
+    } else if (edit.kind === "remove_route_geometry") {
+      projected.routes = projected.routes.filter((r) => r.id !== edit.routeId);
+    } else {
+      throw new Error(`Not a transform geometry edit: ${edit.kind}`);
+    }
+  }
+  return projected;
+}

--- a/packages/edit-engine/src/routing-planner.ts
+++ b/packages/edit-engine/src/routing-planner.ts
@@ -46,7 +46,8 @@ import type { SymbolResolver } from "@icm/symbols";
 
 import type { SchematicEdit } from "./transaction.js";
 import { endpointOwnerNetId } from "./transaction-routing.js";
-import { planDirectEndpointConnection } from "./direct-contact-planner.js";
+import { createContactPlanningDraft } from "./contact-planning-draft.js";
+import { projectRoutingEditGeometry } from "./routing-geometry-projection.js";
 import { routeHasExternalOwner } from "./direct-contact-route-normalization.js";
 import { rebuildRoutePath } from "./route-leg-mutation.js";
 
@@ -591,143 +592,154 @@ type EndpointLanding =
   | { kind: "span"; routeId: string; segmentIndex: number }
   | { kind: "contact"; targetEndpoint: RouteEndpoint };
 
-/** The endpoint of `candidate` that sits exactly at `point`, if either does. */
-function routeEndpointAt(
-  document: SchematicDocument,
-  candidate: RouteBranch,
-  point: Point,
-): RouteEndpoint | null {
-  for (const endpoint of routeEndpoints(candidate)) {
-    if (endpoint.kind !== "junction") continue;
-    const junction = document.junctions.find(
-      (record) => record.id === endpoint.junctionId,
-    );
-    if (!junction) continue;
-    if (junction.position.x === point.x && junction.position.y === point.y) {
-      return endpoint;
-    }
-  }
-  return null;
-}
-
-/** The visible pin whose exact contact point is `point`, if one is there. */
-function terminalEndpointAt(
+/**
+ * Collect all contacts at a deliberately moved endpoint, not the first object
+ * in document order. Endpoint identity wins over a split for THAT route; a
+ * different conductor passing through the same point is still a real target.
+ * Geometric crossings away from the moved endpoint are never considered.
+ */
+function endpointLandingsAt(
   document: SchematicDocument,
   resolver: SymbolResolver,
   point: Point,
-): RouteEndpoint | null {
+  movedEndpoint: RouteEndpoint,
+  travellingRouteIds: ReadonlySet<string>,
+): EndpointLanding[] {
+  const movedNetId = endpointOwnerNetId(document, movedEndpoint);
+  const contacts = new Map<string, EndpointLanding>();
+  const spans: EndpointLanding[] = [];
+  const consider = (endpoint: RouteEndpoint): boolean => {
+    const connection = resolveEndpointConnection(document, resolver, endpoint);
+    if (
+      !connection ||
+      connection.contactPoint.x !== point.x ||
+      connection.contactPoint.y !== point.y
+    )
+      return false;
+    if (
+      endpointKey(endpoint) !== endpointKey(movedEndpoint) &&
+      endpointOwnerNetId(document, endpoint) !== movedNetId
+    ) {
+      contacts.set(endpointKey(endpoint), {
+        kind: "contact",
+        targetEndpoint: endpoint,
+      });
+    }
+    return true;
+  };
   for (const instance of document.instances) {
     if (!instance.placement) continue;
     const resolved = resolver.resolve(
       instance.symbolId,
       instance.symbolVariantId,
     );
-    if (!resolved) continue;
-    for (const pin of resolved.definition.pins) {
+    for (const pin of resolved?.definition.pins ?? []) {
       const endpoint: RouteEndpoint = {
         kind: "terminal",
         instanceId: instance.id,
         pinName: pin.name,
       };
-      if (!isVisibleEndpoint(document, resolver, endpoint)) continue;
-      const connection = resolveEndpointConnection(
-        document,
-        resolver,
-        endpoint,
-      );
-      if (!connection) continue;
-      if (
-        connection.contactPoint.x === point.x &&
-        connection.contactPoint.y === point.y
-      ) {
-        return endpoint;
-      }
+      if (isVisibleEndpoint(document, resolver, endpoint)) consider(endpoint);
     }
   }
-  return null;
-}
-
-/**
- * What one moved end comes to rest on, once it is let go of at `point`.
- *
- * Only the moved END is considered. A wire whose middle crosses another wire
- * touches it at an interior point of both and connects nothing — a Crossing is
- * not a Junction, and that invariant is the reason this looks at the released
- * end rather than at the whole translated path.
- *
- * Conductors already on `movedNetId` are skipped because there is nothing to
- * merge, as are the ones travelling with the gesture: their coincidence is
- * geometry moving together, not an end being put somewhere.
- */
-function endpointLandingAt(
-  document: SchematicDocument,
-  resolver: SymbolResolver,
-  point: Point,
-  movedNetId: string | null,
-  travellingRouteIds: ReadonlySet<string>,
-): EndpointLanding | null {
-  const terminal = terminalEndpointAt(document, resolver, point);
-  if (terminal && endpointOwnerNetId(document, terminal) !== movedNetId) {
-    return { kind: "contact", targetEndpoint: terminal };
+  for (const junction of document.junctions) {
+    consider({ kind: "junction", junctionId: junction.id });
   }
   for (const candidate of document.routes) {
     if (travellingRouteIds.has(candidate.id)) continue;
-    if (candidate.netId === movedNetId) continue;
-    // An end resting on the other wire's end is checked first: such a point
-    // also satisfies "on the segment", and taking it as a span landing is
-    // exactly the splice that cannot be made.
-    const targetEndpoint = routeEndpointAt(document, candidate, point);
-    if (targetEndpoint) return { kind: "contact", targetEndpoint };
+    // Check BOTH endpoint kinds even when the terminal has no visible handle.
+    // An existing route end is never an interior point that can be split.
+    const atEndpoint = routeEndpoints(candidate).map(consider).some(Boolean);
+    if (atEndpoint || candidate.netId === movedNetId) continue;
     const geometry = resolveRouteGeometry(document, resolver, candidate);
     const segmentIndex = geometry?.segments.findIndex((segment) =>
       pointOnSegment(point, segment.from, segment.to),
     );
     if (segmentIndex === undefined || segmentIndex < 0) continue;
-    return { kind: "span", routeId: candidate.id, segmentIndex };
+    spans.push({ kind: "span", routeId: candidate.id, segmentIndex });
   }
-  return null;
+  return [
+    ...[...contacts.entries()]
+      .sort(([a], [b]) => a.localeCompare(b, "en"))
+      .map(([, value]) => value),
+    ...spans.sort((a, b) =>
+      a.kind === "span" && b.kind === "span"
+        ? a.routeId.localeCompare(b.routeId, "en")
+        : 0,
+    ),
+  ];
 }
 
 /**
- * Turn one landing into the edits that state it.
- *
- * The two shapes need different primitives and must not be collapsed into
- * one: a contact is an explicit zero-length bond between two real endpoints,
- * while a span landing makes the moved end the common node of two Route
- * halves. Both are primitives the routing gate reads for itself, so no
- * expected-effect declaration is written here and none is needed.
+ * One membership draft for ALL ends and ALL conductors in a drop. Geometry is
+ * already projected to the final position; only after every compatible Net
+ * has been folded do we compile far-to-near splits against the stable legs.
  */
-function landingEdits(
+function endpointLandingEdits(
   document: SchematicDocument,
-  movedEndpoint: RouteEndpoint,
-  movedNetId: string | null,
-  landing: EndpointLanding,
-  point: Point,
+  resolver: SymbolResolver,
+  endpoints: readonly RouteEndpoint[],
+  travellingRouteIds: ReadonlySet<string>,
   suffix: string,
 ): SchematicEdit[] {
-  if (landing.kind === "contact") {
-    const direct = planDirectEndpointConnection(document, {
-      from: movedEndpoint,
-      to: landing.targetEndpoint,
-      newNetId: `net-${suffix}`,
-    });
-    // Incompatible power domains are the one case this gesture cannot settle:
-    // joining a VDD conductor to a ground one is not something a drag should
-    // decide. The move still happens and the ends still touch, leaving the
-    // existing finding standing for the author to resolve deliberately.
-    return direct.ok ? [...direct.edits] : [];
-  }
-  return [
-    ...proposeEndpointRouteAttachment(
+  const draft = createContactPlanningDraft(document, resolver);
+  const spanRequests = new Map<string, EndpointRouteAttachmentRequest[]>();
+  for (const endpoint of endpoints) {
+    const point = resolveEndpointConnection(
       document,
-      movedEndpoint,
-      movedNetId,
-      landing.routeId,
+      resolver,
+      endpoint,
+    )?.contactPoint;
+    if (!point) continue;
+    for (const landing of endpointLandingsAt(
+      document,
+      resolver,
       point,
-      landing.segmentIndex,
-      suffix,
-    ).edits,
-  ];
+      endpoint,
+      travellingRouteIds,
+    )) {
+      const target =
+        landing.kind === "contact"
+          ? landing.targetEndpoint
+          : draft.document.routes.find((route) => route.id === landing.routeId)!
+              .start;
+      const connection = draft.connect(endpoint, target, `net-${suffix}`);
+      // Preserve the existing move-without-joining policy for incompatible
+      // power domains; never weaken the transaction's electrical validation.
+      if (!connection.ok) continue;
+      if (landing.kind !== "span") continue;
+      const requests = spanRequests.get(landing.routeId) ?? [];
+      const existing = requests.find(
+        (request) => request.point.x === point.x && request.point.y === point.y,
+      );
+      // Coincident moved endpoints have just been electrically joined by the
+      // draft. One geometric split suffices; duplicate splits would be zero length.
+      if (!existing)
+        requests.push({
+          endpoint,
+          endpointNetId: connection.netId,
+          point,
+          segmentIndex: landing.segmentIndex,
+        });
+      spanRequests.set(landing.routeId, requests);
+    }
+  }
+  const edits = [...draft.edits];
+  for (const [routeId, requests] of spanRequests) {
+    const netId = draft.document.routes.find(
+      (route) => route.id === routeId,
+    )!.netId;
+    edits.push(
+      ...proposeEndpointsRouteAttachment(
+        draft.document,
+        resolver,
+        routeId,
+        requests.map((request) => ({ ...request, endpointNetId: netId })),
+        suffix,
+      ).edits,
+    );
+  }
+  return edits;
 }
 
 /**
@@ -785,61 +797,16 @@ export function proposeLooseRouteTranslation(
   ];
   if (!landing) return { routeId, edits };
 
-  // Both anchors may land, and two landings on one target Route have to be
-  // spliced together so the second addresses the leg identity the first left
-  // behind. Contacts carry no such ordering and are emitted as they are found.
-  const spanRequests = new Map<string, EndpointRouteAttachmentRequest[]>();
-  for (const junctionId of anchors) {
-    const junction = document.junctions.find(
-      (candidate) => candidate.id === junctionId,
-    );
-    if (!junction) continue;
-    const movedEndpoint: RouteEndpoint = { kind: "junction", junctionId };
-    const point = {
-      x: junction.position.x + delta.x,
-      y: junction.position.y + delta.y,
-    };
-    const landed = endpointLandingAt(
-      document,
+  const projected = projectRoutingEditGeometry(document, edits);
+  edits.push(
+    ...endpointLandingEdits(
+      projected,
       landing.resolver,
-      point,
-      route.netId,
+      anchors.map((junctionId) => ({ kind: "junction", junctionId })),
       new Set([route.id]),
-    );
-    if (!landed) continue;
-    if (landed.kind === "contact") {
-      edits.push(
-        ...landingEdits(
-          document,
-          movedEndpoint,
-          route.netId,
-          landed,
-          point,
-          landing.suffix,
-        ),
-      );
-      continue;
-    }
-    const requests = spanRequests.get(landed.routeId) ?? [];
-    requests.push({
-      endpoint: movedEndpoint,
-      endpointNetId: route.netId,
-      point,
-      segmentIndex: landed.segmentIndex,
-    });
-    spanRequests.set(landed.routeId, requests);
-  }
-  for (const [targetRouteId, requests] of spanRequests) {
-    edits.push(
-      ...proposeEndpointsRouteAttachment(
-        document,
-        landing.resolver,
-        targetRouteId,
-        requests,
-        landing.suffix,
-      ).edits,
-    );
-  }
+      landing.suffix,
+    ),
+  );
   return { routeId, edits };
 }
 
@@ -1025,23 +992,18 @@ export function proposeRouteEndpointMove(
     // Route against its persisted endpoint would put the end back on the pin.
     ...routeEdits(base, proposal.routes),
   ];
-  const landing = suffix
-    ? endpointLandingAt(
-        base,
-        resolver,
-        point,
-        route.netId,
-        new Set(proposal.routes.map((moved) => moved.routeId)),
-      )
-    : null;
-  if (landing && suffix) {
+  if (suffix) {
+    // Detachment is already represented in base; project only the stretch.
+    const projected = projectRoutingEditGeometry(
+      base,
+      edits.slice(detachEdits.length),
+    );
     edits.push(
-      ...landingEdits(
-        base,
-        { kind: "junction", junctionId },
-        route.netId,
-        landing,
-        point,
+      ...endpointLandingEdits(
+        projected,
+        resolver,
+        [{ kind: "junction", junctionId }],
+        new Set(proposal.routes.map((moved) => moved.routeId)),
         suffix,
       ),
     );


### PR DESCRIPTION
## Summary
- Resolve endpoint contacts before interior splits, and fold all contacts through one current Net membership draft to avoid stale Net IDs.
- Repair newly introduced terminal foldbacks through shared routing operations, preserving authored detours, locked segments and arbitrary-angle intent.
- Preview all affected routes and junctions using the same snapped geometry as commit.
- Add contact, rotated/mirrored Port, resistor detour and preview parity regressions. Separate Windows-only selection assertion portability correction is documented in its own commit.

## Validation
- 3191 unit tests passed, 28 skipped; 82 selected browser regressions passed.
- TypeScript, build, performance, visual/export goldens, production preview and packaged release/MCP smoke passed.
- Initial full browser run: 398/402; all four failures repaired and replayed successfully. A fresh complete delivery gate is running for merge.
- No schema, symbol assets or electrical validation guards relaxed.

Test-Impact: tests-updated