### PR TITLE
refactor(simulation): hide native configuration and quiet Cell hints

### DIFF
--- a/apps/editor/e2e/simulation-workspace.spec.ts
+++ b/apps/editor/e2e/simulation-workspace.spec.ts
@@ -23,6 +23,82 @@ import {
 import { ota, profile, editSimulationFile } from "./simulation-e2e-fixtures.js";
 
 const loadModule = createRequire(import.meta.url);
+test("native metadata is hidden per folder while damaged configuration stays repairable", async ({
+  page,
+}) => {
+  const project = parseProject(JSON.stringify(ota));
+  const native = createSimulationFolder({
+    id: "native",
+    name: "Native",
+    documentId: project.topDocumentId,
+    profileId: profile.id,
+  });
+  const repair = createSimulationFolder({
+    id: "repair",
+    name: "Repair",
+    documentId: project.topDocumentId,
+    profileId: profile.id,
+  });
+  const config = repair.input.files.find(
+    (file) => file.path === repair.input.configPath,
+  )!;
+  const original = config.text;
+  config.text = "{";
+  project.simulationFolders = [native, repair];
+  await page.route("**/api/simulate", (route) =>
+    route.fulfill({
+      status: 503,
+      json: { error: "Offline authoring fixture" },
+    }),
+  );
+  await page.goto("/editor");
+  await page.getByTestId("project-file").setInputFiles({
+    name: "metadata.icproj.json",
+    mimeType: "application/json",
+    buffer: Buffer.from(JSON.stringify(project)),
+  });
+  await page.getByTestId("open-analog-simulation").click();
+  const panel = page.getByRole("region", { name: "Analog simulation" });
+  await expect(
+    panel.locator(
+      '[data-folder-id="native"][data-file-path="experiment.json"]',
+    ),
+  ).toHaveCount(0);
+  await panel
+    .getByRole("treeitem", { name: "Folder Repair", exact: true })
+    .click();
+  await panel
+    .getByRole("button", { name: "Toggle Repair", exact: true })
+    .click();
+  await panel
+    .getByRole("treeitem", { name: "experiment.json", exact: true })
+    .click();
+  const editor = panel.getByRole("textbox", {
+    name: "Simulation source editor",
+  });
+  await expect(editor).toHaveText("{");
+  await editor.fill(original);
+  await panel.getByRole("button", { name: "Save source", exact: true }).click();
+  await expect(
+    panel.getByRole("treeitem", { name: "experiment.json", exact: true }),
+  ).toHaveCount(0);
+  await expect(panel.getByRole("tab", { name: "Configuration" })).toHaveCount(
+    0,
+  );
+  await expect(panel.getByRole("tab", { name: /run\.cir/ })).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+  const saved = parseProject(
+    (await downloadBytes(page, "File", "Export Project File…")).toString(),
+  );
+  for (const folder of saved.simulationFolders)
+    expect(
+      folder.input.files.find((file) => file.path === folder.input.configPath)!
+        .text,
+    ).toBe(original);
+});
+
 test("Code adds and removes source AC clauses and routes parameter declarations to authored Code", async ({
   page,
 }) => {
@@ -171,12 +247,22 @@ test("new experiments explicitly bind the selected Cell without requiring a Test
     name: "Folder OTA direct",
     exact: true,
   });
-  await expect(folderRow).toContainText("Cell: ota_5t");
+  await expect(folderRow).toHaveText("OTA direct");
+  await expect(folderRow).toHaveAttribute("title", "Cell: ota_5t");
+  await expect(folderRow).toHaveAttribute("aria-description", "Cell: ota_5t");
   const editor = page.getByRole("textbox", {
     name: "Simulation source editor",
   });
   await expect(editor).toContainText('.include "circuit.spice"');
   await expect(editor).toContainText("op");
+  await expect(
+    page.getByRole("treeitem", { name: "experiment.json", exact: true }),
+  ).toHaveCount(0);
+  await editor.focus();
+  const folderWidth = (await folderRow.boundingBox())!.width;
+  await folderRow.hover();
+  await expect(editor).toBeFocused();
+  expect((await folderRow.boundingBox())!.width).toBe(folderWidth);
   await page.getByRole("tab", { name: /circuit\.spice/ }).click();
   await expect(editor).toContainText("XM1");
   await expect(editor).not.toContainText("XDUT");
@@ -222,7 +308,7 @@ test("new experiments explicitly bind the selected Cell without requiring a Test
     .click();
   await expect(cell).toHaveValue(project.topDocumentId);
   await cell.press("Escape");
-  await expect(folderRow).toContainText("Cell: ota_5t");
+  await expect(folderRow).toHaveAttribute("title", "Cell: ota_5t");
   const unchanged = parseProject(
     (await downloadBytes(page, "File", "Export Project File…")).toString(),
   );
@@ -233,7 +319,7 @@ test("new experiments explicitly bind the selected Cell without requiring a Test
     mimeType: "application/json",
     buffer: Buffer.from(JSON.stringify(unchanged)),
   });
-  await expect(folderRow).toContainText("Cell: ota_5t");
+  await expect(folderRow).toHaveAttribute("title", "Cell: ota_5t");
 });
 
 test("tab context menus replace workspace more actions without discarding source", async ({
@@ -246,6 +332,7 @@ test("tab context menus replace workspace more actions without discarding source
     documentId: project.topDocumentId,
     profileId: profile.id,
   });
+  folder.input.files.push({ path: "notes.json", text: "{}\n" });
   project.simulationFolders = [folder];
   await page.route("**/api/simulate", (route) =>
     route.fulfill({
@@ -279,11 +366,12 @@ test("tab context menus replace workspace more actions without discarding source
     .getByRole("treeitem", { name: "circuit.spice", exact: true })
     .click();
   await panel
-    .getByRole("treeitem", { name: "experiment.json", exact: true })
+    .getByRole("treeitem", { name: "notes.json", exact: true })
     .click();
-  await expect(
-    panel.getByRole("tab", { name: "Configuration" }),
-  ).toHaveAttribute("aria-selected", "true");
+  await expect(panel.getByRole("tab", { name: "notes.json" })).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
   await circuitTab.click({ button: "right" });
   await page
     .getByRole("menuitem", { name: "Close others", exact: true })
@@ -2045,7 +2133,7 @@ test("Explorer context downloads preserve multi-selection and directory contents
   await run.click({ modifiers: ["Shift"] });
   await expect(
     alphaFiles.getByRole("treeitem", { selected: true }),
-  ).toHaveCount(3);
+  ).toHaveCount(2);
   await expect(
     workspace.getByRole("tab", { name: /circuit\.spice/ }),
   ).toHaveAttribute("aria-selected", "true");
@@ -2096,7 +2184,7 @@ test("Explorer context downloads preserve multi-selection and directory contents
   expect(
     names.filter((path) => path.endsWith("models/bias/local.cir")),
   ).toHaveLength(1);
-  expect(names).toContain("Alpha/source/experiment.json");
+  expect(names).not.toContain("Alpha/source/experiment.json");
   await workspace.screenshot({
     path: test.info().outputPath("compact-explorer.png"),
   });

--- a/apps/editor/src/features/simulation/code-workspace.css
+++ b/apps/editor/src/features/simulation/code-workspace.css
@@ -206,12 +206,6 @@
   background: var(--icm-surface);
   color: var(--icm-text);
 }
-.simulation-folder-cell {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  max-width: 50%;
-}
 .workspace-editor-content {
   height: 100%;
 }

--- a/apps/editor/src/features/simulation/simulation-file-tree.tsx
+++ b/apps/editor/src/features/simulation/simulation-file-tree.tsx
@@ -422,7 +422,8 @@ export function SimulationFileTree(props: SimulationCodeWorkspaceProps) {
                 node.kind === "folder" ? "Folder " + node.name : node.name
               }
               aria-current={active ? "page" : undefined}
-              title={node.file?.path ?? node.name}
+              title={node.cellLabel ?? node.file?.path ?? node.name}
+              aria-description={node.cellLabel}
               onClick={(event) => {
                 choose(node, event);
                 if (!event.ctrlKey && !event.metaKey && !event.shiftKey) {
@@ -473,14 +474,6 @@ export function SimulationFileTree(props: SimulationCodeWorkspaceProps) {
                 </svg>
               </span>
               <span className="simulation-file-name">{node.name}</span>
-              {node.cellLabel ? (
-                <small
-                  className="simulation-folder-cell"
-                  title={node.cellLabel}
-                >
-                  {node.cellLabel}
-                </small>
-              ) : null}
               {node.tmp ? <small>tmp</small> : null}
               {node.file?.dirty ? (
                 <span className="simulation-file-state" title="Unsaved">

--- a/apps/editor/src/features/simulation/simulation-source-visibility.test.ts
+++ b/apps/editor/src/features/simulation/simulation-source-visibility.test.ts
@@ -1,0 +1,53 @@
+import { createSimulationFolder } from "@icm/model";
+import { describe, expect, it } from "vitest";
+import { isVisibleSimulationSource } from "./simulation-source-visibility";
+
+const create = () =>
+  createSimulationFolder({
+    id: "f",
+    name: "Native",
+    profileId: "hosted",
+    documentId: "d",
+  });
+describe("simulation source visibility", () => {
+  it("hides native metadata by config path without mutating or hiding ordinary files", () => {
+    const folder = create();
+    const before = structuredClone(folder);
+    expect(isVisibleSimulationSource(folder, folder.input.configPath)).toBe(
+      false,
+    );
+    expect(isVisibleSimulationSource(folder, folder.input.entry)).toBe(true);
+    expect(isVisibleSimulationSource(folder, "user.json")).toBe(true);
+    expect(folder).toEqual(before);
+    const config = folder.input.files.find(
+      (file) => file.path === folder.input.configPath,
+    )!;
+    config.path = folder.input.configPath = "internal/environment.json";
+    expect(isVisibleSimulationSource(folder, config.path)).toBe(false);
+    expect(isVisibleSimulationSource(folder, "experiment.json")).toBe(true);
+  });
+  it("keeps legacy and malformed configurations available for repair", () => {
+    const folder = create();
+    const config = folder.input.files.find(
+      (file) => file.path === folder.input.configPath,
+    )!;
+    for (const text of [
+      "{",
+      JSON.stringify({ version: 1, environment: { profileId: "hosted" } }),
+      JSON.stringify({ version: 2, environment: {} }),
+    ]) {
+      config.text = text;
+      expect(isVisibleSimulationSource(folder, config.path)).toBe(true);
+    }
+  });
+  it("keeps pending and persisted drafts visible, including accidentally configured run entries", () => {
+    const folder = create();
+    const path = folder.input.configPath;
+    expect(isVisibleSimulationSource(folder, path, true)).toBe(true);
+    folder.input.drafts = [{ path, base: "original", text: "{" }];
+    expect(isVisibleSimulationSource(folder, path)).toBe(true);
+    folder.input.drafts = [];
+    folder.input.entry = path;
+    expect(isVisibleSimulationSource(folder, path)).toBe(true);
+  });
+});

--- a/apps/editor/src/features/simulation/simulation-source-visibility.ts
+++ b/apps/editor/src/features/simulation/simulation-source-visibility.ts
@@ -1,0 +1,21 @@
+import {
+  readSimulationExperimentConfig,
+  type ProjectSimulationFolder,
+} from "@icm/model";
+
+/** Hide only valid machine metadata, never a legacy setting or a repair draft. */
+export function isVisibleSimulationSource(
+  folder: ProjectSimulationFolder,
+  path: string,
+  hasDraft = false,
+): boolean {
+  if (
+    path !== folder.input.configPath ||
+    path === folder.input.entry ||
+    hasDraft ||
+    folder.input.drafts?.some((draft) => draft.path === path)
+  )
+    return true;
+  const config = readSimulationExperimentConfig(folder);
+  return !config.ok || config.authority !== "code";
+}

--- a/apps/editor/src/features/simulation/source-code-pane.tsx
+++ b/apps/editor/src/features/simulation/source-code-pane.tsx
@@ -54,6 +54,7 @@ import { sourceProbeChoices } from "./source-probe-choices";
 import { SourceProbePicker } from "./source-probe-picker";
 import { SimulationActionIcon } from "./simulation-action-icon";
 import { flushSelectedFolders } from "./flush-selected-folders";
+import { isVisibleSimulationSource } from "./simulation-source-visibility";
 
 export type SourceFlush =
   | { ok: true; folder: ProjectSimulationFolder; revision: number }
@@ -151,7 +152,18 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
       setRecoveryAvailable(cache.write(drafts.current));
     }, [cache, draftRevision]);
     const [paths, setPaths] = useState<Record<string, string>>({});
-    const path = paths[props.folder.id] ?? props.folder.input.entry;
+    const visibleSource = (folder: ProjectSimulationFolder, path: string) => {
+      const draft = drafts.current.get(`${folder.id}\u0000${path}`);
+      return isVisibleSimulationSource(
+        folder,
+        path,
+        !!draft && draft.text !== draft.base,
+      );
+    };
+    const requestedPath = paths[props.folder.id] ?? props.folder.input.entry;
+    const path = visibleSource(props.folder, requestedPath)
+      ? requestedPath
+      : props.folder.input.entry;
     const setPath = (value: string, folderId = props.folder.id) => {
       setPaths((current) => ({ ...current, [folderId]: value }));
       if (folderId !== props.folder.id) props.folders?.onSelect(folderId);
@@ -938,29 +950,31 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
                   ]);
                   return {
                     ...node,
-                    files: [...names].map((path) => {
-                      const draft = drafts.current.get(
-                        `${node.id}\u0000${path}`,
-                      );
-                      const modified = !!draft && draft.text !== draft.base;
-                      return {
-                        path,
-                        kind: folder.input.circuitBindings.some(
-                          (b) => b.path === path,
-                        )
-                          ? ("generated" as const)
-                          : ("authored" as const),
-                        draft: modified,
-                        dirty:
-                          modified &&
-                          !folder.input.drafts?.some(
-                            (saved) =>
-                              saved.path === path &&
-                              saved.base === draft.base &&
-                              saved.text === draft.text,
-                          ),
-                      };
-                    }),
+                    files: [...names]
+                      .filter((path) => visibleSource(folder, path))
+                      .map((path) => {
+                        const draft = drafts.current.get(
+                          `${node.id}\u0000${path}`,
+                        );
+                        const modified = !!draft && draft.text !== draft.base;
+                        return {
+                          path,
+                          kind: folder.input.circuitBindings.some(
+                            (b) => b.path === path,
+                          )
+                            ? ("generated" as const)
+                            : ("authored" as const),
+                          draft: modified,
+                          dirty:
+                            modified &&
+                            !folder.input.drafts?.some(
+                              (saved) =>
+                                saved.path === path &&
+                                saved.base === draft.base &&
+                                saved.text === draft.text,
+                            ),
+                        };
+                      }),
                   };
                 }),
               }
@@ -986,26 +1000,28 @@ export const SourceCodePane = forwardRef<SourceCodeHandle, Props>(
         onDownloadSelection={(selection, archive) =>
           void downloadSelection(selection, archive)
         }
-        files={ownFiles.map((filePath) => ({
-          path: filePath,
-          kind: input.circuitBindings.some((b) => b.path === filePath)
-            ? "generated"
-            : "authored",
-          dirty:
-            !!drafts.current.get(key(filePath)) &&
-            drafts.current.get(key(filePath))!.text !==
-              drafts.current.get(key(filePath))!.base &&
-            !input.drafts?.some(
-              (saved) =>
-                saved.path === filePath &&
-                saved.text === drafts.current.get(key(filePath))!.text &&
-                saved.base === drafts.current.get(key(filePath))!.base,
-            ),
-          draft:
-            !!drafts.current.get(key(filePath)) &&
-            drafts.current.get(key(filePath))!.text !==
-              drafts.current.get(key(filePath))!.base,
-        }))}
+        files={ownFiles
+          .filter((filePath) => visibleSource(props.folder, filePath))
+          .map((filePath) => ({
+            path: filePath,
+            kind: input.circuitBindings.some((b) => b.path === filePath)
+              ? "generated"
+              : "authored",
+            dirty:
+              !!drafts.current.get(key(filePath)) &&
+              drafts.current.get(key(filePath))!.text !==
+                drafts.current.get(key(filePath))!.base &&
+              !input.drafts?.some(
+                (saved) =>
+                  saved.path === filePath &&
+                  saved.text === drafts.current.get(key(filePath))!.text &&
+                  saved.base === drafts.current.get(key(filePath))!.base,
+              ),
+            draft:
+              !!drafts.current.get(key(filePath)) &&
+              drafts.current.get(key(filePath))!.text !==
+                drafts.current.get(key(filePath))!.base,
+          }))}
         activePath={path}
         onSelectFile={setPath}
         onFileAction={async (

--- a/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
@@ -64,7 +64,7 @@ describe("source workspace default cutover", () => {
     expect(markup).toContain('aria-label="Open simulation files"');
     expect(markup).toContain("circuit.spice");
     expect(markup).toContain("run.cir");
-    expect(markup).toContain("experiment.json");
+    expect(markup).not.toContain("experiment.json");
     expect(markup).toContain('aria-label="Simulation folders"');
     expect(markup).not.toContain('aria-label="Simulation setup"');
     expect(markup).not.toContain("Prepare deck");
@@ -75,6 +75,7 @@ describe("source workspace default cutover", () => {
   });
   it("retains the editor for invalid authored configuration rather than crashing or restoring a second form", () => {
     const markup = render(true, true);
+    expect(markup).toContain("experiment.json");
     expect(markup).toContain('aria-label="Simulation Code workspace"');
     expect(markup).toContain("run.cir");
     expect(markup).not.toContain('aria-label="Measurements settings"');

--- a/docs/specs/simulation-code-workspace.md
+++ b/docs/specs/simulation-code-workspace.md
@@ -156,7 +156,8 @@ New experiments ask for a name and an explicit Cell selection, defaulting to the
 current Canvas Cell. They bind the selected Cell as the top-level circuit and
 create a small `op` starter; they do not ask for OP/AC/TRAN or TB/DUT/source mode.
 Any Cell can be the simulation root, not only a dedicated Testbench. The Explorer
-shows the bound Cell name (or a missing-Cell marker); changing the active Canvas
+shows the bound Cell name (or a missing-Cell marker) in a non-focusing folder
+hover hint, not inline beside the folder name; changing the active Canvas
 does not rebind an existing experiment. The existing circuit binding is the sole
 source mapping, with no duplicate Cell setting in `experiment.json`. Creation
 does not wrap the Cell in an invented DUT call or guess stimuli. Helpers can
@@ -201,8 +202,11 @@ an explicit save list to `all`.
 Discovery and completion use the compiler's authored call-path mapping; they
 show the Canvas name alongside the executable native vector. Native vectors
 remain available for text-only or statically unresolvable scopes.
-`experiment.json` is available through the Explorer's advanced configuration
-command, not a compulsory fourth panel.
+Valid version-2 `experiment.json` is internal hosted-environment metadata, hidden
+from the Explorer and file tabs. It remains in Project persistence and complete
+backups. Legacy, malformed and pending-draft configuration remains visible for
+repair; ordinary authored JSON files are not hidden. No environment picker is
+provided in the normal Code workspace.
 
 Folder expansion is independent of active execution and batch selection. New
 files/folders and renames use inline text input (Enter accepts, Escape cancels),

--- a/docs/user/analog-simulation.md
+++ b/docs/user/analog-simulation.md
@@ -39,13 +39,17 @@ covered by the Project's browser recovery, not a cloud backup. **File → Save**
 (or the project-level shortcut outside code) still saves the entire Project to
 the signed-in cloud account.
 
-Open **experiment.json** from Source for configuration; it is not a default tab.
+New experiments use the hosted environment automatically. Their internal
+`experiment.json` is hidden from Source and file tabs, but retained in Project
+backups. Legacy or damaged configurations and pending configuration drafts stay
+visible for compatibility and repair; they are not a new environment picker.
+Hover a folder to see its bound Cell without adding text to the file row.
 Use file/folder context menus to copy, download or create files. Right-click a
 file tab (or press Shift+F10 while it is focused) to close it, close other tabs,
-or close all tabs. Closing tabs retains files and pending drafts. Configuration owns
-Profile/corner, output labels and bindings, measurements and the managed Run
-Plan. Native analyses and nominal temperature belong in SPICE, not hidden
-Settings fields. This example runs OP and AC and retains both plots:
+or close all tabs. Closing tabs retains files and pending drafts. Native analyses,
+acquisition, measurements and nominal temperature belong in SPICE. Older
+experiments retain their legacy configuration until explicitly migrated through
+Helper. This example runs OP and AC and retains both plots:
 
 ```spice
 .control


### PR DESCRIPTION
## Summary
- Hide valid native experiment metadata from Source and tabs; keep it in full Project backups.
- Preserve legacy configuration, invalid configuration and pending drafts as repairable files.
- Replace inline Cell labels with non-focusing folder hover hints and accessible descriptions.

## Validation
- Frozen dependency install and static/test-impact preflight passed.
- Workspace unit gate and 7 focused unit tests passed.
- All 29 selected analog browser scenarios passed across initial run and corrected workspace rerun (13/13).
- Coverage includes repair, Project backup retention, folder ZIP contents, ordinary JSON tabs and hover focus/width.
- No schema, simulation-service or deployment policy changes.