### PR TITLE
refactor(simulation): make Code authoritative for native experiments

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -12,6 +12,7 @@ on:
       - "containers/ngspice/**"
       - ".github/workflows/container.yml"
       - ".dockerignore"
+      - "scripts/simulation-source-native.test.mjs"
   workflow_dispatch:
 
 permissions:

--- a/apps/editor/e2e/simulation-batch.spec.ts
+++ b/apps/editor/e2e/simulation-batch.spec.ts
@@ -111,13 +111,29 @@ test("a saved-folder batch prepares first and exposes each ordinary run", async 
   });
   await clickNetlistWorkflowCommand(page, "open-analog-simulation");
   const panel = page.getByRole("region", { name: "Analog simulation" });
-  await panel.getByRole("treeitem", { name: "Folder TT", exact: true }).click();
+  const openEntry = async (name: string, folderId: string) => {
+    const folder = panel.getByRole("treeitem", {
+      name: `Folder ${name}`,
+      exact: true,
+    });
+    if ((await folder.getAttribute("aria-expanded")) !== "true")
+      await folder.click();
+    await panel
+      .locator(
+        `[role="treeitem"][data-folder-id="${folderId}"][data-file-path="run.cir"]`,
+      )
+      .click();
+    await expect(
+      panel.getByRole("button", { name: "Run", exact: true }),
+    ).toHaveAttribute("title", `Run ${name}`);
+  };
+  await openEntry("TT", "folder-tt");
   await editSimulationFile(
     page,
     "run.cir",
     deck.replace("divider", "divider TT draft"),
   );
-  await panel.getByRole("treeitem", { name: "Folder FF", exact: true }).click();
+  await openEntry("FF", "folder-ff");
   await editSimulationFile(
     page,
     "run.cir",

--- a/apps/editor/e2e/simulation-batch.spec.ts
+++ b/apps/editor/e2e/simulation-batch.spec.ts
@@ -41,6 +41,7 @@ test("a saved-folder batch prepares first and exposes each ordinary run", async 
     return folder;
   });
   let executions = 0;
+  const executedDecks: string[] = [];
   await page.route("**/api/simulate", async (route) => {
     const body = route.request().postDataJSON();
     if (body.operation === "capabilities")
@@ -67,6 +68,7 @@ test("a saved-folder batch prepares first and exposes each ordinary run", async 
         },
       });
     executions++;
