### PR TITLE
refactor(simulation): focus file tree and unify action icons

### DIFF
--- a/apps/editor/e2e/simulation-batch.spec.ts
+++ b/apps/editor/e2e/simulation-batch.spec.ts
@@ -263,12 +263,13 @@ test("a saved Run Plan prepares without executing and Run starts its ordinary ba
     JSON.stringify(config, null, 2),
   );
   await panel.getByRole("button", { name: "More code actions" }).click();
-  await page.getByRole("menuitem", { name: "View final deck" }).click();
+  await page.getByRole("menuitem", { name: "Preview input netlist…" }).click();
   await panel.getByTitle("Batch queue", { exact: true }).click();
   await expect(panel.locator(".simulation-batch-menu-popover")).toContainText(
     "Batch · prepared",
   );
-  await expect(panel.getByLabel("Prepare temporary files")).toBeVisible();
+  await expect(panel.getByLabel("Prepare temporary files")).toHaveCount(0);
+  await expect(panel.getByRole("tab", { name: /prepared\.cir/ })).toBeVisible();
   expect(executions).toBe(0);
   await panel.getByRole("button", { name: "Run", exact: true }).click();
   await expect(panel.locator(".simulation-batch-menu-popover")).toContainText(

--- a/apps/editor/e2e/simulation-setup.spec.ts
+++ b/apps/editor/e2e/simulation-setup.spec.ts
@@ -4,6 +4,7 @@ import {
 } from "@icm/model";
 import { test, expect } from "@playwright/test";
 import { parseProject } from "@icm/project-protocol";
+import { unzipSync } from "fflate";
 
 import {
   clickNetlistWorkflowCommand,
@@ -193,16 +194,8 @@ test("the qualified OTA folder opens unchanged and preserves all root and hierar
     JSON.stringify(config, null, 2),
   );
   await panel.getByRole("button", { name: "More code actions" }).click();
-  await page.getByRole("menuitem", { name: "View final deck" }).click();
-  const prepareFiles = panel.getByLabel("Prepare temporary files");
-  await expect(prepareFiles).toBeVisible();
-  await prepareFiles
-    .getByRole("button", { name: "Toggle Prepare", exact: true })
-    .click();
-  await prepareFiles
-    .getByRole("button", { name: "Toggle Netlist", exact: true })
-    .click();
-  await panel.getByRole("treeitem", { name: /prepared\.cir/ }).click();
+  await page.getByRole("menuitem", { name: "Preview input netlist…" }).click();
+  await expect(panel.getByLabel("Prepare temporary files")).toHaveCount(0);
   const preview = panel.getByRole("region", { name: "File preview" });
   const download = page.waitForEvent("download");
   await preview.getByRole("button", { name: "Download", exact: true }).click();
@@ -224,6 +217,24 @@ test("the qualified OTA folder opens unchanged and preserves all root and hierar
   expect(deck).toContain('.lib "icm-models.lib" tt');
   expect(deck).toContain("tran 2e-8 0.000004");
   expect(executions).toBe(0);
+  await panel.getByRole("button", { name: "More code actions" }).click();
+  await expect(
+    page.getByRole("menuitem", { name: "View executed netlist…" }),
+  ).toBeDisabled();
+  const diagnosticDownload = page.waitForEvent("download");
+  await page
+    .getByRole("menuitem", { name: "Export diagnostic bundle…" })
+    .click();
+  const diagnosticStream = await (await diagnosticDownload).createReadStream();
+  const diagnosticChunks: Buffer[] = [];
+  for await (const chunk of diagnosticStream!)
+    diagnosticChunks.push(Buffer.from(chunk));
+  const diagnosticPaths = Object.keys(
+    unzipSync(Buffer.concat(diagnosticChunks)),
+  );
+  expect(diagnosticPaths).toContain("netlist/prepared.cir");
+  expect(diagnosticPaths).toContain("evidence/source-map.json");
+  expect(diagnosticPaths).not.toContain("netlist/executed.cir");
   const saved = await downloadBytes(page, "File", "Export Project File…");
   const reloaded = parseProject(saved.toString());
   expect(

--- a/apps/editor/e2e/simulation-workspace.spec.ts
+++ b/apps/editor/e2e/simulation-workspace.spec.ts
@@ -992,50 +992,82 @@ test("human simulation uses saved folder, survives minimizing, recovers a bad in
   await waveformDialog.getByRole("button", { name: "Close plot" }).click();
   await panel.getByRole("button", { name: "Restore results" }).click();
   const runFiles = panel.getByLabel("Run temporary files");
+  await expect(panel.getByLabel("Prepare temporary files")).toHaveCount(0);
   await runFiles
     .getByRole("button", { name: "Toggle Run", exact: true })
     .click();
   await runFiles
     .getByRole("button", { name: "Toggle Results", exact: true })
     .click();
-  await runFiles
-    .getByRole("button", { name: "Toggle Evidence", exact: true })
-    .click();
   await expect(
-    panel.getByRole("treeitem", {
-      name: /evidence-manifest\.json/,
-    }),
+    runFiles.getByRole("treeitem", { name: "Logs", exact: true }),
   ).toBeVisible();
-  const download = page.waitForEvent("download");
-  await runFiles
+  await expect(
+    runFiles.getByRole("treeitem", {
+      name: /Evidence|Netlist|Other|[.]json|[.]cir/,
+    }),
+  ).toHaveCount(0);
+  const csvFile = runFiles
     .locator('button[data-tree-row="artifact"]')
-    .filter({ hasText: /\.csv/ })
-    .first()
-    .click();
+    .filter({ hasText: /[.]csv/ })
+    .first();
+  const download = page.waitForEvent("download");
+  await csvFile.click();
   await panel
     .getByLabel("File preview")
     .getByRole("button", { name: "Download", exact: true })
     .click();
-  expect((await download).suggestedFilename()).toMatch(/\.csv$/);
-  await expect(runFiles).toBeVisible();
+  expect((await download).suggestedFilename()).toMatch(/[.]csv$/);
+  const rawFile = runFiles.getByRole("treeitem", {
+    name: "out.raw",
+    exact: true,
+  });
+  await rawFile.click({ modifiers: ["Control"] });
+  await rawFile.click({ button: "right" });
+  const menuZip = async (name: string) => {
+    const pending = page.waitForEvent("download");
+    await page.getByRole("menuitem", { name, exact: true }).click();
+    const stream = await (await pending).createReadStream();
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream!) chunks.push(Buffer.from(chunk));
+    return unzipSync(Buffer.concat(chunks));
+  };
+  const selectedEntries = await menuZip("Download selected (2)…");
+  expect(Object.keys(selectedEntries)).toHaveLength(2);
   await runFiles
-    .getByRole("treeitem", { name: /evidence-manifest\.json/ })
-    .click({ modifiers: ["Control"] });
-  await runFiles
-    .getByRole("treeitem", { name: /evidence-manifest\.json/ })
+    .getByRole("treeitem", { name: "Run", exact: true })
     .click({ button: "right" });
-  const bundleDownload = page.waitForEvent("download");
-  await page.getByRole("menuitem", { name: "Download selected (2)…" }).click();
-  expect((await bundleDownload).suggestedFilename()).toMatch(
-    /-selected-files\.zip$/,
-  );
+  const visibleEntries = await menuZip("Download…");
+  expect(
+    Object.keys(visibleEntries).some((path) => path.startsWith("run/logs/")),
+  ).toBe(true);
+  expect(
+    Object.keys(visibleEntries).every((path) =>
+      /[.](raw|csv|log|txt)$/.test(path),
+    ),
+  ).toBe(true);
+  await runFiles
+    .getByRole("treeitem", { name: "Run", exact: true })
+    .click({ button: "right" });
+  const diagnostics = await menuZip("Export diagnostic bundle…");
+  for (const path of [
+    "netlist/prepared.cir",
+    "netlist/executed.cir",
+    "evidence/source-map.json",
+    "evidence/prepared.json",
+    "evidence/result.json",
+    "evidence/evidence-manifest.json",
+  ])
+    expect(diagnostics[path]).toBeDefined();
   await panel.getByRole("button", { name: "More code actions" }).click();
-  await page.getByRole("menuitem", { name: "View final deck" }).click();
-  await expect(panel.getByLabel("Prepare temporary files")).toBeVisible();
-  await expect(panel.getByLabel("Run temporary files")).toBeVisible();
-  await expect(panel.getByText("Input identity", { exact: true })).toHaveCount(
-    0,
-  );
+  await page.getByRole("menuitem", { name: "View executed netlist…" }).click();
+  await expect(
+    panel.getByRole("tab", { name: /executed[.]cir/ }),
+  ).toBeVisible();
+  const executedBeforeEdit = await panel
+    .getByLabel("File preview")
+    .locator("pre")
+    .innerText();
   expect(executions).toBe(1);
   config.outputs[0]!.label = "new-output";
   await editSimulationFile(
@@ -1052,6 +1084,23 @@ test("human simulation uses saved folder, survives minimizing, recovers a bad in
   await expect(panel.locator(".simulation-code-status")).toContainText(
     "earlier Project revision",
   );
+  await panel.getByRole("button", { name: "More code actions" }).click();
+  await page.getByRole("menuitem", { name: "Preview input netlist…" }).click();
+  await expect(panel.getByLabel("File preview").locator("pre")).toContainText(
+    ".temp 30",
+  );
+  await panel.getByRole("button", { name: "More code actions" }).click();
+  await page.getByRole("menuitem", { name: "View executed netlist…" }).click();
+  await expect(panel.getByLabel("File preview").locator("pre")).toHaveText(
+    executedBeforeEdit,
+  );
+  await runFiles
+    .getByRole("treeitem", { name: "Run", exact: true })
+    .click({ button: "right" });
+  const oldRunDiagnostics = await menuZip("Export diagnostic bundle…");
+  expect(
+    Buffer.from(oldRunDiagnostics["netlist/prepared.cir"]!).toString(),
+  ).toBe(Buffer.from(diagnostics["netlist/prepared.cir"]!).toString());
   await panel.getByRole("tab", { name: "Plot", exact: true }).click();
   await panel.getByRole("button", { name: "Maximize results" }).click();
   await panel.getByRole("tab", { name: "Plot" }).click();
@@ -1340,6 +1389,26 @@ test("Simulation creates an ordinary testbench and defaults a new experiment to 
     expect(box!.height).toBeLessThanOrEqual(24);
   }
   expect((await taskbar.boundingBox())!.height).toBeLessThanOrEqual(32);
+  const saveButton = taskbar.getByRole("button", {
+    name: "Save project",
+    exact: true,
+  });
+  const runButton = taskbar.getByRole("button", { name: "Run", exact: true });
+  expect((await saveButton.boundingBox())!.width).toBe(runBox!.width);
+  expect(runBox!.width).toBe(22);
+  await expect(saveButton).toHaveText("");
+  await expect(runButton).toHaveText("");
+  await expect(saveButton).toHaveAttribute("title", /Save project.*Ctrl\+S/);
+  await expect(saveButton).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
+  await expect(runButton).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
+  await taskbar.getByRole("button", { name: "More code actions" }).click();
+  await expect(
+    page.getByRole("menuitem", { name: "View executed netlist…" }),
+  ).toBeDisabled();
+  await expect(
+    page.getByRole("menuitem", { name: "Export diagnostic bundle…" }),
+  ).toBeDisabled();
+  await page.keyboard.press("Escape");
   await page
     .getByRole("treeitem", { name: "run.cir", exact: true })
     .first()

--- a/apps/editor/src/features/simulation/code-workspace.css
+++ b/apps/editor/src/features/simulation/code-workspace.css
@@ -94,9 +94,6 @@
   padding: 0 5px;
   font-size: 11px;
 }
-.simulation-code-workspace .simulation-run-button {
-  width: 20px;
-}
 .simulation-code-toolbar .simulation-window-actions,
 .simulation-code-toolbar .simulation-code-more {
   flex: none;
@@ -520,35 +517,59 @@
 .simulation-code-status:empty {
   display: none;
 }
-.simulation-code-actions [data-workspace-save] {
-  min-width: 68px;
+.simulation-code-workspace .simulation-code-toolbar .simulation-action-button {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 22px;
+  width: 22px;
+  min-width: 22px;
+  height: 22px;
+  padding: 0;
+  border: 0;
   border-radius: 3px;
-  transition:
-    background 120ms ease,
-    color 120ms ease,
-    box-shadow 120ms ease;
+  background: transparent;
+  color: var(--icm-text-muted);
 }
-.simulation-code-actions [data-workspace-save][data-save-state="dirty"] {
-  background: var(--icm-accent);
-  color: white;
-  box-shadow: 0 1px 2px #0002;
-}
-.simulation-code-actions [data-workspace-save][data-save-state="saving"] {
-  opacity: 1;
-  background: color-mix(in srgb, var(--icm-accent) 16%, var(--icm-surface));
+.simulation-code-workspace
+  .simulation-code-toolbar
+  .simulation-action-button:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--icm-text) 8%, transparent);
   color: var(--icm-text);
 }
-.simulation-code-actions [data-workspace-save][data-save-state="saved"],
-.simulation-code-actions
-  [data-workspace-save][data-save-state="saved"]:disabled {
+.simulation-code-workspace
+  .simulation-action-button[data-save-state="dirty"]::after {
+  content: "";
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: currentColor;
+}
+.simulation-code-workspace
+  .simulation-code-toolbar
+  .simulation-action-button[data-save-state="saved"] {
   opacity: 1;
   color: #26734d;
-  background: color-mix(in srgb, #38a169 12%, var(--icm-surface));
 }
-.simulation-code-actions [data-workspace-save][data-save-state="failed"] {
-  opacity: 1;
+.simulation-code-workspace .simulation-action-button[data-save-state="failed"] {
   color: #b42318;
-  background: color-mix(in srgb, #b42318 10%, var(--icm-surface));
+}
+.simulation-action-button[aria-busy="true"] svg {
+  animation: simulation-action-spin 1s linear infinite;
+}
+@keyframes simulation-action-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .simulation-action-button[aria-busy="true"] svg {
+    animation: none;
+  }
 }
 .simulation-code-workspace.is-maximized .simulation-code-source-area,
 .simulation-code-workspace.is-maximized .simulation-code-output-resizer {

--- a/apps/editor/src/features/simulation/code-workspace.test.tsx
+++ b/apps/editor/src/features/simulation/code-workspace.test.tsx
@@ -81,7 +81,7 @@ describe("approved simulation Code layout", () => {
     expect(markup).not.toContain(">Results</button>");
     expect(markup).toContain('aria-label="Close run.cir"');
   });
-  it("defaults Source open and temporary Prepare/Run files closed in Explorer", () => {
+  it("defaults Source open and Run outputs closed without exposing preparation", () => {
     const artifact = {
       id: "artifact-1",
       name: "prepared.cir",
@@ -99,9 +99,9 @@ describe("approved simulation Code layout", () => {
           files={[{ path: "run.cir", kind: "authored" }]}
           artifactGroups={[
             {
-              key: "prepare",
-              label: "Prepare",
-              description: "Compiled input",
+              key: "run",
+              label: "Run",
+              description: "Execution output",
               artifacts: [artifact],
             },
           ]}
@@ -124,7 +124,8 @@ describe("approved simulation Code layout", () => {
     );
     expect(markup).toContain('aria-label="Source"');
     expect(markup).toContain('aria-expanded="true"');
-    expect(markup).toContain('aria-label="Prepare"');
+    expect(markup).not.toContain('aria-label="Prepare"');
+    expect(markup).toContain('aria-label="Run"');
     expect(markup).toContain('aria-expanded="false"');
     expect(markup).toContain(">tmp</small>");
     expect(markup).not.toContain("prepared.cir");

--- a/apps/editor/src/features/simulation/code-workspace.tsx
+++ b/apps/editor/src/features/simulation/code-workspace.tsx
@@ -28,14 +28,14 @@ export interface SimulationCodeFile {
   draft?: boolean;
 }
 export interface SimulationExplorerArtifactGroup {
-  key: "prepare" | "run";
+  key: "run";
   label: string;
   description: string;
   artifacts: readonly ArtifactRef[];
 }
 export type SimulationExplorerSelection =
   | { kind: "source"; folderId: string; path: string }
-  | { kind: "artifact"; groupKey: "prepare" | "run"; artifact: ArtifactRef };
+  | { kind: "artifact"; groupKey: "run"; artifact: ArtifactRef };
 export interface SimulationCodeWorkspaceProps {
   workspaceKey: string;
   files: readonly SimulationCodeFile[];

--- a/apps/editor/src/features/simulation/simulation-action-icon.tsx
+++ b/apps/editor/src/features/simulation/simulation-action-icon.tsx
@@ -1,0 +1,41 @@
+/** Small monochrome controls matching the source toolbar's file icons. */
+export function SimulationActionIcon({
+  kind,
+}: {
+  kind: "save" | "run" | "stop" | "saving" | "saved" | "failed";
+}) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      focusable="false"
+    >
+      {kind === "save" ? (
+        <>
+          <path d="M4 3h10l3 3v11H3V3h1Z" />
+          <path d="M6 3v5h7V3M6 17v-6h8v6" />
+        </>
+      ) : kind === "run" ? (
+        <path d="m6 3 10 7-10 7V3Z" />
+      ) : kind === "stop" ? (
+        <rect x="5" y="5" width="10" height="10" rx="1" />
+      ) : kind === "saved" ? (
+        <path d="m4 10 4 4 8-8" />
+      ) : kind === "saving" ? (
+        <path d="M16 10a6 6 0 1 1-6-6" />
+      ) : (
+        <>
+          <circle cx="10" cy="10" r="7" />
+          <path d="M10 6v5m0 3h.01" />
+        </>
+      )}
+    </svg>
+  );
+}

--- a/apps/editor/src/features/simulation/simulation-artifact-files.test.ts
+++ b/apps/editor/src/features/simulation/simulation-artifact-files.test.ts
@@ -8,9 +8,39 @@ import {
   formatSimulationArtifactPreview,
   readSimulationArtifactPreview,
   simulationArtifactCategory,
+  simulationExplorerArtifactCategory,
 } from "./simulation-artifact-files";
 
 describe("simulation artifact files", () => {
+  it("keeps diagnostic bytes exportable without classifying them as Explorer outputs", async () => {
+    const files = new SimulationFiles();
+    const entries = await Promise.all(
+      [
+        ["out.raw", "Results"],
+        ["outputs-ac-0.csv", "Results"],
+        ["simulator.log", "Logs"],
+        ["prepared.cir", null],
+        ["executed.cir", null],
+        ["prepared.json", null],
+        ["source-map.json", null],
+        ["evidence-manifest.json", null],
+        ["result.json", null],
+        ["outputs.json", null],
+        ["circuit.spice", null],
+      ].map(async ([name, category]) => {
+        const artifact = await files.put(name!, "text/plain", name!);
+        expect(simulationExplorerArtifactCategory(artifact)).toBe(category);
+        return artifact;
+      }),
+    );
+    const archive = await buildSimulationArtifactArchive(files, entries);
+    expect(archive.ok).toBe(true);
+    if (!archive.ok) return;
+    const contents = Object.values(unzipSync(archive.bytes)).map((bytes) =>
+      strFromU8(bytes),
+    );
+    expect(contents.sort()).toEqual(entries.map((entry) => entry.name).sort());
+  });
   it("previews bounded text and formats complete JSON", async () => {
     const files = new SimulationFiles();
     const json = await files.put(

--- a/apps/editor/src/features/simulation/simulation-artifact-files.ts
+++ b/apps/editor/src/features/simulation/simulation-artifact-files.ts
@@ -185,6 +185,18 @@ export function simulationArtifactCategory(artifact: ArtifactRef): string {
   return "Other";
 }
 
+/** Explorer shows usable outputs, while diagnostic exports retain every artifact. */
+export function simulationExplorerArtifactCategory(
+  artifact: ArtifactRef,
+): "Results" | "Logs" | null {
+  const category = simulationArtifactCategory(artifact);
+  return category === "Results"
+    ? "Results"
+    : category === "Log"
+      ? "Logs"
+      : null;
+}
+
 export function formatSimulationArtifactPreview(
   content: SimulationArtifactContent,
 ): string {

--- a/apps/editor/src/features/simulation/simulation-file-tree.tsx
+++ b/apps/editor/src/features/simulation/simulation-file-tree.tsx
@@ -10,7 +10,7 @@ import type {
   SimulationExplorerSelection,
   SimulationCodeFile,
 } from "./code-workspace";
-import { simulationArtifactCategory } from "./simulation-artifact-files";
+import { simulationExplorerArtifactCategory } from "./simulation-artifact-files";
 import {
   useWorkspaceInteractions,
   WorkspaceNameInput,
@@ -131,7 +131,8 @@ export function SimulationFileTree(props: SimulationCodeWorkspaceProps) {
           tmp: true,
         };
         for (const artifact of group.artifacts) {
-          const category = simulationArtifactCategory(artifact);
+          const category = simulationExplorerArtifactCategory(artifact);
+          if (!category) continue;
           let categoryNode = directory.children!.find(
             (node) => node.name === category,
           );
@@ -260,6 +261,12 @@ export function SimulationFileTree(props: SimulationCodeWorkspaceProps) {
             targets.some((target) => Boolean(target.children)),
           ),
       });
+    if (
+      targets.length === 1 &&
+      node?.folderId === activeId &&
+      (node.kind === "folder" || node.id === activeId + "/run")
+    )
+      items.push(...(props.additionalActions ?? []));
     if (targets.length === 1 && node?.file) {
       items.push(
         { label: "Open", run: () => openFile(node) },

--- a/apps/editor/src/features/simulation/source-code-pane.tsx
+++ b/apps/editor/src/features/simulation/source-code-pane.tsx
@@ -45,9 +45,11 @@ import {
 import {
   buildSimulationWorkspaceArchive,
   simulationArtifactCategory,
+  simulationExplorerArtifactCategory,
 } from "./simulation-artifact-files";
 import { sourceProbeChoices } from "./source-probe-choices";
 import { SourceProbePicker } from "./source-probe-picker";
+import { SimulationActionIcon } from "./simulation-action-icon";
 
 export type SourceFlush =
   | { ok: true; folder: ProjectSimulationFolder; revision: number }
@@ -76,7 +78,7 @@ interface Props extends Pick<
   actions: ReactNode;
   toolbarEnd?: ReactNode;
   folders?: SimulationCodeWorkspaceProps["folders"];
-  onPrepare?(): void;
+  additionalActions?: SimulationCodeWorkspaceProps["additionalActions"];
   console: ReactNode;
   results: ReactNode;
   outputActions?: ReactNode;
@@ -803,7 +805,7 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
           if (item.kind === "artifact")
             return {
               kind: "artifact" as const,
-              path: `${item.groupKey}/${simulationArtifactCategory(item.artifact).toLowerCase()}/${item.artifact.name}`,
+              path: `${item.groupKey}/${(simulationExplorerArtifactCategory(item.artifact) ?? simulationArtifactCategory(item.artifact)).toLowerCase()}/${item.artifact.name}`,
               artifact: item.artifact,
             };
           const folder = props.project.simulationFolders.find(
@@ -829,6 +831,23 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
       anchor.click();
       setTimeout(() => URL.revokeObjectURL(url), 0);
     };
+    const saveState =
+      saveRequested || saving || props.projectSaveState === "saving"
+        ? "saving"
+        : props.projectSaveState === "failed" ||
+            props.projectSaveState === "offline"
+          ? "failed"
+          : props.projectSaveState === "clean" && !dirty
+            ? "saved"
+            : "dirty";
+    const saveFeedback =
+      saveState === "saving"
+        ? "Saving project…"
+        : saveState === "saved"
+          ? "Project saved"
+          : saveState === "failed"
+            ? "Save failed; drafts remain local. Retry save."
+            : "Save project";
     return (
       <SimulationCodeWorkspace
         workspaceKey={props.folder.id}
@@ -876,9 +895,7 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
               }
             : undefined
         }
-        additionalActions={[
-          { label: "View final deck", run: () => props.onPrepare?.() },
-        ]}
+        additionalActions={props.additionalActions ?? []}
         {...(props.artifactGroups
           ? { artifactGroups: props.artifactGroups }
           : {})}
@@ -1085,43 +1102,19 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
         actions={
           <>
             <button
+              className="simulation-action-button"
               data-workspace-save="true"
-              data-save-state={
-                saveRequested || saving || props.projectSaveState === "saving"
-                  ? "saving"
-                  : props.projectSaveState === "failed" ||
-                      props.projectSaveState === "offline"
-                    ? "failed"
-                    : props.projectSaveState === "clean" && !dirty
-                      ? "saved"
-                      : "dirty"
-              }
+              data-save-state={saveState}
               aria-label="Save project"
-              title={
-                props.projectSaveState === "failed" ||
-                props.projectSaveState === "offline"
-                  ? "Save failed; drafts remain local. Retry save."
-                  : "Save Project · Ctrl+S"
-              }
-              disabled={
-                saveRequested ||
-                saving ||
-                props.projectSaveState === "saving" ||
-                (props.projectSaveState === "clean" && !dirty)
-              }
-              aria-busy={
-                saveRequested || saving || props.projectSaveState === "saving"
-              }
+              aria-description={saveFeedback}
+              title={`${saveFeedback} · Ctrl+S`}
+              disabled={saveState === "saving" || saveState === "saved"}
+              aria-busy={saveState === "saving"}
               onClick={() => void requestSave()}
             >
-              {saveRequested || saving || props.projectSaveState === "saving"
-                ? "Saving…"
-                : props.projectSaveState === "clean" && !dirty
-                  ? "✓ Saved"
-                  : props.projectSaveState === "failed" ||
-                      props.projectSaveState === "offline"
-                    ? "Retry save"
-                    : "Save"}
+              <SimulationActionIcon
+                kind={saveState === "dirty" ? "save" : saveState}
+              />
             </button>
             {props.actions}
           </>

--- a/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
@@ -48,11 +48,19 @@ function render(
 }
 describe("source workspace default cutover", () => {
   it("projects the Project save lifecycle instead of claiming a buffer flush saved to cloud", () => {
-    expect(render(true, false, "saving")).toContain("Saving…");
+    expect(render(true, false, "saving")).toContain(
+      'aria-description="Saving project…"',
+    );
     expect(render(true, false, "saving")).toContain('aria-busy="true"');
-    expect(render(true, false, "clean")).toContain(">✓ Saved</button>");
+    expect(render(true, false, "clean")).toContain(
+      'aria-description="Project saved"',
+    );
     expect(render(true, false, "clean")).toContain('data-save-state="saved"');
     expect(render(true, false, "failed")).toContain("Retry save");
+    expect(render(true, false, "clean")).not.toContain(">✓ Saved</button>");
+    expect(render(true, false, "saving")).toContain(
+      'class="simulation-action-button"',
+    );
   });
   it("offers creation without restoring the retired Settings form", () => {
     const markup = render(false);

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -38,6 +38,7 @@ import {
 } from "./source-presentation";
 import { SimulationProblemView } from "./simulation-problem-view";
 import { SimulationRunDetails } from "./simulation-run-details";
+import { SimulationActionIcon } from "./simulation-action-icon";
 import { AcResultsExplorer } from "./ac-results-explorer";
 import { DcResultsExplorer } from "./dc-results-explorer";
 import { TransientResultsExplorer } from "./transient-results-explorer";
@@ -411,13 +412,18 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
       clearTimeout(timer);
     };
   }, [batch?.id, batch?.state, session, project]);
-  const execute = async (start: boolean) => {
+  const execute = async (start: boolean, inspect = false) => {
     if (lock.current) return;
     const authored = await codeRef.current?.flush();
     if (!authored?.ok) return;
     const selectedConfig = readSimulationExperimentConfig(authored.folder);
     if (selectedConfig.ok && selectedConfig.config.runPlan.mode === "sweep") {
-      await executeSweep(selectedConfig.config.runPlan.axes, start, authored);
+      await executeSweep(
+        selectedConfig.config.runPlan.axes,
+        start,
+        authored,
+        inspect,
+      );
       return;
     }
     lock.current = true;
@@ -440,6 +446,18 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
         });
       }
       receive(reply);
+      if (
+        inspect &&
+        reply.ok &&
+        "prepared" in reply &&
+        alive.current &&
+        activeFolderId.current === authored.folder.id
+      ) {
+        const deck = reply.prepared.artifacts.find(
+          (artifact) => artifact.name === "prepared.cir",
+        );
+        if (deck) await preview(deck);
+      }
       if (start && reply.ok && "prepared" in reply && alive.current)
         receive(
           await session.handle({
@@ -516,6 +534,7 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
     axes: readonly SimulationRunPlanAxis[],
     start: boolean,
     authored: Extract<SourceFlush, { ok: true }>,
+    inspect = false,
   ) => {
     if (lock.current || !selectedFolder) return;
     lock.current = true;
@@ -548,7 +567,19 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
         );
       else {
         const first = preparedReply.batch.items[0];
-        if (first) await showBatchItem(first);
+        if (first) {
+          await showBatchItem(first);
+          if (
+            inspect &&
+            alive.current &&
+            activeFolderId.current === authored.folder.id
+          ) {
+            const deck = first.prepared.artifacts.find(
+              (artifact) => artifact.name === "prepared.cir",
+            );
+            if (deck) await preview(deck);
+          }
+        }
       }
     } finally {
       lock.current = false;
@@ -619,7 +650,7 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
     setArtifactPreview(result.content);
   };
   const downloadBundle = async (
-    key: "prepare" | "run",
+    key: "diagnostics" | "run",
     artifacts: readonly ArtifactRef[],
   ) => {
     setArtifactBusy(`bundle:${key}`);
@@ -897,12 +928,6 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
   );
   const artifactGroups = [
     {
-      key: "prepare" as const,
-      label: "Prepare",
-      description: "Compiled input",
-      artifacts: prepared?.artifacts ?? [],
-    },
-    {
       key: "run" as const,
       label: "Run",
       description: "Execution output",
@@ -910,6 +935,30 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
         run?.artifacts.filter(
           (artifact) => !runPreparedArtifactIds.has(artifact.id),
         ) ?? [],
+    },
+  ];
+  // A run's diagnostics must stay tied to that run, never a newer prepared input.
+  const diagnosticArtifacts = run?.artifacts ?? prepared?.artifacts ?? [];
+  const executedDeck = run?.artifacts.find(
+    (artifact) => artifact.name === "executed.cir",
+  );
+  const diagnosticActions = [
+    {
+      label: "Preview input netlist…",
+      disabled: busy || running,
+      run: () => void execute(false, true),
+    },
+    {
+      label: "View executed netlist…",
+      disabled: !executedDeck || artifactBusy !== undefined,
+      run: () => {
+        if (executedDeck) void preview(executedDeck);
+      },
+    },
+    {
+      label: "Export diagnostic bundle…",
+      disabled: diagnosticArtifacts.length === 0 || artifactBusy !== undefined,
+      run: () => void downloadBundle("diagnostics", diagnosticArtifacts),
     },
   ];
   const resultCsvArtifacts = run
@@ -1534,7 +1583,9 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
     <div className="simulation-task-actions">
       {running ? (
         <button
-          className="simulation-stop-button"
+          className="simulation-stop-button simulation-action-button"
+          aria-label={batchRunning ? "Cancel batch" : "Cancel run"}
+          title={batchRunning ? "Cancel batch" : "Cancel run"}
           disabled={
             batch?.state === "cancelling" || run?.state === "cancelling"
           }
@@ -1549,17 +1600,18 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
                 .then(receive);
           }}
         >
-          {batchRunning ? "Cancel batch" : "Cancel run"}
+          <SimulationActionIcon kind="stop" />
         </button>
       ) : selectedFolder ? (
         <button
-          className="simulation-primary-button simulation-run-button"
+          className="simulation-action-button simulation-run-button"
+          aria-busy={busy}
           disabled={busy}
           onClick={() => void execute(true)}
           aria-label="Run"
           title={`Run ${selectedFolder.name}`}
         >
-          ▶
+          <SimulationActionIcon kind={busy ? "saving" : "run"} />
         </button>
       ) : (
         <button
@@ -1740,7 +1792,7 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
           maximized={resultsMaximized}
           onToggleMaximize={toggleResultsMaximized}
           onRun={() => void execute(true)}
-          onPrepare={() => void execute(false)}
+          additionalActions={diagnosticActions}
           folders={{
             folders: project.simulationFolders.map((folder) => ({
               ...folder,

--- a/docs/user/analog-simulation.md
+++ b/docs/user/analog-simulation.md
@@ -6,10 +6,11 @@ workspace is separate from the development-only Digital tool.
 
 ## Circuit, source and files
 
-Code and Properties share the right dock but remember independent widths.
+Sim Code and Properties share the right dock but remember independent widths.
 **Explorer** opens a narrow project tree beside the code. Each experiment puts
-Source first, expanded by default. Prepared and Run artifacts appear beneath it,
-marked **tmp** and collapsed by default, with expandable artifact categories.
+Source first, expanded by default. **Run · tmp** is collapsed by default and
+contains expandable **Results** (raw/CSV) and **Logs** groups. Preparation
+snapshots and internal evidence are not shown in the everyday file tree.
 Source paths also form expandable directories. Choose an experiment there, or
 create, clone, rename or delete one. Multiple experiments can use the same drawn
 Testbench; a different topology is an ordinary separate Cell.
@@ -26,8 +27,12 @@ is the Run target even while viewing another file. Invalid SPICE or JSON can
 be saved; preparation reports what needs repair rather than losing the draft.
 
 **New experiment** asks only for a name. It uses the current Canvas Cell and an
-OP starter. Muted AC, TRAN and DC examples below the editor show what to try next;
-they are hints and never enter the saved file until you type or insert them.
+OP starter. Helper offers analysis commands and argument hints without adding
+text to the saved file until you explicitly insert or type it.
+
+The compact Save and Run icons share the toolbar with Explorer. Save's tooltip
+and icon distinguish unsaved, saving, saved and failed states; Ctrl+S remains
+available. A failed save retains the draft and can be retried.
 
 **More code actions** opens advanced configuration, copies/exports the current
 file, or creates a source file. Configuration is not a default tab. It owns
@@ -107,7 +112,9 @@ qualification before making that claim.
 
 ## Prepare, run and recover
 
-**Prepare** compiles without executing. **Run** captures source and starts the
+**Preview input netlist…**, in More code actions or the active experiment's
+context menu, compiles without executing and opens the prepared input read-only.
+**Run** captures source and starts the
 ordinary run, or the sequential batch for a saved Run Plan. **Stop / Cancel
 run** requests cancellation; closing/minimizing a presentation is not cancel.
 Input errors affect that operation, not the Project or Agent session. Correct
@@ -117,7 +124,7 @@ it does not block editing or saving.
 Managed sweeps live in configuration `runPlan`: corner, temperature, named
 variable or exact Instance parameter axes. Nominal values are native `.param`
 and `.temp` source; config variable bindings do not duplicate those values.
-Prepare shows combinations before execution. Multi-experiment batch selection,
+Input preview shows combinations before execution. Multi-experiment batch selection,
 cancel/retry and ordinary per-item results reuse the same Run service.
 
 The current qualified analysis/corner set comes from capabilities/Profile.
@@ -126,6 +133,15 @@ Agent merely for a large estimate. An actual safety/capacity limit can still
 refuse a run with a repairable explanation.
 
 ## Results, history and exports
+
+**View executed netlist…** opens the actual deck captured for the selected run,
+not a newly compiled version of the current source. **Export diagnostic bundle…**
+exports that run's complete evidence, including preparation snapshots, source
+maps, environment/result metadata and execution artifacts. These commands are
+available from More code actions and the active experiment/Run context menus.
+Before any run, the diagnostic export uses the latest prepared input instead.
+Ordinary file-tree downloads contain only the selected visible source/output
+files; hiding diagnostics does not delete them or remove Agent access.
 
 Console, Plot, OP and Compare share one tab row below code. Measurements,
 history and exports stay inside these views. Maximize results temporarily uses the workspace;

--- a/scripts/preview-source-gui-journey.mjs
+++ b/scripts/preview-source-gui-journey.mjs
@@ -137,7 +137,7 @@ function entryFromZip(entries, name) {
   assert(value, `Missing exported ${name}`);
   return Buffer.from(value).toString();
 }
-async function downloadArtifactGroup(label, name) {
+async function downloadArtifactGroup(label, name, action = "Download…") {
   const explorer = panel.getByRole("complementary", {
     name: "Simulation files",
   });
@@ -151,7 +151,7 @@ async function downloadArtifactGroup(label, name) {
     .click({ button: "right" });
   return unzipSync(
     await download(
-      page.getByRole("menuitem", { name: "Download…", exact: true }),
+      page.getByRole("menuitem", { name: action, exact: true }),
       name,
     ),
   );
@@ -225,7 +225,7 @@ try {
     ),
   );
   await panel.getByRole("button", { name: "More code actions" }).click();
-  await page.getByRole("menuitem", { name: "View final deck" }).click();
+  await page.getByRole("menuitem", { name: "Preview input netlist…" }).click();
   await expect(panel).toContainText("missing-gui-acceptance.spice", {
     timeout: 30_000,
   });
@@ -240,12 +240,20 @@ try {
   await expect(
     panel.getByRole("tab", { name: "Results", exact: true }),
   ).toHaveCount(0);
-  const preparedEntries = await downloadArtifactGroup("Prepare", "prepare.zip");
+  await expect(panel.getByLabel("Prepare temporary files")).toHaveCount(0);
+  const diagnosticEntries = await downloadArtifactGroup(
+    "Run",
+    "diagnostics.zip",
+    "Export diagnostic bundle…",
+  );
   const runEntries = await downloadArtifactGroup("Run", "run.zip");
+  assert(
+    Object.keys(runEntries).every((path) => /\.(raw|csv|log|txt)$/.test(path)),
+  );
   await panel.getByRole("button", { name: "Maximize results" }).click();
-  const input = JSON.parse(entryFromZip(preparedEntries, "prepared.json"));
-  const result = JSON.parse(entryFromZip(runEntries, "result.json"));
-  const outputs = JSON.parse(entryFromZip(runEntries, "outputs.json"));
+  const input = JSON.parse(entryFromZip(diagnosticEntries, "prepared.json"));
+  const result = JSON.parse(entryFromZip(diagnosticEntries, "result.json"));
+  const outputs = JSON.parse(entryFromZip(diagnosticEntries, "outputs.json"));
   assert.equal(
     result.outcome.status,
     "completed",
@@ -273,7 +281,7 @@ try {
     ),
   );
   assert(
-    entryFromZip(preparedEntries, "prepared.cir").includes("noise v(vout)"),
+    entryFromZip(diagnosticEntries, "prepared.cir").includes("noise v(vout)"),
   );
   assert(entryFromZip(runEntries, "out.raw").includes("Plotname:"));
   assert(Object.keys(runEntries).some((path) => path.endsWith(".csv")));
@@ -305,7 +313,7 @@ try {
   };
   await edit(folder.input.configPath, JSON.stringify(config, null, 2));
   await panel.getByRole("button", { name: "More code actions" }).click();
-  await page.getByRole("menuitem", { name: "View final deck" }).click();
+  await page.getByRole("menuitem", { name: "Preview input netlist…" }).click();
   await panel.getByTitle("Batch queue", { exact: true }).click();
   await expect(panel.locator(".simulation-batch-menu-popover")).toContainText(
     "Batch · prepared",

--- a/scripts/preview-workflow.test.mjs
+++ b/scripts/preview-workflow.test.mjs
@@ -119,18 +119,20 @@ describe("the preview deploy", () => {
     expect(agentJourney).not.toContain("invalidSetup.input.outputs");
   });
 
-  it("exports GUI simulation evidence through the unified Explorer", () => {
+  it("separates GUI output downloads from complete diagnostic exports", () => {
     expect(sourceGuiJourney).toContain('name: "Simulation files"');
-    expect(sourceGuiJourney).toContain(
-      'getByRole("menuitem", { name: "Download…"',
-    );
-    expect(sourceGuiJourney).toContain(
-      'downloadArtifactGroup("Prepare", "prepare.zip")',
-    );
+    expect(sourceGuiJourney).toContain('getByRole("menuitem", { name: action');
+    expect(sourceGuiJourney).toContain('"Export diagnostic bundle…"');
     expect(sourceGuiJourney).toContain(
       'downloadArtifactGroup("Run", "run.zip")',
     );
     expect(sourceGuiJourney).not.toContain('getByRole("tab", { name: "Files"');
+    expect(sourceGuiJourney).toContain(
+      'entryFromZip(diagnosticEntries, "prepared.json")',
+    );
+    expect(sourceGuiJourney).toContain(
+      'entryFromZip(diagnosticEntries, "result.json")',
+    );
   });
 
   it("imports a Cloud Project Cell before compiling the cross-Project Testbench", () => {


### PR DESCRIPTION
Converge Sim Code on user-facing files: Source stays expanded and Run tmp exposes only Results and Logs. Preparation snapshots and JSON evidence stay available internally, but leave the default tree.

More code actions and active experiment/Run context menus expose Preview input netlist, View executed netlist, and Export diagnostic bundle. A new preparation never substitutes for the selected run's original executed deck or diagnostic snapshot. Ordinary context downloads contain only visible files.

Save and Run use matching neutral 22px icon buttons with hover/focus feedback. Save retains saving/saved/failure feedback, accessible descriptions, tooltips and Ctrl+S; cancellation stays accessible by its existing name.

Validation: frozen install, static preflight and editor dependency graph build passed; affected gate passed 3181 unit tests and 24 analog browser tests. Tests cover preparation-only exports, hidden-but-exportable evidence, stale-run identity, visible-only downloads and button dimensions. Hosted GUI acceptance now retrieves diagnostic evidence separately from public outputs and will run on Preview after merge.

Test-Impact: tests-updated