### PR TITLE
Fix predictable Net Label placement

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -3707,7 +3707,7 @@ test("stacks complementary scripts under one uninterrupted overbar", async ({
   ).toEqual([]);
 });
 
-test("L names first, previews a floating Net Label, then places it on a wire", async ({
+test("L labels a selected wire or snaps near an unselectable wire", async ({
   page,
 }) => {
   await page.goto("/editor");
@@ -3718,18 +3718,23 @@ test("L names first, previews a floating Net Label, then places it on a wire", a
   await page.getByTestId("terminal-R2-1").click();
   await page.keyboard.press("Escape");
 
+  // The selection-first flow remains a one-step edit after naming.
+  await clickRoute(page, "route-ui-1", 0.7, 0);
   await page.keyboard.press("l");
   const editor = page.getByTestId("net-label-editor");
   await expect(editor).toBeVisible();
   await editor.getByRole("textbox", { name: "Net Label" }).fill("SIGNAL");
   await editor.getByRole("textbox", { name: "Net Label" }).press("Enter");
   const preview = page.getByTestId("net-label-placement-preview");
-  await expect(preview).toContainText("SIGNAL");
-  await clickRoute(page, "route-ui-1", 0.7, 0);
   await expect(preview).toHaveCount(0);
   await expect(page.locator('[data-layer="annotations"]')).toContainText(
     "SIGNAL",
   );
+  await expect(
+    page.locator(
+      '[data-object-id="net-label-route-ui-1"] [data-text-run="subscript"]',
+    ),
+  ).toHaveCount(0);
   await expect(page.getByTestId("flightline")).toHaveCount(0);
   await page.keyboard.press("Delete");
   await expect(
@@ -3737,12 +3742,42 @@ test("L names first, previews a floating Net Label, then places it on a wire", a
   ).toHaveCount(0);
   await expect(page.getByTestId("flightline")).toHaveCount(0);
 
+  // Selection Filter must not disable an electrical creation target.
+  await page.keyboard.press("Control+f");
+  const filter = page.getByTestId("selection-filter-popover");
+  await filter.getByRole("button", { name: "None" }).click();
+  await filter.getByRole("button", { name: "Close" }).click();
+
   await page.keyboard.press("l");
   await editor.getByRole("textbox", { name: "Net Label" }).fill("VREF");
   await editor.getByRole("textbox", { name: "Net Label" }).press("Enter");
-  await clickRoute(page, "route-ui-1", 0.25, 0);
+  await expect(preview).toContainText("VREF");
+  const routePoint = await page
+    .getByTestId("route-hit-route-ui-1")
+    .evaluate((element) => {
+      const polyline = element as SVGPolylineElement;
+      const first = polyline.points.getItem(0);
+      const second = polyline.points.getItem(1);
+      const matrix = polyline.getScreenCTM();
+      if (!first || !second || !matrix) return null;
+      const point = new DOMPoint(
+        first.x + (second.x - first.x) * 0.25,
+        first.y + (second.y - first.y) * 0.25,
+      ).matrixTransform(matrix);
+      return { x: point.x, y: point.y };
+    });
+  if (!routePoint) throw new Error("Route is not measurable");
+  await page.mouse.move(routePoint.x, routePoint.y + 9);
+  // An SVG line has zero CSS width/height, so assert its rendered presence
+  // rather than Playwright's box-based visibility heuristic.
+  await expect(page.locator(".smart-snap-guide")).toHaveCount(1);
+  await page.mouse.click(routePoint.x, routePoint.y + 9);
+  await expect(preview).toHaveCount(0);
   await expect(page.locator('[data-layer="annotations"]')).toContainText(
     "VREF",
+  );
+  await expect(page.getByTestId("route-hit-route-ui-1")).not.toHaveClass(
+    /selected/,
   );
 
   await page.keyboard.press("l");

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -304,7 +304,9 @@ import {
   effectiveRouteAttachment,
   instanceValueAnnotation,
   isRoutedMarker,
+  netLabelPlacementTargetAtPoint,
 } from "../features/wiring/route-interaction-geometry";
+import type { NetLabelPlacementTarget } from "../features/wiring/route-interaction-geometry";
 import { useWireCanvasController } from "../features/wiring/use-wire-canvas-controller";
 import {
   EMPTY_WIRE_DRAFT_PREVIEW,
@@ -354,6 +356,7 @@ function defaultPropertiesWidth(viewportWidth: number): number {
 const COMPACT_LAYOUT_MEDIA_QUERY = "(max-width: 860px)";
 const DRAG_START_DISTANCE_PX = 4;
 const SNAP_CAPTURE_RADIUS_PX = 4;
+const NET_LABEL_SNAP_CAPTURE_RADIUS_PX = 12;
 
 /** Persisted Junctions are grid points, including on ±45° Route segments. */
 
@@ -3108,9 +3111,16 @@ export function App({
       setPanPreview,
       getInteractionKind: () => getCurrentInteractionState().kind,
       paintSnapGuides,
-      noteCanvasPoint: (point) => {
+      noteCanvasPoint: (point, rawPoint, svg) => {
         lastCanvasPointRef.current = point;
-        updateNetLabelPlacementPosition(point);
+        if (netLabelPlacement?.phase === "placing") {
+          const target = resolveNetLabelPlacementTarget(rawPoint, svg);
+          updateNetLabelPlacementPosition(
+            target?.labelPosition ?? rawPoint,
+            target,
+          );
+          paintSnapGuides(netLabelSnapGuides(target));
+        }
       },
       setStatus,
       measureCanvasView,
@@ -3769,6 +3779,45 @@ export function App({
     replaceCanvasSnapGuides(snapGuideLayerRef.current, guides);
   }
 
+  function resolveNetLabelPlacementTarget(
+    point: Point,
+    svg?: SVGSVGElement,
+    preferredRouteId?: string,
+  ): NetLabelPlacementTarget | null {
+    return netLabelPlacementTargetAtPoint(
+      routeGeometryRecords,
+      point,
+      svg ? logicalRadiusForPixels(svg, NET_LABEL_SNAP_CAPTURE_RADIUS_PX) : 0,
+      preferredRouteId,
+    );
+  }
+
+  function netLabelSnapGuides(
+    target: NetLabelPlacementTarget | null,
+  ): readonly SnapGuideLine[] {
+    if (!target) return [];
+    const horizontalOffset =
+      Math.abs(target.labelPosition.x - target.conductorPoint.x) >=
+      Math.abs(target.labelPosition.y - target.conductorPoint.y);
+    return [
+      horizontalOffset
+        ? {
+            axis: "y",
+            coordinate: target.conductorPoint.y,
+            from: Math.min(target.labelPosition.x, target.conductorPoint.x),
+            to: Math.max(target.labelPosition.x, target.conductorPoint.x),
+            kind: "route",
+          }
+        : {
+            axis: "x",
+            coordinate: target.conductorPoint.x,
+            from: Math.min(target.labelPosition.y, target.conductorPoint.y),
+            to: Math.max(target.labelPosition.y, target.conductorPoint.y),
+            kind: "route",
+          },
+    ];
+  }
+
   /**
    * Editor-only visual state must never outlive the interaction that produced
    * it. In particular, Smart Snap guides are imperative SVG children so React
@@ -4036,6 +4085,7 @@ export function App({
       if (event.key === "Escape" && netLabelPlacement) {
         event.preventDefault();
         cancelNetLabelEditing();
+        paintSnapGuides([]);
         return;
       }
       if (event.key === "Escape" && simulationPickActive) {
@@ -4156,12 +4206,22 @@ export function App({
           return;
         case "edit-net-label":
           activateTool("pointer");
-          beginNetLabelEditing(
-            lastCanvasPointRef.current ?? {
+          {
+            const position = lastCanvasPointRef.current ?? {
               x: viewBox.x + viewBox.width / 2,
               y: viewBox.y + viewBox.height / 2,
-            },
-          );
+            };
+            beginNetLabelEditing(
+              position,
+              selectedRoute
+                ? resolveNetLabelPlacementTarget(
+                    position,
+                    undefined,
+                    selectedRoute.id,
+                  )
+                : null,
+            );
+          }
           return;
         case "toggle-display-settings":
           activateTool("pointer");
@@ -4480,7 +4540,17 @@ export function App({
     },
     netLabelPlacement: {
       active: netLabelPlacement?.phase === "placing",
-      place: placeNetLabel,
+      placeAt: (position, svg) => {
+        const target = resolveNetLabelPlacementTarget(position, svg);
+        placeNetLabel(target);
+        if (target) paintSnapGuides([]);
+      },
+      clearHover: () => {
+        if (netLabelPlacement?.phase === "placing") {
+          updateNetLabelPlacementPosition(netLabelPlacement.position, null);
+        }
+        paintSnapGuides([]);
+      },
     },
     report: setStatus,
     consumePickupClick: () => {
@@ -6486,7 +6556,10 @@ export function App({
             netLabelEditorInputRef,
             onNetLabelDraftChange: updateNetLabelPlacementDraft,
             onNetLabelSubmit: commitNetLabelEditing,
-            onNetLabelEscape: cancelNetLabelEditing,
+            onNetLabelEscape: () => {
+              cancelNetLabelEditing();
+              paintSnapGuides([]);
+            },
             flightlines: displayedFlightlines,
             onFlightlineClick: handleFlightline,
             wireDraftPreview,

--- a/apps/editor/src/canvas/canvas-gesture-controller.ts
+++ b/apps/editor/src/canvas/canvas-gesture-controller.ts
@@ -95,7 +95,11 @@ export interface CanvasGestureControllerDependencies {
     setPanPreview: (preview: PanPreview | null) => void;
     getInteractionKind: () => string;
     paintSnapGuides: (guides: readonly SnapGuideLine[]) => void;
-    noteCanvasPoint: (point: Point) => void;
+    noteCanvasPoint: (
+      point: Point,
+      rawPoint: Point,
+      svg: SVGSVGElement,
+    ) => void;
     setStatus: (status: string) => void;
     /** A completed right-button frame consumes that gesture's context menu. */
     setContextMenuSuppressed: (suppressed: boolean) => void;
@@ -534,7 +538,11 @@ export function createCanvasGestureController({
       event.clientY,
       event.currentTarget,
     );
-    noteCanvasPoint(point);
+    noteCanvasPoint(
+      point,
+      rawPointFromClient(event.clientX, event.clientY, event.currentTarget),
+      event.currentTarget,
+    );
     if (waveformPlacementPending) {
       setWaveformPreviewPoint(point);
       return;

--- a/apps/editor/src/canvas/editor-canvas-event-handlers.ts
+++ b/apps/editor/src/canvas/editor-canvas-event-handlers.ts
@@ -124,7 +124,8 @@ interface CanvasEventHandlerDependencies {
   };
   netLabelPlacement: {
     active: boolean;
-    place: (routeId: string | null, position: Point) => void;
+    placeAt: (position: Point, svg: SVGSVGElement) => void;
+    clearHover: () => void;
   };
   report: (status: string) => void;
   /**
@@ -201,18 +202,14 @@ export function createEditorCanvasEventHandlers({
       if (netLabelPlacement.active) {
         event.preventDefault();
         event.stopPropagation();
-        const routeHit = rankCanvasHits(
-          event.currentTarget.ownerDocument.elementsFromPoint(
+        netLabelPlacement.placeAt(
+          pointFromClient(
             event.clientX,
             event.clientY,
+            event.currentTarget,
+            false,
           ),
-          (hit) =>
-            hit.kind === "route" &&
-            selectionPolicy.allowsCanvasHit(hit, "edit"),
-        ).find((hit) => hit.kind === "route");
-        netLabelPlacement.place(
-          routeHit?.id ?? null,
-          pointFromClient(event.clientX, event.clientY, event.currentTarget),
+          event.currentTarget,
         );
         return;
       }
@@ -343,6 +340,7 @@ export function createEditorCanvasEventHandlers({
     onPointerMove: continueCanvasGesture,
     onPointerLeave() {
       const kind = interactionKind();
+      if (netLabelPlacement.active) netLabelPlacement.clearHover();
       if (pendingSymbolId) clearComponentPreview();
       if (vddRailMode) clearVddRailPreview();
       if (kind === "copy-placement") clearCopyPreview();

--- a/apps/editor/src/features/properties/property-edit-planner.test.ts
+++ b/apps/editor/src/features/properties/property-edit-planner.test.ts
@@ -103,9 +103,10 @@ describe("property edit planner", () => {
     );
   });
 
-  it("places a new L-command label at the explicit canvas point", () => {
+  it("commits the same route attachment resolved by the L-command preview", () => {
     const input = routedFixture();
     const planner = createPropertyEditPlanner(input);
+    const legId = input.document.routes[0]!.legs[0]!.id;
 
     const edits = planner.netLabelEditsForRoute(
       input.document.routes[0]!,
@@ -113,7 +114,14 @@ describe("property edit planner", () => {
       {
         alignment: "start",
         sizeScale: 1,
-        position: { x: 73, y: 14 },
+        position: { x: 70, y: -8 },
+        routeAttachment: {
+          routeId: "route",
+          legId,
+          t: 0.7,
+          normalOffset: -8,
+          direction: "forward",
+        },
       },
     );
 
@@ -125,8 +133,14 @@ describe("property edit planner", () => {
             id: "net-label-route",
             alignment: "start",
             anchor: {
-              kind: "free",
-              position: { x: 70, y: 10 },
+              kind: "route",
+              routeId: "route",
+              legId,
+              t: 0.7,
+              normalOffset: -8,
+              direction: "forward",
+              orientation: "follow",
+              fallbackPosition: { x: 70, y: -8 },
             },
           }),
         }),

--- a/apps/editor/src/features/properties/property-edit-planner.ts
+++ b/apps/editor/src/features/properties/property-edit-planner.ts
@@ -9,6 +9,7 @@ import {
   type CircuitProject,
   type ConnectivityEvidence,
   type RichTextDocument,
+  type RouteAnnotationAttachment,
   type RouteBranch,
   type SchematicDocument,
 } from "@icm/model";
@@ -76,6 +77,8 @@ export function createPropertyEditPlanner({
       formatOverride?: RichTextDocument;
       /** Explicit canvas placement from the Cadence-style L workflow. */
       position?: { x: number; y: number };
+      /** Projection shared by the Label preview and its committed anchor. */
+      routeAttachment?: RouteAnnotationAttachment;
     },
   ): SchematicEdit[] | null => {
     const net = document.nets.find((candidate) => candidate.id === route.netId);
@@ -136,18 +139,18 @@ export function createPropertyEditPlanner({
     );
     const from = geometry.centerline[segment]!;
     const to = geometry.centerline[segment + 1] ?? from;
-    const position = snapGridPoint(
-      presentation?.position ??
-        (existingLabel
-          ? existingLabel.anchor.kind === "free"
-            ? existingLabel.anchor.position
-            : existingLabel.anchor.fallbackPosition
-          : undefined) ?? {
-          x: (from.x + to.x) / 2,
-          y: (from.y + to.y) / 2 - 8,
-        },
-      document.presentation.grid,
-    );
+    const requestedPosition = presentation?.position ??
+      (existingLabel
+        ? existingLabel.anchor.kind === "free"
+          ? existingLabel.anchor.position
+          : existingLabel.anchor.fallbackPosition
+        : undefined) ?? {
+        x: (from.x + to.x) / 2,
+        y: (from.y + to.y) / 2 - 8,
+      };
+    const position = presentation?.routeAttachment
+      ? requestedPosition
+      : snapGridPoint(requestedPosition, document.presentation.grid);
     const previousAnchor =
       existingLabel?.anchor.kind === "route" &&
       existingLabel.anchor.routeId === route.id
@@ -161,20 +164,27 @@ export function createPropertyEditPlanner({
         kind: "net-label",
         binding: { kind: "net-name", netId: targetNetId },
         netId: targetNetId,
-        anchor: presentation?.position
-          ? { kind: "free", position }
-          : previousAnchor
-            ? { ...previousAnchor, fallbackPosition: position }
-            : {
-                kind: "route",
-                routeId: route.id,
-                legId: route.legs[segment]!.id,
-                t: 0.5,
-                normalOffset: -8,
-                direction: "forward",
-                orientation: "follow",
-                fallbackPosition: position,
-              },
+        anchor: presentation?.routeAttachment
+          ? {
+              kind: "route",
+              ...presentation.routeAttachment,
+              orientation: "follow",
+              fallbackPosition: position,
+            }
+          : presentation?.position
+            ? { kind: "free", position }
+            : previousAnchor
+              ? { ...previousAnchor, fallbackPosition: position }
+              : {
+                  kind: "route",
+                  routeId: route.id,
+                  legId: route.legs[segment]!.id,
+                  t: 0.5,
+                  normalOffset: -8,
+                  direction: "forward",
+                  orientation: "follow",
+                  fallbackPosition: position,
+                },
         alignment:
           presentation?.alignment ?? existingLabel?.alignment ?? "middle",
         rotation: 0,

--- a/apps/editor/src/features/properties/use-properties-editor.ts
+++ b/apps/editor/src/features/properties/use-properties-editor.ts
@@ -13,6 +13,7 @@ import type {
   DraftingObject,
   Point,
   RichTextDocument,
+  RouteAnnotationAttachment,
   SchematicDocument,
 } from "@icm/model";
 import type { SymbolResolver } from "@icm/symbols";
@@ -35,6 +36,7 @@ import {
 } from "../text-editing/text-editing";
 import type { TextEditingSession } from "../text-editing/text-editing";
 import { planElectricalMarkerName } from "./electrical-marker-name";
+import type { NetLabelPlacementTarget } from "../wiring/route-interaction-geometry";
 
 export interface InstancePropertyDraft {
   instanceId: string | null;
@@ -118,6 +120,7 @@ export interface UsePropertiesEditorOptions {
       sizeScale: number;
       formatOverride?: RichTextDocument;
       position?: Point;
+      routeAttachment?: RouteAnnotationAttachment;
     },
   ) => SchematicEdit[] | null;
   netLabelScopeEdit: (
@@ -154,6 +157,8 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
     phase: "naming" | "placing";
     draft: string;
     position: Point;
+    target: NetLabelPlacementTarget | null;
+    commitAfterNaming: boolean;
   } | null>(null);
   const [instancePropertyDraft, setInstancePropertyDraft] =
     useState<InstancePropertyDraft>(EMPTY_INSTANCE_PROPERTY_DRAFT);
@@ -164,6 +169,7 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
     null,
   );
   const netLabelDraftRouteRef = useRef<string | null>(null);
+  const netLabelDraftDirtyRef = useRef(false);
   const lastSelectedInstanceKeyRef = useRef<string | null>(null);
   const instancePropertyDraftRef = useRef<InstancePropertyDraft>(
     EMPTY_INSTANCE_PROPERTY_DRAFT,
@@ -236,7 +242,9 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
   const commitPendingNetLabelDraft = (): void => {
     const routeId = netLabelDraftRouteRef.current;
     netLabelDraftRouteRef.current = null;
-    if (!routeId) return;
+    const dirty = netLabelDraftDirtyRef.current;
+    netLabelDraftDirtyRef.current = false;
+    if (!routeId || !dirty) return;
     const route = options.document.routes.find(
       (candidate) => candidate.id === routeId,
     );
@@ -274,6 +282,7 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
           )
         : "",
     );
+    netLabelDraftDirtyRef.current = false;
     netLabelDraftRouteRef.current = options.selectedRoute.id;
   }, [options.selectedRoute, options.selectedRouteNetLabel]);
 
@@ -401,6 +410,7 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
     const edits = options.netLabelEditsForRoute(route, netLabelDraft);
     if (!edits || !transactNamedNet(edits)) return;
     netLabelDraftRouteRef.current = null;
+    netLabelDraftDirtyRef.current = false;
     if (!name) {
       options.replaceSelectionKind("annotation", []);
       options.setStatus(
@@ -429,9 +439,14 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
           resolveAnnotationText(options.document, existing),
         ).trim()
       : "";
-    if (nextName === currentName || (!nextName && !existing)) return;
+    if (nextName === currentName || (!nextName && !existing)) {
+      netLabelDraftDirtyRef.current = false;
+      return;
+    }
+    netLabelDraftDirtyRef.current = true;
     const edits = options.netLabelEditsForRoute(route, draft);
     if (!edits || !transactNamedNet(edits)) return;
+    netLabelDraftDirtyRef.current = false;
     options.setStatus(
       nextName ? `Saved Net Label ${nextName}` : "Removed Net Label",
     );
@@ -454,6 +469,7 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
     ) {
       options.replaceSelectionKind("annotation", []);
       setNetLabelDraft("");
+      netLabelDraftDirtyRef.current = false;
       options.setStatus(
         `Deleted Net Label ${flattenRichText(resolveAnnotationText(options.document, label))}`,
       );
@@ -580,28 +596,66 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
     }
   };
 
-  const beginNetLabelEditing = (position: Point): void => {
-    setNetLabelPlacement({ phase: "naming", draft: "", position });
+  const beginNetLabelEditing = (
+    position: Point,
+    target: NetLabelPlacementTarget | null = null,
+  ): void => {
+    setNetLabelPlacement({
+      phase: "naming",
+      draft: "",
+      position,
+      target,
+      commitAfterNaming: target !== null,
+    });
     options.setStatus("Type a Net Label name, then press Enter to place it");
     requestAnimationFrame(() =>
       options.netLabelEditorInputRef.current?.focus(),
     );
   };
 
-  const commitNetLabelEditing = (): void => {
-    setNetLabelPlacement((current) => {
-      if (!current) return null;
-      const draft = current.draft.trim();
-      if (!draft) {
-        options.setStatus("Net Label name cannot be empty");
-        requestAnimationFrame(() =>
-          options.netLabelEditorInputRef.current?.focus(),
-        );
-        return current;
-      }
-      options.setStatus(`Place Net Label ${draft} on a wire · Esc cancels`);
-      return { ...current, draft, phase: "placing" };
+  const commitNetLabelAtTarget = (
+    placement: NonNullable<typeof netLabelPlacement>,
+    target: NetLabelPlacementTarget,
+  ): boolean => {
+    const route = options.document.routes.find(
+      (candidate) => candidate.id === target.routeId,
+    );
+    if (!route) {
+      options.setStatus("The target wire is no longer available");
+      return false;
+    }
+    const existingLabel = options.netLabelForRoute(route);
+    const edits = options.netLabelEditsForRoute(route, placement.draft, {
+      alignment: "start",
+      sizeScale: 1,
+      position: target.labelPosition,
+      routeAttachment: target.routeAttachment,
     });
+    if (!edits || !transactNamedNet(edits)) return false;
+    const labelId = existingLabel?.id ?? `net-label-${route.id}`;
+    options.selectOnly("annotation", [labelId]);
+    setNetLabelPlacement(null);
+    options.setStatus(`Placed Net Label ${placement.draft}`);
+    return true;
+  };
+
+  const commitNetLabelEditing = (): void => {
+    if (!netLabelPlacement) return;
+    const draft = netLabelPlacement.draft.trim();
+    if (!draft) {
+      options.setStatus("Net Label name cannot be empty");
+      requestAnimationFrame(() =>
+        options.netLabelEditorInputRef.current?.focus(),
+      );
+      return;
+    }
+    const ready = { ...netLabelPlacement, draft, phase: "placing" as const };
+    if (ready.commitAfterNaming && ready.target) {
+      commitNetLabelAtTarget(ready, ready.target);
+      return;
+    }
+    options.setStatus(`Place Net Label ${draft} near a wire · Esc cancels`);
+    setNetLabelPlacement(ready);
   };
 
   const updateNetLabelPlacementDraft = (draft: string): void => {
@@ -610,36 +664,22 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
     );
   };
 
-  const updateNetLabelPlacementPosition = (position: Point): void => {
+  const updateNetLabelPlacementPosition = (
+    position: Point,
+    target: NetLabelPlacementTarget | null,
+  ): void => {
     setNetLabelPlacement((current) =>
-      current?.phase === "placing" ? { ...current, position } : current,
+      current?.phase === "placing" ? { ...current, position, target } : current,
     );
   };
 
-  const placeNetLabel = (routeId: string | null, position: Point): void => {
+  const placeNetLabel = (target: NetLabelPlacementTarget | null): void => {
     if (!netLabelPlacement || netLabelPlacement.phase !== "placing") return;
-    if (!routeId) {
-      options.setStatus("Place the Net Label on a wire · Esc cancels");
+    if (!target) {
+      options.setStatus("Move closer to a wire before placing the Net Label");
       return;
     }
-    const route = options.document.routes.find(
-      (candidate) => candidate.id === routeId,
-    );
-    if (!route) {
-      options.setStatus("The target wire is no longer available");
-      return;
-    }
-    const existingLabel = options.netLabelForRoute(route);
-    const edits = options.netLabelEditsForRoute(
-      route,
-      netLabelPlacement.draft,
-      { alignment: "start", sizeScale: 1, position },
-    );
-    if (!edits || !transactNamedNet(edits)) return;
-    const labelId = existingLabel?.id ?? `net-label-${route.id}`;
-    options.selectOnly("annotation", [labelId]);
-    setNetLabelPlacement(null);
-    options.setStatus(`Placed Net Label ${netLabelPlacement.draft}`);
+    commitNetLabelAtTarget(netLabelPlacement, target);
   };
 
   const cancelNetLabelEditing = (): void => {

--- a/apps/editor/src/features/wiring/route-interaction-geometry.test.ts
+++ b/apps/editor/src/features/wiring/route-interaction-geometry.test.ts
@@ -16,6 +16,7 @@ import {
   routeTapPoint,
   defaultInstanceLabel,
   dragNetLabelAttachmentAtPoint,
+  netLabelPlacementTargetAtPoint,
   dragRouteAttachmentAtPoint,
   effectiveRouteAttachment,
   looseRouteAnchorIds,
@@ -185,6 +186,35 @@ describe("route interaction geometry", () => {
         normalOffset: -24,
       },
       position: { x: 80, y: 0 },
+    });
+  });
+
+  it("uses one tolerant Route projection for Net Label preview and commit", () => {
+    const document = looseRouteDocument();
+    const record = routeRecord(document);
+
+    expect(
+      netLabelPlacementTargetAtPoint([record], { x: 70, y: 6 }, 7),
+    ).toEqual({
+      routeId: "route-1",
+      routeAttachment: {
+        routeId: "route-1",
+        legId: document.routes[0]!.legs[0]!.id,
+        t: 0.7,
+        direction: "forward",
+        normalOffset: -8,
+      },
+      conductorPoint: { x: 70, y: 0 },
+      labelPosition: { x: 70, y: -8 },
+    });
+    expect(
+      netLabelPlacementTargetAtPoint([record], { x: 70, y: 8 }, 7),
+    ).toBeNull();
+    expect(
+      netLabelPlacementTargetAtPoint([record], { x: 70, y: 30 }, 0, "route-1"),
+    ).toMatchObject({
+      routeId: "route-1",
+      conductorPoint: { x: 70, y: 0 },
     });
   });
 

--- a/apps/editor/src/features/wiring/route-interaction-geometry.ts
+++ b/apps/editor/src/features/wiring/route-interaction-geometry.ts
@@ -76,6 +76,13 @@ export interface RouteGeometryRecord {
   geometry: ResolvedRouteGeometry;
 }
 
+export interface NetLabelPlacementTarget {
+  routeId: string;
+  routeAttachment: RouteAnnotationAttachment;
+  conductorPoint: Point;
+  labelPosition: Point;
+}
+
 export const ROUTED_MARKER_MIN_NORMAL_OFFSET = 12;
 export const ROUTED_MARKER_MAX_NORMAL_OFFSET = 40;
 // Net labels keep their electrical binding to the route but may be placed in
@@ -194,6 +201,59 @@ export function attachmentAtPoint(
         position: closest.position,
       }
     : null;
+}
+
+/**
+ * Resolve the temporary target used while creating a Net Label.
+ *
+ * Label creation is an electrical pick mode, not Selection. It therefore
+ * resolves directly from current Route geometry and remains available when
+ * Wires are disabled in the Selection Filter. The returned position and
+ * attachment are one projection consumed by both preview and commit.
+ */
+export function netLabelPlacementTargetAtPoint(
+  routeGeometryRecords: readonly RouteGeometryRecord[],
+  candidate: Point,
+  captureTolerance: number,
+  preferredRouteId?: string,
+): NetLabelPlacementTarget | null {
+  const attached = attachmentAtPoint(
+    routeGeometryRecords,
+    candidate,
+    preferredRouteId,
+    -NET_LABEL_MIN_NORMAL_OFFSET,
+  );
+  if (!attached) return null;
+  if (
+    !preferredRouteId &&
+    Math.hypot(
+      attached.position.x - candidate.x,
+      attached.position.y - candidate.y,
+    ) > captureTolerance
+  ) {
+    return null;
+  }
+  const record = routeGeometryRecords.find(
+    ({ route }) => route.id === attached.routeAttachment.routeId,
+  );
+  const placement = record
+    ? resolveRouteAttachment(record.geometry, attached.routeAttachment)
+    : null;
+  if (!placement) return null;
+  const conductorPoint = {
+    x: Math.round(attached.position.x),
+    y: Math.round(attached.position.y),
+  };
+  const labelPosition = {
+    x: Math.round(placement.labelPoint.x),
+    y: Math.round(placement.labelPoint.y),
+  };
+  return {
+    routeId: attached.routeAttachment.routeId,
+    routeAttachment: attached.routeAttachment,
+    conductorPoint,
+    labelPosition,
+  };
 }
 
 /**

--- a/apps/editor/src/styles/editor-canvas.css
+++ b/apps/editor/src/styles/editor-canvas.css
@@ -63,7 +63,8 @@
 .net-label-placement-preview {
   fill: var(--icm-accent);
   font-size: 12px;
-  font-weight: 500;
+  font-style: italic;
+  font-weight: 700;
   paint-order: stroke;
   stroke: var(--icm-surface);
   stroke-width: 3px;

--- a/packages/model/src/semantic-text.test.ts
+++ b/packages/model/src/semantic-text.test.ts
@@ -25,20 +25,34 @@ describe("semantic formal-Port text", () => {
     });
   });
 
-  it("preserves punctuation instead of interpreting it as subscript markup", () => {
+  it("preserves punctuation without applying implicit Net Label markup", () => {
     const port = semanticTextDocument("V_{in,cm}", "formal-port");
     const net = semanticTextDocument("V_{in,cm}", "net-label");
 
-    expect(port).toEqual(net);
+    expect(port).not.toEqual(net);
     expect(flattenRichText(port)).toBe("V_{in,cm}");
+    expect(flattenRichText(net)).toBe("V_{in,cm}");
     expect(port.runs[1]).toMatchObject({
       kind: "span",
       style: "subscript",
       children: [{ children: [{ value: "_{in,cm}" }] }],
     });
+    expect(net.runs).toEqual([
+      {
+        kind: "span",
+        style: "italic",
+        children: [
+          {
+            kind: "span",
+            style: "bold",
+            children: [{ kind: "text", value: "V_{in,cm}" }],
+          },
+        ],
+      },
+    ]);
   });
 
-  it("splits every Port and Net name into a symbol and its subscript", () => {
+  it("keeps the Port convention but gives a Net Label no implicit subscript", () => {
     const port = semanticTextDocument("CLK", "formal-port");
     const net = semanticTextDocument("NET1", "net-label");
 
@@ -68,20 +82,27 @@ describe("semantic formal-Port text", () => {
         },
       ],
     });
-    expect(net).toMatchObject({
-      runs: [
-        { kind: "span", style: "italic" },
-        { kind: "span", style: "subscript" },
-      ],
-    });
+    expect(net.runs).toEqual([
+      {
+        kind: "span",
+        style: "italic",
+        children: [
+          {
+            kind: "span",
+            style: "bold",
+            children: [{ kind: "text", value: "NET1" }],
+          },
+        ],
+      },
+    ]);
     expect(flattenRichText(net)).toBe("NET1");
   });
 });
 
 describe("house text style", () => {
   it("keeps a supply subscript italic while ordinary subscripts stay upright", () => {
-    const supply = semanticTextDocument("VDD", "net-label");
-    const signal = semanticTextDocument("Vin", "net-label");
+    const supply = semanticTextDocument("VDD", "power-label");
+    const signal = semanticTextDocument("Vin", "formal-port");
 
     expect(flattenRichText(supply)).toBe("VDD");
     // Scripts render upright by default, so the supply exception is carried
@@ -98,8 +119,8 @@ describe("house text style", () => {
     });
   });
 
-  it("preserves the leading symbol case while subscripting the remainder", () => {
-    const content = semanticTextDocument("vout", "net-label");
+  it("preserves the leading symbol case while subscripting a Formal Port", () => {
+    const content = semanticTextDocument("vout", "formal-port");
 
     expect(flattenRichText(content)).toBe("vout");
     expect(content.runs[0]).toMatchObject({

--- a/packages/model/src/semantic-text.ts
+++ b/packages/model/src/semantic-text.ts
@@ -87,13 +87,23 @@ export function plainNameDocument(value: string): RichTextDocument {
 /** Construct current-authoring RichText for a conventional semantic label. */
 export function semanticTextDocument(
   value: string,
-  _kind: SemanticTextKind,
+  kind: SemanticTextKind,
 ): RichTextDocument {
   if (value.length === 0) return { runs: [{ kind: "line-break" }] };
-  // Every authored label follows one styling rule: leading symbol, then the
-  // remainder as its subscript. A trailing polarity sign stays outside the
-  // subscript because it qualifies the whole identifier.
+  // A Net Label is a complete authored name, not an instance designator or a
+  // symbolic variable with an implicit index. Keep the Razavi bold-italic
+  // face, but require an explicit RichText edit for subscript semantics.
+  // A trailing polarity sign still qualifies the whole name.
   const signed = /^(.+?)([+-])$/u.exec(value);
+  if (kind === "net-label") {
+    return {
+      runs: signed
+        ? [mathBase(signed[1]!), { kind: "text", value: signed[2]! }]
+        : [mathBase(value)],
+    };
+  }
+  // Other semantic identifiers retain the established leading-symbol and
+  // subscript convention.
   if (!signed) return { runs: symbolRuns(value) };
   return {
     runs: [

--- a/packages/render-svg/src/schematic-text.test.ts
+++ b/packages/render-svg/src/schematic-text.test.ts
@@ -31,7 +31,7 @@ describe("Razavi schematic typography", () => {
 
   it("draws an ordinary subscript upright", () => {
     const rendered = renderRichTextDocument(
-      semanticTextDocument("Vin", "net-label"),
+      semanticTextDocument("Vin", "formal-port"),
       razaviTextbookProfile,
       {
         fontSize: schematicTextFontSize("net-label", razaviTextbookProfile),
@@ -40,6 +40,20 @@ describe("Razavi schematic typography", () => {
     expect(rendered).toContain(
       '<tspan data-text-run="span" style="font-style:normal;font-weight:700">in</tspan>',
     );
+  });
+
+  it("keeps a default Net Label bold italic without an implicit subscript", () => {
+    const rendered = renderRichTextDocument(
+      semanticTextDocument("Vin", "net-label"),
+      razaviTextbookProfile,
+      {
+        fontSize: schematicTextFontSize("net-label", razaviTextbookProfile),
+      },
+    );
+    expect(rendered).toContain(
+      '<tspan data-text-run="span" style="font-style:italic;font-weight:700">Vin</tspan>',
+    );
+    expect(rendered).not.toContain('data-text-run="subscript"');
   });
 
   it("uses semantic profile sizes", () => {


### PR DESCRIPTION
## Summary
- restore selected-wire Label placement and prevent stale Properties drafts from deleting new labels
- snap Label preview and commit to the same Route anchor independently of Selection Filter
- keep Razavi bold-italic Net Labels without implicit subscripts

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm gate:full (before rebasing the disjoint simulation-only #782 change)

Test-Impact: tests-updated