+    executedDecks.push(body.preparedDeck);
     return route.fulfill({
       json: {
         outcome: { status: "completed" },
@@ -110,6 +112,18 @@ test("a saved-folder batch prepares first and exposes each ordinary run", async 
   await clickNetlistWorkflowCommand(page, "open-analog-simulation");
   const panel = page.getByRole("region", { name: "Analog simulation" });
   await panel.getByRole("treeitem", { name: "Folder TT", exact: true }).click();
+  await editSimulationFile(
+    page,
+    "run.cir",
+    deck.replace("divider", "divider TT draft"),
+  );
+  await panel.getByRole("treeitem", { name: "Folder FF", exact: true }).click();
+  await editSimulationFile(
+    page,
+    "run.cir",
+    deck.replace("divider", "divider FF draft"),
+  );
+  await panel.getByRole("treeitem", { name: "Folder TT", exact: true }).click();
   await panel
     .getByRole("treeitem", { name: "Folder FF", exact: true })
     .click({ modifiers: ["Control"] });
@@ -129,6 +143,8 @@ test("a saved-folder batch prepares first and exposes each ordinary run", async 
     batch.getByRole("button", { name: /FF finished/ }),
   ).toBeEnabled();
   expect(executions).toBe(2);
+  expect(executedDecks.some((text) => text.includes("TT draft"))).toBe(true);
+  expect(executedDecks.some((text) => text.includes("FF draft"))).toBe(true);
   await batch.getByRole("button", { name: /FF finished/ }).click();
   await expect(
     panel.getByRole("treeitem", { name: "Folder FF", exact: true }),

--- a/apps/editor/e2e/simulation-setup.spec.ts
+++ b/apps/editor/e2e/simulation-setup.spec.ts
@@ -99,7 +99,7 @@ test("the qualified OTA folder opens unchanged and preserves all root and hierar
   });
   await clickNetlistWorkflowCommand(page, "open-analog-simulation");
   const panel = page.getByRole("region", { name: "Analog simulation" });
-  // Ordinary picks write native save text; current instrumentation keeps its owner.
+  // New Helper picks write native Code even in a retained legacy experiment.
   const helper = async (name: string) => {
     await panel.getByRole("button", { name: "Helper", exact: true }).click();
     await panel.getByRole("option", { name, exact: true }).click();
@@ -121,7 +121,7 @@ test("the qualified OTA folder opens unchanged and preserves all root and hierar
   await expect(
     panel.getByRole("textbox", { name: "Simulation source editor" }),
   ).not.toBeFocused();
-  // Repeated current picks stay active without duplicating instrumentation.
+  // Repeated current picks stay active without duplicating native acquisition.
   await page.getByTestId("terminal-VINP-+").click();
   await page.getByTestId("terminal-VINP--").click();
   await expect(page.getByTestId("schematic-canvas")).toHaveClass(
@@ -143,10 +143,11 @@ test("the qualified OTA folder opens unchanged and preserves all root and hierar
   const pickedConfig = readSimulationExperimentConfig(
     pickedProject.simulationFolders[0]!,
   );
-  expect(pickedConfig.ok && pickedConfig.config.outputs.length).toBe(5);
-  expect(
-    pickedConfig.ok && pickedConfig.config.outputs.at(-1)?.expression,
-  ).toMatchObject({ kind: "current" });
+  expect(pickedConfig.ok && pickedConfig.config).toEqual(originalSetupInput);
+  const pickedSource = pickedProject.simulationFolders[0]!.input.files.find(
+    (file) => file.path === savedSetup.input.entry,
+  )!.text;
+  expect(pickedSource).toContain("i(vinp)");
   const circuit = {
     bindingId: savedSetup.input.circuitBindings[0]!.id,
     callPath: [],

--- a/apps/editor/src/features/simulation/code-editor.tsx
+++ b/apps/editor/src/features/simulation/code-editor.tsx
@@ -391,11 +391,12 @@ export default function SimulationCodeEditor(props: SimulationCodeEditorProps) {
       props.saveRequest.directives,
     );
     const anchor = edit.anchor;
-    editor.dispatch({
-      changes: { from: 0, to: editor.state.doc.length, insert: edit.text },
-      selection: { anchor },
-      scrollIntoView: true,
-    });
+    // Compose insertions into one undoable transaction. Replacing the whole
+    // document would normalize untouched mixed newlines in the exact-source field.
+    editor.dispatch(
+      ...edit.changes.map((changes) => ({ changes, sequential: true })),
+      { selection: { anchor }, scrollIntoView: true, sequential: true },
+    );
     saveAnchor.current = {
       session: props.saveRequest.session,
       path: props.path,

--- a/apps/editor/src/features/simulation/code-editor.tsx
+++ b/apps/editor/src/features/simulation/code-editor.tsx
@@ -76,7 +76,7 @@ import {
   parameterGuide,
 } from "./code-parameter-guide";
 import { CodeHelperList, type CodeHelperAction } from "./code-helper-list";
-import { nativeSaveEdit } from "./native-save-edit";
+import { nativeAcquisitionEdit } from "./native-save-edit";
 
 export interface SimulationCodeEditorProps {
   path: string;
@@ -108,7 +108,9 @@ export interface SimulationCodeEditorProps {
   relatedSources?: readonly string[];
   signalNames?: (() => Readonly<Record<string, string>>) | undefined;
   onFocusSignal?: ((vector: string | null) => void) | undefined;
-  saveRequest?: { id: string; session: string; vectors: string[] } | undefined;
+  saveRequest?:
+    | { id: string; session: string; vectors: string[]; directives?: string[] }
+    | undefined;
   reveal?:
     { sourceOffset: number; requestId: string; focus?: boolean } | undefined;
 }
@@ -378,7 +380,7 @@ export default function SimulationCodeEditor(props: SimulationCodeEditorProps) {
       props.mode === "json"
     )
       return;
-    const edit = nativeSaveEdit(
+    const edit = nativeAcquisitionEdit(
       editor.state.doc.toString(),
       saveAnchor.current?.session === props.saveRequest.session &&
         saveAnchor.current.path === props.path
@@ -386,10 +388,11 @@ export default function SimulationCodeEditor(props: SimulationCodeEditorProps) {
         : editor.state.selection.main.head,
       props.saveRequest.vectors,
       !!props.entry,
+      props.saveRequest.directives,
     );
-    const anchor = edit.from + edit.insert.replace(/[\r\n]+$/u, "").length;
+    const anchor = edit.anchor;
     editor.dispatch({
-      changes: { from: edit.from, insert: edit.insert },
+      changes: { from: 0, to: editor.state.doc.length, insert: edit.text },
       selection: { anchor },
       scrollIntoView: true,
     });

--- a/apps/editor/src/features/simulation/flush-selected-folders.test.ts
+++ b/apps/editor/src/features/simulation/flush-selected-folders.test.ts
@@ -1,0 +1,39 @@
+import { createSimulationFolder } from "@icm/model";
+import { describe, expect, it, vi } from "vitest";
+import {
+  flushSelectedFolders,
+  type FolderFlush,
+} from "./flush-selected-folders";
+
+describe("selected-folder source capture", () => {
+  it("flushes background selections too, once each, using the prior committed revision", async () => {
+    const flush = vi.fn(
+      async (id: string, revision: number): Promise<FolderFlush> => ({
+        ok: true,
+        revision: revision + 1,
+        folder: createSimulationFolder({ id, name: id, profileId: "test" }),
+      }),
+    );
+    const result = await flushSelectedFolders(
+      ["background", "active", "background"],
+      4,
+      flush,
+    );
+    expect(flush.mock.calls).toEqual([
+      ["background", 4],
+      ["active", 5],
+    ]);
+    expect(result.ok && result.revision).toBe(6);
+    expect(result.ok && result.folders.map((folder) => folder.id)).toEqual([
+      "background",
+      "active",
+    ]);
+  });
+  it("does not return runnable inputs when any selected draft cannot be applied", async () => {
+    const flush = vi.fn(async (): Promise<FolderFlush> => ({ ok: false }));
+    expect(await flushSelectedFolders(["broken", "next"], 4, flush)).toEqual({
+      ok: false,
+    });
+    expect(flush).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/editor/src/features/simulation/flush-selected-folders.ts
+++ b/apps/editor/src/features/simulation/flush-selected-folders.ts
@@ -1,0 +1,24 @@
+import type { ProjectSimulationFolder } from "@icm/model";
+
+export type FolderFlush =
+  | { ok: true; folder: ProjectSimulationFolder; revision: number }
+  | { ok: false };
+
+/** Capture every selected source before preparing any jobs, carrying the shared revision. */
+export async function flushSelectedFolders(
+  ids: readonly string[],
+  revision: number,
+  flush: (id: string, revision: number) => Promise<FolderFlush>,
+): Promise<
+  | { ok: true; folders: ProjectSimulationFolder[]; revision: number }
+  | { ok: false }
+> {
+  const folders: ProjectSimulationFolder[] = [];
+  for (const id of new Set(ids)) {
+    const result = await flush(id, revision);
+    if (!result.ok) return result;
+    folders.push(result.folder);
+    revision = result.revision;
+  }
+  return { ok: true, folders, revision };
+}

--- a/apps/editor/src/features/simulation/native-measurement-results.test.tsx
+++ b/apps/editor/src/features/simulation/native-measurement-results.test.tsx
@@ -1,0 +1,40 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { NativeMeasurementResults } from "./native-measurement-results";
+
+describe("native measurement evidence", () => {
+  it("keeps repeated reports distinct and missing reports unavailable", () => {
+    const html = renderToStaticMarkup(
+      <NativeMeasurementResults
+        measurements={[
+          {
+            name: "peak",
+            status: "available",
+            occurrence: 1,
+            value: 0.5,
+            logLine: 2,
+            detail: "peak = 0.5",
+          },
+          {
+            name: "peak",
+            status: "available",
+            occurrence: 2,
+            value: 1,
+            logLine: 4,
+            detail: "peak = 1",
+          },
+          {
+            name: "missing",
+            status: "unavailable",
+            occurrence: 0,
+            detail: "Not reported",
+          },
+        ]}
+      />,
+    );
+    expect(html.match(/<th>peak<\/th>/gu)).toHaveLength(2);
+    expect(html).toContain("Console line 4");
+    expect(html).toContain("Unavailable");
+    expect(html).toContain("Not reported");
+  });
+});

--- a/apps/editor/src/features/simulation/native-measurement-results.tsx
+++ b/apps/editor/src/features/simulation/native-measurement-results.tsx
@@ -1,0 +1,49 @@
+import type { SimulationOutputData } from "@icm/simulation-service/contract";
+
+export function NativeMeasurementResults({
+  measurements,
+}: {
+  measurements: NonNullable<SimulationOutputData["nativeMeasurements"]>;
+}) {
+  if (!measurements.length) return null;
+  return (
+    <section
+      className="simulation-measurement-results"
+      aria-label="Native measurements"
+    >
+      <h4>Code measurements</h4>
+      <p>
+        Scalars reported by ngspice. Repeated names retain their report order;
+        units and plot associations are not inferred.
+      </p>
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Report</th>
+            <th>Value</th>
+            <th>Evidence</th>
+          </tr>
+        </thead>
+        <tbody>
+          {measurements.map((measurement, index) => (
+            <tr key={index}>
+              <th>{measurement.name}</th>
+              <td>{measurement.occurrence || "—"}</td>
+              <td>
+                {measurement.status === "available"
+                  ? measurement.value.toPrecision(7)
+                  : "Unavailable"}
+              </td>
+              <td title={measurement.detail}>
+                {measurement.status === "available"
+                  ? `Console line ${measurement.logLine}`
+                  : measurement.detail}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
+  );
+}

--- a/apps/editor/src/features/simulation/native-save-edit.test.ts
+++ b/apps/editor/src/features/simulation/native-save-edit.test.ts
@@ -2,8 +2,37 @@ import { describe, expect, it } from "vitest";
 import { EditorState } from "@codemirror/state";
 import { nativeSaveEdit, nativeAcquisitionEdit } from "./native-save-edit";
 import { parameterGuide } from "./code-parameter-guide";
+import { editorText } from "./code-text-coordinates";
+import { exactSourceField } from "./code-source-state";
 
 describe("native save authoring", () => {
+  it("preserves untouched mixed newlines when composing probe and save insertions", () => {
+    const text = "* title\r\nR1 a 0 1k\n.control\r\nop\n.endc\r\n.end\n";
+    const state = EditorState.create({
+      doc: editorText(text),
+      extensions: [exactSourceField.init(() => text)],
+    });
+    const edit = nativeAcquisitionEdit(
+      state.doc.toString(),
+      0,
+      ["v(a)"],
+      true,
+      [".probe i(r1,1)"],
+    );
+    const next = state.update(
+      ...edit.changes.map((changes) => ({ changes, sequential: true })),
+    ).state;
+    expect(next.field(exactSourceField)).toBe(
+      text
+        .replace("R1 a", ".probe i(r1,1)\r\nR1 a")
+        .replace(".control\r\n", ".control\r\nsave v(a)\r\n"),
+    );
+    expect(
+      nativeAcquisitionEdit(edit.text, edit.anchor, ["v(a)"], true, [
+        ".probe i(r1,1)",
+      ]).changes,
+    ).toEqual([]);
+  });
   it("keeps a title-only entry before native probe cards", () => {
     expect(
       nativeAcquisitionEdit("My deck", 7, [], true, [".probe i(r1,1)"]).text,

--- a/apps/editor/src/features/simulation/native-save-edit.test.ts
+++ b/apps/editor/src/features/simulation/native-save-edit.test.ts
@@ -1,9 +1,29 @@
 import { describe, expect, it } from "vitest";
 import { EditorState } from "@codemirror/state";
-import { nativeSaveEdit } from "./native-save-edit";
+import { nativeSaveEdit, nativeAcquisitionEdit } from "./native-save-edit";
 import { parameterGuide } from "./code-parameter-guide";
 
 describe("native save authoring", () => {
+  it("keeps a title-only entry before native probe cards", () => {
+    expect(
+      nativeAcquisitionEdit("My deck", 7, [], true, [".probe i(r1,1)"]).text,
+    ).toBe("My deck\n.probe i(r1,1)\n");
+  });
+  it("places native terminal probes outside control and never creates an empty save", () => {
+    const text = "* title\n.control\nop\nwrite out.raw\n.endc\n.end\n";
+    const first = nativeAcquisitionEdit(text, text.length, [], true, [
+      ".probe i(r1,2)",
+    ]);
+    expect(first.text).toBe(
+      text.replace(".control", ".probe i(r1,2)\n.control"),
+    );
+    expect(
+      nativeAcquisitionEdit(first.text, first.anchor, [], true, [
+        ".probe i(r1,2)",
+      ]).text,
+    ).toBe(first.text);
+    expect(first.text).not.toContain("save ");
+  });
   it("inserts before control analyses rather than after their write", () => {
     const text = "* title\n.control\nop\nwrite out.raw\n.endc\n.end\n";
     const edit = nativeSaveEdit(text, text.length, ["v(out)"], true);

--- a/apps/editor/src/features/simulation/native-save-edit.ts
+++ b/apps/editor/src/features/simulation/native-save-edit.ts
@@ -52,6 +52,7 @@ export function nativeAcquisitionEdit(
   );
   let next = text;
   let anchor = cursor;
+  const changes: { from: number; insert: string }[] = [];
   if (missing.length) {
     const from = entry
       ? text.indexOf("\n") < 0
@@ -62,14 +63,16 @@ export function nativeAcquisitionEdit(
       (from > 0 && text[from - 1] !== "\n" ? eol : "") +
       missing.join(eol) +
       eol;
+    changes.push({ from, insert });
     next = text.slice(0, from) + insert + text.slice(from);
     anchor = cursor >= from ? cursor + insert.length : cursor;
     if (!vectors.length) anchor = from + insert.length;
   }
   if (vectors.length) {
     const edit = nativeSaveEdit(next, anchor, vectors, entry);
+    if (edit.insert) changes.push(edit);
     next = next.slice(0, edit.from) + edit.insert + next.slice(edit.from);
     anchor = edit.from + edit.insert.replace(/[\r\n]+$/u, "").length;
   }
-  return { text: next, anchor };
+  return { text: next, anchor, changes };
 }

--- a/apps/editor/src/features/simulation/native-save-edit.ts
+++ b/apps/editor/src/features/simulation/native-save-edit.ts
@@ -34,3 +34,42 @@ export function nativeSaveEdit(
       `${control ? "save" : ".save"} ${vectors.join(" ")}${eol}`,
   };
 }
+
+/** One undoable native edit, including deck-level .probe cards when required. */
+export function nativeAcquisitionEdit(
+  text: string,
+  cursor: number,
+  vectors: readonly string[],
+  entry: boolean,
+  directives: readonly string[] = [],
+) {
+  const eol = text.includes("\r\n") ? "\r\n" : "\n";
+  const existing = new Set(
+    text.split(/\r?\n/u).map((line) => line.trim().toLowerCase()),
+  );
+  const missing = directives.filter(
+    (line) => !existing.has(line.toLowerCase()),
+  );
+  let next = text;
+  let anchor = cursor;
+  if (missing.length) {
+    const from = entry
+      ? text.indexOf("\n") < 0
+        ? text.length
+        : text.indexOf("\n") + 1
+      : 0;
+    const insert =
+      (from > 0 && text[from - 1] !== "\n" ? eol : "") +
+      missing.join(eol) +
+      eol;
+    next = text.slice(0, from) + insert + text.slice(from);
+    anchor = cursor >= from ? cursor + insert.length : cursor;
+    if (!vectors.length) anchor = from + insert.length;
+  }
+  if (vectors.length) {
+    const edit = nativeSaveEdit(next, anchor, vectors, entry);
+    next = next.slice(0, edit.from) + edit.insert + next.slice(edit.from);
+    anchor = edit.from + edit.insert.replace(/[\r\n]+$/u, "").length;
+  }
+  return { text: next, anchor };
+}

--- a/apps/editor/src/features/simulation/simulation-output-results.tsx
+++ b/apps/editor/src/features/simulation/simulation-output-results.tsx
@@ -17,6 +17,7 @@ import {
 } from "./ac-results-explorer";
 import { ScalarResultsExplorer } from "./transient-results-explorer";
 import { SimulationMeasurementResults } from "./simulation-measurement-results";
+import { NativeMeasurementResults } from "./native-measurement-results";
 import { NoiseResultsExplorer } from "./noise-results-explorer";
 
 export type SimulationAnalysisKind = "op" | "dc" | "ac" | "tran" | "noise";
@@ -454,6 +455,7 @@ export function SimulationOutputResults({
           visibleAnalyses.has(measurement.analysis),
         )}
       />
+      <NativeMeasurementResults measurements={data.nativeMeasurements ?? []} />
     </div>
   );
 }

--- a/apps/editor/src/features/simulation/source-code-pane.tsx
+++ b/apps/editor/src/features/simulation/source-code-pane.tsx
@@ -25,6 +25,9 @@ import {
   planCircuitSourceEdit,
   compileSourceSimulation,
   simulationSignals,
+  nativeSimulationDevices,
+  nativeTerminalCurrent,
+  migrateSimulationConfigToNative,
 } from "@icm/netlist";
 import type { SimulationFiles } from "@icm/simulation-service/files";
 import { sha256 } from "@icm/simulation-service/files";
@@ -50,12 +53,14 @@ import {
 import { sourceProbeChoices } from "./source-probe-choices";
 import { SourceProbePicker } from "./source-probe-picker";
 import { SimulationActionIcon } from "./simulation-action-icon";
+import { flushSelectedFolders } from "./flush-selected-folders";
 
 export type SourceFlush =
   | { ok: true; folder: ProjectSimulationFolder; revision: number }
   | { ok: false };
 export interface SourceCodeHandle {
   flush(): Promise<SourceFlush>;
+  flushFolders(ids: readonly string[]): ReturnType<typeof flushSelectedFolders>;
   save(): Promise<boolean>;
   discard(): void;
   reveal(location: SimulationSourceLocation): Promise<void>;
@@ -166,6 +171,7 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
       id: string;
       session: string;
       vectors: string[];
+      directives?: string[];
     }>();
     const saveSession = useRef(crypto.randomUUID());
     const beginSignalSelection = () => {
@@ -180,6 +186,9 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
       terminal: props.pickedTerminal?.sequence,
     });
     const input = props.folder.input;
+    const configState = readSimulationExperimentConfig(props.folder);
+    const legacyConfig =
+      configState.ok && configState.authority === "legacy-config";
     const signals = useMemo(
       () =>
         simulationSignals(props.project, {
@@ -193,7 +202,9 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
         }),
       [props.project, input, draftRevision],
     );
-    const [probePicker, setProbePicker] = useState<"voltage" | "current">();
+    const [probePicker, setProbePicker] = useState<
+      "voltage" | "current" | "device-op"
+    >();
     const probeChoices = useMemo(
       () =>
         probePicker
@@ -223,7 +234,7 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
       label: string,
       expression: SimulationSourceExpression,
     ): boolean => {
-      const insert = (vectors: string[]) => {
+      const insert = (vectors: string[], directives?: string[]) => {
         if (
           input.circuitBindings.some((b) => b.path === path) ||
           path.endsWith(".json")
@@ -233,6 +244,7 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
           id: crypto.randomUUID(),
           session: saveSession.current,
           vectors,
+          ...(directives ? { directives } : {}),
         });
       };
       if (expression.kind === "vector") {
@@ -246,6 +258,45 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
           return false;
         }
         insert([expression.vector]);
+        return true;
+      }
+      if (expression.kind === "current") {
+        const sourceInput = {
+          ...input,
+          files: input.files.map((f) => ({
+            ...f,
+            text:
+              drafts.current.get(`${props.folder.id}\u0000${f.path}`)?.text ??
+              f.text,
+          })),
+        };
+        const device = nativeSimulationDevices(props.project, sourceInput).find(
+          (item) =>
+            item.documentId === expression.documentId &&
+            item.instanceId === expression.instanceId &&
+            JSON.stringify(item.occurrence) ===
+              JSON.stringify(expression.occurrence) &&
+            item.circuit.bindingId === expression.circuit.bindingId &&
+            item.circuit.callPath.join(".").toLowerCase() ===
+              expression.circuit.callPath.join(".").toLowerCase(),
+        );
+        const result = device
+          ? nativeTerminalCurrent(device, expression.pinName)
+          : {
+              ok: false as const,
+              message:
+                "The selected device no longer has a reachable native occurrence",
+            };
+        if (!result.ok) {
+          props.onProblem(
+            inputProblem(
+              "SIMULATION_NATIVE_CURRENT_UNAVAILABLE",
+              result.message,
+            ),
+          );
+          return false;
+        }
+        insert(result.vectors, result.directives);
         return true;
       }
       const file = props.folder.input.files.find(
@@ -273,7 +324,6 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
         );
         return false;
       }
-      const previousOutputs = [...parsed.config.outputs];
       parsed.config.outputs.push({
         id: `output-${crypto.randomUUID()}`,
         label,
@@ -319,23 +369,6 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
       const nativeVectors = resolved.vectors
         .filter((v) => acquisitionIds.has(v.probeId))
         .map((v) => v.vector);
-      // Only terminal-current targets require a durable instrumentation owner.
-      // Ordinary voltage picks are native save text, not a second output setup.
-      if (expression.kind !== "current")
-        parsed.config.outputs = previousOutputs;
-      else if (
-        previousOutputs.some(
-          (o) => JSON.stringify(o.expression) === JSON.stringify(expression),
-        )
-      )
-        parsed.config.outputs = previousOutputs;
-      if (expression.kind === "current") {
-        drafts.current.set(`${props.folder.id}\u0000${input.configPath}`, {
-          base: draft?.base ?? file?.text ?? "",
-          text: JSON.stringify(parsed.config, null, 2) + "\n",
-          committed: draft?.committed ?? props.project.structureRevision,
-        });
-      }
       insert(nativeVectors.length ? nativeVectors : ["v(0)"]);
       render((v) => v + 1);
       return true;
@@ -504,18 +537,38 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
           drafts.current.delete(key(file.path));
       }
     }, [props.project]);
-    const flush = async (onlyPath?: string): Promise<SourceFlush> => {
+    const flush = async (
+      onlyPath?: string,
+      folderId?: string,
+      expectedRevision?: number,
+    ): Promise<SourceFlush> => {
       if (savingRef.current) return { ok: false };
       savingRef.current = true;
       setSaving(true);
       try {
-        let revision = current.current.project.structureRevision;
-        let folder = current.current.folder;
+        let revision =
+          expectedRevision ?? current.current.project.structureRevision;
+        let folder = folderId
+          ? current.current.project.simulationFolders.find(
+              (item) => item.id === folderId,
+            )
+          : current.current.folder;
+        if (!folder) {
+          props.onProblem(
+            inputProblem(
+              "SIMULATION_FOLDER_MISSING",
+              `Selected folder ${folderId} no longer exists`,
+            ),
+          );
+          return { ok: false };
+        }
+        const selectedFolderId = folder.id;
         const pending = [...drafts.current].filter(
           ([key, value]) =>
-            key.startsWith(`${folder.id}\u0000`) &&
+            key.startsWith(`${selectedFolderId}\u0000`) &&
             value.text !== value.base &&
-            (onlyPath === undefined || key === `${folder.id}\u0000${onlyPath}`),
+            (onlyPath === undefined ||
+              key === `${selectedFolderId}\u0000${onlyPath}`),
         );
         const authored: Array<{ path: string; text: string }> = [];
         const circuitEdits: Array<{
@@ -619,6 +672,12 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
     };
     useImperativeHandle(ref, () => ({
       flush,
+      flushFolders: (ids) =>
+        flushSelectedFolders(
+          ids,
+          current.current.project.structureRevision,
+          (id, revision) => flush(undefined, id, revision),
+        ),
       save: async () => {
         const applied = await flush();
         // Preserve every folder's remaining buffer, including invalid values and
@@ -1128,8 +1187,14 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
         maximized={props.maximized}
         onToggleMaximize={props.onToggleMaximize}
         status={
-          !recoveryAvailable || conflict || props.status ? (
+          !recoveryAvailable || conflict || props.status || legacyConfig ? (
             <>
+              {legacyConfig ? (
+                <span title="This existing experiment still uses version-1 JSON bindings and measurements. Convert through Helper after moving its electrical intent into Code.">
+                  Legacy configuration · migration required for Code-only
+                  execution
+                </span>
+              ) : null}
               {!recoveryAvailable ? (
                 <span role="alert">
                   Draft recovery unavailable — save or export before leaving.
@@ -1202,6 +1267,54 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
                 ?.text ?? file.text,
           )}
           helperActions={[
+            ...(legacyConfig
+              ? [
+                  {
+                    id: "convert-native",
+                    label: "Convert legacy experiment to native Code…",
+                    keywords: "migrate configuration experiment.json 迁移",
+                    run: async () => {
+                      const applied = await flush();
+                      if (!applied.ok) return;
+                      const converted = migrateSimulationConfigToNative(
+                        current.current.project,
+                        applied.folder,
+                      );
+                      if (!converted.ok) {
+                        props.onProblem(
+                          inputProblem(
+                            "SIMULATION_NATIVE_MIGRATION_REQUIRED",
+                            converted.message,
+                          ),
+                        );
+                        return;
+                      }
+                      const result = await props.files.handle({
+                        action: "update",
+                        owner: {
+                          kind: "project-folder",
+                          folderId: applied.folder.id,
+                        },
+                        expectedRevision: applied.revision,
+                        writes: converted.folder.input.files.filter(
+                          (file) =>
+                            file.path === converted.folder.input.configPath,
+                        ),
+                      });
+                      if (!result.ok) props.onProblem(result.error);
+                    },
+                  },
+                ]
+              : []),
+            {
+              id: "save-device-op",
+              label: "Save device operating point…",
+              keywords: "MOS gm gds vth id 工作点",
+              run: () => {
+                beginSignalSelection();
+                setProbePicker("device-op");
+              },
+            },
             {
               id: "save-voltage",
               label: "Save voltage…",

--- a/apps/editor/src/features/simulation/source-probe-choices.test.ts
+++ b/apps/editor/src/features/simulation/source-probe-choices.test.ts
@@ -4,6 +4,8 @@ import {
   createSimulationStarter,
   simulationSignalNames,
   simulationSignals,
+  nativeSimulationDevices,
+  nativeTerminalCurrent,
 } from "@icm/netlist";
 import { resolveSimulationVoltageProbeNetId } from "./simulation-probe-options";
 import ota from "../../examples/five-transistor-ota-sky130.icproj.json";
@@ -11,6 +13,34 @@ import { sourceProbeChoices } from "./source-probe-choices";
 
 const project = parseProject(JSON.stringify(ota));
 describe("source Probe discovery", () => {
+  it("uses native device identities for hierarchical OP and refuses hidden current instrumentation", () => {
+    const before = JSON.stringify(project);
+    const devices = nativeSimulationDevices(
+      project,
+      project.simulationFolders[0]!.input,
+    );
+    const mos = devices.find(
+      (device) => device.polarity && device.reference.includes("."),
+    )!;
+    expect(mos.nativeDevice).toMatch(/^m\..*\.msky130_fd_pr__/u);
+    expect(nativeTerminalCurrent(mos, "D")).toMatchObject({
+      ok: true,
+      vectors: [`@${mos.nativeDevice}[id]`],
+      directives: [],
+    });
+    expect(nativeTerminalCurrent(mos, "G")).toMatchObject({ ok: false });
+    const choices = sourceProbeChoices(
+      project,
+      project.simulationFolders[0]!.input,
+    );
+    expect(
+      choices.some(
+        (choice) =>
+          choice.kind === "device-op" && choice.label.includes("[gm]"),
+      ),
+    ).toBe(true);
+    expect(JSON.stringify(project)).toBe(before);
+  });
   it("maps native vectors back to valid Canvas nets through the same naming traversal", () => {
     const input = project.simulationFolders[0]!.input;
     const signals = simulationSignals(project, input);

--- a/apps/editor/src/features/simulation/source-probe-choices.ts
+++ b/apps/editor/src/features/simulation/source-probe-choices.ts
@@ -8,12 +8,14 @@ import {
   inspectSimulationSourceGraph,
   listAuthoredCircuitScopes,
   simulationSignalNames,
+  nativeSimulationDevices,
+  nativeDeviceOpVectors,
 } from "@icm/netlist";
 import { deriveSimulationProbeOptions } from "./simulation-probe-options";
 
 export interface SourceProbeChoice {
   label: string;
-  kind: "voltage" | "current";
+  kind: "voltage" | "current" | "device-op";
   expression: SimulationSourceExpression;
 }
 export function sourceProbeChoices(
@@ -22,6 +24,13 @@ export function sourceProbeChoices(
 ): SourceProbeChoice[] {
   const graph = inspectSimulationSourceGraph(input);
   const choices: SourceProbeChoice[] = [];
+  for (const device of nativeSimulationDevices(project, input))
+    for (const vector of nativeDeviceOpVectors(device))
+      choices.push({
+        kind: "device-op",
+        label: `${device.reference} · ${vector.slice(vector.lastIndexOf("[") + 1, -1).toUpperCase()} — ${vector}`,
+        expression: { kind: "vector", vector },
+      });
   for (const binding of input.circuitBindings) {
     if (!graph.paths.includes(binding.path)) continue;
     const analysis = analyzeDesignNetlist(project, {

--- a/apps/editor/src/features/simulation/source-probe-picker.tsx
+++ b/apps/editor/src/features/simulation/source-probe-picker.tsx
@@ -9,7 +9,7 @@ export function SourceProbePicker({
   onClose,
 }: {
   choices: readonly SourceProbeChoice[];
-  kind: "voltage" | "current";
+  kind: "voltage" | "current" | "device-op";
   onAdd(label: string, expression: SimulationSourceExpression): boolean;
   onClose(): void;
 }) {
@@ -36,8 +36,7 @@ export function SourceProbePicker({
   }, [onClose]);
   const filtered = choices.filter(
     (c) =>
-      c.kind === (kind === "current" ? "current" : "voltage") &&
-      c.label.toLowerCase().includes(query.toLowerCase()),
+      c.kind === kind && c.label.toLowerCase().includes(query.toLowerCase()),
   );
   const add = (choice: SourceProbeChoice) => {
     const key = JSON.stringify(choice.expression);
@@ -91,7 +90,7 @@ export function SourceProbePicker({
           onClick={() =>
             add({
               label: query.trim(),
-              kind: kind === "current" ? "current" : "voltage",
+              kind,
               expression: { kind: "vector", vector: query.trim() },
             })
           }

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -473,12 +473,7 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
   };
   const executeBatch = async (selection: readonly string[]) => {
     if (lock.current) return;
-    const authored = await codeRef.current?.flush();
-    if (authored && !authored.ok) return;
-    const folders = project.simulationFolders.filter((folder) =>
-      selection.includes(folder.id),
-    );
-    if (folders.length < 2) {
+    if (new Set(selection).size < 2) {
       setProblem(
         uiProblem(
           "SIMULATION_BATCH_SELECTION_REQUIRED",
@@ -492,11 +487,12 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
     setProblem(undefined);
     hydratedBatchRuns.current.clear();
     try {
+      const authored = await codeRef.current?.flushFolders(selection);
+      if (!authored?.ok) return;
+      const folders = authored.folders;
       const preparedReply = await session.handle({
         operation: "prepare-batch",
-        expectedStructureRevision: authored?.ok
-          ? authored.revision
-          : project.structureRevision,
+        expectedStructureRevision: authored.revision,
         items: folders.map((folder) => ({
           id: folder.id,
           folderId: folder.id,
@@ -510,11 +506,7 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
         );
         if (!folder) continue;
         preparedPresentations.current.set(item.prepared.id, {
-          ...sourcePresentation(
-            authored?.ok && authored.folder.id === folder.id
-              ? authored.folder
-              : folder,
-          ),
+          ...sourcePresentation(folder),
           prepared: structuredClone(item.prepared),
         });
         folderResults.current.set(folder.id, { prepared: item.prepared });

--- a/apps/mcp-server/src/simulation-authoring-tools.ts
+++ b/apps/mcp-server/src/simulation-authoring-tools.ts
@@ -170,6 +170,14 @@ async function read(
         `${parsed.path}: ${parsed.message}. Source files remain editable through simulation_files.`,
       ),
     };
+  if (parsed.authority === "code")
+    return {
+      ok: false as const,
+      result: failure(
+        "SIMULATION_NATIVE_CODE_REQUIRED",
+        "This experiment is Code-authoritative. Read/edit save, .probe, let and meas through simulation_files; Device OP uses save @device[parameter] followed by op. Legacy JSON helpers cannot downgrade it or add another electrical authority.",
+      ),
+    };
   return {
     ok: true as const,
     folder,
@@ -295,7 +303,7 @@ export const simulationAuthoringTools: readonly Entry[] = [
   ),
   tool(
     "simulation_output",
-    "Manage experiment output ASTs in the one configuration source file. Use {kind:'vector',vector:'v(out)'} for native vectors, circuit-qualified voltage/current for Canvas anchors, and unary/binary math ASTs. Native SPICE expressions in run.cir remain freely editable. Missing runtime vectors diagnose at prepare/result time, never end the session.",
+    "Legacy version-1 experiments only: manage output ASTs in their configuration file. Code-authoritative version-2 experiments require simulation_files to edit save/.probe/let and cannot be downgraded by this helper. Missing runtime vectors diagnose at prepare/result time.",
     OutputArgs,
     async (parsed, session) => {
       const result = await read(session, parsed.folderId, parsed.documentId);
@@ -329,7 +337,7 @@ export const simulationAuthoringTools: readonly Entry[] = [
   ),
   tool(
     "simulation_measurement",
-    "Manage saved per-record scalar measurements in the experiment configuration source. value, sample-at, minimum, maximum, peak-to-peak, mean and RMS share the runtime schema. A measurement may be authored before its analysis or output exists; prepare and result diagnostics identify unresolved references without blocking file editing.",
+    "Legacy version-1 experiments only: manage saved per-record scalar measurements. Code-authoritative version-2 experiments use native meas through simulation_files; ngspice evaluates them and the app displays reported evidence. This helper cannot add JSON measurement rules to version 2.",
     MeasurementArgs,
     async (parsed, session) => {
       const result = await read(session, parsed.folderId, parsed.documentId);
@@ -364,7 +372,7 @@ export const simulationAuthoringTools: readonly Entry[] = [
   ),
   tool(
     "simulation_device_operating_point",
-    "Select MOS occurrences for terminal-derived VGS, VDS, VBS and drain-entering ID. circuit names the generated binding and authored X callPath; occurrence addresses hierarchy inside that binding. This edits the same experiment configuration used by Code, not a second folder object. OP may be added to the native program before or after this helper.",
+    "Legacy version-1 experiments only: select MOS occurrences for terminal-derived VGS/VDS/VBS/ID. Code-authoritative version-2 experiments use simulation_files to write native save @device[parameter], then op and write. This helper cannot create JSON selections in version 2.",
     DeviceArgs,
     async (parsed, session) => {
       const result = await read(session, parsed.folderId, parsed.documentId);

--- a/apps/mcp-server/src/tools.test.ts
+++ b/apps/mcp-server/src/tools.test.ts
@@ -254,7 +254,7 @@ describe("mcp tool surface", () => {
       error: { code: "SIMULATION_FOLDER_UPDATE_EMPTY" },
     });
   });
-  it("writes output, measurement and MOS helpers into the one config source, preserving native programs", async () => {
+  it("retains legacy JSON helpers without permitting native experiments to downgrade", async () => {
     const http = new FakeAgentHttp(),
       { session } = await toolSession(http);
     await callTool("connect", { claimCode: "session-1.code" }, session);
@@ -284,6 +284,46 @@ describe("mcp tool surface", () => {
       }
       return capabilitiesResponse(request.requestId);
     };
+    const original = JSON.stringify(snapshot.project.simulationFolders);
+    for (const name of [
+      "simulation_output",
+      "simulation_measurement",
+      "simulation_device_operating_point",
+    ]) {
+      expect(
+        parseText(
+          await callTool(name, { action: "list", folderId: "s" }, session),
+        ),
+      ).toMatchObject({
+        ok: false,
+        error: { code: "SIMULATION_NATIVE_CODE_REQUIRED" },
+      });
+    }
+    expect(
+      parseText(
+        await callTool(
+          "simulation_output",
+          {
+            action: "upsert",
+            folderId: "s",
+            label: "Vout",
+            expression: { kind: "vector", vector: "v(out)" },
+          },
+          session,
+        ),
+      ),
+    ).toMatchObject({
+      ok: false,
+      error: { code: "SIMULATION_NATIVE_CODE_REQUIRED" },
+    });
+    expect(JSON.stringify(snapshot.project.simulationFolders)).toBe(original);
+    // Explicit fixture for the retained v1 compatibility lane.
+    snapshot.project.simulationFolders[0]!.input.files.find(
+      (f) => f.path === "experiment.json",
+    )!.text = JSON.stringify({
+      version: 1,
+      environment: { profileId: "test" },
+    });
     const cfg = () => {
       const result = readSimulationExperimentConfig(
         snapshot.project.simulationFolders[0]!,
@@ -421,7 +461,10 @@ describe("mcp tool surface", () => {
           session,
         ),
       ),
-    ).toMatchObject({ ok: true, outputs: [] });
+    ).toMatchObject({
+      ok: false,
+      error: { code: "SIMULATION_NATIVE_CODE_REQUIRED" },
+    });
   });
 
   it("inspect and search refresh by default so human edits are visible", async () => {

--- a/docs/specs/simulation-code-workspace.md
+++ b/docs/specs/simulation-code-workspace.md
@@ -29,13 +29,66 @@ are outside this work.
 
 ## 1. One owner for each fact
 
+### Native Code authority (configuration version 2)
+
+New experiments use a strict minimal sidecar:
+
+```json
+{ "version": 2, "environment": { "profileId": "hosted-sky130-v1" } }
+```
+
+The profile ID above is illustrative; use the ID advertised by the executor.
+SPICE owns `.param`, parameter references, `.temp`, `.lib` selection, analyses,
+`save`/`.probe`, `let`, `meas`, and control loops. None has an editable JSON
+counterpart. Generated Circuit parameter slots accept numeric literals or braced
+and single-quoted parameter expressions. They still map back to the same Canvas
+Instance through one transaction; topology remains protected. Reviewed SKY130
+Code dimensions are in micrometres and Canvas dimensions in metres; expression
+wrappers explicitly preserve that conversion, including round trips.
+
+Batch is a queue of selected experiment folders, invoked by **Run selected
+folders** in the Explorer context menu. All selected folders' drafts are applied
+before preparation, not just the active folder. Native loops remain one native
+program, not an app-expanded sweep. Execution variants are rejected for version 2.
+
+Device OP is derived from vectors actually collected by Code. `op` takes no
+parameters: request e.g. `save @m1[id] @m1[gm]`, then `op`, then `write result.raw`.
+Helper resolves Canvas and authored hierarchy identities, including reviewed
+SKY130 wrapper primitives. It never adds JSON selections or hidden Canvas sense
+sources. Top-level terminal picks use native `.probe`; hierarchical picks support
+only model-native readable drain currents and voltage-source branch currents.
+Unsupported internal terminals report the limitation without modifying the project.
+Native raw names and model values remain evidence; there is no reconstructed
+`gm`, threshold or saturation-region algorithm.
+
+Native `meas` results are finite scalar reports read from the simulator log, with
+report order and Console line retained. Missing results are unavailable, not zero.
+Repeated names are not guessed to belong to particular raw plots, and units are
+not inferred. Existing automatic result summaries remain app-derived views.
+
+The one-rawfile executor derives its collector from reachable literal `write`
+paths. Repeated writes may use one path with `set appendwrite`; dynamic paths and
+multiple distinct paths are diagnosed. No `write` means a console/artifact-only
+run, not an invented `out.raw`. The profile and safe dependency manifests remain
+application responsibilities; an explicit native `.lib` selects its corner.
+
+Version-1 experiments are a **legacy compatibility lane**, not Code-only
+experiments. They retain their original JSON behavior and show a visible legacy
+notice. Helper can explicitly convert sidecars with no remaining advanced intent
+and a matching collector. Bindings, sweep plans, named outputs, Device OP selections,
+measurements and corners that need translation block that conversion and list the
+required work; no intent is silently erased. Automated translation of arbitrary
+legacy advanced experiments is not implemented. The version-1 descriptions below
+document that compatibility lane only and do not authorize new sidecar features.
+
 | Fact                                                                  | Authority                                | Permitted editor                                              |
 | --------------------------------------------------------------------- | ---------------------------------------- | ------------------------------------------------------------- |
 | Canvas circuit topology, interfaces, model/device identity            | Existing Project Cells and Instances     | Existing Project edits                                        |
 | Persistent circuit dimensions and exposed instance values             | Instance netlist parameters              | Properties or mapped code edits, through the same transaction |
 | Text-authored Testbench, sources, loads, analyses and control flow    | Authored SPICE files                     | Human, Agent, template or helper                              |
 | Drawn Testbench topology and source values                            | Its ordinary Cell                        | Canvas/Properties or mapped parameter edits                   |
-| Profile, managed Run Plan, output bindings and saved measurements     | Authored experiment configuration file   | Human, Agent or helper                                        |
+| Runtime Profile ID                                                  | Authored minimal experiment configuration | Human or Agent                                                |
+| Variables, acquisition, analysis, loops and native measurements       | Authored SPICE (version 2)                | Human, Agent or Helper                                        |
 | Generated text, ASTs, effective parameters and object/vector mappings | Derived from one captured input          | Read-only projections                                         |
 | Prepared artifacts, run state and results                             | Existing simulation service and executor | Existing lifecycle and artifact resources                     |
 
@@ -136,9 +189,9 @@ added choices are marked and cannot insert duplicates within that selection sess
 Canvas picking continues until Done or Escape. Successive picks extend the session's
 save statement without focusing the editor; the file row exposes picking status
 and Done. Failed additions keep the selection available and report their cause.
-Terminal-current picks retain their existing configuration owner when generated
-measurement wiring is required. An explicit
-save list is never silently widened to `all` by that instrumentation.
+Terminal-current picks write native `.probe` or a model-native `save` vector.
+They never create new legacy configuration instrumentation or silently widen
+an explicit save list to `all`.
 Discovery and completion use the compiler's authored call-path mapping; they
 show the Canvas name alongside the executable native vector. Native vectors
 remain available for text-only or statically unresolvable scopes.
@@ -152,7 +205,7 @@ ordinary authored text; entry/includes determine whether it executes. Optional
 Canvas templates produce protected generated bindings, not a writable copy of
 the circuit. All persistence still uses the shared folder/file operations.
 
-### Experiment configuration
+### Legacy experiment configuration (version 1 only)
 
 The JSON text at `configPath` is the sole configuration authority. Its version-1
 object has these fields; bounded leaves reuse the existing model schemas:
@@ -196,7 +249,7 @@ structural evaluator into a purported complete ngspice evaluator. A binding
 whose descriptor cannot faithfully project an expression receives a located
 binding diagnostic; unrelated free SPICE expressions do not become illegal.
 
-### Acquisition scope
+### Legacy acquisition scope
 
 Canvas voltage/current expression leaves and device-OP selections add:
 

--- a/docs/specs/simulation-code-workspace.md
+++ b/docs/specs/simulation-code-workspace.md
@@ -321,10 +321,11 @@ exact object/parameter target, descriptor, original value and generation input
 digest. These spans are derived, never persisted. The digest covers every
 reached Document revision and folder state needed for that generation.
 
-- Initial editable fields are MOS W/L and existing descriptor-backed numeric
-  dimension/multiplicity fields, R/C/L value, and numeric V/I DC, AC and selected
+- Editable fields are MOS W/L and existing descriptor-backed
+  dimension/multiplicity fields, R/C/L value, and V/I DC, AC and selected
   waveform fields **where a reversible printer mapping exists**. Model identity,
   pin order, nodes, references, source kind and arbitrary model text are locked.
+  Numeric literals and delimited native parameter expressions share those spans.
 - Descriptor-backed does not imply reversibility. The compiler must report the
   exact editable fields and conversions; a new unsupported field remains
   read-only. W/L, `nf`, `m`, SI units and PDK scaling use existing semantics,
@@ -340,10 +341,11 @@ reached Document revision and folder state needed for that generation.
   retains that draft; an exported Project must not claim it contains the edit.
 - Definition edits affect all occurrences and experiments sharing the Cell.
   The UI/helper explains this once at the edit target. Experiment-only changes
-  use source parameters or the prepared Run Plan projection instead.
+  use source parameters/control Code; only legacy experiments retain prepared
+  Run Plan projections.
 
 The editable Circuit view shows persistent Instance values, not a projected
-Batch member disguised as an editable circuit. When a variable binding masks
+Batch member disguised as an editable circuit. When a legacy variable binding masks
 such a value, expose that binding and link to its authored declaration. The
 read-only Prepared view shows the effective projection used for execution.
 
@@ -379,15 +381,16 @@ Profile paths resolve through the existing dependency resolver, never through
 client machine paths. Known model-backed acquisition and execution eligibility
 remain Profile-governed; unknown static syntax is not a new analysis blacklist.
 
-Terminal-current sense sources stay in prepared IR, with the existing positive
-current-entering-terminal rule. Keep hierarchy aliases, MOS operating points
-and exact object mappings. Do not replace this path with today's unbound raw
-adapter or guess MOS currents from `i(m1)`.
+Legacy terminal-current sense sources stay in prepared IR for compatibility.
+Native Helper acquisition is defined in source (`.probe` or model vectors), not
+in that legacy IR instrumentation path. Keep hierarchy aliases and exact object
+mappings; never guess MOS currents from `i(m1)`.
 
 ### Frozen first collection boundary
 
-One Run has at most one declared ASCII rawfile, default `out.raw`, matching the
-current executor artifact boundary. Do not add a host filesystem or arbitrary
+One Run has at most one declared ASCII rawfile, matching the
+current executor artifact boundary. Version 2 derives the path from Code; version 1
+retains its JSON collector and `out.raw` default. Do not add a host filesystem or arbitrary
 output directory collector in this refactor. Retain other artifacts already
 supported by the executor, but do not promise arbitrary user-written files are
 downloadable. A different safe rawfile name requires collection support from
@@ -399,7 +402,7 @@ A provable mismatch with authored capture is a located, repairable diagnostic.
 
 The default template sets `filetype=ascii` and `appendwrite` in a fresh run
 directory and writes immediately after each analysis. The compiler emits the
-Canvas acquisition `.save` declarations in an inspectable generated preamble;
+legacy Canvas acquisition `.save` declarations in an inspectable generated preamble;
 they are regenerated with the binding map, not pasted as another editable
 vector list into author text. Default capture uses bare `write out.raw` to
 write the current saved plot. Without configured acquisitions, preserve native
@@ -628,14 +631,8 @@ and this `experiment.json`:
 
 ```json
 {
-  "version": 1,
-  "environment": { "profileId": "sky130-core-continuous-ngspice46-v1" },
-  "runPlan": { "mode": "nominal" },
-  "variables": [],
-  "outputs": [],
-  "deviceOperatingPoints": [],
-  "measurements": [],
-  "collection": { "rawfile": "out.raw" }
+  "version": 2,
+  "environment": { "profileId": "sky130-core-continuous-ngspice46-v1" }
 }
 ```
 

--- a/packages/devices/src/index.ts
+++ b/packages/devices/src/index.ts
@@ -3,3 +3,4 @@ export * from "./registry.js";
 export * from "./reference.js";
 export * from "./reviewed-external.js";
 export * from "./validation.js";
+export * from "./parameter-expression.js";

--- a/packages/devices/src/parameter-expression.ts
+++ b/packages/devices/src/parameter-expression.ts
@@ -1,0 +1,28 @@
+/**
+ * Recognize one delimited native parameter expression, without evaluating it.
+ * Unknown parameters/functions belong to ngspice. Card delimiters and unfinished
+ * grouping do not belong inside a reversible Circuit parameter slot.
+ */
+export function parameterExpressionBody(value: string): string | undefined {
+  const text = value.trim();
+  if (!(
+    (text.startsWith("{") && text.endsWith("}")) ||
+    (text.startsWith("'") && text.endsWith("'"))
+  ))
+    return undefined;
+  const body = text.slice(1, -1).trim();
+  if (
+    !body ||
+    /[\r\n;"'$\\]/u.test(body) ||
+    /[+*/%^=<>!&|?:,-]\s*$/u.test(body)
+  )
+    return undefined;
+  const stack: string[] = [];
+  for (const char of body) {
+    if (char === "(" || char === "{") stack.push(char);
+    else if (char === ")" || char === "}") {
+      if (stack.pop() !== (char === ")" ? "(" : "{")) return undefined;
+    } else if (!/[A-Za-z0-9_.,+\-*/%^=<>!&|?:\s]/u.test(char)) return undefined;
+  }
+  return stack.length ? undefined : body;
+}

--- a/packages/devices/src/reviewed-external.test.ts
+++ b/packages/devices/src/reviewed-external.test.ts
@@ -74,6 +74,18 @@ describe("reviewed external device bindings", () => {
 
   it("converts reviewed geometry in both directions without aliasing counts", () => {
     expect(projectLengthToSky130Micrometres("150n")).toBe("0.15");
+    expect(projectLengthToSky130Micrometres("{WIDTH}")).toBe("{(WIDTH) / 1u}");
+    expect(sky130MicrometresToProjectLength("{WIDTH}")).toBe("{(WIDTH) * 1u}");
+    expect(
+      projectLengthToSky130Micrometres(
+        sky130MicrometresToProjectLength("{WIDTH * 2}"),
+      ),
+    ).toBe("{WIDTH * 2}");
+    expect(
+      sky130MicrometresToProjectLength(
+        projectLengthToSky130Micrometres("{WIDTH * 2}"),
+      ),
+    ).toBe("{WIDTH * 2}");
     expect(projectLengthToSky130Micrometres("5.5u")).toBe("5.5");
     expect(sky130MicrometresToProjectLength("0.15")).toBe("150n");
     expect(sky130MicrometresToProjectLength("5.5")).toBe("5.5u");

--- a/packages/devices/src/reviewed-external.ts
+++ b/packages/devices/src/reviewed-external.ts
@@ -1,4 +1,5 @@
 import type { DeviceParameterDefinition } from "./contract.js";
+import { parameterExpressionBody } from "./parameter-expression.js";
 
 export type ReviewedExternalBindingId =
   | "sky130-nfet-01v8"
@@ -312,12 +313,22 @@ function parseSpiceNumber(value: string): number {
 
 /** Canonical Project length (metres) to the reviewed SKY130 plain-um form. */
 export function projectLengthToSky130Micrometres(value: string): string {
+  const expression = parameterExpressionBody(value);
+  if (expression !== undefined) {
+    const inverse = /^\((.*)\) \* 1u$/u.exec(expression);
+    return inverse ? `{${inverse[1]}}` : `{(${expression}) / 1u}`;
+  }
   return `${Number((parseSpiceNumber(value) / 1e-6).toPrecision(12))}`;
 }
 
 /** Reviewed SKY130 plain-um input to the canonical Project length spelling. */
 export function sky130MicrometresToProjectLength(value: string): string {
   const text = value.trim();
+  const expression = parameterExpressionBody(text);
+  if (expression !== undefined) {
+    const inverse = /^\((.*)\) \/ 1u$/u.exec(expression);
+    return inverse ? `{${inverse[1]}}` : `{(${expression}) * 1u}`;
+  }
   if (!/^[+-]?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?$/iu.test(text)) {
     throw new Error(
       `Reviewed SKY130 geometry must be a plain micrometre number: ${value}`,

--- a/packages/model/src/schema/simulation-source.ts
+++ b/packages/model/src/schema/simulation-source.ts
@@ -233,7 +233,16 @@ export const SimulationSourceDeviceOperatingPointSchema =
     circuit: SimulationCircuitScopeSchema,
   });
 
-/** Parse on prepare/helper invocation; persist only the JSON source text. */
+/** Native experiments define all electrical behavior in SPICE, not a sidecar. */
+export const NativeSimulationExperimentConfigSchema = z.strictObject({
+  version: z.literal(2),
+  environment: z.strictObject({ profileId: z.string().min(1).max(256) }),
+});
+export type NativeSimulationExperimentConfig = z.infer<
+  typeof NativeSimulationExperimentConfigSchema
+>;
+
+/** Version-1 compatibility reader. New experiments use the native version-2 contract. */
 export const SimulationExperimentConfigSchema = z
   .strictObject({
     version: z.literal(1),

--- a/packages/model/src/simulation-source-authoring.ts
+++ b/packages/model/src/simulation-source-authoring.ts
@@ -1,6 +1,7 @@
 import {
   ProjectSimulationFolderSchema,
   SimulationExperimentConfigSchema,
+  NativeSimulationExperimentConfigSchema,
   type ProjectSimulationFolder,
   type SimulationExperimentConfig,
 } from "./schema.js";
@@ -15,8 +16,8 @@ export function createSimulationFolder(options: {
   /** Supplied from the canonical netlist interface when authoring a textual TB. */
   dut?: { name: string; ports: string[] };
 }): ProjectSimulationFolder {
-  const config = SimulationExperimentConfigSchema.parse({
-    version: 1,
+  const config = NativeSimulationExperimentConfigSchema.parse({
+    version: 2,
     environment: { profileId: options.profileId },
   });
   return ProjectSimulationFolderSchema.parse({
@@ -86,7 +87,11 @@ export function createSimulationFolder(options: {
 export function readSimulationExperimentConfig(
   folder: ProjectSimulationFolder,
 ):
-  | { ok: true; config: SimulationExperimentConfig }
+  | {
+      ok: true;
+      config: SimulationExperimentConfig;
+      authority: "code" | "legacy-config";
+    }
   | {
       ok: false;
       message: string;
@@ -106,9 +111,26 @@ export function readSimulationExperimentConfig(
       fields: [],
     };
   }
-  const parsed = SimulationExperimentConfigSchema.safeParse(value);
+  const native =
+    typeof value === "object" &&
+    value !== null &&
+    "version" in value &&
+    value.version === 2;
+  const parsed = native
+    ? NativeSimulationExperimentConfigSchema.safeParse(value)
+    : SimulationExperimentConfigSchema.safeParse(value);
   return parsed.success
-    ? { ok: true, config: parsed.data }
+    ? {
+        ok: true,
+        authority: native ? "code" : "legacy-config",
+        // Compatibility-shaped execution metadata is derived, never persisted beside Code.
+        config: native
+          ? SimulationExperimentConfigSchema.parse({
+              version: 1,
+              environment: parsed.data.environment,
+            })
+          : (parsed.data as SimulationExperimentConfig),
+      }
     : {
         ok: false,
         message: "Correct the experiment configuration",

--- a/packages/netlist/src/index.ts
+++ b/packages/netlist/src/index.ts
@@ -14,3 +14,5 @@ export * from "./simulation-source-projection.js";
 export * from "./simulation-starter.js";
 export * from "./simulation-source-scopes.js";
 export * from "./simulation-signal-names.js";
+export * from "./simulation-native-devices.js";
+export * from "./simulation-native-migration.js";

--- a/packages/netlist/src/simulation-circuit-source.test.ts
+++ b/packages/netlist/src/simulation-circuit-source.test.ts
@@ -190,7 +190,7 @@ describe("Circuit parameter source projection", () => {
       planCircuitSourceEdit(source, replace(source, [{ index, text: "-1" }])),
     ).toMatchObject({ ok: false, code: "SIMULATION_PARAMETER_INVALID" });
     expect(
-      planCircuitSourceEdit(source, replace(source, [{ index, text: "{W}" }])),
+      planCircuitSourceEdit(source, replace(source, [{ index, text: "{W+}" }])),
     ).toMatchObject({ ok: false, code: "SIMULATION_PARAMETER_INVALID" });
     expect(
       planCircuitSourceEdit(source, replace(source, [{ index, text: "25u" }])),
@@ -212,4 +212,41 @@ describe("Circuit parameter source projection", () => {
     const plan = planCircuitSourceEdit(source, replace(source, widths));
     expect(plan.ok && plan.changes.length).toBe(2);
   });
+  it("round-trips native parameter references through Canvas and reviewed PDK units", () => {
+    const { project, source } = fixture();
+    const index = source.parameters.findIndex((p) => p.parameter === "w");
+    const edited = replace(source, [{ index, text: "{WIDTH * 2}" }]);
+    const plan = planCircuitSourceEdit(source, edited);
+    expect(plan.ok).toBe(true);
+    if (!plan.ok) return;
+    expect(plan.changes[0]!.value).toBe("{(WIDTH * 2) * 1u}");
+    for (const change of plan.changes)
+      project.documents
+        .find((d) => d.id === change.documentId)!
+        .instances.find((i) => i.id === change.instanceId)!.netlist!.parameters[
+        change.parameter
+      ] = change.value;
+    const regenerated = generateCircuitSource(project, source.binding);
+    expect(regenerated.ok).toBe(true);
+    if (!regenerated.ok) return;
+    expect(regenerated.source.text).toBe(edited);
+    expect(planCircuitSourceEdit(regenerated.source, edited)).toEqual({
+      ok: true,
+      changes: [],
+    });
+    const exported = analyzeDesignNetlist(project, {
+      rootDocumentId: source.binding.documentId,
+    });
+    expect(exported.ir).not.toBeNull();
+  });
+  it.each(["{}", "{W", "{W;quit}", "{W}\nRnew out 0 1", "{W) + 1}"])(
+    "does not let an expression escape its Circuit slot: %s",
+    (text) => {
+      const { source } = fixture();
+      const index = source.parameters.findIndex((p) => p.parameter === "w");
+      expect(
+        planCircuitSourceEdit(source, replace(source, [{ index, text }])).ok,
+      ).toBe(false);
+    },
+  );
 });

--- a/packages/netlist/src/simulation-circuit-source.ts
+++ b/packages/netlist/src/simulation-circuit-source.ts
@@ -1,6 +1,7 @@
 import type { CircuitProject, SimulationCircuitBinding } from "@icm/model";
 import {
   deviceDescriptor,
+  parameterExpressionBody,
   reviewedExternalDeviceBindings,
   sky130MicrometresToProjectLength,
   type DeviceParameterDefinition,
@@ -195,7 +196,7 @@ export function planCircuitSourceEdit(
     if (!nextText.startsWith(fixed, nextOffset))
       return fail(
         "SIMULATION_CIRCUIT_STRUCTURE_LOCKED",
-        "Only highlighted numeric parameters can change; edit topology, references and model identity on Canvas",
+        "Only highlighted parameter values or expressions can change; edit topology, references and model identity on Canvas",
       );
     nextOffset += fixed.length;
     const nextStart = spans[index + 1]?.startOffset ?? source.text.length;
@@ -238,10 +239,14 @@ export function planCircuitSourceEdit(
       continue;
     }
     const number = parseSpiceNumber(raw);
-    if (!number || !Number.isFinite(number.value) || /\s/u.test(raw)) {
+    const expression = parameterExpressionBody(raw);
+    if (
+      expression === undefined &&
+      (!number || !Number.isFinite(number.value) || /\s/u.test(raw))
+    ) {
       invalid ??= fail(
         "SIMULATION_PARAMETER_INVALID",
-        `Finish the numeric value for ${span.descriptor.label} before applying`,
+        `Finish the number or braced parameter expression for ${span.descriptor.label} before applying`,
       );
       originalOffset = span.endOffset;
       nextOffset = end;
@@ -251,6 +256,7 @@ export function planCircuitSourceEdit(
       ["width", "length", "multiplier", "finger-count"].includes(
         span.descriptor.displayRole,
       ) &&
+      number &&
       number.value <= 0
     ) {
       invalid ??= fail(
@@ -263,6 +269,7 @@ export function planCircuitSourceEdit(
     }
     if (
       span.descriptor.displayRole === "finger-count" &&
+      number &&
       !Number.isInteger(number.value)
     ) {
       invalid ??= fail(

--- a/packages/netlist/src/simulation-compile.ts
+++ b/packages/netlist/src/simulation-compile.ts
@@ -154,12 +154,12 @@ export interface CompiledSimulationOutput {
 }
 
 export type SimulationDeviceOperatingPointParameter =
-  "vgs" | "vds" | "vbs" | "id";
+  "vgs" | "vds" | "vbs" | "id" | "gm" | "gds" | "gmbs" | "vth" | "vdsat";
 
 export interface CompiledSimulationDeviceOperatingPointValue {
   readonly parameter: SimulationDeviceOperatingPointParameter;
-  readonly label: "VGS" | "VDS" | "VBS" | "ID";
-  readonly unit: "V" | "A";
+  readonly label: string;
+  readonly unit: "V" | "A" | "S";
   readonly expression: CompiledSimulationExpression;
 }
 

--- a/packages/netlist/src/simulation-native-collection.ts
+++ b/packages/netlist/src/simulation-native-collection.ts
@@ -1,0 +1,42 @@
+import { isSimulationInputPath } from "@icm/model";
+import { unquoteSimulationToken } from "@icm/spice";
+import type {
+  SimulationSourceGraph,
+  SimulationSourceDiagnostic,
+} from "./simulation-source-graph.js";
+
+/** The current executor collects one ASCII rawfile; its name comes from Code. */
+export function nativeSourceCollection(graph: SimulationSourceGraph) {
+  const paths = new Set<string>();
+  const diagnostics: SimulationSourceDiagnostic[] = [];
+  for (const item of graph.statements) {
+    const statement = item.statement;
+    if (
+      statement.kind !== "control_command" ||
+      statement.command.toLowerCase() !== "write"
+    )
+      continue;
+    const path = unquoteSimulationToken(statement.arguments[0] ?? "");
+    if (!path || /[${}]/u.test(path) || !isSimulationInputPath(path)) {
+      diagnostics.push({
+        code: "SIMULATION_NATIVE_COLLECTION_PATH",
+        severity: "error",
+        path: item.path,
+        sourceRef: statement.sourceRef,
+        message:
+          "This executor needs an explicit, workspace-relative write path. Use one literal rawfile path for all collected plots; dynamic collection is not supported yet.",
+      });
+    } else paths.add(path);
+  }
+  if (paths.size > 1)
+    diagnostics.push({
+      code: "SIMULATION_NATIVE_COLLECTION_MULTIPLE",
+      severity: "error",
+      message:
+        "This executor collects one rawfile. Write collected plots to the same path with set appendwrite; separate rawfile collection is not supported yet.",
+    });
+  return {
+    collection: { rawfile: paths.values().next().value ?? null },
+    diagnostics,
+  };
+}

--- a/packages/netlist/src/simulation-native-devices.ts
+++ b/packages/netlist/src/simulation-native-devices.ts
@@ -1,0 +1,170 @@
+import type {
+  CircuitProject,
+  SimulationCircuitScope,
+  SimulationSourceInput,
+} from "@icm/model";
+import { reviewedExternalDeviceBindings } from "@icm/devices";
+import { mosBulkKind } from "@icm/derived";
+import { analyzeDesignNetlist } from "./extract.js";
+import type { DesignNetlistCell, DesignNetlistInstance } from "./ir.js";
+import { inspectSimulationSourceGraph } from "./simulation-source-graph.js";
+import {
+  listAuthoredCircuitScopes,
+  resolveAuthoredCircuitScope,
+} from "./simulation-source-scopes.js";
+
+export interface NativeSimulationDevice {
+  documentId: string;
+  instanceId: string;
+  occurrence: string[];
+  circuit: SimulationCircuitScope;
+  reference: string;
+  card: DesignNetlistInstance;
+  /** ngspice's flattened primitive identity, not the display reference. */
+  nativeDevice?: string;
+  polarity?: "nmos" | "pmos";
+}
+
+/** Derived from the same authored call scopes and Canvas IR as voltage naming. */
+export function nativeSimulationDevices(
+  project: CircuitProject,
+  input: SimulationSourceInput,
+): NativeSimulationDevice[] {
+  const graph = inspectSimulationSourceGraph(input);
+  const result: NativeSimulationDevice[] = [];
+  for (const binding of input.circuitBindings) {
+    if (!graph.paths.includes(binding.path)) continue;
+    const ir = analyzeDesignNetlist(project, {
+      format: "spice",
+      rootDocumentId: binding.documentId,
+    }).ir;
+    if (!ir) continue;
+    const root = ir.cells.find((cell) => cell.id === ir.topCellId);
+    if (!root) continue;
+    for (const circuit of listAuthoredCircuitScopes(graph, binding, ir)) {
+      const resolved = resolveAuthoredCircuitScope(graph, binding, ir, circuit);
+      if (!resolved.ok) continue;
+      let visits = 0;
+      function visit(
+        cell: DesignNetlistCell,
+        path: string[],
+        occurrence: string[],
+        ancestors: Set<string>,
+      ) {
+        if (++visits > 4096 || ancestors.has(cell.id)) return;
+        const document = project.documents.find((d) => d.id === cell.id)!;
+        for (const card of cell.instances) {
+          const reference = [...path, card.reference.toLowerCase()].join(".");
+          const authored = document.instances.find((i) => i.id === card.id);
+          const polarity = authored ? mosBulkKind(authored) : undefined;
+          const reviewed = reviewedExternalDeviceBindings.find(
+            (item) => item.id === card.reviewedExternalBindingId,
+          );
+          // The reviewed SKY130 MOS wrappers have one m<masterName> primitive.
+          // This mapping is deliberately not applied to arbitrary external subcircuits.
+          const nativeDevice =
+            card.invocationKind === "primitive"
+              ? path.length
+                ? `${card.reference[0]!.toLowerCase()}.${reference}`
+                : reference
+              : reviewed?.deviceClass === "mos"
+                ? `m.${reference}.m${reviewed.masterName}`
+                : undefined;
+          result.push({
+            documentId: cell.id,
+            instanceId: card.id,
+            occurrence,
+            circuit,
+            reference,
+            card,
+            ...(nativeDevice ? { nativeDevice } : {}),
+            ...(polarity ? { polarity } : {}),
+          });
+          const child =
+            card.deviceClass === "hierarchical"
+              ? ir!.cells.find((c) => c.name === card.target)
+              : undefined;
+          if (child)
+            visit(
+              child,
+              [...path, card.reference.toLowerCase()],
+              [...occurrence, card.id],
+              new Set([...ancestors, cell.id]),
+            );
+        }
+      }
+      visit(root, resolved.prefix, [], new Set());
+    }
+  }
+  return result;
+}
+
+export const NATIVE_MOS_OP_PARAMETERS = [
+  "id",
+  "vgs",
+  "vds",
+  "vbs",
+  "gm",
+  "gds",
+  "gmbs",
+  "vth",
+  "vdsat",
+] as const;
+
+export function nativeDeviceOpVectors(
+  device: NativeSimulationDevice,
+): string[] {
+  if (!device.polarity || !device.nativeDevice) return [];
+  // Threshold spellings vary across primitive model families; only the reviewed
+  // BSIM SKY130 wrappers advertise vth/vdsat in Helper. Exact vectors stay editable.
+  return NATIVE_MOS_OP_PARAMETERS.filter(
+    (p) =>
+      device.card.reviewedExternalBindingId || !["vth", "vdsat"].includes(p),
+  ).map((parameter) => `@${device.nativeDevice}[${parameter}]`);
+}
+
+export function nativeTerminalCurrent(
+  device: NativeSimulationDevice,
+  pinName: string,
+):
+  | { ok: true; vectors: string[]; directives: string[] }
+  | { ok: false; message: string } {
+  const reviewed = reviewedExternalDeviceBindings.find(
+    (item) => item.id === device.card.reviewedExternalBindingId,
+  );
+  const pin =
+    reviewed?.terminals.find((t) => t.pinName === pinName)?.targetName ??
+    pinName;
+  const index = device.card.nodes.findIndex((node) => node.pinName === pin);
+  if (index < 0)
+    return {
+      ok: false,
+      message: `No mapped terminal ${device.reference}.${pinName}`,
+    };
+  if (!device.reference.includes(".")) {
+    if (device.card.deviceClass === "voltage-source" && index === 0)
+      return { ok: true, vectors: [`i(${device.reference})`], directives: [] };
+    // Native .probe owns its sense source and collection. No JSON instrumentation.
+    return {
+      ok: true,
+      vectors: [],
+      directives: [`.probe i(${device.reference},${index + 1})`],
+    };
+  }
+  if (device.polarity && device.nativeDevice && pinName.toLowerCase() === "d")
+    return {
+      ok: true,
+      vectors: [`@${device.nativeDevice}[id]`],
+      directives: [],
+    };
+  if (
+    device.card.deviceClass === "voltage-source" &&
+    device.nativeDevice &&
+    index === 0
+  )
+    return { ok: true, vectors: [`i(${device.nativeDevice})`], directives: [] };
+  return {
+    ok: false,
+    message: `Native current acquisition is unavailable for ${device.reference}.${pinName}. Hierarchical terminals currently support model-native drain current and voltage-source branch current only; no hidden sense circuit is inserted.`,
+  };
+}

--- a/packages/netlist/src/simulation-native-migration.ts
+++ b/packages/netlist/src/simulation-native-migration.ts
@@ -1,0 +1,70 @@
+import {
+  NativeSimulationExperimentConfigSchema,
+  readSimulationExperimentConfig,
+  type CircuitProject,
+  type ProjectSimulationFolder,
+} from "@icm/model";
+import { compileSourceSimulation } from "./simulation-source-compile.js";
+
+/**
+ * Explicit, non-destructive migration boundary. Never silently erase a legacy
+ * binding, sweep, measurement or label that cannot be represented losslessly.
+ */
+export function migrateSimulationConfigToNative(
+  project: CircuitProject,
+  folder: ProjectSimulationFolder,
+):
+  | { ok: true; folder: ProjectSimulationFolder }
+  | { ok: false; message: string } {
+  const parsed = readSimulationExperimentConfig(folder);
+  if (!parsed.ok) return { ok: false, message: parsed.message };
+  if (parsed.authority === "code") return { ok: true, folder };
+  const config = parsed.config;
+  const pending: string[] = [];
+  if (config.variables.some((variable) => variable.bindings.length))
+    pending.push(
+      "replace Canvas variable bindings with explicit parameter expressions and Cell interfaces",
+    );
+  if (config.runPlan.mode !== "nominal")
+    pending.push("move the saved sweep into native control Code");
+  if (config.outputs.length)
+    pending.push("move named outputs/expressions into native save/let Code");
+  if (config.deviceOperatingPoints.length)
+    pending.push(
+      "use Helper to save native Device OP vectors, then remove legacy Device OP selections",
+    );
+  if (config.measurements.length)
+    pending.push("move saved measurement rules into native meas Code");
+  if (config.environment.corner)
+    pending.push(
+      "declare the model dependency and .lib corner in Code, then remove environment.corner",
+    );
+  if (pending.length)
+    return {
+      ok: false,
+      message: `Legacy intent is retained. Before converting: ${pending.join("; ")}. No source or configuration was changed.`,
+    };
+  const next = structuredClone(folder);
+  next.input.files.find((file) => file.path === next.input.configPath)!.text =
+    JSON.stringify(
+      NativeSimulationExperimentConfigSchema.parse({
+        version: 2,
+        environment: { profileId: config.environment.profileId },
+      }),
+      null,
+      2,
+    ) + "\n";
+  const compiled = compileSourceSimulation(project, next);
+  if (!compiled.ok)
+    return {
+      ok: false,
+      message: compiled.diagnostics.map((d) => d.message).join("; "),
+    };
+  if (compiled.config.collection.rawfile !== config.collection.rawfile)
+    return {
+      ok: false,
+      message:
+        "The native write path differs from the legacy collector. Reconcile write and collection.rawfile before converting; no files were changed.",
+    };
+  return { ok: true, folder: next };
+}

--- a/packages/netlist/src/simulation-native.test.ts
+++ b/packages/netlist/src/simulation-native.test.ts
@@ -1,0 +1,146 @@
+import {
+  createEmptyProject,
+  createSimulationFolder,
+  readSimulationExperimentConfig,
+  NativeSimulationExperimentConfigSchema,
+} from "@icm/model";
+import { describe, expect, it } from "vitest";
+import { compileSourceSimulation } from "./simulation-source-compile.js";
+import { nativeSourceCollection } from "./simulation-native-collection.js";
+import { inspectSimulationSourceGraph } from "./simulation-source-graph.js";
+import { migrateSimulationConfigToNative } from "./simulation-native-migration.js";
+
+function fixture(program: string) {
+  const project = createEmptyProject("native", "Native");
+  const folder = createSimulationFolder({
+    id: "native",
+    name: "Native",
+    profileId: "test",
+  });
+  folder.input.files.find((f) => f.path === folder.input.entry)!.text =
+    `* native\n.param RVAL=1k\nV1 in 0 1\nR1 in 0 {RVAL}\n.control\nset filetype=ascii\n${program}\n.endc\n.end\n`;
+  return { project, folder };
+}
+
+describe("native Code is the experiment authority", () => {
+  it("explicitly converts safe legacy metadata and retains unsupported intent without data loss", () => {
+    const { project, folder } = fixture("op\nwrite result.raw");
+    const file = folder.input.files.find(
+      (f) => f.path === folder.input.configPath,
+    )!;
+    file.text = JSON.stringify({
+      version: 1,
+      environment: { profileId: "test" },
+      collection: { rawfile: "result.raw" },
+    });
+    const original = JSON.stringify(folder);
+    const converted = migrateSimulationConfigToNative(project, folder);
+    expect(
+      converted.ok && readSimulationExperimentConfig(converted.folder),
+    ).toMatchObject({ ok: true, authority: "code" });
+    expect(JSON.stringify(folder)).toBe(original);
+    file.text = JSON.stringify({
+      version: 1,
+      environment: { profileId: "test" },
+      runPlan: {
+        mode: "sweep",
+        axes: [{ kind: "temperature", values: [0, 27] }],
+      },
+    });
+    const blocked = JSON.stringify(folder);
+    expect(migrateSimulationConfigToNative(project, folder)).toMatchObject({
+      ok: false,
+    });
+    expect(JSON.stringify(folder)).toBe(blocked);
+  });
+  it("creates no electrical sidecar fields and rejects adding a second authority", () => {
+    const { folder } = fixture("op\nwrite result.raw");
+    const config = JSON.parse(
+      folder.input.files.find((f) => f.path === folder.input.configPath)!.text,
+    );
+    expect(config).toEqual({ version: 2, environment: { profileId: "test" } });
+    for (const field of [
+      "variables",
+      "outputs",
+      "deviceOperatingPoints",
+      "measurements",
+      "runPlan",
+      "collection",
+    ])
+      expect(
+        NativeSimulationExperimentConfigSchema.safeParse({
+          ...config,
+          [field]: [],
+        }).success,
+      ).toBe(false);
+    expect(readSimulationExperimentConfig(folder)).toMatchObject({
+      ok: true,
+      authority: "code",
+    });
+  });
+  it("reads the collection path and native save/parameter changes from source, never JSON", () => {
+    const { project, folder } = fixture("save v(in)\nop\nwrite result.raw");
+    const before = folder.input.files.find(
+      (f) => f.path === folder.input.configPath,
+    )!.text;
+    const compiled = compileSourceSimulation(project, folder);
+    expect(compiled).toMatchObject({
+      ok: true,
+      authority: "code",
+      config: {
+        collection: { rawfile: "result.raw" },
+        outputs: [],
+        variables: [],
+      },
+    });
+    const entry = folder.input.files.find(
+      (f) => f.path === folder.input.entry,
+    )!;
+    entry.text = entry.text
+      .replace("RVAL=1k", "RVAL=2k")
+      .replace("result.raw", "changed.raw")
+      .replace("save v(in)", "save i(v1)");
+    const changed = compileSourceSimulation(project, folder);
+    expect(changed).toMatchObject({
+      ok: true,
+      config: { collection: { rawfile: "changed.raw" } },
+    });
+    if (changed.ok)
+      expect(changed.files.find((f) => f.path === entry.path)!.text).toBe(
+        entry.text,
+      );
+    expect(
+      folder.input.files.find((f) => f.path === folder.input.configPath)!.text,
+    ).toBe(before);
+  });
+  it("does not split native loops or persist a sweep plan", () => {
+    const { project, folder } = fixture(
+      "foreach point 1k 2k\nalterparam RVAL=$point\nreset\nop\nwrite result.raw\nend",
+    );
+    expect(compileSourceSimulation(project, folder)).toMatchObject({
+      ok: true,
+    });
+    expect(
+      compileSourceSimulation(project, folder, {
+        variables: [{ variableId: "x", value: "2k" }],
+      }),
+    ).toMatchObject({ ok: false });
+  });
+  it.each(["write $target", "write one.raw\nwrite two.raw"])(
+    "diagnoses unsupported collector contracts without guessing: %s",
+    (program) => {
+      const { folder } = fixture(program);
+      expect(
+        nativeSourceCollection(inspectSimulationSourceGraph(folder.input))
+          .diagnostics.length,
+      ).toBeGreaterThan(0);
+    },
+  );
+  it("permits console-only native programs without inventing out.raw", () => {
+    const { project, folder } = fixture("op\nprint v(in)");
+    expect(compileSourceSimulation(project, folder)).toMatchObject({
+      ok: true,
+      config: { collection: { rawfile: null } },
+    });
+  });
+});

--- a/packages/netlist/src/simulation-source-compile.ts
+++ b/packages/netlist/src/simulation-source-compile.ts
@@ -39,6 +39,11 @@ import {
   type SimulationSourceGraph,
 } from "./simulation-source-graph.js";
 import { resolveAuthoredCircuitScope } from "./simulation-source-scopes.js";
+import { nativeSourceCollection } from "./simulation-native-collection.js";
+import {
+  nativeSimulationDevices,
+  NATIVE_MOS_OP_PARAMETERS,
+} from "./simulation-native-devices.js";
 
 type Plan = Extract<CompiledSimulation, { ok: true }>;
 type BoundLeaf = Extract<
@@ -56,6 +61,7 @@ export type SourceSimulationCompilation =
   | {
       ok: true;
       config: SimulationExperimentConfig;
+      authority: "code" | "legacy-config";
       /** Original source bytes remain separate from the execution projection. */
       authoredFiles: { path: string; text: string }[];
       files: { path: string; text: string }[];
@@ -125,6 +131,16 @@ export function compileSourceSimulation(
   );
   const effective = projection.project;
   const config = projection.config;
+  if (parsedConfig.authority === "code") {
+    const native = nativeSourceCollection(graph);
+    config.collection = native.collection;
+    diagnostics.push(...native.diagnostics);
+    if (variant && Object.values(variant).some((value) => value !== undefined))
+      fail(
+        "SIMULATION_NATIVE_VARIANT_UNSUPPORTED",
+        "Native experiments define sweeps and overrides in Code. Batch selects folders; it does not override their parameters.",
+      );
+  }
   diagnostics.push(...projection.diagnostics);
   const reachable = new Set(graph.paths);
   const bindings = folder.input.circuitBindings.filter((b) =>
@@ -435,6 +451,32 @@ export function compileSourceSimulation(
       })),
     };
   });
+  // Discover mappings, but do not request any acquisition here. Only vectors
+  // actually returned by the native program become Device OP rows.
+  if (parsedConfig.authority === "code") {
+    for (const device of nativeSimulationDevices(project, folder.input)) {
+      if (!device.polarity || !device.nativeDevice) continue;
+      deviceOperatingPoints.push({
+        id: `native-op:${device.nativeDevice}`,
+        documentId: device.documentId,
+        instanceId: device.instanceId,
+        occurrence: device.occurrence,
+        reference: device.reference,
+        polarity: device.polarity,
+        values: NATIVE_MOS_OP_PARAMETERS.map((parameter) => ({
+          parameter,
+          label: parameter.toUpperCase(),
+          unit:
+            parameter === "id" ? "A" : parameter.startsWith("g") ? "S" : "V",
+          expression: acquisition(
+            `@${device.nativeDevice}[${parameter}]`,
+            "native",
+            false,
+          ),
+        })),
+      });
+    }
+  }
   for (const measurement of config.measurements)
     if (
       !outputs.some((o) => o.id === measurement.outputId) &&
@@ -479,6 +521,7 @@ export function compileSourceSimulation(
   return {
     ok: true,
     config,
+    authority: parsedConfig.authority,
     authoredFiles: structuredClone(folder.input.files),
     files: mappedFiles.map(({ path, text }) => ({ path, text })),
     sourceMaps: mappedFiles.map(({ path, segments }) => ({ path, segments })),

--- a/packages/simulation-service/src/contract.ts
+++ b/packages/simulation-service/src/contract.ts
@@ -136,9 +136,19 @@ export const CompiledDeviceOperatingPointSchema: z.ZodType<CompiledSimulationDev
     polarity: z.enum(["nmos", "pmos"]),
     values: z.array(
       z.strictObject({
-        parameter: z.enum(["vgs", "vds", "vbs", "id"]),
-        label: z.enum(["VGS", "VDS", "VBS", "ID"]),
-        unit: z.enum(["V", "A"]),
+        parameter: z.enum([
+          "vgs",
+          "vds",
+          "vbs",
+          "id",
+          "gm",
+          "gds",
+          "gmbs",
+          "vth",
+          "vdsat",
+        ]),
+        label: z.string(),
+        unit: z.enum(["V", "A", "S"]),
         expression: CompiledOutputExpressionSchema,
       }),
     ),
@@ -275,6 +285,26 @@ export const AutomaticMeasurementSchema = z.discriminatedUnion("status", [
 ]);
 export const SimulationOutputDataSchema = z.strictObject({
   schemaVersion: z.literal(1),
+  nativeMeasurements: z
+    .array(
+      z.discriminatedUnion("status", [
+        z.strictObject({
+          name: z.string(),
+          occurrence: z.number().int().positive(),
+          status: z.literal("available"),
+          value: z.number().finite(),
+          logLine: z.number().int().positive(),
+          detail: z.string(),
+        }),
+        z.strictObject({
+          name: z.string(),
+          occurrence: z.literal(0),
+          status: z.literal("unavailable"),
+          detail: z.string(),
+        }),
+      ]),
+    )
+    .optional(),
   analyses: z.array(EvaluatedAnalysisSchema),
   measurements: z.array(AutomaticMeasurementSchema).optional(),
   deviceOperatingPoints: z

--- a/packages/simulation-service/src/native-measurements.test.ts
+++ b/packages/simulation-service/src/native-measurements.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { nativeMeasurementResults } from "./native-measurements.js";
+import { SimulationOutputDataSchema } from "./contract.js";
+
+describe("native measurement reports", () => {
+  const files = [
+    {
+      path: "run.cir",
+      text: "* test\n.control\nmeas tran peak MAX v(out)\nmeas ac bandwidth WHEN v(out)=1\n.endc\n",
+    },
+  ];
+  it("preserves repeated reports without inventing a raw-plot association or recalculating", () => {
+    const result = nativeMeasurementResults(
+      files,
+      "run.cir",
+      "noise = 4\npeak = 1.2e-3 at=2e-6\npeak = 2.4e-3 at=3e-6\n",
+    );
+    expect(result).toMatchObject([
+      { name: "peak", occurrence: 1, value: 0.0012, logLine: 2 },
+      { name: "peak", occurrence: 2, value: 0.0024, logLine: 3 },
+      { name: "bandwidth", status: "unavailable" },
+    ]);
+    expect(
+      SimulationOutputDataSchema.safeParse({
+        schemaVersion: 1,
+        analyses: [],
+        diagnostics: [],
+        nativeMeasurements: result,
+      }).success,
+    ).toBe(true);
+  });
+  it("does not fabricate zero from missing or nonfinite evidence", () => {
+    const result = nativeMeasurementResults(
+      files,
+      "run.cir",
+      "peak = nan\nbandwidth = 1e999",
+    );
+    expect(result.every((item) => item.status === "unavailable")).toBe(true);
+  });
+});

--- a/packages/simulation-service/src/native-measurements.ts
+++ b/packages/simulation-service/src/native-measurements.ts
@@ -1,0 +1,71 @@
+import { parseSpiceSource } from "@icm/spice";
+import type { SimulationOutputData } from "./contract.js";
+
+/**
+ * ngspice owns measurement evaluation. Read its scalar reports without guessing
+ * which raw plot a loop iteration belongs to. Log line/occurrence are evidence.
+ */
+export function nativeMeasurementResults(
+  files: readonly { path: string; text: string }[],
+  entry: string,
+  log: string,
+): NonNullable<SimulationOutputData["nativeMeasurements"]> {
+  const declarations = new Map<string, string>();
+  for (const file of files) {
+    if (file.path.endsWith(".json")) continue;
+    for (const statement of parseSpiceSource(
+      {
+        id: file.path,
+        path: file.path,
+        text: file.text,
+        hash: "",
+        encoding: "utf-8",
+      },
+      { titleLine: file.path === entry },
+    ).statements) {
+      const command =
+        statement.kind === "control_command"
+          ? statement.command
+          : statement.kind === "directive"
+            ? statement.name
+            : "";
+      if (!["meas", "measure"].includes(command.toLowerCase())) continue;
+      const args = "arguments" in statement ? statement.arguments : [];
+      const name = args[1];
+      if (name && /^[A-Za-z_][A-Za-z0-9_]*$/u.test(name))
+        declarations.set(name.toLowerCase(), name);
+    }
+  }
+  const result: NonNullable<SimulationOutputData["nativeMeasurements"]> = [];
+  const counts = new Map<string, number>();
+  log.split(/\r?\n/u).forEach((line, index) => {
+    const match =
+      /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*([+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?)(?=\s|$)/u.exec(
+        line,
+      );
+    const key = match?.[1]?.toLowerCase();
+    if (!match || !key || !declarations.has(key)) return;
+    const value = Number(match[2]);
+    if (!Number.isFinite(value)) return;
+    const occurrence = (counts.get(key) ?? 0) + 1;
+    counts.set(key, occurrence);
+    result.push({
+      name: declarations.get(key)!,
+      occurrence,
+      status: "available",
+      value,
+      logLine: index + 1,
+      detail: line.trim(),
+    });
+  });
+  for (const [key, name] of declarations)
+    if (!counts.has(key))
+      result.push({
+        name,
+        occurrence: 0,
+        status: "unavailable",
+        detail:
+          "No finite scalar was reported by ngspice. The command may have failed or not executed; inspect Console.",
+      });
+  return result;
+}

--- a/packages/simulation-service/src/output-evaluation.test.ts
+++ b/packages/simulation-service/src/output-evaluation.test.ts
@@ -7,6 +7,132 @@ import {
 import { SimulationOutputDataSchema } from "./contract.js";
 
 describe("simulation output evaluation", () => {
+  it("resolves ngspice46 typed raw names for hierarchical device parameters", () => {
+    const result = evaluateSimulationOutputs(
+      {
+        schemaVersion: 1,
+        analyses: [
+          {
+            analysis: "op",
+            plotName: "OP",
+            probes: [
+              {
+                name: "i(@m.x1.m2[id])",
+                quantity: "current",
+                unit: "A",
+                value: 0.000125,
+              },
+              {
+                name: "v(@m.x1.m2[vgs])",
+                quantity: "voltage",
+                unit: "V",
+                value: 1,
+              },
+            ],
+          },
+        ],
+      },
+      [
+        { probeId: "id", vector: "@m.x1.m2[id]", quantity: "native" },
+        { probeId: "vgs", vector: "@m.x1.m2[vgs]", quantity: "native" },
+      ],
+      [
+        {
+          id: "id",
+          label: "ID",
+          expression: {
+            kind: "acquisition",
+            acquisitionId: "id",
+            quantity: "native",
+          },
+        },
+        {
+          id: "vgs",
+          label: "VGS",
+          expression: {
+            kind: "acquisition",
+            acquisitionId: "vgs",
+            quantity: "native",
+          },
+        },
+      ],
+    );
+    expect(result.analyses[0]?.outputs).toMatchObject([
+      { unit: "A", values: [0.000125] },
+      { unit: "V", values: [1] },
+    ]);
+    expect(result.diagnostics).toEqual([]);
+  });
+  it("only shows native Device OP quantities that the Code actually collected", () => {
+    const result = evaluateSimulationOutputs(
+      {
+        schemaVersion: 1,
+        analyses: [
+          {
+            analysis: "op",
+            plotName: "OP",
+            probes: [
+              {
+                name: "@m1[gm]",
+                quantity: "admittance",
+                unit: "S",
+                value: 0.002,
+              },
+            ],
+          },
+        ],
+      },
+      [
+        { probeId: "gm", vector: "@m1[gm]", quantity: "native" },
+        { probeId: "id", vector: "@m1[id]", quantity: "native" },
+      ],
+      [],
+      [],
+      [
+        {
+          id: "native-op:m1",
+          documentId: "dut",
+          instanceId: "M1",
+          occurrence: [],
+          reference: "M1",
+          polarity: "nmos",
+          values: [
+            {
+              parameter: "gm",
+              label: "GM",
+              unit: "S",
+              expression: {
+                kind: "acquisition",
+                acquisitionId: "gm",
+                quantity: "native",
+              },
+            },
+            {
+              parameter: "id",
+              label: "ID",
+              unit: "A",
+              expression: {
+                kind: "acquisition",
+                acquisitionId: "id",
+                quantity: "native",
+              },
+            },
+          ],
+        },
+      ],
+      true,
+    );
+    expect(result.deviceOperatingPoints?.[0]?.values).toEqual([
+      {
+        parameter: "gm",
+        label: "GM",
+        unit: "S",
+        status: "available",
+        value: 0.002,
+      },
+    ]);
+    expect(SimulationOutputDataSchema.safeParse(result).success).toBe(true);
+  });
   it("exposes saved native vectors alongside configured outputs with run-local names", () => {
     const result = evaluateSimulationOutputs(
       {

--- a/packages/simulation-service/src/output-evaluation.ts
+++ b/packages/simulation-service/src/output-evaluation.ts
@@ -206,7 +206,14 @@ function sourceSeries(
   );
   const result = new Map<string, ComplexSeries>();
   for (const vector of vectors) {
-    const source = byName.get(vector.vector.toLowerCase());
+    const name = vector.vector.toLowerCase();
+    // ngspice 46 writes saved device parameters as i(@m[id]) / v(@m[vgs]),
+    // but admittance parameters retain @m[gm]. Keep raw names as evidence.
+    const source =
+      byName.get(name) ??
+      (name.startsWith("@")
+        ? (byName.get(`i(${name})`) ?? byName.get(`v(${name})`))
+        : undefined);
     if (!source) continue;
     const unit =
       vector.quantity === "native"
@@ -382,11 +389,20 @@ export function evaluateSimulationOutputs(
   );
   const records = operatingPoints.length ? operatingPoints : [undefined];
   const deviceOperatingPoints = records.flatMap((record) =>
-    deviceOperatingPointSpecs.map((device) => {
+    deviceOperatingPointSpecs.flatMap((device) => {
       const operatingPoint = record?.analysis;
       const acquisitions = operatingPoint
         ? sourceSeries(operatingPoint, vectors)
         : new Map();
+      const native = device.id.startsWith("native-op:");
+      const values = native
+        ? device.values.filter(
+            (value) =>
+              value.expression.kind === "acquisition" &&
+              acquisitions.has(value.expression.acquisitionId),
+          )
+        : device.values;
+      if (native && !values.length) return [];
       return {
         id: device.id,
         ...(record ? { analysisIndex: record.index } : {}),
@@ -398,7 +414,7 @@ export function evaluateSimulationOutputs(
         occurrence: [...device.occurrence],
         reference: device.reference,
         polarity: device.polarity,
-        values: device.values.map((parameter) => {
+        values: values.map((parameter) => {
           if (!operatingPoint)
             return {
               parameter: parameter.parameter,

--- a/packages/simulation-service/src/prepare-source.test.ts
+++ b/packages/simulation-service/src/prepare-source.test.ts
@@ -274,6 +274,24 @@ describe("source execution preparation", () => {
         ],
       },
     });
+    folder.input.files.find(
+      (file) => file.path === folder.input.configPath,
+    )!.text = JSON.stringify({
+      version: 2,
+      environment: { profileId: profile.id },
+    });
+    const nativeBefore = JSON.stringify(folder);
+    const nativeCorner = await prepareSourceExecutionInput(
+      circuit,
+      folder,
+      caps,
+    );
+    expect(nativeCorner.ok, JSON.stringify(nativeCorner)).toBe(true);
+    if (nativeCorner.ok) {
+      expect(nativeCorner.input.environment?.corner).toBe("ff");
+      expect(nativeCorner.input.preparedDeck.match(/\.lib /gu)).toHaveLength(1);
+    }
+    expect(JSON.stringify(folder)).toBe(nativeBefore);
   });
   it("returns located diagnostics for invalid drafts and capability problems without mutating them", async () => {
     const folder = native();

--- a/packages/simulation-service/src/prepare-source.ts
+++ b/packages/simulation-service/src/prepare-source.ts
@@ -147,17 +147,19 @@ export async function prepareSourceExecutionInput(
       dependency = { ...library, mountPath };
       dependencies.push(dependency);
     }
+    const existingLoads = compiled.includes.filter(
+      (include) => include.target === dependency.mountPath,
+    );
     const selectedCorner =
-      config.environment.corner ?? caps.modelLibrary?.section;
+      compiled.authority === "code" && existingLoads.length
+        ? existingLoads[0]!.section
+        : (config.environment.corner ?? caps.modelLibrary?.section);
     if (!selectedCorner || !profile.corners.includes(selectedCorner))
       return problem(
         "SIMULATION_CORNER_UNSUPPORTED",
         "Select a qualified model corner before preparation",
         "prepare",
       );
-    const existingLoads = compiled.includes.filter(
-      (include) => include.target === dependency.mountPath,
-    );
     if (
       existingLoads.some(
         (load) => load.section?.toLowerCase() !== selectedCorner.toLowerCase(),
@@ -202,6 +204,9 @@ export async function prepareSourceExecutionInput(
       files[entryIndex] = { path: mapped.path, text: mapped.text };
       sourceMaps[entryIndex] = { path: mapped.path, segments: mapped.segments };
     }
+    // Record the actual native model selection in the execution receipt only.
+    if (compiled.authority === "code")
+      config.environment.corner = selectedCorner;
   }
   const output = config.collection.rawfile;
   if (

--- a/packages/simulation-service/src/service.ts
+++ b/packages/simulation-service/src/service.ts
@@ -17,6 +17,7 @@ import {
   simulationOutputAnalysisToCsv,
 } from "./output-evaluation.js";
 import { automaticMeasurementsToCsv } from "./automatic-measurements.js";
+import { nativeMeasurementResults } from "./native-measurements.js";
 
 import {
   ExecutionFailure,
@@ -770,11 +771,30 @@ export class SimulationService {
           run.prepared.signalNames,
         );
       }
+      const nativeMeasurements = nativeMeasurementResults(
+        input.files,
+        input.entryPath ?? "run.cir",
+        output.result.log,
+      );
+      if (nativeMeasurements.length) {
+        run.view.outputData ??= {
+          schemaVersion: 1,
+          analyses: [],
+          diagnostics: [],
+        };
+        run.view.outputData.nativeMeasurements = nativeMeasurements;
+      }
       const artifact = async (name: string, type: string, text: string) =>
         run.view.artifacts.push(
           await this.publishArtifact(epoch, name, type, text),
         );
       await artifact("log.txt", "text/plain", output.result.log);
+      if (nativeMeasurements.length)
+        await artifact(
+          "native-measurements.json",
+          "application/json",
+          JSON.stringify(nativeMeasurements, null, 2),
+        );
       if (output.rawfile !== undefined)
         await artifact("out.raw", "text/plain", output.rawfile);
       if (output.executedDeck !== undefined)

--- a/packages/spice-run/src/result-data.ts
+++ b/packages/spice-run/src/result-data.ts
@@ -181,6 +181,10 @@ export type SimulationDataReading =
 const UNIT_BY_QUANTITY = new Map<string, string>([
   ["voltage", "V"],
   ["current", "A"],
+  ["admittance", "S"],
+  ["conductance", "S"],
+  ["capacitance", "F"],
+  ["resistance", "Ω"],
   ["time", "s"],
   ["frequency", "Hz"],
   ["temp-sweep", "°C"],

--- a/scripts/simulation-source-native.test.mjs
+++ b/scripts/simulation-source-native.test.mjs
@@ -52,6 +52,59 @@ async function run(request, name) {
 }
 
 describe.skipIf(!endpoint)("candidate ngspice46 source qualification", () => {
+  it("collects native hierarchical Device OP and top-level terminal probes", async () => {
+    const response = await post({ operation: "capabilities" });
+    const caps = CapabilitiesSchema.parse(await response.json());
+    const folder = createSimulationFolder({
+      id: "native-device",
+      name: "Native device",
+      profileId: profile.id,
+    });
+    folder.input.files.find((file) => file.path === folder.input.entry).text = [
+      "Native naming contract; illustrative MOS1, not a PDK qualification",
+      ".model NM NMOS level=1 vto=0.5 kp=100u",
+      "V1 d 0 1",
+      "V2 g 0 1",
+      "R1 d 0 1k",
+      "X1 d g inner",
+      ".subckt inner d g",
+      "M2 d g 0 0 NM w=10u l=1u",
+      ".ends",
+      ".probe i(r1,2)",
+      ".control",
+      "set filetype=ascii",
+      "save @m.x1.m2[id] @m.x1.m2[gm] @m.x1.m2[vgs]",
+      "op",
+      "write native.raw",
+      ".endc",
+      ".end",
+      "",
+    ].join("\n");
+    const compiled = await prepareSourceExecutionInput(
+      createEmptyProject("native-device", "Native"),
+      folder,
+      caps,
+    );
+    expect(compiled.ok, JSON.stringify(compiled)).toBe(true);
+    const result = await run(compiled.input, "native-device");
+    expect(result.outcome.status, JSON.stringify(result)).toBe("completed");
+    const probes = result.data.analyses.find(
+      (analysis) => analysis.analysis === "op",
+    ).probes;
+    expect(
+      probes.find((probe) => probe.name === "i(@m.x1.m2[id])").value,
+    ).toBeCloseTo(0.000125, 8);
+    expect(
+      probes.find((probe) => probe.name === "@m.x1.m2[gm]").value,
+    ).toBeCloseTo(0.0005, 8);
+    expect(
+      probes.find((probe) => probe.name === "v(@m.x1.m2[vgs])").value,
+    ).toBeCloseTo(1, 8);
+    expect(probes.find((probe) => probe.name === "i(r1:n2)").value).toBeCloseTo(
+      -0.001,
+      8,
+    );
+  });
   for (const [name, compile, validate] of [
     ["ota-op-dc-ac", compileHostedSky130Project, validateHostedSky130Result],
     [

--- a/scripts/simulation-source-native.test.mjs
+++ b/scripts/simulation-source-native.test.mjs
@@ -74,7 +74,15 @@ describe.skipIf(!endpoint)("candidate ngspice46 source qualification", () => {
     const devices = nativeSimulationDevices(circuit, folder.input).filter(
       (device) => device.polarity,
     );
-    expect(devices).toHaveLength(5);
+    // The fixture includes the five-transistor core plus its bias device XM6.
+    expect(devices.map((device) => device.reference).sort()).toEqual([
+      "xdut.xm1",
+      "xdut.xm2",
+      "xdut.xm3",
+      "xdut.xm4",
+      "xdut.xm5",
+      "xdut.xm6",
+    ]);
     const entry = folder.input.files.find(
       (file) => file.path === folder.input.entry,
     );

--- a/scripts/simulation-source-native.test.mjs
+++ b/scripts/simulation-source-native.test.mjs
@@ -1,6 +1,9 @@
 import { mkdir, writeFile } from "node:fs/promises";
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { createEmptyProject, createSimulationFolder } from "@icm/model";
+import { parseProject } from "@icm/project-protocol";
+import { nativeSimulationDevices, nativeDeviceOpVectors } from "@icm/netlist";
 import {
   prepareSourceExecutionInput,
   CapabilitiesSchema,
@@ -52,6 +55,55 @@ async function run(request, name) {
 }
 
 describe.skipIf(!endpoint)("candidate ngspice46 source qualification", () => {
+  it("reads the reviewed SKY130 wrapper's native OP parameters", async () => {
+    const circuit = parseProject(
+      readFileSync(
+        new URL(
+          "../apps/editor/src/examples/five-transistor-ota-sky130.icproj.json",
+          import.meta.url,
+        ),
+        "utf8",
+      ),
+    );
+    const folder = createSimulationFolder({
+      id: "native-sky130",
+      name: "Native SKY130",
+      profileId: profile.id,
+      documentId: "document-ota-5t-testbench",
+    });
+    const devices = nativeSimulationDevices(circuit, folder.input).filter(
+      (device) => device.polarity,
+    );
+    expect(devices).toHaveLength(5);
+    const entry = folder.input.files.find(
+      (file) => file.path === folder.input.entry,
+    );
+    entry.text = entry.text.replace(
+      "\nop\n",
+      `\nsave ${devices.flatMap(nativeDeviceOpVectors).join(" ")}\nop\n`,
+    );
+    const response = await post({ operation: "capabilities" });
+    const compiled = await prepareSourceExecutionInput(
+      circuit,
+      folder,
+      CapabilitiesSchema.parse(await response.json()),
+    );
+    expect(compiled.ok, JSON.stringify(compiled)).toBe(true);
+    const result = await run(compiled.input, "native-sky130-op");
+    expect(result.outcome.status, JSON.stringify(result)).toBe("completed");
+    const probes = result.data.analyses.find(
+      (analysis) => analysis.analysis === "op",
+    ).probes;
+    // Acquisition availability/identity, not a new electrical golden or an
+    // invented threshold. Numeric OTA qualification remains the existing tests.
+    for (const vector of devices.flatMap(nativeDeviceOpVectors)) {
+      const probe = probes.find((candidate) =>
+        [vector, `i(${vector})`, `v(${vector})`].includes(candidate.name),
+      );
+      expect(probe, vector).toBeDefined();
+      expect(Number.isFinite(probe.value), vector).toBe(true);
+    }
+  }, 160_000);
   it("collects native hierarchical Device OP and top-level terminal probes", async () => {
     const response = await post({ operation: "capabilities" });
     const caps = CapabilitiesSchema.parse(await response.json());


### PR DESCRIPTION
## Summary

- New experiments use strict version-2 profile-only metadata. Native SPICE owns parameters, saves, measurements, loops and the literal rawfile collection path.
- Circuit parameter spans accept expressions with reversible SKY130 unit conversion. Helper writes native acquisition Code; Device OP maps actual collected model vectors. Internal hierarchy currents are limited to native-readable currents, without inserted Canvas sense circuits.
- Multi-folder Batch applies every selected folder's pending draft before preparation. Existing context-menu selection remains the queue entry point.
- Preserve existing v1 experiments behind an explicit legacy notice; safe conversion is available, while advanced legacy intent requires deliberate source translation. No lossy migration. MCP legacy helpers cannot silently downgrade v2.
- Display simulator-reported native measurement evidence; do not infer units or plot associations. Native Helper insertions preserve untouched exact source bytes and one undo boundary. Quick start is unchanged.

## Validation

- Frozen install, preflight, typecheck, focused tests passed.
- Final commit `de59095b`: all seven required CI checks and the additional pinned-image check are green. The browser layer ran all four full-suite shards.
- Local full gate passed static, 3215 unit tests, build, performance budgets, visual/export goldens, production and packaged release smokes. Browser run passed 401/402 initially; the sole failure was a test navigation assumption (folder selection is not file activation). After correcting that assumption, both Batch cases passed. Final exact-source preservation changes passed eight focused unit tests, typecheck and all 12 affected browser cases.
- Windows ngspice 46 verified `.probe`, hierarchical model currents and typed raw names using an explicitly illustrative MOS1 circuit. This is not PDK electrical qualification.
- Added isolated pinned-image qualification for both MOS1 naming and all six reviewed SKY130 native OP occurrences (five core devices plus bias XM6). The container workflow now triggers on this qualification script. Docker daemon is unavailable locally; remote container acceptance passed, including existing OTA OP/DC/AC/TRAN/Noise electrical contracts.

## Compatibility boundary

Automatic translation of arbitrary old bindings, saved sweep programs, named output ASTs and measurement rules is intentionally not claimed. They retain the original legacy execution behavior until explicitly moved into Code. No merge or Production promotion is requested by this PR.

Test-Impact: tests-updated
