### PR TITLE
refactor(simulation): retire redundant workspace more menu

### DIFF
--- a/apps/editor/e2e/simulation-batch.spec.ts
+++ b/apps/editor/e2e/simulation-batch.spec.ts
@@ -294,7 +294,9 @@ test("a saved Run Plan prepares without executing and Run starts its ordinary ba
     "experiment.json",
     JSON.stringify(config, null, 2),
   );
-  await panel.getByRole("button", { name: "More code actions" }).click();
+  await panel
+    .getByRole("treeitem", { name: "Run", exact: true })
+    .click({ button: "right" });
   await page.getByRole("menuitem", { name: "Preview input netlist…" }).click();
   await panel.getByTitle("Batch queue", { exact: true }).click();
   await expect(panel.locator(".simulation-batch-menu-popover")).toContainText(

--- a/apps/editor/e2e/simulation-code-editor.spec.ts
+++ b/apps/editor/e2e/simulation-code-editor.spec.ts
@@ -168,8 +168,16 @@ test("Explorer opens sideways, configuration is advanced, and results maximize/r
   const after = await editor.boundingBox();
   expect(after!.y).toBe(before!.y);
   expect(after!.x - before!.x).toBeGreaterThan(100);
-  await page.getByRole("button", { name: "More code actions" }).click();
-  await page.getByRole("menuitem", { name: "Advanced configuration" }).click();
+  if (
+    (await page
+      .getByRole("button", { name: "Explorer", exact: true })
+      .getAttribute("aria-expanded")) !== "true"
+  )
+    await page.getByRole("button", { name: "Explorer", exact: true }).click();
+  await page
+    .getByRole("treeitem", { name: "experiment.json", exact: true })
+    .first()
+    .click();
   await expect(
     page.getByRole("tab", { name: "Configuration" }),
   ).toHaveAttribute("aria-selected", "true");
@@ -268,8 +276,16 @@ test("file switching preserves caret, selection, scroll and local Undo history",
   const scroller = page.locator(".cm-scroller");
   const scroll = await scroller.evaluate((el) => el.scrollTop);
   expect(scroll).toBeGreaterThan(100);
-  await page.getByRole("button", { name: "More code actions" }).click();
-  await page.getByRole("menuitem", { name: "Advanced configuration" }).click();
+  if (
+    (await page
+      .getByRole("button", { name: "Explorer", exact: true })
+      .getAttribute("aria-expanded")) !== "true"
+  )
+    await page.getByRole("button", { name: "Explorer", exact: true }).click();
+  await page
+    .getByRole("treeitem", { name: "experiment.json", exact: true })
+    .first()
+    .click();
   await editor.fill('{"version":1,"different":true}');
   await page.getByRole("tab", { name: "run.cir" }).click();
   await editor.focus();

--- a/apps/editor/e2e/simulation-e2e-fixtures.ts
+++ b/apps/editor/e2e/simulation-e2e-fixtures.ts
@@ -37,9 +37,20 @@ export async function editSimulationFile(
 ) {
   const panel = page.getByRole("region", { name: "Analog simulation" });
   if (path === "experiment.json") {
-    await panel.getByRole("button", { name: "More code actions" }).click();
-    await page
-      .getByRole("menuitem", { name: "Advanced configuration" })
+    if (
+      (await panel
+        .getByRole("button", { name: "Explorer", exact: true })
+        .getAttribute("aria-expanded")) !== "true"
+    )
+      await panel
+        .getByRole("button", { name: "Explorer", exact: true })
+        .click();
+    const folderId = await panel
+      .getByRole("treeitem", { name: "Run", exact: true })
+      .getAttribute("data-folder-id");
+    await panel
+      .getByRole("treeitem", { name: "experiment.json", exact: true })
+      .and(panel.locator(`[data-folder-id="${folderId}"]`))
       .click();
   } else await panel.getByRole("tab", { name: path, exact: false }).click();
   const editor = panel.getByRole("textbox", {

--- a/apps/editor/e2e/simulation-setup.spec.ts
+++ b/apps/editor/e2e/simulation-setup.spec.ts
@@ -194,7 +194,9 @@ test("the qualified OTA folder opens unchanged and preserves all root and hierar
     savedSetup.input.configPath,
     JSON.stringify(config, null, 2),
   );
-  await panel.getByRole("button", { name: "More code actions" }).click();
+  await panel
+    .getByRole("treeitem", { name: "Run", exact: true })
+    .click({ button: "right" });
   await page.getByRole("menuitem", { name: "Preview input netlist…" }).click();
   await expect(panel.getByLabel("Prepare temporary files")).toHaveCount(0);
   const preview = panel.getByRole("region", { name: "File preview" });
@@ -218,7 +220,9 @@ test("the qualified OTA folder opens unchanged and preserves all root and hierar
   expect(deck).toContain('.lib "icm-models.lib" tt');
   expect(deck).toContain("tran 2e-8 0.000004");
   expect(executions).toBe(0);
-  await panel.getByRole("button", { name: "More code actions" }).click();
+  await panel
+    .getByRole("treeitem", { name: "Run", exact: true })
+    .click({ button: "right" });
   await expect(
     page.getByRole("menuitem", { name: "View executed netlist…" }),
   ).toBeDisabled();
@@ -257,8 +261,16 @@ test("the qualified OTA folder opens unchanged and preserves all root and hierar
     buffer: saved,
   });
   await clickNetlistWorkflowCommand(page, "open-analog-simulation");
-  await panel.getByRole("button", { name: "More code actions" }).click();
-  await page.getByRole("menuitem", { name: "Advanced configuration" }).click();
+  if (
+    (await panel
+      .getByRole("button", { name: "Explorer", exact: true })
+      .getAttribute("aria-expanded")) !== "true"
+  )
+    await panel.getByRole("button", { name: "Explorer", exact: true }).click();
+  await panel
+    .getByRole("treeitem", { name: "experiment.json", exact: true })
+    .first()
+    .click();
   await expect(
     panel.getByRole("textbox", { name: "Simulation source editor" }),
   ).toContainText(profile.id);

--- a/apps/editor/e2e/simulation-workspace.spec.ts
+++ b/apps/editor/e2e/simulation-workspace.spec.ts
@@ -23,6 +23,88 @@ import {
 import { ota, profile, editSimulationFile } from "./simulation-e2e-fixtures.js";
 
 const loadModule = createRequire(import.meta.url);
+test("tab context menus replace workspace more actions without discarding source", async ({
+  page,
+}) => {
+  const project = parseProject(JSON.stringify(ota));
+  const folder = createSimulationFolder({
+    id: "tab-actions",
+    name: "Tab actions",
+    documentId: project.topDocumentId,
+    profileId: profile.id,
+  });
+  project.simulationFolders = [folder];
+  await page.route("**/api/simulate", (route) =>
+    route.fulfill({
+      status: 503,
+      json: { error: "Offline authoring fixture" },
+    }),
+  );
+  await page.goto("/editor");
+  await page.getByTestId("project-file").setInputFiles({
+    name: "tabs.icproj.json",
+    mimeType: "application/json",
+    buffer: Buffer.from(JSON.stringify(project)),
+  });
+  await page.getByTestId("open-analog-simulation").click();
+  const panel = page.getByRole("region", { name: "Analog simulation" });
+  await expect(
+    panel.getByRole("button", { name: "More code actions" }),
+  ).toHaveCount(0);
+  const editor = panel.getByRole("textbox", {
+    name: "Simulation source editor",
+  });
+  const runTab = panel.getByRole("tab", { name: /run\.cir/ });
+  const circuitTab = panel.getByRole("tab", { name: /circuit\.spice/ });
+  const draft = "* retained after closing tabs\n";
+  await editor.fill(draft);
+  await circuitTab.click({ button: "right" });
+  await page.getByRole("menuitem", { name: "Close", exact: true }).click();
+  await expect(circuitTab).toHaveCount(0);
+  await expect(runTab).toHaveAttribute("aria-selected", "true");
+  await panel
+    .getByRole("treeitem", { name: "circuit.spice", exact: true })
+    .click();
+  await panel
+    .getByRole("treeitem", { name: "experiment.json", exact: true })
+    .click();
+  await expect(
+    panel.getByRole("tab", { name: "Configuration" }),
+  ).toHaveAttribute("aria-selected", "true");
+  await circuitTab.click({ button: "right" });
+  await page
+    .getByRole("menuitem", { name: "Close others", exact: true })
+    .click();
+  await expect(
+    panel
+      .getByRole("tablist", { name: "Open simulation files" })
+      .getByRole("tab"),
+  ).toHaveCount(1);
+  await expect(circuitTab).toHaveAttribute("aria-selected", "true");
+  await panel.getByRole("treeitem", { name: "run.cir", exact: true }).click();
+  await expect(editor).toHaveText(draft);
+  await runTab.focus();
+  await runTab.press("Shift+F10");
+  await page.getByRole("menuitem", { name: "Close all", exact: true }).click();
+  await expect(
+    panel
+      .getByRole("tablist", { name: "Open simulation files" })
+      .getByRole("tab"),
+  ).toHaveCount(0);
+  await expect(
+    panel.getByText(
+      "Select a file to edit. Closing tabs does not delete files.",
+    ),
+  ).toBeVisible();
+  await panel.getByRole("treeitem", { name: "run.cir", exact: true }).click();
+  await expect(editor).toHaveText(draft);
+  await runTab.click({ button: "right" });
+  await expect(
+    page.getByRole("menuitem", { name: "Close others", exact: true }),
+  ).toBeDisabled();
+  await page.keyboard.press("Escape");
+});
+
 test("source save applies locally while signed out and leaves File Save cloud-owned", async ({
   page,
 }) => {
@@ -1140,7 +1222,9 @@ test("human simulation uses saved folder, survives minimizing, recovers a bad in
     "evidence/evidence-manifest.json",
   ])
     expect(diagnostics[path]).toBeDefined();
-  await panel.getByRole("button", { name: "More code actions" }).click();
+  await panel
+    .getByRole("treeitem", { name: "Run", exact: true })
+    .click({ button: "right" });
   await page.getByRole("menuitem", { name: "View executed netlist…" }).click();
   await expect(
     panel.getByRole("tab", { name: /executed[.]cir/ }),
@@ -1149,6 +1233,23 @@ test("human simulation uses saved folder, survives minimizing, recovers a bad in
     .getByLabel("File preview")
     .locator("pre")
     .innerText();
+  const executedTab = panel.getByRole("tab", { name: /executed[.]cir/ });
+  await executedTab.click({ button: "right" });
+  await page
+    .getByRole("menuitem", { name: "Close others", exact: true })
+    .click();
+  await expect(
+    panel
+      .getByRole("tablist", { name: "Open simulation files" })
+      .getByRole("tab"),
+  ).toHaveCount(1);
+  await executedTab.focus();
+  await executedTab.press("ControlOrMeta+w");
+  await expect(panel.getByLabel("File preview")).toHaveCount(0);
+  await panel
+    .getByRole("treeitem", { name: folder.input.entry, exact: true })
+    .and(panel.locator(`[data-folder-id="${folder.id}"]`))
+    .click();
   expect(executions).toBe(1);
   config.outputs[0]!.label = "new-output";
   await editSimulationFile(
@@ -1165,12 +1266,16 @@ test("human simulation uses saved folder, survives minimizing, recovers a bad in
   await expect(panel.locator(".simulation-code-status")).toContainText(
     "earlier Project revision",
   );
-  await panel.getByRole("button", { name: "More code actions" }).click();
+  await panel
+    .getByRole("treeitem", { name: "Run", exact: true })
+    .click({ button: "right" });
   await page.getByRole("menuitem", { name: "Preview input netlist…" }).click();
   await expect(panel.getByLabel("File preview").locator("pre")).toContainText(
     ".temp 30",
   );
-  await panel.getByRole("button", { name: "More code actions" }).click();
+  await panel
+    .getByRole("treeitem", { name: "Run", exact: true })
+    .click({ button: "right" });
   await page.getByRole("menuitem", { name: "View executed netlist…" }).click();
   await expect(panel.getByLabel("File preview").locator("pre")).toHaveText(
     executedBeforeEdit,
@@ -1485,7 +1590,9 @@ test("Simulation creates an ordinary testbench and defaults a new experiment to 
   );
   await expect(saveButton).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
   await expect(runButton).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
-  await taskbar.getByRole("button", { name: "More code actions" }).click();
+  await page
+    .getByRole("treeitem", { name: "Run", exact: true })
+    .click({ button: "right" });
   await expect(
     page.getByRole("menuitem", { name: "View executed netlist…" }),
   ).toBeDisabled();

--- a/apps/editor/src/features/simulation/code-workspace.css
+++ b/apps/editor/src/features/simulation/code-workspace.css
@@ -77,9 +77,6 @@
   min-width: 0;
   gap: 4px;
 }
-.simulation-code-more {
-  position: relative;
-}
 .simulation-code-workspace .simulation-code-toolbar {
   min-height: 30px;
   gap: 4px;
@@ -87,15 +84,13 @@
 }
 .simulation-code-workspace .simulation-code-toolbar > button,
 .simulation-code-workspace .simulation-code-actions > button,
-.simulation-code-workspace .simulation-task-actions > button,
-.simulation-code-workspace .simulation-code-more > button {
+.simulation-code-workspace .simulation-task-actions > button {
   height: 22px;
   min-height: 22px;
   padding: 0 5px;
   font-size: 11px;
 }
-.simulation-code-toolbar .simulation-window-actions,
-.simulation-code-toolbar .simulation-code-more {
+.simulation-code-toolbar .simulation-window-actions {
   flex: none;
 }
 .workspace-context-menu {

--- a/apps/editor/src/features/simulation/code-workspace.test.tsx
+++ b/apps/editor/src/features/simulation/code-workspace.test.tsx
@@ -39,6 +39,7 @@ describe("approved simulation Code layout", () => {
     expect(markup).toContain("+ New experiment");
     expect(markup).toContain("Source");
     expect(markup).not.toContain("Run target");
+    expect(markup).not.toContain("More code actions");
     expect(markup).not.toContain("New file");
     expect(markup).not.toContain("Setup");
     expect(markup).not.toContain('class="simulation-code-status"');

--- a/apps/editor/src/features/simulation/code-workspace.tsx
+++ b/apps/editor/src/features/simulation/code-workspace.tsx
@@ -4,6 +4,8 @@ import {
   useId,
   useState,
   type ReactNode,
+  type MouseEvent,
+  type KeyboardEvent,
 } from "react";
 import type { ArtifactRef } from "@icm/simulation-service/contract";
 import {
@@ -45,7 +47,6 @@ export interface SimulationCodeWorkspaceProps {
   onSelectFile(path: string, folderId?: string): void;
   onNewFile?(folderId?: string): void;
   onCopyFile?(path: string, folderId?: string): void;
-  onExportFile?(path: string, folderId?: string): void;
   onFileAction?(
     action: "rename" | "delete" | "entry" | "discard",
     path: string,
@@ -145,6 +146,52 @@ export function SimulationCodeWorkspace(props: SimulationCodeWorkspaceProps) {
     setOpened(next);
     if (props.activePath === path) props.onSelectFile(next.at(-1) ?? "");
   };
+  const closeAll = () => {
+    setOpened([]);
+    props.onSelectFile("");
+    props.onCloseArtifact?.();
+  };
+  const tabMenu = (path: string | null, x: number, y: number) =>
+    ui.menu(
+      x,
+      y,
+      [
+        {
+          label: "Close",
+          run: () =>
+            path === null ? props.onCloseArtifact?.() : closeFile(path),
+        },
+        {
+          label: "Close others",
+          disabled: tabs.length + Number(Boolean(props.artifactPreview)) <= 1,
+          run: () => {
+            setOpened(path === null ? [] : [path]);
+            props.onSelectFile(path ?? "");
+            if (path !== null) props.onCloseArtifact?.();
+          },
+        },
+        { label: "Close all", run: closeAll },
+      ],
+      "Editor tab actions",
+    );
+  const tabMenuHandlers = (path: string | null) => ({
+    onContextMenu: (event: MouseEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      tabMenu(path, event.clientX, event.clientY);
+    },
+    onKeyDown: (event: KeyboardEvent<HTMLDivElement>) => {
+      if (
+        event.key === "ContextMenu" ||
+        (event.shiftKey && event.key === "F10")
+      ) {
+        event.preventDefault();
+        event.stopPropagation();
+        const rect = event.currentTarget.getBoundingClientRect();
+        tabMenu(path, rect.left, rect.bottom);
+      }
+    },
+  });
   return (
     <section
       className={`simulation-code-workspace${props.maximized ? " is-maximized" : ""}`}
@@ -167,7 +214,8 @@ export function SimulationCodeWorkspace(props: SimulationCodeWorkspaceProps) {
         ) {
           event.preventDefault();
           event.stopPropagation();
-          if (props.activePath) closeFile(props.activePath);
+          if (props.artifactPreview) props.onCloseArtifact?.();
+          else if (props.activePath) closeFile(props.activePath);
         }
       }}
     >
@@ -181,46 +229,6 @@ export function SimulationCodeWorkspace(props: SimulationCodeWorkspaceProps) {
           Explorer
         </button>
         <div className="simulation-code-actions">{props.actions}</div>
-        <div className="simulation-code-more">
-          <button
-            type="button"
-            aria-label="More code actions"
-            onClick={(event) => {
-              const rect = event.currentTarget.getBoundingClientRect();
-              ui.menu(
-                rect.left,
-                rect.bottom,
-                [
-                  {
-                    label: "Advanced configuration",
-                    run: () => openFile(props.configPath),
-                  },
-                  {
-                    label: "Copy current file",
-                    disabled: !props.activePath,
-                    run: () => props.onCopyFile?.(props.activePath),
-                  },
-                  {
-                    label: "Export current file…",
-                    disabled: !props.activePath,
-                    run: () => props.onExportFile?.(props.activePath),
-                  },
-                  {
-                    label: "Close all editors",
-                    run: () => {
-                      setOpened([]);
-                      props.onSelectFile("");
-                    },
-                  },
-                  ...(props.additionalActions ?? []),
-                ],
-                "Code actions",
-              );
-            }}
-          >
-            ···
-          </button>
-        </div>
         {props.toolbarEnd}
       </header>
       <div className="simulation-code-source-area">
@@ -290,7 +298,10 @@ export function SimulationCodeWorkspace(props: SimulationCodeWorkspaceProps) {
               aria-label="Open simulation files"
             >
               {props.artifactPreview ? (
-                <div className="simulation-code-tab simulation-artifact-tab">
+                <div
+                  className="simulation-code-tab simulation-artifact-tab"
+                  {...tabMenuHandlers(null)}
+                >
                   <button type="button" role="tab" aria-selected="true">
                     {props.artifactPreview.artifact.name}
                     <span> tmp</span>
@@ -307,7 +318,11 @@ export function SimulationCodeWorkspace(props: SimulationCodeWorkspaceProps) {
               {tabs.map((path) => {
                 const file = props.files.find((f) => f.path === path)!;
                 return (
-                  <div className="simulation-code-tab" key={path}>
+                  <div
+                    className="simulation-code-tab"
+                    key={path}
+                    {...tabMenuHandlers(path)}
+                  >
                     <button
                       type="button"
                       role="tab"

--- a/apps/editor/src/features/simulation/source-code-pane.tsx
+++ b/apps/editor/src/features/simulation/source-code-pane.tsx
@@ -1137,16 +1137,6 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
               ),
             );
         }}
-        onExportFile={(filePath, folderId = props.folder.id) => {
-          const result = downloadTextArtifact(
-            fileText(folderId, filePath),
-            filePath.split("/").at(-1)!,
-          );
-          if (result.status === "failed")
-            props.onProblem(
-              inputProblem("SOURCE_EXPORT_FAILED", result.message),
-            );
-        }}
         onNewFile={async (folderId = props.folder.id) => {
           const path = await ui.name({
             kind: "file",

--- a/docs/user/analog-simulation.md
+++ b/docs/user/analog-simulation.md
@@ -39,8 +39,10 @@ covered by the Project's browser recovery, not a cloud backup. **File → Save**
 (or the project-level shortcut outside code) still saves the entire Project to
 the signed-in cloud account.
 
-**More code actions** opens advanced configuration, copies/exports the current
-file, or creates a source file. Configuration is not a default tab. It owns
+Open **experiment.json** from Source for configuration; it is not a default tab.
+Use file/folder context menus to copy, download or create files. Right-click a
+file tab (or press Shift+F10 while it is focused) to close it, close other tabs,
+or close all tabs. Closing tabs retains files and pending drafts. Configuration owns
 Profile/corner, output labels and bindings, measurements and the managed Run
 Plan. Native analyses and nominal temperature belong in SPICE, not hidden
 Settings fields. This example runs OP and AC and retains both plots:

--- a/scripts/preview-source-gui-journey.mjs
+++ b/scripts/preview-source-gui-journey.mjs
@@ -90,9 +90,17 @@ let panel;
 const digest = (value) => createHash("sha256").update(value).digest("hex");
 async function edit(path, text) {
   if (path === folder.input.configPath) {
-    await panel.getByRole("button", { name: "More code actions" }).click();
-    await page
-      .getByRole("menuitem", { name: "Advanced configuration" })
+    if (
+      (await panel
+        .getByRole("button", { name: "Explorer", exact: true })
+        .getAttribute("aria-expanded")) !== "true"
+    )
+      await panel
+        .getByRole("button", { name: "Explorer", exact: true })
+        .click();
+    await panel
+      .getByRole("treeitem", { name: path, exact: true })
+      .first()
       .click();
   } else await panel.getByRole("tab", { name: path, exact: false }).click();
   const editor = panel.getByRole("textbox", {
@@ -224,7 +232,9 @@ try {
       '.include "missing-gui-acceptance.spice"\n.control',
     ),
   );
-  await panel.getByRole("button", { name: "More code actions" }).click();
+  await panel
+    .getByRole("treeitem", { name: "Run", exact: true })
+    .click({ button: "right" });
   await page.getByRole("menuitem", { name: "Preview input netlist…" }).click();
   await expect(panel).toContainText("missing-gui-acceptance.spice", {
     timeout: 30_000,
@@ -312,7 +322,9 @@ try {
     axes: [{ kind: "temperature", values: [27, 28] }],
   };
   await edit(folder.input.configPath, JSON.stringify(config, null, 2));
-  await panel.getByRole("button", { name: "More code actions" }).click();
+  await panel
+    .getByRole("treeitem", { name: "Run", exact: true })
+    .click({ button: "right" });
   await page.getByRole("menuitem", { name: "Preview input netlist…" }).click();
   await panel.getByTitle("Batch queue", { exact: true }).click();
   await expect(panel.locator(".simulation-batch-menu-popover")).toContainText(

--- a/scripts/preview-workflow.test.mjs
+++ b/scripts/preview-workflow.test.mjs
@@ -120,6 +120,8 @@ describe("the preview deploy", () => {
   });
 
   it("separates GUI output downloads from complete diagnostic exports", () => {
+    expect(sourceGuiJourney).not.toContain("More code actions");
+    expect(sourceGuiJourney).not.toContain("Advanced configuration");
     expect(sourceGuiJourney).toContain('name: "Simulation files"');
     expect(sourceGuiJourney).toContain('getByRole("menuitem", { name: action');
     expect(sourceGuiJourney).toContain('"Export diagnostic bundle…"');


### PR DESCRIPTION
## Change
Remove the toolbar more menu. Configuration opens from Source; file operations and diagnostic actions stay in their existing context menus. Add Close / Close others / Close all to source and artifact tabs, including keyboard access. Closing tabs preserves drafts. Update the Preview GUI acceptance to use surviving controls.

## Validation
- Frozen install and final preflight passed.
- 3216 unit tests passed (30 skipped).
- All 26 simulation browser tests passed.
- Editor and dependency build passed.
- Corrected an ambiguous test locator and rebuilt stale local package output before the successful full browser rerun.

No project or service contract changes. Not deployed until merge.