### PR TITLE
feat(simulation): choose the Cell when creating an experiment

### DIFF
--- a/apps/editor/e2e/simulation-workspace.spec.ts
+++ b/apps/editor/e2e/simulation-workspace.spec.ts
@@ -23,6 +23,108 @@ import {
 import { ota, profile, editSimulationFile } from "./simulation-e2e-fixtures.js";
 
 const loadModule = createRequire(import.meta.url);
+test("new experiments explicitly bind the selected Cell without requiring a Testbench", async ({
+  page,
+}) => {
+  const project = parseProject(JSON.stringify(ota));
+  project.simulationFolders = [];
+  const dut = project.documents.find((cell) => cell.name === "ota_5t")!;
+  await page.route("**/api/simulate", (route) =>
+    route.fulfill({
+      status: 503,
+      json: { error: "Offline authoring fixture" },
+    }),
+  );
+  await page.goto("/editor");
+  await page.getByTestId("project-file").setInputFiles({
+    name: "cell-selection.icproj.json",
+    mimeType: "application/json",
+    buffer: Buffer.from(JSON.stringify(project)),
+  });
+  await page.getByTestId("open-analog-simulation").click();
+  await page.getByRole("button", { name: "Set up", exact: true }).click();
+  const name = page.getByLabel("New simulation folder name");
+  const cell = page.getByRole("combobox", {
+    name: "Simulation Cell",
+    exact: true,
+  });
+  await expect(cell).toHaveValue(project.topDocumentId);
+  await name.fill("OTA direct");
+  await name.press("Tab");
+  await expect(cell).toBeFocused();
+  await cell.selectOption(dut.id);
+  // Moving between fields must not prematurely create the folder.
+  await expect(name).toBeVisible();
+  await page.getByRole("button", { name: "Create", exact: true }).click();
+  const folderRow = page.getByRole("treeitem", {
+    name: "Folder OTA direct",
+    exact: true,
+  });
+  await expect(folderRow).toContainText("Cell: ota_5t");
+  const editor = page.getByRole("textbox", {
+    name: "Simulation source editor",
+  });
+  await expect(editor).toContainText('.include "circuit.spice"');
+  await expect(editor).toContainText("op");
+  await page.getByRole("tab", { name: /circuit\.spice/ }).click();
+  await expect(editor).toContainText("XM1");
+  await expect(editor).not.toContainText("XDUT");
+  const saved = parseProject(
+    (await downloadBytes(page, "File", "Export Project File…")).toString(),
+  );
+  const folder = saved.simulationFolders[0]!;
+  expect(folder.input.circuitBindings).toEqual([
+    {
+      id: "circuit",
+      path: "circuit.spice",
+      documentId: dut.id,
+      emission: "top-level",
+    },
+  ]);
+  expect(folder.input.files.map((file) => file.path)).toEqual([
+    "run.cir",
+    "experiment.json",
+  ]);
+  expect(saved.topDocumentId).toBe(project.topDocumentId);
+  expect(saved.documents).toEqual(project.documents);
+  const generated = generateCircuitSource(
+    saved,
+    folder.input.circuitBindings[0]!,
+  );
+  expect(generated.ok).toBe(true);
+  if (!generated.ok) throw new Error("Expected generated Cell source");
+  expect((await editor.innerText()).trim()).toBe(generated.source.text.trim());
+
+  // The next default follows Canvas, not the existing experiment's root.
+  await page.getByTestId("document-selector").selectOption(dut.id);
+  await page
+    .getByRole("button", { name: "+ New experiment", exact: true })
+    .click();
+  await expect(cell).toHaveValue(dut.id);
+  await cell.press("Escape");
+  await expect(name).toHaveCount(0);
+  await page
+    .getByTestId("document-selector")
+    .selectOption(project.topDocumentId);
+  await page
+    .getByRole("button", { name: "+ New experiment", exact: true })
+    .click();
+  await expect(cell).toHaveValue(project.topDocumentId);
+  await cell.press("Escape");
+  await expect(folderRow).toContainText("Cell: ota_5t");
+  const unchanged = parseProject(
+    (await downloadBytes(page, "File", "Export Project File…")).toString(),
+  );
+  expect(unchanged.simulationFolders).toEqual(saved.simulationFolders);
+  // Binding and label survive reopening the saved Project.
+  await page.getByTestId("project-file").setInputFiles({
+    name: "reopen.icproj.json",
+    mimeType: "application/json",
+    buffer: Buffer.from(JSON.stringify(unchanged)),
+  });
+  await expect(folderRow).toContainText("Cell: ota_5t");
+});
+
 test("source save applies locally while signed out and leaves File Save cloud-owned", async ({
   page,
 }) => {

--- a/apps/editor/src/features/simulation/code-workspace.css
+++ b/apps/editor/src/features/simulation/code-workspace.css
@@ -198,6 +198,25 @@
   margin-top: 4px;
   font: inherit;
 }
+.workspace-cell-selection {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 4px;
+}
+.workspace-cell-selection select {
+  flex: 1;
+  min-width: 0;
+  margin-top: 0;
+  background: var(--icm-surface);
+  color: var(--icm-text);
+}
+.simulation-folder-cell {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 50%;
+}
 .workspace-editor-content {
   height: 100%;
 }

--- a/apps/editor/src/features/simulation/simulation-file-tree.tsx
+++ b/apps/editor/src/features/simulation/simulation-file-tree.tsx
@@ -26,6 +26,7 @@ export interface SimulationFolderNode {
     draft?: boolean;
   }[];
   configPath?: string;
+  cellLabel?: string;
 }
 export type FolderAction =
   "new" | "duplicate" | "rename" | "delete" | "run" | "export" | "batch";
@@ -49,6 +50,7 @@ interface TreeNode {
   file?: SimulationCodeFile;
   expanded?: boolean;
   tmp?: boolean;
+  cellLabel?: string;
 }
 const collect = (node: TreeNode): SimulationExplorerSelection[] =>
   node.entry ? [node.entry] : (node.children ?? []).flatMap(collect);
@@ -159,6 +161,7 @@ export function SimulationFileTree(props: SimulationCodeWorkspaceProps) {
     return {
       id: folder.id,
       name: folder.name,
+      ...(folder.cellLabel ? { cellLabel: folder.cellLabel } : {}),
       folderId: folder.id,
       kind: "folder",
       children,
@@ -470,6 +473,14 @@ export function SimulationFileTree(props: SimulationCodeWorkspaceProps) {
                 </svg>
               </span>
               <span className="simulation-file-name">{node.name}</span>
+              {node.cellLabel ? (
+                <small
+                  className="simulation-folder-cell"
+                  title={node.cellLabel}
+                >
+                  {node.cellLabel}
+                </small>
+              ) : null}
               {node.tmp ? <small>tmp</small> : null}
               {node.file?.dirty ? (
                 <span className="simulation-file-state" title="Unsaved">
@@ -522,7 +533,11 @@ export function SimulationFileTree(props: SimulationCodeWorkspaceProps) {
         )
           return;
         event.stopPropagation();
-        if (event.target instanceof HTMLInputElement) return;
+        if (
+          event.target instanceof HTMLInputElement ||
+          event.target instanceof HTMLSelectElement
+        )
+          return;
         if (
           (event.ctrlKey || event.metaKey) &&
           event.key.toLowerCase() === "a"

--- a/apps/editor/src/features/simulation/source-code-pane.tsx
+++ b/apps/editor/src/features/simulation/source-code-pane.tsx
@@ -1047,15 +1047,17 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
             return;
           const nextPath =
             action === "rename"
-              ? await ui.name({
-                  kind: "file",
-                  folderId: targetFolderId,
-                  path: filePath,
-                  label: "Relative file path",
-                  initial: filePath,
-                  validate: (name) =>
-                    validateFileName(name, targetFolderId, filePath),
-                })
+              ? (
+                  await ui.name({
+                    kind: "file",
+                    folderId: targetFolderId,
+                    path: filePath,
+                    label: "Relative file path",
+                    initial: filePath,
+                    validate: (name) =>
+                      validateFileName(name, targetFolderId, filePath),
+                  })
+                )?.name
               : filePath;
           if (!nextPath || (action === "rename" && nextPath === filePath))
             return;
@@ -1148,13 +1150,15 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
             );
         }}
         onNewFile={async (folderId = props.folder.id) => {
-          const path = await ui.name({
-            kind: "file",
-            folderId,
-            label: "Relative file path",
-            initial: "stimulus.cir",
-            validate: (name) => validateFileName(name, folderId),
-          });
+          const path = (
+            await ui.name({
+              kind: "file",
+              folderId,
+              label: "Relative file path",
+              initial: "stimulus.cir",
+              validate: (name) => validateFileName(name, folderId),
+            })
+          )?.name;
           if (!path) return;
           drafts.current.set(`${folderId}\u0000${path}`, {
             base: "",

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -1025,10 +1025,27 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
       );
       return;
     }
-    const name = await interaction.name({
+    const selection = await interaction.name({
       kind: "folder",
       ...(action === "rename" && current ? { folderId: current.id } : {}),
       label: action === "rename" ? "Folder name" : "New simulation folder name",
+      ...(action === "new"
+        ? {
+            cellSelection: {
+              initial: props.activeDocumentId,
+              options: latestProject.documents.map(({ id, name }) => ({
+                id,
+                name,
+              })),
+              validate: (documentId: string) =>
+                session
+                  .currentProject()
+                  ?.documents.some((cell) => cell.id === documentId)
+                  ? undefined
+                  : "Select an existing Cell for this experiment.",
+            },
+          }
+        : {}),
       validate: (value) =>
         session
           .currentProject()
@@ -1047,13 +1064,13 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
             ? `${current?.name} copy`
             : `Simulation ${latestProject.simulationFolders.length + 1}`,
     });
-    if (!name?.trim()) return;
+    if (!selection) return;
     const identity = {
       id:
         action === "rename" && current
           ? current.id
           : `simulation-folder-${crypto.randomUUID()}`,
-      name: name.trim(),
+      name: selection.name,
     };
     // Naming is non-modal: refresh the revision and source after the user finishes.
     const namingProject = session.currentProject();
@@ -1065,11 +1082,26 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
     let created: typeof current;
     if (newest) created = { ...structuredClone(newest), ...identity };
     else {
+      // Creation is non-modal: never silently substitute a different Cell if
+      // the selected one disappeared while the user was naming the folder.
+      if (
+        !selection.documentId ||
+        !namingProject.documents.some(
+          (cell) => cell.id === selection.documentId,
+        )
+      ) {
+        setProblem(
+          uiProblem(
+            "SIMULATION_STARTER_INVALID",
+            "The selected Cell no longer exists. Select a Cell and create the experiment again.",
+          ),
+        );
+        return;
+      }
       const result = createSimulationStarter(namingProject, {
         ...identity,
         mode: "circuit",
-        documentId:
-          props.draftContext?.rootDocumentId ?? props.activeDocumentId,
+        documentId: selection.documentId,
         profileId: capabilities?.profiles[0]?.id ?? authoringProfile.id,
         template: "op",
       });
@@ -1789,6 +1821,19 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
             folders: project.simulationFolders.map((folder) => ({
               ...folder,
               configPath: folder.input.configPath,
+              cellLabel: folder.input.circuitBindings.length
+                ? "Cell: " +
+                  [
+                    ...new Set(
+                      folder.input.circuitBindings.map(
+                        (binding) =>
+                          project.documents.find(
+                            (cell) => cell.id === binding.documentId,
+                          )?.name ?? `Missing (${binding.documentId})`,
+                      ),
+                    ),
+                  ].join(", ")
+                : "No Canvas Cell",
               files: [
                 ...folder.input.files.map((file) => ({
                   path: file.path,

--- a/apps/editor/src/features/simulation/workspace-interactions.tsx
+++ b/apps/editor/src/features/simulation/workspace-interactions.tsx
@@ -21,6 +21,15 @@ interface NameRequest {
   label: string;
   initial: string;
   validate?(name: string): string | undefined;
+  cellSelection?: {
+    initial: string;
+    options: readonly { id: string; name: string }[];
+    validate(documentId: string): string | undefined;
+  };
+}
+interface NameResult {
+  name: string;
+  documentId?: string;
 }
 interface Confirmation {
   title: string;
@@ -29,8 +38,8 @@ interface Confirmation {
 }
 interface Interactions {
   edit: (NameRequest & { requestId: number }) | undefined;
-  name(request: NameRequest): Promise<string | null>;
-  finishName(value: string | null, restoreFocus?: boolean): void;
+  name(request: NameRequest): Promise<NameResult | null>;
+  finishName(value: NameResult | null, restoreFocus?: boolean): void;
   confirm(request: Confirmation): Promise<boolean>;
   menu(x: number, y: number, items: WorkspaceMenuItem[], label?: string): void;
   closeMenu(restore?: boolean): void;
@@ -46,7 +55,7 @@ export function useWorkspaceInteractions() {
 export function WorkspaceInteractions({ children }: { children: ReactNode }) {
   const [edit, setEdit] = useState<NameRequest & { requestId: number }>();
   const nameSequence = useRef(0);
-  const nameResolver = useRef<((value: string | null) => void) | undefined>(
+  const nameResolver = useRef<((value: NameResult | null) => void) | undefined>(
     undefined,
   );
   const [confirmation, setConfirmation] = useState<Confirmation>();
@@ -69,7 +78,7 @@ export function WorkspaceInteractions({ children }: { children: ReactNode }) {
     setMenu(undefined);
     if (focus) restore();
   };
-  const finishName = (value: string | null, restoreFocus = false) => {
+  const finishName = (value: NameResult | null, restoreFocus = false) => {
     const resolve = nameResolver.current;
     nameResolver.current = undefined;
     setEdit(undefined);
@@ -80,13 +89,13 @@ export function WorkspaceInteractions({ children }: { children: ReactNode }) {
           edit.kind === "folder"
             ? value
               ? document.querySelector<HTMLElement>(
-                  `[aria-label="${CSS.escape(`Folder ${value}`)}"]`,
+                  `[aria-label="${CSS.escape(`Folder ${value.name}`)}"]`,
                 )
               : document.querySelector<HTMLElement>(
                   `[data-folder-id="${CSS.escape(edit.folderId ?? "")}"][data-tree-row="folder"]`,
                 )
             : document.querySelector<HTMLElement>(
-                `[data-folder-id="${CSS.escape(edit.folderId ?? "")}"][data-file-path="${CSS.escape(value ?? edit.path ?? "")}"]`,
+                `[data-folder-id="${CSS.escape(edit.folderId ?? "")}"][data-file-path="${CSS.escape(value?.name ?? edit.path ?? "")}"]`,
               );
         (
           row ??
@@ -269,6 +278,9 @@ function NameInput() {
   const interaction = useWorkspaceInteractions();
   const request = interaction.edit!;
   const [value, setValue] = useState(request.initial);
+  const [documentId, setDocumentId] = useState(
+    request.cellSelection?.initial ?? "",
+  );
   const [error, setError] = useState<string>();
   const input = useRef<HTMLInputElement>(null);
   const finished = useRef(false);
@@ -279,13 +291,25 @@ function NameInput() {
   const finish = (cancel = false, restoreFocus = false) => {
     if (finished.current) return;
     const name = value.trim();
-    const problem = !cancel && name ? request.validate?.(name) : undefined;
+    const problem =
+      !cancel && name
+        ? (request.validate?.(name) ??
+          request.cellSelection?.validate(documentId))
+        : undefined;
     if (problem) {
       setError(problem);
       return;
     }
     finished.current = true;
-    interaction.finishName(cancel || !name ? null : name, restoreFocus);
+    interaction.finishName(
+      cancel || !name
+        ? null
+        : {
+            name,
+            ...(request.cellSelection ? { documentId } : {}),
+          },
+      restoreFocus,
+    );
   };
   return (
     <div
@@ -316,6 +340,39 @@ function NameInput() {
           }
         }}
       />
+      {request.cellSelection ? (
+        <div className="workspace-cell-selection">
+          <label htmlFor={`simulation-cell-${request.requestId}`}>Cell</label>
+          <select
+            id={`simulation-cell-${request.requestId}`}
+            aria-label="Simulation Cell"
+            value={documentId}
+            onChange={(event) => {
+              setDocumentId(event.currentTarget.value);
+              setError(undefined);
+            }}
+            onKeyDown={(event) => {
+              event.stopPropagation();
+              if (event.key === "Escape") {
+                event.preventDefault();
+                finish(true, true);
+              }
+            }}
+          >
+            <option value="" disabled>
+              Select a Cell
+            </option>
+            {request.cellSelection.options.map((cell) => (
+              <option key={cell.id} value={cell.id}>
+                {cell.name}
+              </option>
+            ))}
+          </select>
+          <button type="button" onClick={() => finish(false, true)}>
+            Create
+          </button>
+        </div>
+      ) : null}
       {error ? <small role="status">{error}</small> : null}
     </div>
   );

--- a/docs/specs/simulation-code-workspace.md
+++ b/docs/specs/simulation-code-workspace.md
@@ -152,9 +152,15 @@ IDs and exact files. Older data is read only at that compatibility boundary.
   otherwise retain the now-unresolved entry/reference for diagnosis. Deleting
   a binding is explicit, not a side effect of editing its displayed filename.
 
-New experiments require only a name. They bind the current Cell as the top-level
-circuit and create a small `op` starter; they do not ask for OP/AC/TRAN or source
-mode. Helpers can insert AC, TRAN and DC commands without making another form
+New experiments ask for a name and an explicit Cell selection, defaulting to the
+current Canvas Cell. They bind the selected Cell as the top-level circuit and
+create a small `op` starter; they do not ask for OP/AC/TRAN or TB/DUT/source mode.
+Any Cell can be the simulation root, not only a dedicated Testbench. The Explorer
+shows the bound Cell name (or a missing-Cell marker); changing the active Canvas
+does not rebind an existing experiment. The existing circuit binding is the sole
+source mapping, with no duplicate Cell setting in `experiment.json`. Creation
+does not wrap the Cell in an invented DUT call or guess stimuli. Helpers can
+insert AC, TRAN and DC commands without making another form
 state authoritative; the editor has no permanent analysis-example footer. The source API
 retains text-only and text-DUT creation for import, Agent and compatibility flows,
 but those are not choices in the normal new-experiment interaction. No starter


### PR DESCRIPTION
## Changes
- New experiment asks for name and Cell, defaulting to the active Canvas Cell.
- The chosen Cell is emitted directly as the top-level circuit with the existing minimal op starter; no TB/DUT mode, guessed stimulus, or new schema/config authority.
- Explorer shows each folder's bound Cell, missing reference, or unbound text status. Existing folders are never rebound by Canvas navigation.
- Preserve inline naming, duplicate/rename behavior and source-file operations.

## Validation
- pnpm gate:preflight -- --base origin/main: passed (static contracts and Test-Impact).
- pnpm gate:affected -- --base origin/main: passed. Unit/module: 477 files and 3216 tests passed, 30 pre-existing skipped tests. All 26 browser tests in the six affected analog-simulation specs passed.
- New browser regression: select ordinary OTA Cell, compare generated netlist, retain binding through Canvas switches and Project reopen, cancel creation.
- All seven required GitHub checks passed on 2a7172fef9a98fe21d51f3e55ef50c384411e7dc, including release/performance and four browser shards.
- git diff --check passed. No electrical model or stimulus changes; validation concerns Cell/root selection and source ownership, not newly claimed electrical behavior.

Test-Impact: tests-updated