### PR TITLE
fix(simulation): save source locally without requiring sign-in

### DIFF
--- a/apps/editor/e2e/simulation-workspace.spec.ts
+++ b/apps/editor/e2e/simulation-workspace.spec.ts
@@ -18,10 +18,84 @@ import { generateCircuitSource, simulationSignals } from "@icm/netlist";
 import {
   clickNetlistWorkflowCommand,
   downloadBytes,
+  readRecoveryRecords,
 } from "./editor-fixtures.js";
 import { ota, profile, editSimulationFile } from "./simulation-e2e-fixtures.js";
 
 const loadModule = createRequire(import.meta.url);
+test("source save applies locally while signed out and leaves File Save cloud-owned", async ({
+  page,
+}) => {
+  const project = parseProject(JSON.stringify(ota));
+  const folder = createSimulationFolder({
+    id: "local-save",
+    name: "Local save",
+    documentId: project.topDocumentId,
+    profileId: profile.id,
+  });
+  project.simulationFolders = [folder];
+  let cloudWrites = 0;
+  await page.route("**/api/projects**", (route) => {
+    if (["POST", "PUT"].includes(route.request().method())) cloudWrites++;
+    return route.fulfill({ status: 401, json: { error: "Sign in" } });
+  });
+  await page.route("**/api/simulate", (route) =>
+    route.fulfill({
+      status: 503,
+      json: { error: "Offline authoring fixture" },
+    }),
+  );
+  await page.goto("/editor");
+  await page.getByTestId("project-file").setInputFiles({
+    name: "local-save.icproj.json",
+    mimeType: "application/json",
+    buffer: Buffer.from(JSON.stringify(project)),
+  });
+  await page.getByTestId("open-analog-simulation").click();
+  const editor = page.getByRole("textbox", {
+    name: "Simulation source editor",
+  });
+  const save = page.getByRole("button", { name: "Save source", exact: true });
+  const source = folder.input.files.find(
+    (file) => file.path === folder.input.entry,
+  )!.text;
+  await editor.fill(`${source}\n* local button save\n`);
+  await expect(save).toHaveAttribute("data-save-state", "dirty");
+  await save.click();
+  await expect(save).toHaveAttribute("data-save-state", "saved");
+  await expect(save).toBeDisabled();
+  await expect(page.getByRole("tab", { name: /run\.cir/ })).not.toContainText(
+    "●",
+  );
+  await editor.fill(`${source}\n* local keyboard save\n`);
+  await editor.press("ControlOrMeta+s");
+  await expect(save).toHaveAttribute("data-save-state", "saved");
+  expect(cloudWrites).toBe(0);
+  await expect(page.getByTestId("status")).not.toContainText("Sign in to save");
+  await expect
+    .poll(async () =>
+      (await readRecoveryRecords(page)).some((record) =>
+        record.projectText.includes("* local keyboard save"),
+      ),
+    )
+    .toBe(true);
+  const bytes = await downloadBytes(page, "File", "Export Project File…");
+  const applied = parseProject(bytes.toString());
+  expect(
+    applied.simulationFolders[0]!.input.files.find(
+      (file) => file.path === folder.input.entry,
+    )!.text,
+  ).toContain("* local keyboard save");
+  await page
+    .locator("summary")
+    .filter({ hasText: /^File$/ })
+    .click();
+  await page.getByTestId("save-cloud-project").click();
+  await expect(page.getByTestId("status")).toContainText("Sign in to save");
+  expect(cloudWrites).toBe(1);
+  await expect(save).toHaveAttribute("data-save-state", "saved");
+});
+
 test("Helper keeps signal selection continuous and shares the file row without stealing focus", async ({
   page,
 }) => {
@@ -156,7 +230,7 @@ test("native save completion previews its mapped Net on the real Canvas", async 
   await editor.fill(`${source.slice(0, source.indexOf(".endc"))}save`);
   await expect(page.locator(".simulation-code-status")).toHaveCount(0);
   await expect(
-    page.getByRole("button", { name: "Save project", exact: true }),
+    page.getByRole("button", { name: "Save source", exact: true }),
   ).toBeEnabled();
   await expect(page.getByRole("tab", { name: /run\.cir/ })).toContainText("●");
   await page.keyboard.type(" ");
@@ -222,6 +296,13 @@ test("incomplete circuit opens Code and saves invalid parameter drafts across re
   const original = source.source.text;
   await editor.press("Control+A");
   await page.keyboard.insertText(original.replace("<value>", "bad-value"));
+  await expect(editor).toContainText("bad-value");
+  const saveSource = panel.getByRole("button", {
+    name: "Save source",
+    exact: true,
+  });
+  await saveSource.click();
+  await expect(saveSource).toHaveAttribute("data-save-state", "failed");
   await expect(editor).toContainText("bad-value");
   const bytes = await downloadBytes(page, "File", "Export Project File…");
   const saved = parseProject(bytes.toString());
@@ -1381,7 +1462,7 @@ test("Simulation creates an ordinary testbench and defaults a new experiment to 
   expect(statusBox!.x).toBeGreaterThanOrEqual(runBox!.x + runBox!.width);
   expect(Math.abs(statusBox!.y - runBox!.y)).toBeLessThanOrEqual(2);
   await expect(taskbar).toHaveCount(1);
-  for (const name of ["Explorer", "Save project"]) {
+  for (const name of ["Explorer", "Save source"]) {
     const box = await taskbar
       .getByRole("button", { name, exact: true })
       .boundingBox();
@@ -1390,7 +1471,7 @@ test("Simulation creates an ordinary testbench and defaults a new experiment to 
   }
   expect((await taskbar.boundingBox())!.height).toBeLessThanOrEqual(32);
   const saveButton = taskbar.getByRole("button", {
-    name: "Save project",
+    name: "Save source",
     exact: true,
   });
   const runButton = taskbar.getByRole("button", { name: "Run", exact: true });
@@ -1398,7 +1479,10 @@ test("Simulation creates an ordinary testbench and defaults a new experiment to 
   expect(runBox!.width).toBe(22);
   await expect(saveButton).toHaveText("");
   await expect(runButton).toHaveText("");
-  await expect(saveButton).toHaveAttribute("title", /Save project.*Ctrl\+S/);
+  await expect(saveButton).toHaveAttribute(
+    "title",
+    /not a cloud save.*Ctrl\+S/,
+  );
   await expect(saveButton).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
   await expect(runButton).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
   await taskbar.getByRole("button", { name: "More code actions" }).click();

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -938,7 +938,6 @@ export function App({
     saveProjectToCloud,
     isSaveInFlight,
     saveBusy,
-    persistenceState,
     exportProjectFile,
     downloadCurrentProjectBackup,
     guardDirtyReplacement,
@@ -5381,8 +5380,6 @@ export function App({
                   onSourceBuffer={(buffer) => {
                     simulationSourceBuffer.current = buffer;
                   }}
-                  onSaveProject={() => saveProjectToCloud()}
-                  projectSaveState={persistenceState}
                   onSaveFolder={(
                     folder,
                     expectedRevision = project.structureRevision,

--- a/apps/editor/src/features/simulation/simulation-surface-types.ts
+++ b/apps/editor/src/features/simulation/simulation-surface-types.ts
@@ -37,10 +37,6 @@ export interface SpiceSimulationSurfaceProps {
   onSourceBuffer?(
     buffer: { flush(): Promise<boolean>; dirty: boolean } | null,
   ): void;
-  onSaveProject?(): void | Promise<unknown>;
-  projectSaveState?:
-    | import("../../document/use-project-file-lifecycle").PersistenceState
-    | undefined;
   pickNetsActive?: boolean;
   pickedNet?: {
     readonly sequence: number;

--- a/apps/editor/src/features/simulation/source-code-pane.tsx
+++ b/apps/editor/src/features/simulation/source-code-pane.tsx
@@ -98,8 +98,6 @@ interface Props extends Pick<
   onProblem(problem: Problem | undefined): void;
   diagnostics?: Problem["diagnostics"];
   onRun(): void;
-  onSaveProject?: (() => void | Promise<unknown>) | undefined;
-  projectSaveState?: SpiceSimulationSurfaceProps["projectSaveState"];
   onHistoryBoundary(direction: "undo" | "redo"): void;
 }
 const inputProblem = (code: string, message: string): Problem => ({
@@ -155,7 +153,8 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
     };
     const [saving, setSaving] = useState(false);
     const [saveRequested, setSaveRequested] = useState(false);
-    const projectSaveRequest = useRef(false);
+    const [saveFailed, setSaveFailed] = useState(false);
+    const sourceSaveRequest = useRef(false);
     const [reveal, setReveal] = useState<{
       sourceOffset: number;
       requestId: string;
@@ -488,6 +487,13 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
       );
     });
     const dirty = unsaved.length > 0;
+    // Persisted repair drafts still need applying; cloud/recovery state is not
+    // evidence that the current folder's source has been applied.
+    const pendingSource = [...drafts.current].some(
+      ([key, draft]) =>
+        key.startsWith(`${props.folder.id}\u0000`) && draft.text !== draft.base,
+    );
+    useEffect(() => setSaveFailed(false), [text, props.folder.id]);
     const activeDirty = unsaved.some(([key]) =>
       key.startsWith(`${props.folder.id}\u0000`),
     );
@@ -761,23 +767,24 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
         : generated.diagnostics.map((d) => `* ${d.message}`).join("\n");
     };
     const requestSave = async () => {
-      if (projectSaveRequest.current) return;
-      projectSaveRequest.current = true;
+      if (sourceSaveRequest.current) return;
+      sourceSaveRequest.current = true;
       setSaveRequested(true);
       try {
-        if (props.onSaveProject) await props.onSaveProject();
-        else await flush();
+        const result = await flush();
+        setSaveFailed(!result.ok);
       } catch (error) {
+        setSaveFailed(true);
         props.onProblem(
           inputProblem(
-            "PROJECT_SAVE_FAILED",
+            "SOURCE_APPLY_FAILED",
             error instanceof Error
               ? error.message
               : "Save failed; drafts retained.",
           ),
         );
       } finally {
-        projectSaveRequest.current = false;
+        sourceSaveRequest.current = false;
         setSaveRequested(false);
       }
     };
@@ -832,22 +839,21 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
       setTimeout(() => URL.revokeObjectURL(url), 0);
     };
     const saveState =
-      saveRequested || saving || props.projectSaveState === "saving"
+      saveRequested || saving
         ? "saving"
-        : props.projectSaveState === "failed" ||
-            props.projectSaveState === "offline"
+        : saveFailed
           ? "failed"
-          : props.projectSaveState === "clean" && !dirty
+          : !pendingSource
             ? "saved"
             : "dirty";
     const saveFeedback =
       saveState === "saving"
-        ? "Saving project…"
+        ? "Applying source…"
         : saveState === "saved"
-          ? "Project saved"
+          ? "Source applied to current project; not a cloud save"
           : saveState === "failed"
-            ? "Save failed; drafts remain local. Retry save."
-            : "Save project";
+            ? "Apply failed; drafts retained. Retry save."
+            : "Save source to current project";
     return (
       <SimulationCodeWorkspace
         workspaceKey={props.folder.id}
@@ -1105,7 +1111,7 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
               className="simulation-action-button"
               data-workspace-save="true"
               data-save-state={saveState}
-              aria-label="Save project"
+              aria-label="Save source"
               aria-description={saveFeedback}
               title={`${saveFeedback} · Ctrl+S`}
               disabled={saveState === "saving" || saveState === "saved"}

--- a/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
@@ -4,11 +4,7 @@ import { describe, expect, it } from "vitest";
 import { BrowserSimulationSession } from "./browser-simulation-session";
 import { SpiceSimulationSurface } from "./spice-simulation-surface";
 
-function render(
-  saved: boolean,
-  broken = false,
-  projectSaveState?: "saving" | "clean" | "failed",
-) {
+function render(saved: boolean, broken = false) {
   const project = createEmptyProject("code", "Code");
   if (saved) {
     const folder = createSimulationFolder({
@@ -42,25 +38,18 @@ function render(
       onSaveFolder={() => ({ status: "applied" })}
       onDeleteFolder={() => true}
       onHistoryBoundary={() => {}}
-      projectSaveState={projectSaveState}
     />,
   );
 }
 describe("source workspace default cutover", () => {
-  it("projects the Project save lifecycle instead of claiming a buffer flush saved to cloud", () => {
-    expect(render(true, false, "saving")).toContain(
-      'aria-description="Saving project…"',
+  it("describes source application without claiming a cloud save", () => {
+    const markup = render(true);
+    expect(markup).toContain('aria-label="Save source"');
+    expect(markup).toContain(
+      'aria-description="Source applied to current project; not a cloud save"',
     );
-    expect(render(true, false, "saving")).toContain('aria-busy="true"');
-    expect(render(true, false, "clean")).toContain(
-      'aria-description="Project saved"',
-    );
-    expect(render(true, false, "clean")).toContain('data-save-state="saved"');
-    expect(render(true, false, "failed")).toContain("Retry save");
-    expect(render(true, false, "clean")).not.toContain(">✓ Saved</button>");
-    expect(render(true, false, "saving")).toContain(
-      'class="simulation-action-button"',
-    );
+    expect(markup).toContain('data-save-state="saved"');
+    expect(markup).not.toContain('aria-label="Save project"');
   });
   it("offers creation without restoring the retired Settings form", () => {
     const markup = render(false);

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -1814,8 +1814,6 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
             onAction: (action, ids) => void folderAction(action, ids),
           }}
           onHistoryBoundary={props.onHistoryBoundary}
-          onSaveProject={props.onSaveProject}
-          projectSaveState={props.projectSaveState}
         />
       ) : (
         <div className="simulation-empty-result">

--- a/docs/user/analog-simulation.md
+++ b/docs/user/analog-simulation.md
@@ -30,9 +30,14 @@ be saved; preparation reports what needs repair rather than losing the draft.
 OP starter. Helper offers analysis commands and argument hints without adding
 text to the saved file until you explicitly insert or type it.
 
-The compact Save and Run icons share the toolbar with Explorer. Save's tooltip
-and icon distinguish unsaved, saving, saved and failed states; Ctrl+S remains
-available. A failed save retains the draft and can be retried.
+The compact Save and Run icons share the toolbar with Explorer. **Save source**
+applies pending files in the current simulation folder to the current Project,
+without signing in or making a cloud request. Ctrl+S inside the code editor does
+the same. Its icon and tooltip distinguish pending, applying, applied and failed
+states; a failed apply retains the draft for repair and retry. Applied source is
+covered by the Project's browser recovery, not a cloud backup. **File → Save**
+(or the project-level shortcut outside code) still saves the entire Project to
+the signed-in cloud account.
 
 **More code actions** opens advanced configuration, copies/exports the current
 file, or creates a source file. Configuration is not a default tab. It owns


### PR DESCRIPTION
## Change
Restore the former GUI Apply setup semantics for Sim Code: Save source and editor Ctrl/Cmd+S apply current-folder source locally. Remove the cloud-save callback and cloud-state coupling. File Save remains cloud-owned and still requires sign-in. Applied source uses existing browser recovery; invalid drafts remain available for repair.

## Validation
- Frozen dependency install and preflight checks.
- 3192 unit tests passed, 28 skipped.
- All 25 simulation browser tests passed, including signed-out save, keyboard save, recovery bytes, and cloud-save separation.
- Manual editor: 153 passed; one Properties revision assertion failed, then passed three repeated runs unchanged. Cause not established; no tests weakened. Required remote checks must pass.

No project schema or cloud service changes. Preview is not updated until merge.