### PR TITLE
fix(simulation): make source parameters editable and guide declarations

### DIFF
--- a/apps/editor/e2e/simulation-workspace.spec.ts
+++ b/apps/editor/e2e/simulation-workspace.spec.ts
@@ -23,6 +23,117 @@ import {
 import { ota, profile, editSimulationFile } from "./simulation-e2e-fixtures.js";
 
 const loadModule = createRequire(import.meta.url);
+test("Code adds and removes source AC clauses and routes parameter declarations to authored Code", async ({
+  page,
+}) => {
+  const project = parseProject(JSON.stringify(ota));
+  const folder = createSimulationFolder({
+    id: "source-parameters",
+    name: "Source parameters",
+    documentId: project.topDocumentId,
+    profileId: profile.id,
+  });
+  project.simulationFolders = [folder];
+  await page.route("**/api/simulate", (route) =>
+    route.fulfill({
+      status: 503,
+      json: { error: "Offline authoring fixture" },
+    }),
+  );
+  await page.goto("/editor");
+  await page.getByTestId("project-file").setInputFiles({
+    name: "source-parameters.icproj.json",
+    mimeType: "application/json",
+    buffer: Buffer.from(JSON.stringify(project)),
+  });
+  await page.getByTestId("open-analog-simulation").click();
+  await page.getByRole("tab", { name: /circuit\.spice/ }).click();
+  const editor = page.getByRole("textbox", {
+    name: "Simulation source editor",
+  });
+  const generated = generateCircuitSource(
+    project,
+    folder.input.circuitBindings[0]!,
+  );
+  if (!generated.ok) throw Error("Expected generated source");
+  // DOM innerText can omit the final newline and includes display-only ghosts.
+  const source = generated.source.text;
+  const edited = source.replace(
+    "VDD vdd 0 DC 1.8",
+    "VDD vdd 0 DC 1.8 AC 1 -90",
+  );
+  expect(edited).not.toBe(source);
+  await editor.fill(edited);
+  await page.getByRole("button", { name: "Save source", exact: true }).click();
+  await expect(
+    page.getByRole("button", { name: "Save source", exact: true }),
+  ).toHaveAttribute("data-save-state", "saved");
+  const saved = parseProject(
+    (await downloadBytes(page, "File", "Export Project File…")).toString(),
+  );
+  const sourceParameters = (p: typeof saved) =>
+    p.documents
+      .find((d) => d.id === project.topDocumentId)!
+      .instances.find((i) => i.id === "VDD")!.netlist!.parameters;
+  expect(sourceParameters(saved)).toMatchObject({
+    acMagnitude: "1",
+    acPhase: "-90",
+  });
+  const applied = generateCircuitSource(
+    saved,
+    folder.input.circuitBindings[0]!,
+  );
+  if (!applied.ok) throw Error("Expected applied source");
+  await editor.fill(
+    applied.source.text.replace(
+      "VDD vdd 0 DC 1.8 AC 1 -90",
+      "VDD vdd 0 DC {VBIAS}",
+    ),
+  );
+  await page.getByRole("button", { name: "Helper", exact: true }).click();
+  await page
+    .getByRole("option", { name: "Design variable (.param)…", exact: true })
+    .click();
+  await expect(page.getByRole("tab", { name: /run\.cir/ })).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+  await expect(editor).toContainText(".param");
+  await expect(page.locator(".simulation-parameter-ghost")).toContainText(
+    "name=expression",
+  );
+  await editor.press("ControlOrMeta+z");
+  await expect(editor).not.toContainText(".param");
+  await editor.press("ControlOrMeta+y");
+  await expect(editor).toContainText(".param");
+  await editor.fill(
+    folder.input.files
+      .find((file) => file.path === "run.cir")!
+      .text.replace(".control", ".param VBIAS=1.8\n.control"),
+  );
+  await page.getByRole("button", { name: "Save source", exact: true }).click();
+  await expect(
+    page.getByRole("button", { name: "Save source", exact: true }),
+  ).toHaveAttribute("data-save-state", "saved");
+  const final = parseProject(
+    (await downloadBytes(page, "File", "Export Project File…")).toString(),
+  );
+  expect(sourceParameters(final)).toMatchObject({ dc: "{VBIAS}" });
+  expect(sourceParameters(final)).not.toHaveProperty("acMagnitude");
+  expect(sourceParameters(final)).not.toHaveProperty("acPhase");
+  expect(
+    final.simulationFolders[0]!.input.files.find((f) => f.path === "run.cir")!
+      .text,
+  ).toContain(".param VBIAS=1.8");
+  expect(
+    JSON.parse(
+      final.simulationFolders[0]!.input.files.find(
+        (f) => f.path === "experiment.json",
+      )!.text,
+    ),
+  ).toEqual({ version: 2, environment: { profileId: profile.id } });
+});
+
 test("new experiments explicitly bind the selected Cell without requiring a Testbench", async ({
   page,
 }) => {

--- a/apps/editor/src/features/simulation/code-editor.tsx
+++ b/apps/editor/src/features/simulation/code-editor.tsx
@@ -97,6 +97,8 @@ export interface SimulationCodeEditorProps {
   /** Generated Circuit uses its mapped-span planner here; invalid numeric drafts may remain editable. */
   acceptChange?(text: string): boolean;
   onRejectedChange?(): void;
+  onParameterDeclaration?(): void;
+  declarationRequest?: string | undefined;
   onSave?(): void;
   onRun?(): void;
   onHistoryBoundary?(direction: "undo" | "redo"): void;
@@ -371,6 +373,39 @@ export default function SimulationCodeEditor(props: SimulationCodeEditorProps) {
     if (props.reveal.focus !== false) editor.focus();
   }, [props.reveal?.requestId]);
 
+  const handledDeclaration = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    const editor = view.current;
+    if (
+      !editor ||
+      !props.declarationRequest ||
+      props.generated ||
+      !props.entry ||
+      handledDeclaration.current === props.declarationRequest
+    )
+      return;
+    handledDeclaration.current = props.declarationRequest;
+    const text = editor.state.field(exactSourceField);
+    const eol = text.includes("\r\n") ? "\r\n" : "\n";
+    const control = /^[ \t]*\.control\b/imu.exec(text);
+    const end = /^[ \t]*\.end\b/imu.exec(text);
+    const from = control?.index ?? end?.index ?? text.length;
+    const prefix = !text
+      ? `* Simulation${eol}`
+      : from > 0 && text[from - 1] !== "\n"
+        ? eol
+        : "";
+    const insert = `${prefix}.param ${eol}`;
+    const next = text.slice(0, from) + insert + text.slice(from);
+    editor.dispatch({
+      changes: { from: editorOffset(text, from), insert },
+      selection: { anchor: editorOffset(next, from + prefix.length + 7) },
+      effects: [restoreExactSource.of(next), dismissParameterGuide.of(false)],
+      userEvent: "input.complete",
+    });
+    editor.focus();
+  }, [props.declarationRequest, props.path]);
+
   useEffect(() => {
     const editor = view.current;
     if (
@@ -415,7 +450,11 @@ export default function SimulationCodeEditor(props: SimulationCodeEditorProps) {
     >
       <button
         type="button"
-        title="Insert / Helper · Ctrl+Space"
+        title={
+          props.generated
+            ? "Shared Cell parameters: edit DC/AC/waveforms and mapped expressions. Changes affect every Folder using this Cell. Use Design variable (.param) for Folder-local declarations. · Ctrl+Space"
+            : "Insert / Helper · Ctrl+Space"
+        }
         data-simulation-helper-trigger
         aria-expanded={helperOpen || Boolean(props.helperContent)}
         onClick={() => {
@@ -467,6 +506,10 @@ export default function SimulationCodeEditor(props: SimulationCodeEditorProps) {
             onChoose={(rule) => {
               const editor = view.current;
               if (!editor || props.readOnly || props.mode === "json") return;
+              if (rule.name === ".param" && props.onParameterDeclaration) {
+                props.onParameterDeclaration();
+                return;
+              }
               const line = editor.state.doc.lineAt(
                 editor.state.selection.main.head,
               );

--- a/apps/editor/src/features/simulation/code-parameter-guide.ts
+++ b/apps/editor/src/features/simulation/code-parameter-guide.ts
@@ -90,17 +90,36 @@ export function parameterGuide(state: EditorState) {
       : p,
   );
   if (/^[VI]$/u.test(help.name) && tokens[2]) {
-    const excitation = tokens[2].value.toUpperCase();
-    if (/^(PULSE|SIN|PWL)\(/u.test(excitation))
-      parameters = parameters.slice(0, 3);
-    else if (excitation === "AC")
-      parameters = [
-        ...parameters.slice(0, 3),
-        { label: "magnitude" },
-        { label: "phase / deg", optional: true },
-      ];
-    else if (excitation !== "DC")
-      parameters = [...parameters.slice(0, 2), { label: "value" }];
+    parameters = parameters.slice(0, 2);
+    let ac = false,
+      waveform = false;
+    const clause = (value: string | undefined) =>
+      /^(?:DC|AC|PULSE|SIN|PWL)(?:\(|$)/iu.test(value ?? "");
+    for (let i = 2; i < tokens.length; i++) {
+      const value = tokens[i]!.value.toUpperCase();
+      if (value === "DC") {
+        parameters.push({ label: "DC" }, { label: "DC value" });
+        i++;
+      } else if (value === "AC") {
+        ac = true;
+        parameters.push({ label: "AC" }, { label: "magnitude" });
+        i++;
+        if (!clause(tokens[i + 1]?.value)) {
+          parameters.push({ label: "phase / deg", optional: true });
+          if (tokens[i + 1]) i++;
+        }
+      } else if (/^(PULSE|SIN|PWL)\(/u.test(value)) {
+        waveform = true;
+        parameters.push({ label: "transient waveform" });
+      } else parameters.push({ label: i === 2 ? "DC value" : "excitation" });
+    }
+    if (!ac)
+      parameters.push({ label: "AC magnitude [phase / deg]", optional: true });
+    if (!waveform)
+      parameters.push({
+        label: "PULSE(...) | SIN(...) | PWL(...)",
+        optional: true,
+      });
   }
   const repeated = parameters.at(-1);
   if (repeated?.repeat) {

--- a/apps/editor/src/features/simulation/code-spice-language.test.ts
+++ b/apps/editor/src/features/simulation/code-spice-language.test.ts
@@ -5,6 +5,31 @@ import { spiceCodeLanguage, spiceCompletion } from "./code-spice-language";
 import { parameterGuide } from "./code-parameter-guide";
 
 describe("SPICE editor assistance", () => {
+  it.each(["V1 in 0 DC 1.8 AC ", "I1 in 0 DC 0 SIN(0 1 1k) AC "])(
+    "guides AC following other source clauses: %s",
+    (doc) => {
+      const guide = parameterGuide(
+        EditorState.create({ doc, selection: { anchor: doc.length } }),
+      )!;
+      expect(guide.parameters[guide.tokens.length]!.label).toBe("magnitude");
+      expect(guide.parameters[guide.tokens.length + 1]!.label).toBe(
+        "phase / deg",
+      );
+    },
+  );
+  it("suggests optional AC on a complete DC source without inserting it", () => {
+    const doc = "V1 in 0 DC 1.8";
+    const state = EditorState.create({
+      doc,
+      selection: { anchor: doc.length },
+    });
+    const guide = parameterGuide(state)!;
+    expect(guide.parameters.slice(guide.tokens.length)).toContainEqual({
+      label: "AC magnitude [phase / deg]",
+      optional: true,
+    });
+    expect(state.doc.toString()).toBe(doc);
+  });
   it("deduplicates SPICE names case-insensitively while retaining Canvas labels", () => {
     const doc = "* test\n.control\nsave ";
     const state = EditorState.create({
@@ -87,7 +112,9 @@ describe("SPICE editor assistance", () => {
         selection: { anchor: completed.length },
       }),
     )!;
-    expect(outer.parameters.slice(outer.tokens.length)).toEqual([]);
+    expect(outer.parameters.slice(outer.tokens.length)).toEqual([
+      { label: "AC magnitude [phase / deg]", optional: true },
+    ]);
     const noise = "* test\n.control\nnoise v(out, ref) VIN ";
     expect(
       parameterGuide(

--- a/apps/editor/src/features/simulation/project-file-host.test.ts
+++ b/apps/editor/src/features/simulation/project-file-host.test.ts
@@ -48,6 +48,59 @@ function fixture(actor: "human" | "agent" = "human") {
   };
 }
 describe("shared human/Agent generated Circuit File Resource", () => {
+  it("adds and unsets source clauses through the same atomic undoable transaction", async () => {
+    const f = fixture();
+    const before = f.controller.project;
+    const source = f.source.sourceBodies!.find(
+      (body) => body.instanceId === "VDD",
+    )!;
+    const write = async (text: string, original: string) =>
+      f.files.handle({
+        action: "update",
+        owner: f.owner,
+        expectedRevision: f.controller.project.structureRevision,
+        circuitEdits: [
+          {
+            path: f.source.binding.path,
+            textDigest: await sha256(original),
+            text,
+          },
+        ],
+      });
+    const added =
+      f.source.text.slice(0, source.endOffset) +
+      " AC 1 -90" +
+      f.source.text.slice(source.endOffset);
+    expect(await write(added, f.source.text)).toMatchObject({ ok: true });
+    const parameters = () =>
+      f.controller.project.documents
+        .find((d) => d.id === source.documentId)!
+        .instances.find((i) => i.id === source.instanceId)!.netlist!.parameters;
+    expect(parameters()).toMatchObject({ acMagnitude: "1", acPhase: "-90" });
+    const generated = generateCircuitSource(
+      f.controller.project,
+      f.source.binding,
+    );
+    if (!generated.ok) throw Error("Expected Circuit");
+    expect(
+      await write(
+        generated.source.text.replace(" AC 1 -90", ""),
+        generated.source.text,
+      ),
+    ).toMatchObject({ ok: true });
+    expect(parameters()).not.toHaveProperty("acMagnitude");
+    expect(parameters()).not.toHaveProperty("acPhase");
+    f.controller.transact([{ kind: "undo" }]);
+    expect(parameters()).toMatchObject({ acMagnitude: "1", acPhase: "-90" });
+    f.controller.transact([{ kind: "undo" }]);
+    expect(
+      f.controller.project.documents.map(
+        ({ revision: _revision, ...document }) => document,
+      ),
+    ).toEqual(
+      before.documents.map(({ revision: _revision, ...document }) => document),
+    );
+  });
   it.each(["human", "agent"] as const)(
     "commits source and mapped sizes atomically with normal undo/redo (%s)",
     async (actor) => {

--- a/apps/editor/src/features/simulation/project-file-host.ts
+++ b/apps/editor/src/features/simulation/project-file-host.ts
@@ -77,7 +77,7 @@ export function createSimulationProjectFileHost(options: {
             "The mapped Circuit changed; reload its generated source",
           );
         const set = Object.fromEntries(
-          group.map((p) => [p.parameter, p.value]),
+          group.filter((p) => !p.unset).map((p) => [p.parameter, p.value]),
         );
         let edit: SchematicEdit;
         if (instance.netlist)
@@ -85,6 +85,7 @@ export function createSimulationProjectFileHost(options: {
             kind: "patch_instance_netlist_parameters",
             instanceId: instance.id,
             set,
+            unset: group.filter((p) => p.unset).map((p) => p.parameter),
           };
         else {
           const initial = initialInstanceNetlist(instance.symbolId, {});

--- a/apps/editor/src/features/simulation/source-code-pane.tsx
+++ b/apps/editor/src/features/simulation/source-code-pane.tsx
@@ -166,6 +166,12 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
       focus?: boolean;
     }>();
     const [sourceDigest, setSourceDigest] = useState("");
+    const [declarationRequest, setDeclarationRequest] = useState<string>();
+    const addParameterDeclaration = () => {
+      setPath(props.folder.input.entry);
+      setDeclarationRequest(crypto.randomUUID());
+      props.onProblem(undefined);
+    };
     const [saveRequest, setSaveRequest] = useState<{
       id: string;
       session: string;
@@ -1271,12 +1277,20 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
             );
           }}
           saveRequest={saveRequest}
+          declarationRequest={declarationRequest}
+          onParameterDeclaration={addParameterDeclaration}
           relatedSources={sourceFiles.map(
             (file) =>
               drafts.current.get(`${props.folder.id}\u0000${file.path}`)
                 ?.text ?? file.text,
           )}
           helperActions={[
+            {
+              id: "design-variable",
+              label: "Design variable (.param)…",
+              keywords: "parameter declaration 参数 变量",
+              run: addParameterDeclaration,
+            },
             ...(legacyConfig
               ? [
                   {
@@ -1423,7 +1437,7 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
             props.onProblem(
               inputProblem(
                 "SIMULATION_CIRCUIT_STRUCTURE_LOCKED",
-                "Circuit topology is Canvas-owned; only mapped numeric parameter values are editable here.",
+                `Circuit topology, references and model identity are Canvas-owned. Edit mapped values/expressions and DC/AC/waveform clauses here. Use Helper → Design variable (.param) to add declarations in ${input.entry}; those declarations belong to this Folder, while Circuit parameter edits affect every Folder using this Cell.`,
               ),
             )
           }

--- a/docs/specs/simulation-code-workspace.md
+++ b/docs/specs/simulation-code-workspace.md
@@ -328,9 +328,14 @@ digest. These spans are derived, never persisted. The digest covers every
 reached Document revision and folder state needed for that generation.
 
 - Editable fields are MOS W/L and existing descriptor-backed
-  dimension/multiplicity fields, R/C/L value, and V/I DC, AC and selected
-  waveform fields **where a reversible printer mapping exists**. Model identity,
-  pin order, nodes, references, source kind and arbitrary model text are locked.
+  dimension/multiplicity fields and R/C/L value **where a reversible printer
+  mapping exists**. V/I source bodies additionally support reversible DC, AC
+  magnitude/phase, and PULSE/SIN/PWL clause edits, including adding/removing AC
+  and changing the transient waveform. Removing a clause unsets its mapped
+  parameters through the same atomic transaction, not an empty-string override.
+  This Canvas subset retains explicit DC and complete seven-argument PULSE
+  waveforms; arbitrary native source syntax belongs in authored files. Model identity,
+  pin order, nodes, references, device class and arbitrary model text are locked.
   Numeric literals and delimited native parameter expressions share those spans.
 - Descriptor-backed does not imply reversibility. The compiler must report the
   exact editable fields and conversions; a new unsupported field remains
@@ -349,6 +354,14 @@ reached Document revision and folder state needed for that generation.
   The UI/helper explains this once at the edit target. Experiment-only changes
   use source parameters/control Code; only legacy experiments retain prepared
   Run Plan projections.
+- Helper → Design variable (`.param`) opens the authored run entry and inserts
+  a declaration before `.control` (or `.end`), outside the generated Circuit.
+  The edit preserves existing text and is one undoable operation. Expressions
+  in Circuit still update the shared Cell; every calling experiment must supply
+  its dependencies. Root Cell formal defaults are emitted as `.param` when the
+  Cell runs top-level, rather than lost with the omitted `.subckt` wrapper.
+- Source ghost guidance treats DC, AC and transient clauses independently.
+  Missing optional AC/waveform clauses remain display-only, not saved defaults.
 
 The editable Circuit view shows persistent Instance values, not a projected
 Batch member disguised as an editable circuit. When a legacy variable binding masks

--- a/packages/netlist/src/printers.test.ts
+++ b/packages/netlist/src/printers.test.ts
@@ -8,6 +8,7 @@ import {
   printDesignNetlist,
   printSpectreNetlist,
   printSpiceNetlist,
+  printSpiceWithLocations,
 } from "./printers.js";
 
 function device(
@@ -371,5 +372,23 @@ describe("design netlist printers", () => {
       rawValue: "2p",
     });
     expect(printSpiceNetlist(ir)).toContain("\n+ parameter_");
+  });
+  it("preserves root Cell defaults when emitting an executable top-level circuit", () => {
+    const ir = structuralIr();
+    const root = ir.cells.find((cell) => cell.id === ir.topCellId)!;
+    root.formalParameters = [
+      { name: "RVAL", defaultValue: "1k" },
+      { name: "RDOUBLE", defaultValue: "{RVAL * 2}" },
+    ];
+    const printed = printSpiceWithLocations(ir, true);
+    expect(printed.text).toContain(".param RVAL=1k RDOUBLE={RVAL * 2}");
+    expect(printed.text).not.toContain(`.subckt ${root.name}`);
+    for (const span of printed.parameters)
+      expect(printed.text.slice(span.startOffset, span.endOffset)).toBe(
+        span.rawValue,
+      );
+    expect(printSpiceWithLocations(ir, false).text).toContain(
+      "params: RVAL=1k RDOUBLE={RVAL * 2}",
+    );
   });
 });

--- a/packages/netlist/src/printers.ts
+++ b/packages/netlist/src/printers.ts
@@ -340,6 +340,19 @@ function renderSpice(
   }
   if (rootAsTopLevel) {
     const root = ir.cells.find((cell) => cell.id === ir.topCellId);
+    const defaults =
+      root?.formalParameters?.filter(
+        (parameter) => parameter.defaultValue !== undefined,
+      ) ?? [];
+    if (defaults.length)
+      append(
+        ...wrapSpice([
+          ".param",
+          ...defaults.map(
+            (parameter) => `${parameter.name}=${parameter.defaultValue}`,
+          ),
+        ]),
+      );
     if (root)
       for (const instance of root.instances) {
         locate(root.id, instance, length + 1);

--- a/packages/netlist/src/simulation-circuit-source.test.ts
+++ b/packages/netlist/src/simulation-circuit-source.test.ts
@@ -46,6 +46,68 @@ function replace(
   return text;
 }
 describe("Circuit parameter source projection", () => {
+  it("adds, changes and removes AC/phase and waveforms while keeping source nodes locked", () => {
+    const { project, source } = fixture();
+    const body = source.sourceBodies!.find(
+      (body) => body.instanceId === "VDD",
+    )!;
+    const edit = (suffix: string) =>
+      planCircuitSourceEdit(
+        source,
+        source.text.slice(0, body.startOffset) +
+          suffix +
+          source.text.slice(body.endOffset),
+      );
+    const plan = edit(" DC {BIAS} AC 1 -90 SIN(0 1 1k)");
+    expect(plan.ok).toBe(true);
+    if (!plan.ok) return;
+    expect(plan.changes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ parameter: "acMagnitude", value: "1" }),
+        expect.objectContaining({ parameter: "acPhase", value: "-90" }),
+        expect.objectContaining({ parameter: "waveform", value: "sin" }),
+      ]),
+    );
+    const instance = project.documents
+      .find((d) => d.id === body.documentId)!
+      .instances.find((i) => i.id === body.instanceId)!;
+    plan.changes.forEach((change) => {
+      instance.netlist!.parameters[change.parameter] = change.value;
+    });
+    const regenerated = generateCircuitSource(project, source.binding);
+    expect(regenerated.ok).toBe(true);
+    if (!regenerated.ok) return;
+    expect(regenerated.source.text).toContain(
+      "DC {BIAS} AC 1 -90 SIN(0 1 1k 0 0 0)",
+    );
+    const nextBody = regenerated.source.sourceBodies!.find(
+      (b) => b.instanceId === "VDD",
+    )!;
+    const removed = planCircuitSourceEdit(
+      regenerated.source,
+      regenerated.source.text.slice(0, nextBody.startOffset) +
+        " DC 1.8" +
+        regenerated.source.text.slice(nextBody.endOffset),
+    );
+    expect(removed).toMatchObject({
+      ok: true,
+      changes: expect.arrayContaining([
+        expect.objectContaining({ parameter: "acMagnitude", unset: true }),
+        expect.objectContaining({ parameter: "acPhase", unset: true }),
+        expect.objectContaining({ parameter: "waveform", value: "dc" }),
+      ]),
+    });
+    expect(
+      planCircuitSourceEdit(
+        source,
+        source.text.replace("VDD vdd 0", "VDD changed 0"),
+      ),
+    ).toMatchObject({ ok: false, code: "SIMULATION_CIRCUIT_STRUCTURE_LOCKED" });
+    expect(edit(" DC 1.8 AC")).toMatchObject({
+      ok: false,
+      code: "SIMULATION_PARAMETER_INVALID",
+    });
+  });
   it("prints an unresolved model slot without crashing or assigning a model", () => {
     const { project, source } = fixture();
     const width = source.parameters.find((p) => p.parameter === "w")!;

--- a/packages/netlist/src/simulation-circuit-source.ts
+++ b/packages/netlist/src/simulation-circuit-source.ts
@@ -14,6 +14,18 @@ import {
   type PrintedSpiceInstance,
 } from "./printers.js";
 import type { NetlistDiagnostic } from "./ir.js";
+import { normalizeIndependentSource } from "./source-waveform.js";
+import { parseEditableSourceParameters } from "./simulation-source-parameters.js";
+
+interface EditableSourceBody {
+  documentId: string;
+  instanceId: string;
+  documentRevision: number;
+  startOffset: number;
+  endOffset: number;
+  rawValue: string;
+  sourceParameters: Record<string, string>;
+}
 
 export interface EditableCircuitParameter extends PrintedSpiceParameter {
   descriptor: DeviceParameterDefinition;
@@ -25,6 +37,7 @@ export interface GeneratedCircuitSource {
   binding: SimulationCircuitBinding;
   text: string;
   parameters: EditableCircuitParameter[];
+  sourceBodies?: EditableSourceBody[];
   instances: PrintedSpiceInstance[];
   reachedDocuments: { id: string; revision: number }[];
 }
@@ -145,6 +158,35 @@ export function generateCircuitSource(
       binding: { ...binding },
       text: printed.text,
       parameters,
+      sourceBodies: printed.instances.flatMap((span): EditableSourceBody[] => {
+        const cell = ir.cells.find((cell) => cell.id === span.documentId)!;
+        const card = cell.instances.find(
+          (card) => card.id === span.instanceId,
+        )!;
+        if (
+          !["voltage-source", "current-source"].includes(card.deviceClass) ||
+          normalizeIndependentSource(card.parameters).extraParameters.length
+        )
+          return [];
+        const text = printed.text.slice(span.startOffset, span.endOffset);
+        const prefix = /^\S+[ \t]+\S+[ \t]+\S+/u.exec(text);
+        if (!prefix) return [];
+        const document = project.documents.find(
+          (d) => d.id === span.documentId,
+        )!;
+        const instance = document.instances.find(
+          (i) => i.id === span.instanceId,
+        )!;
+        return [
+          {
+            ...span,
+            startOffset: span.startOffset + prefix[0].length,
+            rawValue: text.slice(prefix[0].length),
+            documentRevision: document.revision,
+            sourceParameters: { ...instance.netlist!.parameters },
+          },
+        ];
+      }),
       instances: printed.instances,
       reachedDocuments: ir.cells.map((cell) => ({
         id: cell.id,
@@ -161,6 +203,7 @@ export interface CircuitParameterChange {
   instanceId: string;
   parameter: string;
   value: string;
+  unset?: true;
 }
 /** Plan exact parameter-only changes. The service checks the generation digest and commits typed edits atomically. */
 export function planCircuitSourceEdit(
@@ -183,10 +226,19 @@ export function planCircuitSourceEdit(
       ? { range: parameterRange }
       : {}),
   });
-  const spans = [...source.parameters].sort(
-    (a, b) => a.startOffset - b.startOffset,
-  );
+  const bodies = source.sourceBodies ?? [];
+  const spans = [
+    ...source.parameters.filter(
+      (p) =>
+        !bodies.some(
+          (body) =>
+            p.startOffset >= body.startOffset && p.endOffset <= body.endOffset,
+        ),
+    ),
+    ...bodies,
+  ].sort((a, b) => a.startOffset - b.startOffset);
   const changes = new Map<string, CircuitParameterChange>();
+  const sourceAppearances = new Map<string, string>();
   let invalid: ReturnType<typeof fail> | undefined;
   let originalOffset = 0;
   let nextOffset = 0;
@@ -214,6 +266,69 @@ export function planCircuitSourceEdit(
       );
     const raw = nextText.slice(nextOffset, end);
     parameterRange = { from: nextOffset, to: end };
+    if ("sourceParameters" in span) {
+      if (raw && !/^\s/u.test(raw))
+        return fail(
+          "SIMULATION_CIRCUIT_STRUCTURE_LOCKED",
+          "Keep source nodes separate from their parameter clauses.",
+        );
+      const identity = JSON.stringify([span.documentId, span.instanceId]);
+      const priorText = sourceAppearances.get(identity);
+      if (priorText !== undefined && priorText !== raw)
+        return fail(
+          "SIMULATION_PARAMETER_CONFLICT",
+          "Repeated appearances of a source must agree.",
+        );
+      sourceAppearances.set(identity, raw);
+      if (raw !== span.rawValue) {
+        const parsed = parseEditableSourceParameters(raw);
+        if (!parsed.ok)
+          invalid ??= fail("SIMULATION_PARAMETER_INVALID", parsed.message);
+        else {
+          const previous = parseEditableSourceParameters(span.rawValue);
+          const names = new Set([
+            ...Object.keys(
+              previous.ok ? previous.parameters : span.sourceParameters,
+            ),
+            ...Object.keys(parsed.parameters),
+          ]);
+          for (const name of names) {
+            const originalName =
+              Object.keys(span.sourceParameters).find(
+                (key) => key.toLowerCase() === name.toLowerCase(),
+              ) ?? name;
+            const value = parsed.parameters[name];
+            if (span.sourceParameters[originalName] === value) continue;
+            const key = JSON.stringify([
+              span.documentId,
+              span.instanceId,
+              originalName,
+            ]);
+            const change: CircuitParameterChange = {
+              documentId: span.documentId,
+              expectedRevision: span.documentRevision,
+              instanceId: span.instanceId,
+              parameter: originalName,
+              value: value ?? "",
+              ...(value === undefined ? { unset: true as const } : {}),
+            };
+            const prior = changes.get(key);
+            if (
+              prior &&
+              (prior.value !== change.value || prior.unset !== change.unset)
+            )
+              return fail(
+                "SIMULATION_PARAMETER_CONFLICT",
+                `Repeated appearances of ${originalName} must agree`,
+              );
+            changes.set(key, change);
+          }
+        }
+      }
+      originalOffset = span.endOffset;
+      nextOffset = end;
+      continue;
+    }
     const key = JSON.stringify([
       span.documentId,
       span.instanceId,
@@ -319,12 +434,14 @@ export function planCircuitSourceEdit(
     ok: true,
     changes: [...changes.values()].filter(
       (change) =>
-        spans.find(
+        !source.parameters.some(
           (s) =>
             s.documentId === change.documentId &&
             s.instanceId === change.instanceId &&
-            s.parameter === change.parameter,
-        )!.originalValue !== change.value,
+            s.parameter === change.parameter &&
+            s.originalValue === change.value &&
+            !change.unset,
+        ),
     ),
   };
 }

--- a/packages/netlist/src/simulation-source-parameters.test.ts
+++ b/packages/netlist/src/simulation-source-parameters.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { parseEditableSourceParameters } from "./simulation-source-parameters.js";
+
+describe("reversible independent-source clauses", () => {
+  it("keeps DC, AC and transient clauses independent with native expressions", () => {
+    expect(
+      parseEditableSourceParameters(" DC {BIAS} AC {GAIN} -90 SIN(0 1 1k) "),
+    ).toEqual({
+      ok: true,
+      parameters: {
+        dc: "{BIAS}",
+        acMagnitude: "{GAIN}",
+        acPhase: "-90",
+        waveform: "sin",
+        offset: "0",
+        amplitude: "1",
+        frequency: "1k",
+      },
+    });
+    expect(
+      parseEditableSourceParameters("1.8 SIN (0 1 1k) AC 2"),
+    ).toMatchObject({
+      ok: true,
+      parameters: { dc: "1.8", acMagnitude: "2", waveform: "sin" },
+    });
+  });
+  it("parses PWL pairs and complete PULSE clauses without inventing timestep defaults", () => {
+    expect(
+      parseEditableSourceParameters("DC 0 PWL(0 {LOW}, 1n {HIGH})"),
+    ).toMatchObject({
+      ok: true,
+      parameters: { pwlPoints: "0 {LOW}, 1n {HIGH}", waveform: "pwl" },
+    });
+    expect(
+      parseEditableSourceParameters("DC 0 AC 1\n+ PULSE(0 1 0 1n 1n 5n 10n)"),
+    ).toMatchObject({
+      ok: true,
+      parameters: { waveform: "pulse", period: "10n" },
+    });
+  });
+  it.each([
+    "DC 1 AC",
+    "DC 1 AC 1 AC 2",
+    "DC 1\nR1 a 0 1k",
+    "DC 1; quit",
+    "DC {V;quit}",
+    "DC 1 PWL(0 1 2)",
+    "DC 1 SIN(0 1)",
+    "DC 1 PULSE(0 1)",
+    "DC 1 SIN(0 1 1k) SIN(0 2 1k)",
+    "DC 1 Rnew",
+    "DC 1 AC {A",
+    "AC 1",
+  ])("does not apply incomplete or unsupported clauses: %s", (text) => {
+    expect(parseEditableSourceParameters(text).ok).toBe(false);
+  });
+});

--- a/packages/netlist/src/simulation-source-parameters.ts
+++ b/packages/netlist/src/simulation-source-parameters.ts
@@ -1,0 +1,94 @@
+import { parameterExpressionBody } from "@icm/devices";
+import { parseSpiceNumber, splitSpiceFields } from "@icm/spice";
+import {
+  PULSE_PARAMETER_NAMES,
+  SIN_REQUIRED_PARAMETER_NAMES,
+  SIN_OPTIONAL_PARAMETER_NAMES,
+} from "./source-waveform.js";
+
+/** The reversible Canvas subset, not a general native-SPICE parser. */
+export function parseEditableSourceParameters(
+  text: string,
+):
+  | { ok: true; parameters: Record<string, string> }
+  | { ok: false; message: string } {
+  const fail = (message: string) => ({ ok: false as const, message });
+  const body = text.replace(/\r?\n\+[ \t]*/gu, " ");
+  if (/[\r\n;]/u.test(body))
+    return fail("A source edit cannot add statements or comments.");
+  const tokens = splitSpiceFields(
+    body.replace(/\b(PULSE|SIN|PWL)\s+\(/giu, "$1("),
+  );
+  const parameters: Record<string, string> = { waveform: "dc" };
+  const valid = (value: string | undefined): value is string =>
+    value !== undefined &&
+    (parameterExpressionBody(value) !== undefined ||
+      Number.isFinite(parseSpiceNumber(value)?.value));
+  let waveform = false;
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i]!;
+    const key = token.toUpperCase();
+    if (key === "DC" || (i === 0 && valid(token))) {
+      if (parameters.dc !== undefined) return fail("Use only one DC value.");
+      const value = key === "DC" ? tokens[++i] : token;
+      if (!valid(value))
+        return fail("Finish the DC number or braced expression.");
+      parameters.dc = value;
+    } else if (key === "AC") {
+      if (parameters.acMagnitude !== undefined)
+        return fail("Use only one AC clause.");
+      const magnitude = tokens[++i];
+      if (!valid(magnitude))
+        return fail(
+          "Finish AC magnitude, followed by optional phase in degrees.",
+        );
+      parameters.acMagnitude = magnitude;
+      if (valid(tokens[i + 1])) parameters.acPhase = tokens[++i]!;
+    } else {
+      const match = /^(PULSE|SIN|PWL)\((.*)\)$/iu.exec(token);
+      if (!match || waveform)
+        return fail(
+          "Use DC, AC magnitude [phase], and one PULSE(...), SIN(...) or PWL(...) waveform.",
+        );
+      waveform = true;
+      const name = match[1]!.toLowerCase();
+      const values = splitSpiceFields(match[2]!);
+      if (!values.every(valid))
+        return fail(
+          "Waveform arguments must be numbers or braced expressions.",
+        );
+      parameters.waveform = name;
+      if (name === "pwl") {
+        if (values.length < 4 || values.length % 2)
+          return fail("PWL needs at least two time/value pairs.");
+        parameters.pwlPoints = values
+          .reduce<string[]>((pairs, value, index) => {
+            if (index % 2 === 0) pairs.push(`${value} ${values[index + 1]}`);
+            return pairs;
+          }, [])
+          .join(", ");
+      } else {
+        const names =
+          name === "pulse"
+            ? PULSE_PARAMETER_NAMES
+            : [
+                ...SIN_REQUIRED_PARAMETER_NAMES,
+                ...SIN_OPTIONAL_PARAMETER_NAMES,
+              ];
+        const required = name === "pulse" ? 7 : 3;
+        if (values.length < required || values.length > names.length)
+          return fail(
+            `${name.toUpperCase()} requires ${required}${required === names.length ? "" : `–${names.length}`} arguments in this Canvas source.`,
+          );
+        values.forEach((value, index) => {
+          parameters[names[index]!] = value;
+        });
+      }
+    }
+  }
+  if (parameters.dc === undefined)
+    return fail(
+      "Keep an explicit DC value for this Canvas source; native text-only sources may omit it.",
+    );
+  return { ok: true, parameters };
+}

--- a/packages/simulation-service/src/project-source-files.ts
+++ b/packages/simulation-service/src/project-source-files.ts
@@ -225,7 +225,10 @@ export async function handleProjectSourceFiles(
         change.parameter,
       ]);
       const existing = parameters.get(key);
-      if (existing && existing.value !== change.value)
+      if (
+        existing &&
+        (existing.value !== change.value || existing.unset !== change.unset)
+      )
         return problem(
           "SIMULATION_PARAMETER_CONFLICT",
           "Repeated Circuit appearances must assign the same parameter value",

--- a/scripts/simulation-source-native.test.mjs
+++ b/scripts/simulation-source-native.test.mjs
@@ -3,7 +3,12 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { createEmptyProject, createSimulationFolder } from "@icm/model";
 import { parseProject } from "@icm/project-protocol";
-import { nativeSimulationDevices, nativeDeviceOpVectors } from "@icm/netlist";
+import {
+  nativeSimulationDevices,
+  nativeDeviceOpVectors,
+  generateCircuitSource,
+  planCircuitSourceEdit,
+} from "@icm/netlist";
 import {
   prepareSourceExecutionInput,
   CapabilitiesSchema,
@@ -55,6 +60,78 @@ async function run(request, name) {
 }
 
 describe.skipIf(!endpoint)("candidate ngspice46 source qualification", () => {
+  it("executes edited AC clauses and preserves top-level Cell parameter defaults", async () => {
+    const caps = CapabilitiesSchema.parse(
+      await (await post({ operation: "capabilities" })).json(),
+    );
+    const project = parseProject(
+      readFileSync(
+        new URL(
+          "../apps/editor/src/examples/five-transistor-ota-sky130.icproj.json",
+          import.meta.url,
+        ),
+        "utf8",
+      ),
+    );
+    const root = project.documents.find(
+      (cell) => cell.id === project.topDocumentId,
+    );
+    root.netlist.formalParameters.push({ name: "VBIAS", defaultValue: "1.8" });
+    const folder = createSimulationFolder({
+      id: "source-edits",
+      name: "Source edits",
+      documentId: root.id,
+      profileId: profile.id,
+    });
+    const generated = generateCircuitSource(
+      project,
+      folder.input.circuitBindings[0],
+    );
+    expect(generated.ok).toBe(true);
+    const body = generated.source.sourceBodies.find(
+      (body) => body.instanceId === "VDD",
+    );
+    const plan = planCircuitSourceEdit(
+      generated.source,
+      generated.source.text.slice(0, body.startOffset) +
+        " DC {VBIAS} AC 1 -90" +
+        generated.source.text.slice(body.endOffset),
+    );
+    expect(plan.ok).toBe(true);
+    for (const change of plan.changes)
+      root.instances.find(
+        (instance) => instance.id === change.instanceId,
+      ).netlist.parameters[change.parameter] = change.value;
+    const entry = folder.input.files.find(
+      (file) => file.path === folder.input.entry,
+    );
+    entry.text =
+      '* source parameters\n.include "circuit.spice"\n.control\nset filetype=ascii\nset appendwrite\nsave v(vdd)\nop\nwrite out.raw\nac lin 2 1k 2k\nwrite out.raw\n.endc\n.end\n';
+    const prepared = await prepareSourceExecutionInput(project, folder, caps);
+    expect(prepared.ok, JSON.stringify(prepared)).toBe(true);
+    const result = await run(prepared.input, "source-parameters-default");
+    expect(result.outcome.status, JSON.stringify(result)).toBe("completed");
+    expect(
+      result.data.analyses
+        .find((a) => a.analysis === "op")
+        .probes.find((p) => p.name === "v(vdd)").value,
+    ).toBeCloseTo(1.8, 8);
+    const ac = result.data.analyses
+      .find((a) => a.analysis === "ac")
+      .probes.find((p) => p.name === "v(vdd)");
+    expect(ac.real[0]).toBeCloseTo(0, 8);
+    expect(ac.imag[0]).toBeCloseTo(-1, 8);
+    entry.text = entry.text.replace(".control", ".param VBIAS=1.7\n.control");
+    const overridden = await prepareSourceExecutionInput(project, folder, caps);
+    expect(overridden.ok, JSON.stringify(overridden)).toBe(true);
+    const next = await run(overridden.input, "source-parameters-override");
+    expect(next.outcome.status, JSON.stringify(next)).toBe("completed");
+    expect(
+      next.data.analyses
+        .find((a) => a.analysis === "op")
+        .probes.find((p) => p.name === "v(vdd)").value,
+    ).toBeCloseTo(1.7, 8);
+  }, 160_000);
   it("reads the reviewed SKY130 wrapper's native OP parameters", async () => {
     const circuit = parseProject(
       readFileSync(


### PR DESCRIPTION
## Changes
- Map DC/AC and existing PULSE/SIN/PWL source clauses to typed atomic parameter set/unset edits, preserving fixed nodes, references, device classes and model identity.
- Guide optional AC and waveform clauses independently, including DC + AC and waveform + AC combinations.
- Route Design variable / .param Helper to authored run Code outside control, preserving native undo and shared-Cell ownership.
- Emit root formal parameter defaults when the Cell is used as a top-level circuit.

## Boundaries
- Canvas-backed source clauses retain explicit DC and full seven-argument PULSE. Arbitrary native source syntax remains available in authored files.
- Definitions in run Code are Folder-local; mapped Circuit expressions are shared Cell edits. No new experiment.json authority or hidden parameter overlays.
- This does not refactor Measurement presentation or unlock topology/model editing.

## Validation
- 53 targeted planner/printer/ghost/file-transaction tests passed.
- New browser regression passed: source AC add/remove, parameter Helper routing, undo/redo, and persisted model/source assertions.
- Shared printer/planner paths select full-delivery. Frozen install, preflight and local full gate passed: 3,236 unit/integration tests and all 405 browser tests, plus static, build, release/performance and golden checks.
- Local ngspice is absent and Docker daemon unavailable; CI candidate-image execution passed all 7 native tests with ngspice46/SKY130, including root default VDD 1.8 V, Code override 1.7 V, and AC 1 at -90 degrees. All seven standard required CI checks passed for head 9607b2912138e52b936682b3dca50e35b49f560c. No merge performed.

Test-Impact: tests-updated
