### PR TITLE
Refactor simulation result semantics and preserve scalar captures

### DIFF
--- a/apps/editor/e2e/simulation-code-editor.spec.ts
+++ b/apps/editor/e2e/simulation-code-editor.spec.ts
@@ -44,6 +44,10 @@ test("native save and dc arguments open automatically and preview their Canvas t
   await expect(
     page.getByRole("option").filter({ hasText: /v\(out\)/i }),
   ).toHaveCount(1);
+  // CodeMirror deliberately ignores completion navigation for 75ms after
+  // opening. Visibility alone does not mean keyboard navigation is armed.
+  // Exercise the post-open interaction, preserving the library's safety delay.
+  await page.waitForTimeout(100);
   await page.keyboard.press("ArrowDown");
   const selected = await page
     .locator(

--- a/apps/editor/e2e/simulation-plot-export.spec.ts
+++ b/apps/editor/e2e/simulation-plot-export.spec.ts
@@ -91,6 +91,21 @@ test("native multi-unit results preserve signs and link only one record", async 
               values: [10, 1000, 1000000],
             },
             outputs,
+            scalars: [
+              {
+                id: "native:peak_gain_db",
+                label: "peak_gain_db",
+                value: index === 0 ? 4.43515 : -2,
+                unit: "dB",
+              },
+              {
+                id: "native:phasor",
+                label: "scalar_phasor",
+                value: 3,
+                imaginary: 4,
+                unit: "",
+              },
+            ],
           })),
         },
       }),
@@ -101,6 +116,19 @@ test("native multi-unit results preserve signs and link only one record", async 
   await expect(records).toHaveCount(2);
   const first = records.nth(0),
     second = records.nth(1);
+  await expect(
+    first.getByRole("region", { name: "Captured scalars record 1" }),
+  ).toContainText("4.43515");
+  await expect(
+    second.getByRole("region", { name: "Captured scalars record 2" }),
+  ).toContainText("-2");
+  await expect(
+    first.getByRole("region", { name: "Captured scalars record 1" }),
+  ).toContainText("Unknown");
+  for (const svg of await root.locator("svg").all()) {
+    await expect(svg).not.toContainText("peak_gain_db");
+    await expect(svg).not.toContainText("scalar_phasor");
+  }
   await expect(first.locator(".simulation-plot-layout")).toHaveCount(3);
   await expect(
     first.getByRole("button", { name: "Magnitude", exact: true }),

--- a/apps/editor/e2e/simulation-plot-export.spec.ts
+++ b/apps/editor/e2e/simulation-plot-export.spec.ts
@@ -157,6 +157,8 @@ test("native multi-unit results preserve signs and link only one record", async 
     .getByLabel("Marker measurements", { exact: true })
     .all())
     await expect(table).toContainText("A");
+  // Capture the whole record, not the clipped portion of a fixed scroll host.
+  await page.setViewportSize({ width: 1280, height: 2000 });
   await test.info().attach("native-multi-unit-results.png", {
     body: await first.screenshot({
       path: test.info().outputPath("native-results.png"),

--- a/apps/editor/e2e/simulation-plot-export.spec.ts
+++ b/apps/editor/e2e/simulation-plot-export.spec.ts
@@ -14,6 +14,157 @@ const { PNG } = loadModule("pngjs") as {
     };
   };
 };
+test("native multi-unit results preserve signs and link only one record", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await expect(page.getByTestId("schematic-canvas")).toBeVisible();
+  await page.evaluate(async () => {
+    const reactPath = "/node_modules/.vite/deps/react.js";
+    const domPath = "/node_modules/.vite/deps/react-dom_client.js";
+    const resultPath = "/src/features/simulation/simulation-output-results.tsx";
+    const { createElement } = (await import(reactPath)).default;
+    const { createRoot } = (await import(domPath)).default;
+    const { SimulationOutputResults } = await import(resultPath);
+    const host = document.createElement("div");
+    host.id = "native-result-regression";
+    host.style.cssText =
+      "position:fixed;inset:0;overflow:auto;background:white;z-index:99999;padding:20px";
+    document.body.append(host);
+    const outputs = [
+      {
+        id: "gain",
+        label: "gain_db",
+        unit: "dB",
+        values: [0, -3, -56],
+        semantics: {
+          valueKind: "real",
+          quantity: "decibel",
+          origin: "expression",
+        },
+      },
+      {
+        id: "gain2",
+        label: "gain_small",
+        unit: "dB",
+        values: [0, -1, -20],
+        semantics: {
+          valueKind: "real",
+          quantity: "decibel",
+          origin: "expression",
+        },
+      },
+      {
+        id: "phase",
+        label: "phase_deg",
+        unit: "deg",
+        values: [0, -45, -90],
+        semantics: {
+          valueKind: "real",
+          quantity: "notype",
+          origin: "expression",
+        },
+      },
+      {
+        id: "unknown",
+        label: "mystery",
+        unit: "",
+        values: [-1, -2, -3],
+        imaginary: [0, 0, 0],
+        semantics: { valueKind: "unknown", quantity: "notype", origin: "raw" },
+      },
+    ];
+    createRoot(host).render(
+      createElement(SimulationOutputResults, {
+        resultKey: "browser-native-rc",
+        outputs: [],
+        data: {
+          schemaVersion: 1,
+          diagnostics: [],
+          analyses: [0, 1].map((index) => ({
+            analysis: "ac",
+            plotName: "RC",
+            rawPlotOrdinals: [index],
+            domain: {
+              name: "Frequency",
+              unit: "Hz",
+              values: [10, 1000, 1000000],
+            },
+            outputs,
+          })),
+        },
+      }),
+    );
+  });
+  const root = page.locator("#native-result-regression");
+  const records = root.locator(".simulation-analysis-card");
+  await expect(records).toHaveCount(2);
+  const first = records.nth(0),
+    second = records.nth(1);
+  await expect(first.locator(".simulation-plot-layout")).toHaveCount(3);
+  await expect(
+    first.getByRole("button", { name: "Magnitude", exact: true }),
+  ).toHaveCount(0);
+  await expect(first.locator('svg[aria-label="AC Decibels"]')).toContainText(
+    "dB",
+  );
+  await expect(first.locator('svg[aria-label="AC Decibels"]')).toContainText(
+    "-",
+  );
+  await expect(first.locator('svg[aria-label="AC Phase"]')).toContainText(
+    "deg",
+  );
+  await first.locator("summary").click();
+  await first
+    .getByLabel("Plot layout", { exact: true })
+    .selectOption("separate");
+  await expect(first.locator(".simulation-plot-layout")).toHaveCount(4);
+  await expect(second.locator(".simulation-plot-layout")).toHaveCount(3);
+  await first.getByLabel("mystery display unit").selectOption("deg");
+  await expect(
+    first.locator('svg[aria-label="AC mystery — Phase"]'),
+  ).toContainText("deg");
+  await first.getByLabel("Plot layout", { exact: true }).selectOption("units");
+  const tools = first.getByLabel("Plot tools", { exact: true });
+  await tools.first().focus();
+  await first
+    .getByRole("button", { name: "Control X axes", exact: true })
+    .first()
+    .click();
+  await first
+    .getByRole("button", { name: "Zoom in", exact: true })
+    .first()
+    .click();
+  for (const button of await first
+    .getByRole("button", { name: "Previous view", exact: true })
+    .all())
+    await expect(button).toBeEnabled();
+  for (const button of await second
+    .getByRole("button", { name: "Previous view", exact: true })
+    .all())
+    await expect(button).toBeDisabled();
+  const interaction = first
+    .getByLabel("Waveform: drag to zoom, click to measure, Shift-drag to pan")
+    .first();
+  await interaction.click({ position: { x: 200, y: 100 } });
+  await expect(
+    first.getByLabel("Marker measurements", { exact: true }),
+  ).toHaveCount(3);
+  await expect(
+    second.getByLabel("Marker measurements", { exact: true }),
+  ).toHaveCount(0);
+  for (const table of await first
+    .getByLabel("Marker measurements", { exact: true })
+    .all())
+    await expect(table).toContainText("A");
+  await test.info().attach("native-multi-unit-results.png", {
+    body: await first.screenshot({
+      path: test.info().outputPath("native-results.png"),
+    }),
+    contentType: "image/png",
+  });
+});
+
 test("plot PNG export retains every curve when the source charts rerender", async ({
   page,
 }) => {

--- a/apps/editor/src/features/simulation/ac-results-explorer.test.tsx
+++ b/apps/editor/src/features/simulation/ac-results-explorer.test.tsx
@@ -9,6 +9,42 @@ import {
 } from "./ac-results-explorer";
 
 describe("AC Results Explorer", () => {
+  it("keeps raw-only archive expressions signed without guessing units from their names", () => {
+    const markup = renderToStaticMarkup(
+      <AcResultsExplorer
+        vectors={[]}
+        probes={[]}
+        analysis={{
+          analysis: "ac",
+          plotName: "Archived RC",
+          frequencyHz: [10, 1000],
+          probes: [
+            {
+              name: "gain_db",
+              quantity: "decibel",
+              unit: null,
+              real: [-0.1, -3],
+              imag: [0, 0],
+            },
+            {
+              name: "phase_deg",
+              quantity: "notype",
+              unit: null,
+              real: [-1, -45],
+              imag: [0, 0],
+            },
+          ],
+        }}
+      />,
+    );
+    expect(markup).toContain('aria-label="AC Decibels"');
+    expect(markup).toContain('aria-label="AC phase_deg — Unknown unit"');
+    expect(markup).not.toContain(">Magnitude</button>");
+    expect(markup).toContain("dB");
+    expect(markup).toContain("unknown");
+    expect(markup).not.toContain("/deg");
+    expect(markup.match(/class="simulation-plot-layout"/gu)).toHaveLength(2);
+  });
   it("unwraps phase without inventing 360-degree discontinuities", () => {
     expect(unwrapPhaseDegrees([170, 179, -178, -165])).toEqual([
       170, 179, 182, 195,

--- a/apps/editor/src/features/simulation/ac-results-explorer.tsx
+++ b/apps/editor/src/features/simulation/ac-results-explorer.tsx
@@ -7,6 +7,8 @@ import { WaveformTraceList } from "./waveform-trace-list";
 import type { SimulationFocusTarget } from "./simulation-focus-target";
 import type { AcResult } from "@icm/spice-run";
 import type { Prepared } from "@icm/simulation-service/contract";
+import { planResultOutput, rawAcOutput } from "./result-plot-plan";
+import { ScalarResultsExplorer } from "./transient-results-explorer";
 
 import {
   acPointValue,
@@ -21,6 +23,9 @@ export interface OutputTrace extends AcTrace {
   id: string;
   quantity: string;
   probe?: SimulationFocusTarget;
+  groupLabel?: string;
+  defaultMode?: "real" | "magnitude";
+  scalarView?: boolean;
 }
 
 interface ExpandedPlot {
@@ -140,6 +145,7 @@ function outputTraces(
   );
   const probesById = new Map(probes.map((probe) => [probe.id, probe]));
   return analysis.probes.map((resultProbe, index) => {
+    const planned = planResultOutput(rawAcOutput(resultProbe));
     const binding = vectorsByName.get(resultProbe.name.toLowerCase());
     const authored = binding ? probesById.get(binding.probeId) : undefined;
     const phases = unwrapPhaseDegrees(
@@ -152,12 +158,12 @@ function outputTraces(
       id: binding?.probeId ?? resultProbe.name,
       label: (binding && labels[binding.probeId]) || resultProbe.name,
       colorIndex: index,
-      unit:
-        resultProbe.unit ?? (resultProbe.quantity === "current" ? "A" : "V"),
-      quantity:
-        (binding && groups[binding.probeId]) ??
-        binding?.quantity ??
-        (resultProbe.quantity === "current" ? "current" : "voltage"),
+      unit: planned.unit || "unknown",
+      quantity: (binding && groups[binding.probeId]) ?? planned.group,
+      groupLabel: planned.groupLabel,
+      defaultMode:
+        planned.kind === "unknown" ? ("real" as const) : ("magnitude" as const),
+      scalarView: !planned.complexView,
       ...(authored ? { probe: authored } : {}),
       points: analysis.frequencyHz.map((frequency, pointIndex) => ({
         ...complexAcPoint(
@@ -215,12 +221,38 @@ export function AcResultsExplorer({
   groups = {},
   ...display
 }: AcResultsExplorerProps) {
+  const traces = outputTraces(analysis, vectors, probes, labels, groups);
   return (
-    <ComplexResultsExplorer
-      {...display}
-      plotName={analysis.plotName}
-      traces={outputTraces(analysis, vectors, probes, labels, groups)}
-    />
+    <>
+      {traces.some((t) => !t.scalarView) ? (
+        <ComplexResultsExplorer
+          {...display}
+          plotName={analysis.plotName}
+          traces={traces.filter((t) => !t.scalarView)}
+        />
+      ) : null}
+      {traces.some((t) => t.scalarView) ? (
+        <ScalarResultsExplorer
+          {...(display.resultKey ? { resultKey: display.resultKey } : {})}
+          plotName={analysis.plotName}
+          domain={analysis.frequencyHz}
+          domainLabel="Frequency"
+          domainUnit="Hz"
+          logarithmicX
+          analysisLabel="AC"
+          traces={traces
+            .filter((t) => t.scalarView)
+            .map((t) => ({
+              ...t,
+              colorIndex: t.colorIndex ?? 0,
+              values: t.points.map((p) => p.real),
+            }))}
+          {...(display.onFocusProbe
+            ? { onFocusProbe: display.onFocusProbe }
+            : {})}
+        />
+      ) : null}
+    </>
   );
 }
 
@@ -250,6 +282,9 @@ export function ComplexResultsExplorer({
     Readonly<Record<string, string>>
   >({});
   const visible = traces.filter((trace) => !hidden.has(trace.id));
+  const labelGroup = (quantity: string) =>
+    traces.find((t) => t.quantity === quantity)?.groupLabel ??
+    groupLabel(quantity);
   useEffect(() => {
     if (!expandedPlot) return;
     const close = (event: KeyboardEvent) => {
@@ -471,7 +506,10 @@ export function ComplexResultsExplorer({
         const quantityTraces = traces.filter(
           (trace) => trace.quantity === quantity,
         );
-        const mode = viewModes[quantity] ?? "magnitude";
+        const mode =
+          viewModes[quantity] ??
+          traces.find((t) => t.quantity === quantity)?.defaultMode ??
+          "magnitude";
         const kinds = displayKinds(mode);
         const referenceActive = mode === "db20" || mode === "bode";
         const rawVisibleQuantityTraces = quantityTraces.filter(
@@ -488,7 +526,7 @@ export function ComplexResultsExplorer({
               <div className="ac-view-toolbar">
                 <div
                   role="group"
-                  aria-label={`${groupLabel(quantity)} display`}
+                  aria-label={`${labelGroup(quantity)} display`}
                 >
                   {VIEW_MODES.map(({ mode: candidate, label }) => (
                     <button
@@ -510,7 +548,7 @@ export function ComplexResultsExplorer({
                   <label>
                     Reference
                     <select
-                      aria-label={`${groupLabel(quantity)} reference`}
+                      aria-label={`${labelGroup(quantity)} reference`}
                       value={referenceId}
                       onChange={(event) =>
                         setReferences((current) => {
@@ -539,7 +577,7 @@ export function ComplexResultsExplorer({
             </div>
             <div className="simulation-plot-layout">
               <WaveformTraceList
-                label={`${groupLabel(quantity)} outputs`}
+                label={`${labelGroup(quantity)} outputs`}
                 traces={quantityTraces.map((trace) => ({
                   id: trace.id,
                   label: trace.label,
@@ -584,13 +622,13 @@ export function ComplexResultsExplorer({
                 className="ac-plot-dialog"
                 role="dialog"
                 aria-modal="true"
-                aria-label={`${expandedPlot.quantity} ${expandedPlot.kind} plot`}
+                aria-label={`${labelGroup(expandedPlot.quantity).toLowerCase()} ${expandedPlot.kind} plot`}
               >
                 <header>
                   <div>
                     <strong>{plotName}</strong>
                     <span>
-                      {groupLabel(expandedPlot.quantity)} ·{" "}
+                      {labelGroup(expandedPlot.quantity)} ·{" "}
                       {plotKindLabel(expandedPlot.kind)}
                     </span>
                   </div>
@@ -604,7 +642,7 @@ export function ComplexResultsExplorer({
                 </header>
                 <div className="simulation-plot-layout expanded">
                   <WaveformTraceList
-                    label={`${groupLabel(expandedPlot.quantity)} outputs`}
+                    label={`${labelGroup(expandedPlot.quantity)} outputs`}
                     traces={traces
                       .filter(
                         (trace) => trace.quantity === expandedPlot.quantity,

--- a/apps/editor/src/features/simulation/captured-scalar-results.tsx
+++ b/apps/editor/src/features/simulation/captured-scalar-results.tsx
@@ -1,0 +1,46 @@
+import type { SimulationOutputData } from "@icm/simulation-service/contract";
+
+export function CapturedScalarResults({
+  scalars,
+  record,
+}: {
+  scalars: NonNullable<SimulationOutputData["analyses"][number]["scalars"]>;
+  record: number;
+}) {
+  if (!scalars.length) return null;
+  return (
+    <section
+      aria-label={`Captured scalars record ${record}`}
+      className="simulation-measurement-results"
+    >
+      <h4>Captured values · Record {record}</h4>
+      <p>
+        Single values stored in this raw plot. These are not samples along its
+        sweep axis. Console measurement reports are listed separately.
+      </p>
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Value</th>
+            <th>Unit</th>
+          </tr>
+        </thead>
+        <tbody>
+          {scalars.map((s) => (
+            <tr key={s.id}>
+              <th>{s.label}</th>
+              <td>
+                {s.value.toPrecision(7)}
+                {s.imaginary !== undefined && s.imaginary !== 0
+                  ? ` ${s.imaginary < 0 ? "−" : "+"} j${Math.abs(s.imaginary).toPrecision(7)}`
+                  : ""}
+              </td>
+              <td>{s.unit === "1" ? "Dimensionless" : s.unit || "Unknown"}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
+  );
+}

--- a/apps/editor/src/features/simulation/result-plot-controls.tsx
+++ b/apps/editor/src/features/simulation/result-plot-controls.tsx
@@ -1,0 +1,79 @@
+import type { ReactNode } from "react";
+import type { SimulationOutputData } from "@icm/simulation-service/contract";
+import { useWaveformView, type WaveformController } from "./waveform-view";
+
+export function ResultRecordView({
+  resultKey,
+  children,
+}: {
+  resultKey: string;
+  children: (view: WaveformController) => ReactNode;
+}) {
+  return children(useWaveformView(resultKey));
+}
+
+/** These declarations are session-only presentation, never writes to native Code. */
+export function ResultPlotControls({
+  view,
+  outputs,
+}: {
+  view: WaveformController;
+  outputs: SimulationOutputData["analyses"][number]["outputs"];
+}) {
+  return (
+    <details className="simulation-plot-controls">
+      <summary>Plot layout and units</summary>
+      <label>
+        Layout{" "}
+        <select
+          aria-label="Plot layout"
+          value={view.state.plotLayout}
+          onChange={(event) =>
+            view.set(
+              "plotLayout",
+              event.target.value === "separate" ? "separate" : "units",
+            )
+          }
+        >
+          <option value="units">Group compatible units</option>
+          <option value="separate">Separate each trace</option>
+        </select>
+      </label>
+      <p>
+        Linked horizontal axis and cursors; independent vertical axes. Unknown
+        units are kept separate.
+      </p>
+      {outputs
+        .filter((o) => !o.unit)
+        .map((output) => (
+          <label key={output.id}>
+            {output.label}{" "}
+            <select
+              aria-label={`${output.label} display unit`}
+              value={view.state.unitOverrides[output.id] ?? ""}
+              onChange={(event) =>
+                view.set("unitOverrides", (previous) => {
+                  const next = { ...previous };
+                  if (event.target.value) next[output.id] = event.target.value;
+                  else delete next[output.id];
+                  return next;
+                })
+              }
+            >
+              <option value="">Unknown unit</option>
+              <option value="1">Dimensionless</option>
+              <option value="V">V</option>
+              <option value="A">A</option>
+              <option value="dB">dB</option>
+              <option value="deg">Degrees</option>
+              <option value="rad">Radians</option>
+            </select>
+          </label>
+        ))}
+      <p>
+        Declaring a display unit labels existing numbers; it does not convert
+        values or rerun the simulation.
+      </p>
+    </details>
+  );
+}

--- a/apps/editor/src/features/simulation/result-plot-plan.test.ts
+++ b/apps/editor/src/features/simulation/result-plot-plan.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { planResultOutput } from "./result-plot-plan";
+
+describe("result plot planning", () => {
+  const base = {
+    id: "x",
+    label: "x",
+    unit: "",
+    values: [-3, -56],
+    imaginary: [0, 0],
+  };
+  it("never turns a signed real dB expression into magnitude", () => {
+    const output = {
+      ...base,
+      unit: "dB",
+      semantics: {
+        valueKind: "real" as const,
+        quantity: "decibel",
+        origin: "expression" as const,
+      },
+    };
+    expect(planResultOutput(output)).toMatchObject({
+      complexView: false,
+      unit: "dB",
+      groupLabel: "Decibels",
+    });
+    expect(output.values).toEqual([-3, -56]);
+    expect(planResultOutput({ ...base, unit: "deg" }).complexView).toBe(false);
+  });
+  it("does not group unknown units or mistake them for dimensionless", () => {
+    const a = planResultOutput(base),
+      b = planResultOutput({ ...base, id: "b" });
+    expect(a.group).not.toBe(b.group);
+    expect(a.groupLabel).toContain("Unknown unit");
+    expect(a.kind).toBe("unknown");
+    expect(a.complexView).toBe(false);
+    expect(planResultOutput({ ...base, unit: "1" }).complexView).toBe(true);
+  });
+  it("groups compatible units but permits splitting very different scales", () => {
+    const a = { ...base, unit: "V" },
+      b = { ...a, id: "b", values: [1e-9, 2e-9] };
+    expect(planResultOutput(a).group).toBe(planResultOutput(b).group);
+    expect(planResultOutput(a, "separate").group).not.toBe(
+      planResultOutput(b, "separate").group,
+    );
+    expect(planResultOutput({ ...a, unit: "A" }).group).not.toBe(
+      planResultOutput(a).group,
+    );
+  });
+  it("keeps imaginary evidence for unknown and contradictory metadata", () => {
+    expect(planResultOutput({ ...base, imaginary: [1, 2] })).toMatchObject({
+      kind: "unknown",
+      complexView: true,
+    });
+    expect(
+      planResultOutput({
+        ...base,
+        unit: "deg",
+        imaginary: [1, 2],
+        semantics: { valueKind: "real", quantity: "phase", origin: "raw" },
+      }).complexView,
+    ).toBe(true);
+  });
+  it("display-unit declarations never change source values or metadata", () => {
+    expect(planResultOutput(base, "units", "deg").unit).toBe("deg");
+    expect(base.unit).toBe("");
+    expect(base.values).toEqual([-3, -56]);
+  });
+});

--- a/apps/editor/src/features/simulation/result-plot-plan.ts
+++ b/apps/editor/src/features/simulation/result-plot-plan.ts
@@ -1,0 +1,85 @@
+import type { SimulationOutputData } from "@icm/simulation-service/contract";
+import type { AcProbe } from "@icm/spice-run";
+
+type Output = SimulationOutputData["analyses"][number]["outputs"][number];
+export type ResultPlotLayout = "units" | "separate";
+export interface PlannedOutput {
+  output: Output;
+  kind: "real" | "complex" | "unknown";
+  complexView: boolean;
+  group: string;
+  groupLabel: string;
+  unit: string;
+}
+
+function unitLabel(unit: string): string {
+  if (unit === "V") return "Voltage";
+  if (unit === "A") return "Current";
+  if (unit === "dB") return "Decibels";
+  if (unit === "deg" || unit === "rad") return "Phase";
+  if (unit === "1") return "Value";
+  return unit || "Unknown unit";
+}
+
+/** Pure presentation over immutable evidence. Never infer semantics from variable names
+ * or classify a physical AC acquisition as real merely because Im happens to be zero. */
+export function planResultOutput(
+  output: Output,
+  layout: ResultPlotLayout = "units",
+  declaredUnit?: string,
+): PlannedOutput {
+  const unit = declaredUnit ?? output.unit;
+  const hasImaginary =
+    output.imaginary?.some((value) => value !== null && value !== 0) ?? false;
+  const knownRealUnit = ["dB", "deg", "°", "rad"].includes(unit);
+  const declaredKind =
+    output.semantics?.valueKind ??
+    (knownRealUnit && !hasImaginary
+      ? "real"
+      : output.imaginary
+        ? output.unit
+          ? "complex"
+          : "unknown"
+        : "real");
+  const kind =
+    declaredKind === "real" && hasImaginary ? "unknown" : declaredKind;
+  // Contradictory legacy/source metadata must not erase imaginary evidence.
+  const complexView =
+    (kind === "complex" || hasImaginary) && Boolean(output.imaginary);
+  const isolate = layout === "separate" || !unit || kind === "unknown";
+  const label =
+    complexView && unit === "1"
+      ? "Ratio"
+      : !complexView && (unit === "V" || unit === "A")
+        ? unitLabel(unit).toLowerCase()
+        : unitLabel(unit);
+  return {
+    output,
+    kind,
+    complexView,
+    unit,
+    group: `${complexView ? "complex" : "real"}:${unit}:${isolate ? output.id : "shared"}`,
+    groupLabel: isolate ? `${output.label} — ${label}` : label,
+  };
+}
+
+/** Archive fallback when only raw data exists. No authored expression is reconstructed. */
+export function rawAcOutput(probe: AcProbe): Output {
+  const q = probe.quantity.toLowerCase();
+  const unit =
+    probe.unit ?? (q === "decibel" ? "dB" : q === "phase" ? "rad" : "");
+  const valueKind =
+    q === "decibel" || q === "phase"
+      ? "real"
+      : /^(?:v|i)\(.+\)$/iu.test(probe.name) || probe.name.startsWith("@")
+        ? "complex"
+        : "unknown";
+  return {
+    id: probe.name,
+    label: probe.name,
+    unit,
+    values: [...probe.real],
+    imaginary: [...probe.imag],
+    semantics: { valueKind, quantity: probe.quantity, origin: "raw" },
+  };
+}

--- a/apps/editor/src/features/simulation/simulation-output-results.test.tsx
+++ b/apps/editor/src/features/simulation/simulation-output-results.test.tsx
@@ -4,6 +4,60 @@ import { describe, expect, it } from "vitest";
 import { SimulationOutputResults } from "./simulation-output-results";
 
 describe("Simulation Output Results", () => {
+  it("renders signed native dB and phase in independent unit-labelled plots", () => {
+    const markup = renderToStaticMarkup(
+      <SimulationOutputResults
+        resultKey="native-rc"
+        outputs={[]}
+        data={{
+          schemaVersion: 1,
+          diagnostics: [],
+          analyses: [
+            {
+              analysis: "ac",
+              plotName: "RC",
+              domain: {
+                name: "Frequency",
+                unit: "Hz",
+                values: [10, 1000, 1000000],
+              },
+              outputs: [
+                {
+                  id: "gain",
+                  label: "gain_db",
+                  unit: "dB",
+                  values: [0, -3, -56],
+                  semantics: {
+                    valueKind: "real",
+                    quantity: "decibel",
+                    origin: "expression",
+                  },
+                },
+                {
+                  id: "phase",
+                  label: "phase_deg",
+                  unit: "deg",
+                  values: [0, -45, -90],
+                  semantics: {
+                    valueKind: "real",
+                    quantity: "notype",
+                    origin: "expression",
+                  },
+                },
+              ],
+            },
+          ],
+        }}
+      />,
+    );
+    expect(markup).toContain('aria-label="AC Decibels"');
+    expect(markup).toContain('aria-label="AC Phase"');
+    expect(markup).toContain("dB");
+    expect(markup).toContain("deg");
+    expect(markup).toMatch(/-\d/);
+    expect(markup).not.toContain(">Magnitude</button>");
+    expect(markup.match(/class="simulation-plot-layout"/gu)).toHaveLength(2);
+  });
   it("uses a compact analysis heading and one trailing measurement summary", () => {
     const markup = renderToStaticMarkup(
       <SimulationOutputResults

--- a/apps/editor/src/features/simulation/simulation-output-results.test.tsx
+++ b/apps/editor/src/features/simulation/simulation-output-results.test.tsx
@@ -7,6 +7,7 @@ describe("Simulation Output Results", () => {
   it("shows captured singletons as record-local table values without rendering a waveform", () => {
     const markup = renderToStaticMarkup(
       <SimulationOutputResults
+        resultKey="captured-scalar-only"
         outputs={[]}
         data={{
           schemaVersion: 1,

--- a/apps/editor/src/features/simulation/simulation-output-results.test.tsx
+++ b/apps/editor/src/features/simulation/simulation-output-results.test.tsx
@@ -4,6 +4,47 @@ import { describe, expect, it } from "vitest";
 import { SimulationOutputResults } from "./simulation-output-results";
 
 describe("Simulation Output Results", () => {
+  it("shows captured singletons as record-local table values without rendering a waveform", () => {
+    const markup = renderToStaticMarkup(
+      <SimulationOutputResults
+        outputs={[]}
+        data={{
+          schemaVersion: 1,
+          diagnostics: [],
+          analyses: [
+            {
+              analysis: "ac",
+              plotName: "AC",
+              rawPlotOrdinals: [0],
+              domain: { name: "Frequency", unit: "Hz", values: [100, 200] },
+              outputs: [],
+              scalars: [
+                {
+                  id: "native:peak",
+                  label: "peak_gain_db",
+                  unit: "",
+                  value: 4.43515,
+                },
+                {
+                  id: "native:z",
+                  label: "phasor",
+                  unit: "V",
+                  value: 3,
+                  imaginary: -4,
+                },
+              ],
+            },
+          ],
+        }}
+      />,
+    );
+    expect(markup).toContain('aria-label="Captured scalars record 1"');
+    expect(markup).toContain("4.435150");
+    expect(markup).toContain("Unknown");
+    expect(markup).toContain("− j4.000000");
+    expect(markup).not.toContain("<svg");
+    expect(markup).not.toContain("waveform-trace-list");
+  });
   it("renders signed native dB and phase in independent unit-labelled plots", () => {
     const markup = renderToStaticMarkup(
       <SimulationOutputResults

--- a/apps/editor/src/features/simulation/simulation-output-results.tsx
+++ b/apps/editor/src/features/simulation/simulation-output-results.tsx
@@ -195,9 +195,11 @@ function simulationAnalysisTitle(kind: SimulationAnalysisKind): string {
 export function SimulationAnalysisCard({
   kind,
   children,
+  toolbar,
 }: {
   kind: SimulationAnalysisKind;
   children: ReactNode;
+  toolbar?: ReactNode;
 }) {
   const title = simulationAnalysisTitle(kind);
   return (
@@ -208,6 +210,7 @@ export function SimulationAnalysisCard({
       <header className="simulation-analysis-card-header">
         <h3>{title}</h3>
       </header>
+      {toolbar}
       <div className="simulation-analysis-card-body">{children}</div>
     </section>
   );
@@ -354,16 +357,25 @@ export function SimulationOutputResults({
                 <SimulationAnalysisCard
                   key={`${analysis.analysis}-${analysisIndex}`}
                   kind={analysis.analysis}
+                  toolbar={
+                    <>
+                      {data.analyses.filter(
+                        (a) => a.analysis === analysis.analysis,
+                      ).length > 1 ? (
+                        <p>
+                          Record {analysisIndex + 1} · {analysis.plotName} · raw
+                          plots{" "}
+                          {analysis.rawPlotOrdinals?.join(", ") ??
+                            "unavailable"}
+                        </p>
+                      ) : null}
+                      <ResultPlotControls
+                        view={view}
+                        outputs={analysis.outputs}
+                      />
+                    </>
+                  }
                 >
-                  {data.analyses.filter((a) => a.analysis === analysis.analysis)
-                    .length > 1 ? (
-                    <p>
-                      Record {analysisIndex + 1} · {analysis.plotName} · raw
-                      plots{" "}
-                      {analysis.rawPlotOrdinals?.join(", ") ?? "unavailable"}
-                    </p>
-                  ) : null}
-                  <ResultPlotControls view={view} outputs={analysis.outputs} />
                   {analysis.analysis === "ac" && complex.length > 0 ? (
                     <ComplexResultsExplorer
                       resultKey={recordKey}

--- a/apps/editor/src/features/simulation/simulation-output-results.tsx
+++ b/apps/editor/src/features/simulation/simulation-output-results.tsx
@@ -18,6 +18,7 @@ import {
 import { ScalarResultsExplorer } from "./transient-results-explorer";
 import { SimulationMeasurementResults } from "./simulation-measurement-results";
 import { NativeMeasurementResults } from "./native-measurement-results";
+import { CapturedScalarResults } from "./captured-scalar-results";
 import { NoiseResultsExplorer } from "./noise-results-explorer";
 import { planResultOutput } from "./result-plot-plan";
 import { ResultRecordView, ResultPlotControls } from "./result-plot-controls";
@@ -355,6 +356,10 @@ export function SimulationOutputResults({
                   key={`${analysis.analysis}-${analysisIndex}`}
                   kind={analysis.analysis}
                 >
+                  <CapturedScalarResults
+                    scalars={analysis.scalars ?? []}
+                    record={analysisIndex + 1}
+                  />
                   {data.analyses.filter((a) => a.analysis === analysis.analysis)
                     .length > 1 ? (
                     <p>

--- a/apps/editor/src/features/simulation/simulation-output-results.tsx
+++ b/apps/editor/src/features/simulation/simulation-output-results.tsx
@@ -19,6 +19,8 @@ import { ScalarResultsExplorer } from "./transient-results-explorer";
 import { SimulationMeasurementResults } from "./simulation-measurement-results";
 import { NativeMeasurementResults } from "./native-measurement-results";
 import { NoiseResultsExplorer } from "./noise-results-explorer";
+import { planResultOutput } from "./result-plot-plan";
+import { ResultRecordView, ResultPlotControls } from "./result-plot-controls";
 
 export type SimulationAnalysisKind = "op" | "dc" | "ac" | "tran" | "noise";
 
@@ -150,7 +152,7 @@ function ScalarPresentationFamilyResults({
         </div>
       </div>
       <ScalarResultsExplorer
-        resultKey={`${resultKey}:${family.base.id}`}
+        resultKey={resultKey}
         plotName={plotName}
         domain={domain}
         analysisLabel={analysisLabel}
@@ -162,7 +164,8 @@ function ScalarPresentationFamilyResults({
             id: family.base.id,
             label: family.base.label,
             colorIndex: 0,
-            quantity: scalarQuantity(selected.result.unit),
+            quantity: `family:${family.base.id}:${selected.result.unit}`,
+            groupLabel: scalarQuantity(selected.result.unit),
             unit: selected.result.unit === "1" ? null : selected.result.unit,
             values: selected.result.values.map((value) => value ?? Number.NaN),
             ...(probe ? { probe } : {}),
@@ -289,152 +292,188 @@ export function SimulationOutputResults({
             </SimulationAnalysisCard>
           );
         if (!analysis.domain) return null;
-        const complex = analysis.outputs.filter((output) => output.imaginary);
-        const complexFamilies = new Set(
-          complex.flatMap((output) => {
-            const expression = authored.get(output.id)?.expression;
-            return expression ? [presentationBase(expression)] : [];
-          }),
-        );
-        const scalarFamilies = presentationFamilies.flatMap((family) => {
-          const baseResult = analysis.outputs.find(
-            (output) => output.id === family.base.id && !output.imaginary,
-          );
-          if (!baseResult) return [];
-          const variants = family.variants.flatMap((spec) => {
-            const result = analysis.outputs.find(
-              (output) => output.id === spec.id && !output.imaginary,
-            );
-            return result ? [{ spec, result }] : [];
-          });
-          return variants.length > 1 ? [{ family, variants }] : [];
-        });
-        const scalarFamilyOutputIds = new Set(
-          scalarFamilies.flatMap(({ variants }) =>
-            variants.map(({ spec }) => spec.id),
-          ),
-        );
-        const scalar = analysis.outputs.filter((output) => {
-          if (output.imaginary) return false;
-          if (scalarFamilyOutputIds.has(output.id)) return false;
-          if (analysis.analysis !== "ac") return true;
-          const expression = authored.get(output.id)?.expression;
-          return !(
-            expression &&
-            PRESENTATION_KINDS.has(expression.kind) &&
-            complexFamilies.has(presentationBase(expression))
-          );
-        });
-        const scalarByUnit = new Map<string, typeof scalar>();
-        for (const output of scalar)
-          scalarByUnit.set(output.unit, [
-            ...(scalarByUnit.get(output.unit) ?? []),
-            output,
-          ]);
+        const recordKey = `${resultKey}:record:${analysisIndex}`;
         return (
-          <SimulationAnalysisCard
-            key={`${analysis.analysis}-${analysisIndex}`}
-            kind={analysis.analysis}
-          >
-            {analysis.analysis === "ac" && complex.length > 0 ? (
-              <ComplexResultsExplorer
-                resultKey={`${resultKey}:complex:${analysisIndex}`}
-                plotName={analysis.plotName}
-                traces={complex.map((output, colorIndex) => {
-                  const phases = unwrapPhaseDegrees(
-                    output.values.map(
-                      (value, i) =>
-                        (Math.atan2(
-                          output.imaginary![i] ?? Number.NaN,
-                          value ?? Number.NaN,
-                        ) *
-                          180) /
-                        Math.PI,
-                    ),
-                  );
-                  const probe = probes.find((probe) => probe.id === output.id);
-                  return {
-                    id: output.id,
-                    label: output.label,
-                    colorIndex,
-                    unit: output.unit,
-                    quantity:
-                      output.unit === "V"
-                        ? "voltage"
-                        : output.unit === "A"
-                          ? "current"
-                          : output.unit === "1"
-                            ? "ratio"
-                            : output.unit,
-                    ...(probe ? { probe } : {}),
-                    points: analysis.domain!.values.map((frequency, i) => ({
-                      ...complexAcPoint(
-                        frequency,
-                        output.values[i] ?? Number.NaN,
-                        output.imaginary![i] ?? Number.NaN,
-                      ),
-                      phaseDeg: phases[i] ?? Number.NaN,
-                    })),
-                  };
-                })}
-                {...(onFocusProbe ? { onFocusProbe } : {})}
-              />
-            ) : null}
-            {scalarFamilies.map(({ family, variants }) => (
-              <ScalarPresentationFamilyResults
-                key={family.base.id}
-                family={family}
-                variants={variants}
-                resultKey={`${resultKey}:${analysis.analysis}:${analysisIndex}`}
-                plotName={analysis.plotName}
-                analysisLabel={
-                  analysis.analysis === "tran"
-                    ? "Transient"
-                    : analysis.analysis.toUpperCase()
-                }
-                domain={analysis.domain!.values}
-                domainLabel={analysis.domain!.name}
-                domainUnit={analysis.domain!.unit}
-                logarithmicX={analysis.analysis === "ac"}
-                probes={probes}
-                {...(onFocusProbe ? { onFocusProbe } : {})}
-              />
-            ))}
-            {[...scalarByUnit.entries()].map(([unit, unitOutputs]) => {
-              return (
-                <ScalarResultsExplorer
-                  key={unit}
-                  resultKey={`${resultKey}:${analysis.analysis}:${analysisIndex}:${unit}`}
-                  plotName={analysis.plotName}
-                  domain={analysis.domain!.values}
-                  analysisLabel={
-                    analysis.analysis === "tran"
-                      ? "Transient"
-                      : analysis.analysis.toUpperCase()
-                  }
-                  domainLabel={analysis.domain!.name}
-                  domainUnit={analysis.domain!.unit}
-                  logarithmicX={analysis.analysis === "ac"}
-                  traces={unitOutputs.map((output, colorIndex) => ({
-                    id: output.id,
-                    label: output.label,
-                    colorIndex,
-                    quantity: scalarQuantity(unit),
-                    unit: unit === "1" ? null : unit,
-                    values: output.values.map((value) => value ?? Number.NaN),
-                    ...(probes.find((probe) => probe.id === output.id)
-                      ? {
-                          probe: probes.find(
-                            (probe) => probe.id === output.id,
-                          )!,
-                        }
-                      : {}),
-                  }))}
-                  {...(onFocusProbe ? { onFocusProbe } : {})}
-                />
+          <ResultRecordView key={recordKey} resultKey={recordKey}>
+            {(view) => {
+              const planned = new Map(
+                analysis.outputs.map((output) => [
+                  output.id,
+                  planResultOutput(
+                    output,
+                    view.state.plotLayout,
+                    view.state.unitOverrides[output.id],
+                  ),
+                ]),
               );
-            })}
-          </SimulationAnalysisCard>
+              const complex = analysis.outputs.filter(
+                (output) => planned.get(output.id)!.complexView,
+              );
+              const complexFamilies = new Set(
+                complex.flatMap((output) => {
+                  const expression = authored.get(output.id)?.expression;
+                  return expression ? [presentationBase(expression)] : [];
+                }),
+              );
+              const scalarFamilies = presentationFamilies.flatMap((family) => {
+                const baseResult = analysis.outputs.find(
+                  (output) => output.id === family.base.id && !output.imaginary,
+                );
+                if (!baseResult) return [];
+                const variants = family.variants.flatMap((spec) => {
+                  const result = analysis.outputs.find(
+                    (output) => output.id === spec.id && !output.imaginary,
+                  );
+                  return result ? [{ spec, result }] : [];
+                });
+                return variants.length > 1 ? [{ family, variants }] : [];
+              });
+              const scalarFamilyOutputIds = new Set(
+                scalarFamilies.flatMap(({ variants }) =>
+                  variants.map(({ spec }) => spec.id),
+                ),
+              );
+              const scalar = analysis.outputs.filter((output) => {
+                if (planned.get(output.id)!.complexView) return false;
+                if (scalarFamilyOutputIds.has(output.id)) return false;
+                if (analysis.analysis !== "ac") return true;
+                const expression = authored.get(output.id)?.expression;
+                return !(
+                  expression &&
+                  PRESENTATION_KINDS.has(expression.kind) &&
+                  complexFamilies.has(presentationBase(expression))
+                );
+              });
+              const scalarByUnit = new Map<string, typeof scalar>();
+              for (const output of scalar)
+                scalarByUnit.set(planned.get(output.id)!.group, [
+                  ...(scalarByUnit.get(planned.get(output.id)!.group) ?? []),
+                  output,
+                ]);
+              return (
+                <SimulationAnalysisCard
+                  key={`${analysis.analysis}-${analysisIndex}`}
+                  kind={analysis.analysis}
+                >
+                  {data.analyses.filter((a) => a.analysis === analysis.analysis)
+                    .length > 1 ? (
+                    <p>
+                      Record {analysisIndex + 1} · {analysis.plotName} · raw
+                      plots{" "}
+                      {analysis.rawPlotOrdinals?.join(", ") ?? "unavailable"}
+                    </p>
+                  ) : null}
+                  <ResultPlotControls view={view} outputs={analysis.outputs} />
+                  {analysis.analysis === "ac" && complex.length > 0 ? (
+                    <ComplexResultsExplorer
+                      resultKey={recordKey}
+                      plotName={analysis.plotName}
+                      traces={complex.map((output) => {
+                        const phases = unwrapPhaseDegrees(
+                          output.values.map(
+                            (value, i) =>
+                              (Math.atan2(
+                                output.imaginary![i] ?? Number.NaN,
+                                value ?? Number.NaN,
+                              ) *
+                                180) /
+                              Math.PI,
+                          ),
+                        );
+                        const probe = probes.find(
+                          (probe) => probe.id === output.id,
+                        );
+                        return {
+                          id: output.id,
+                          label: output.label,
+                          colorIndex: analysis.outputs.indexOf(output),
+                          unit: planned.get(output.id)!.unit || "unknown",
+                          quantity: planned.get(output.id)!.group,
+                          groupLabel: planned.get(output.id)!.groupLabel,
+                          defaultMode:
+                            planned.get(output.id)!.kind === "unknown"
+                              ? ("real" as const)
+                              : ("magnitude" as const),
+                          ...(probe ? { probe } : {}),
+                          points: analysis.domain!.values.map(
+                            (frequency, i) => ({
+                              ...complexAcPoint(
+                                frequency,
+                                output.values[i] ?? Number.NaN,
+                                output.imaginary![i] ?? Number.NaN,
+                              ),
+                              phaseDeg: phases[i] ?? Number.NaN,
+                            }),
+                          ),
+                        };
+                      })}
+                      {...(onFocusProbe ? { onFocusProbe } : {})}
+                    />
+                  ) : null}
+                  {scalarFamilies.map(({ family, variants }) => (
+                    <ScalarPresentationFamilyResults
+                      key={family.base.id}
+                      family={family}
+                      variants={variants}
+                      resultKey={recordKey}
+                      plotName={analysis.plotName}
+                      analysisLabel={
+                        analysis.analysis === "tran"
+                          ? "Transient"
+                          : analysis.analysis.toUpperCase()
+                      }
+                      domain={analysis.domain!.values}
+                      domainLabel={analysis.domain!.name}
+                      domainUnit={analysis.domain!.unit}
+                      logarithmicX={analysis.analysis === "ac"}
+                      probes={probes}
+                      {...(onFocusProbe ? { onFocusProbe } : {})}
+                    />
+                  ))}
+                  {[...scalarByUnit.entries()].map(([group, unitOutputs]) => {
+                    return (
+                      <ScalarResultsExplorer
+                        key={group}
+                        resultKey={recordKey}
+                        plotName={analysis.plotName}
+                        domain={analysis.domain!.values}
+                        analysisLabel={
+                          analysis.analysis === "tran"
+                            ? "Transient"
+                            : analysis.analysis.toUpperCase()
+                        }
+                        domainLabel={analysis.domain!.name}
+                        domainUnit={analysis.domain!.unit}
+                        logarithmicX={analysis.analysis === "ac"}
+                        traces={unitOutputs.map((output) => ({
+                          id: output.id,
+                          label: output.label,
+                          colorIndex: analysis.outputs.indexOf(output),
+                          quantity: group,
+                          groupLabel: planned.get(output.id)!.groupLabel,
+                          unit:
+                            planned.get(output.id)!.unit === "1"
+                              ? null
+                              : planned.get(output.id)!.unit || "unknown",
+                          values: output.values.map(
+                            (value) => value ?? Number.NaN,
+                          ),
+                          ...(probes.find((probe) => probe.id === output.id)
+                            ? {
+                                probe: probes.find(
+                                  (probe) => probe.id === output.id,
+                                )!,
+                              }
+                            : {}),
+                        }))}
+                        {...(onFocusProbe ? { onFocusProbe } : {})}
+                      />
+                    );
+                  })}
+                </SimulationAnalysisCard>
+              );
+            }}
+          </ResultRecordView>
         );
       })}
       {data.diagnostics.length > 0 ? (

--- a/apps/editor/src/features/simulation/transient-results-explorer.test.tsx
+++ b/apps/editor/src/features/simulation/transient-results-explorer.test.tsx
@@ -9,6 +9,14 @@ import {
 } from "./transient-results-explorer";
 
 describe("Transient Results Explorer", () => {
+  it("fits a log-frequency window to the same line intersections it draws", () => {
+    const values = transientVisibleValues([1, 1000], [0, -90], [10, 100], true);
+    expect(values[0]).toBeCloseTo(-30);
+    expect(values[1]).toBeCloseTo(-60);
+    expect(transientVisibleValues([0, 100], [0, -90], [10, 50], true)).toEqual(
+      [],
+    );
+  });
   it("maps the simulator's actual time coordinates rather than point indices", () => {
     const points = transientPolylinePoints([0, 1e-9, 10e-9], [0, 0.5, 1]);
     const x = points.split(" ").map((point) => Number(point.split(",")[0]));

--- a/apps/editor/src/features/simulation/transient-results-explorer.tsx
+++ b/apps/editor/src/features/simulation/transient-results-explorer.tsx
@@ -98,20 +98,29 @@ export function transientVisibleValues(
   times: readonly number[],
   values: readonly number[],
   range: readonly [number, number],
+  logarithmicX = false,
 ): number[] {
   const result: number[] = [];
   for (let i = 0; i < Math.min(times.length, values.length); i++) {
     const x = times[i]!,
       y = values[i]!;
-    if (!Number.isFinite(x) || !Number.isFinite(y)) continue;
+    if (!Number.isFinite(x) || !Number.isFinite(y) || (logarithmicX && x <= 0))
+      continue;
     if (x >= range[0] && x <= range[1]) result.push(y);
     if (i === 0) continue;
     const prevX = times[i - 1]!,
       prevY = values[i - 1]!;
-    if (!Number.isFinite(prevY) || x <= prevX) continue;
+    if (!Number.isFinite(prevY) || x <= prevX || (logarithmicX && prevX <= 0))
+      continue;
     for (const edge of range)
       if (prevX < edge && x > edge)
-        result.push(prevY + ((y - prevY) * (edge - prevX)) / (x - prevX));
+        result.push(
+          prevY +
+            (y - prevY) *
+              (logarithmicX
+                ? Math.log(edge / prevX) / Math.log(x / prevX)
+                : (edge - prevX) / (x - prevX)),
+        );
   }
   return result;
 }
@@ -300,7 +309,7 @@ export function ScalarResultsExplorer({
     const range = timeRange ?? fullRange;
     const clipId = `${clipPrefix}-${[...quantity].map((c) => c.codePointAt(0)!.toString(16)).join("-")}-${expanded}`;
     const visibleValues = quantityTraces.flatMap((trace) =>
-      transientVisibleValues(domain, trace.values, range),
+      transientVisibleValues(domain, trace.values, range, logarithmicX),
     );
     const automaticExtent = transientValueExtent(visibleValues);
     const extent = valueRanges[quantity] ?? automaticExtent;

--- a/apps/editor/src/features/simulation/transient-results-explorer.tsx
+++ b/apps/editor/src/features/simulation/transient-results-explorer.tsx
@@ -18,6 +18,7 @@ export interface ScalarTrace {
   readonly label: string;
   readonly colorIndex: number;
   readonly quantity: string;
+  readonly groupLabel?: string;
   readonly unit: string | null;
   readonly values: readonly number[];
   readonly probe?: SimulationFocusTarget;
@@ -247,6 +248,9 @@ export function ScalarResultsExplorer({
   const timeRange = controller.view.x;
   const valueRanges = controller.view.y;
   const [expandedQuantity, setExpandedQuantity] = useState<string | null>(null);
+  const expandedLabel =
+    traces.find((trace) => trace.quantity === expandedQuantity)?.groupLabel ??
+    expandedQuantity;
   const visible = traces.filter((trace) => !hidden.has(trace.id));
   const fullRange = finiteExtent(domain);
   const xFraction = (value: number, range: readonly [number, number]) =>
@@ -294,7 +298,7 @@ export function ScalarResultsExplorer({
   ) => {
     const geometry = expanded ? EXPANDED_PLOT : { ...PLOT, ...slotSize };
     const range = timeRange ?? fullRange;
-    const clipId = `${clipPrefix}-${quantity}-${expanded}`;
+    const clipId = `${clipPrefix}-${[...quantity].map((c) => c.codePointAt(0)!.toString(16)).join("-")}-${expanded}`;
     const visibleValues = quantityTraces.flatMap((trace) =>
       transientVisibleValues(domain, trace.values, range),
     );
@@ -383,7 +387,7 @@ export function ScalarResultsExplorer({
         >
           <svg
             role="img"
-            aria-label={`${analysisLabel} ${quantity}`}
+            aria-label={`${analysisLabel} ${quantityTraces[0]?.groupLabel ?? quantity}`}
             viewBox={`0 0 ${geometry.width} ${geometry.height}`}
           >
             <line
@@ -469,7 +473,7 @@ export function ScalarResultsExplorer({
               x={geometry.left}
               y={geometry.top - 5}
             >
-              {quantity}
+              {quantityTraces[0]?.groupLabel ?? quantity}
               {yLabels.unit ? `/${yLabels.unit}` : ""}
             </text>
             {waveformTicks(
@@ -704,7 +708,7 @@ export function ScalarResultsExplorer({
           >
             <div className="simulation-plot-layout">
               <WaveformTraceList
-                label={`${analysisLabel} ${quantity} outputs`}
+                label={`${analysisLabel} ${quantityTraces[0]?.groupLabel ?? quantity} outputs`}
                 traces={quantityTraces.map((trace) => ({
                   id: trace.id,
                   label: trace.label,
@@ -743,14 +747,13 @@ export function ScalarResultsExplorer({
                 className="ac-plot-dialog"
                 role="dialog"
                 aria-modal="true"
-                aria-label={`${analysisLabel} ${expandedQuantity} plot`}
+                aria-label={`${analysisLabel} ${expandedLabel} plot`}
               >
                 <header>
                   <div>
                     <strong>{plotName}</strong>
                     <span>
-                      {expandedQuantity} · {analysisLabel.toLowerCase()}{" "}
-                      waveform
+                      {expandedLabel} · {analysisLabel.toLowerCase()} waveform
                     </span>
                   </div>
                   <button
@@ -763,7 +766,7 @@ export function ScalarResultsExplorer({
                 </header>
                 <div className="simulation-plot-layout expanded">
                   <WaveformTraceList
-                    label={`${analysisLabel} ${expandedQuantity} outputs`}
+                    label={`${analysisLabel} ${expandedLabel} outputs`}
                     traces={traces
                       .filter((trace) => trace.quantity === expandedQuantity)
                       .map((trace) => ({

--- a/apps/editor/src/features/simulation/waveform-view.ts
+++ b/apps/editor/src/features/simulation/waveform-view.ts
@@ -1,4 +1,9 @@
-import { useEffect, useState, type SetStateAction } from "react";
+import {
+  useCallback,
+  useState,
+  useSyncExternalStore,
+  type SetStateAction,
+} from "react";
 
 export type WaveformRange = readonly [number, number];
 export type WaveformAxes = "xy" | "x" | "y";
@@ -15,6 +20,8 @@ export interface WaveformState {
   activeMarker: MarkerName;
   hidden: ReadonlySet<string>;
   selected: string | null;
+  plotLayout: "units" | "separate";
+  unitOverrides: Readonly<Record<string, string>>;
 }
 export function initialWaveformState(): WaveformState {
   return {
@@ -25,6 +32,8 @@ export function initialWaveformState(): WaveformState {
     activeMarker: "A",
     hidden: new Set(),
     selected: null,
+    plotLayout: "units",
+    unitOverrides: {},
   };
 }
 
@@ -60,23 +69,49 @@ export function travelWaveformView(
 /** Session-only result views. Unique run/analysis keys prevent reuse on a new run.
  * Bounded storage survives tab/panel unmounts without retaining numeric results.
  */
-const resultViews = new Map<string, WaveformState>();
+const resultViews = new Map<
+  string,
+  { state: WaveformState; listeners: Set<() => void> }
+>();
+function resultView(key: string) {
+  let entry = resultViews.get(key);
+  if (!entry) {
+    entry = { state: initialWaveformState(), listeners: new Set() };
+    resultViews.set(key, entry);
+  }
+  for (const [oldKey, old] of resultViews) {
+    if (resultViews.size <= 24) break;
+    if (oldKey !== key && !old.listeners.size) resultViews.delete(oldKey);
+  }
+  return entry;
+}
 export function useWaveformView(resultKey?: string) {
-  const [state, setState] = useState(
-    () =>
-      (resultKey ? resultViews.get(resultKey) : undefined) ??
-      initialWaveformState(),
+  const [local, setLocal] = useState(initialWaveformState);
+  const subscribe = useCallback(
+    (listener: () => void) => {
+      if (!resultKey) return () => {};
+      const entry = resultView(resultKey);
+      entry.listeners.add(listener);
+      return () => {
+        entry.listeners.delete(listener);
+      };
+    },
+    [resultKey],
   );
-  useEffect(() => {
-    if (resultKey) {
-      resultViews.delete(resultKey);
-      resultViews.set(resultKey, state);
-      if (resultViews.size > 24)
-        resultViews.delete(resultViews.keys().next().value!);
+  const snapshot = useCallback(
+    () => (resultKey ? resultView(resultKey).state : local),
+    [resultKey, local],
+  );
+  const state = useSyncExternalStore(subscribe, snapshot, snapshot);
+  const update = (apply: (current: WaveformState) => WaveformState) => {
+    if (!resultKey) {
+      setLocal(apply);
+      return;
     }
-  }, [resultKey, state]);
-  const update = (apply: (current: WaveformState) => WaveformState) =>
-    setState(apply);
+    const entry = resultView(resultKey);
+    entry.state = apply(entry.state);
+    for (const listener of entry.listeners) listener();
+  };
   const set = <K extends keyof WaveformState>(
     key: K,
     value: SetStateAction<WaveformState[K]>,

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -1889,6 +1889,23 @@
   align-items: start;
   min-width: 0;
 }
+.simulation-plot-controls {
+  color: var(--icm-text-muted);
+  font-size: 12px;
+  margin-bottom: 8px;
+}
+.simulation-plot-controls summary {
+  cursor: pointer;
+}
+.simulation-plot-controls label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin: 8px 12px 0 0;
+}
+.simulation-plot-controls p {
+  margin: 6px 0;
+}
 .simulation-plot-stack {
   display: grid;
   gap: 8px;

--- a/docs/specs/simulation-results.md
+++ b/docs/specs/simulation-results.md
@@ -203,6 +203,34 @@ and Preview checks:
 Preview qualification may additionally require a named environment, probes,
 and numeric tolerances. It does not reclassify the underlying run.
 
+### Captured native scalars
+
+AC, DC and transient plots may include short vectors declared by ngspice's
+`dims=1` variable qualifier. Their first real/imaginary value is captured in
+the record's optional `scalars` array; the remaining rawfile padding is not
+sweep data. Constant waveforms and single-point sweeps without that declaration
+remain waveforms. Unsupported short arrays and malformed dimensions produce
+diagnostics instead of being plotted against the wrong axis.
+
+The evaluated record also carries `scalars`, separate from curve `outputs`.
+Results shows these in a **Captured values** table per record, preserving signed
+and complex numbers. They do not generate curve min/max/span/RMS summaries and
+are not image-export traces. Both raw and evaluated CSV append a separately
+headed scalar table. Unknown units stay explicitly unknown; a variable suffix
+such as `_db` does not establish a unit.
+
+Console measurement reports remain separate evidence: only declarations reached
+from the executed entry/include graph participate, and repeated report names
+retain Console order. The UI does not invent an association between Console
+lines and raw records. A value may therefore appear as both a captured scalar
+and a Console report, with their different provenance made explicit.
+
+Hosted responses with numeric data and explicit rawfile dimensions are re-read
+by the same canonical reader to handle executor-image version skew. Missing
+numeric data is not resurrected. Archives without retained dimension evidence
+cannot be safely repaired from names or zero padding; rerun them to capture
+the corrected result.
+
 ### Authored measurements
 
 An authored measurement references one enabled analysis and one named Output.

--- a/docs/specs/simulation-results.md
+++ b/docs/specs/simulation-results.md
@@ -239,7 +239,35 @@ crossing or insufficient sample window must not become zero and must not change
 an otherwise completed Run into a failed Run. The service is the sole numerical
 owner: GUI, Agent responses, and `measurements.csv` consume the same rows.
 
-## Validation
+## Plot semantics and grouping
+
+Evaluated outputs may carry `semantics`: `valueKind` (`real`, `complex`, or
+`unknown`), the raw `quantity`, `origin` (`raw` or `expression`), and the
+captured native `expression` when available. This metadata is derived from
+the executed source snapshot, never from later editor text or variable-name
+suffixes. Existing archives without it remain readable.
+
+Complex rawfile storage is not an instruction to take magnitude. Physical AC
+acquisitions remain complex even when every imaginary sample is zero. Native
+`db`, `ph`/`cph`, and supported explicit degree conversions are already real
+results: their signs are preserved without applying another magnitude, logarithm,
+or phase transformation. Source inference is deliberately bounded; conflicting
+assignments, dynamic control programs and unsupported expressions stay unknown.
+It does not execute ngspice or replace its numeric results.
+
+Waveform views group compatible units and representations, with independent
+vertical axes. Unknown outputs are isolated, not labelled dimensionless.
+Users may separate each trace for scale differences and declare an unknown
+display unit; declarations label existing values rather than converting them.
+Within one analysis record, plots share horizontal range, history and cursors.
+Repeated records remain separate, with independent view state. These preferences
+are session-only and do not modify Code, the Project, or the simulation input.
+Image exports use the same renderer; raw numeric exports retain recorded values.
+Older archives without sufficient semantics use conservative raw/real display
+for unknown values instead of guessing from names. XY plots, cross-run alignment
+and persisted plot templates are outside this contract.
+
+## Validation evidence
 
 Rawfile, result-data, expression, and measurement tests protect parsing and
 numerical meaning. Closed-form fixtures and model-backed hosted qualification

--- a/fixtures/agent-api/agent-circuit.openapi.json
+++ b/fixtures/agent-api/agent-circuit.openapi.json
@@ -33914,6 +33914,9 @@
                                       "type": "string",
                                       "const": "op"
                                     },
+                                    "scalars": {
+                                      "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema18"
+                                    },
                                     "plotName": {
                                       "type": "string"
                                     },
@@ -33923,13 +33926,13 @@
                                         "type": "object",
                                         "properties": {
                                           "name": {
-                                            "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema18"
-                                          },
-                                          "quantity": {
                                             "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema19"
                                           },
-                                          "unit": {
+                                          "quantity": {
                                             "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema20"
+                                          },
+                                          "unit": {
+                                            "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema21"
                                           },
                                           "value": {
                                             "type": "number"
@@ -33959,6 +33962,9 @@
                                       "type": "string",
                                       "const": "ac"
                                     },
+                                    "scalars": {
+                                      "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema18"
+                                    },
                                     "rawPlotOrdinals": {
                                       "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema16"
                                     },
@@ -33977,13 +33983,13 @@
                                         "type": "object",
                                         "properties": {
                                           "name": {
-                                            "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema18"
-                                          },
-                                          "quantity": {
                                             "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema19"
                                           },
-                                          "unit": {
+                                          "quantity": {
                                             "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema20"
+                                          },
+                                          "unit": {
+                                            "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema21"
                                           },
                                           "real": {
                                             "type": "array",
@@ -34024,6 +34030,9 @@
                                       "type": "string",
                                       "const": "dc"
                                     },
+                                    "scalars": {
+                                      "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema18"
+                                    },
                                     "rawPlotOrdinals": {
                                       "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema16"
                                     },
@@ -34034,13 +34043,13 @@
                                       "type": "object",
                                       "properties": {
                                         "name": {
-                                          "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema18"
-                                        },
-                                        "quantity": {
                                           "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema19"
                                         },
-                                        "unit": {
+                                        "quantity": {
                                           "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema20"
+                                        },
+                                        "unit": {
+                                          "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema21"
                                         },
                                         "values": {
                                           "type": "array",
@@ -34063,13 +34072,13 @@
                                         "type": "object",
                                         "properties": {
                                           "name": {
-                                            "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema18"
-                                          },
-                                          "quantity": {
                                             "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema19"
                                           },
-                                          "unit": {
+                                          "quantity": {
                                             "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema20"
+                                          },
+                                          "unit": {
+                                            "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema21"
                                           },
                                           "value": {
                                             "type": "array",
@@ -34103,6 +34112,9 @@
                                       "type": "string",
                                       "const": "tran"
                                     },
+                                    "scalars": {
+                                      "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema18"
+                                    },
                                     "rawPlotOrdinals": {
                                       "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema16"
                                     },
@@ -34121,13 +34133,13 @@
                                         "type": "object",
                                         "properties": {
                                           "name": {
-                                            "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema18"
-                                          },
-                                          "quantity": {
                                             "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema19"
                                           },
-                                          "unit": {
+                                          "quantity": {
                                             "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema20"
+                                          },
+                                          "unit": {
+                                            "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema21"
                                           },
                                           "value": {
                                             "type": "array",
@@ -34160,6 +34172,9 @@
                                     "analysis": {
                                       "type": "string",
                                       "const": "noise"
+                                    },
+                                    "scalars": {
+                                      "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema18"
                                     },
                                     "rawPlotOrdinals": {
                                       "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema16"
@@ -34452,46 +34467,17 @@
                                   "values": {
                                     "type": "array",
                                     "items": {
-                                      "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema21"
+                                      "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema22"
                                     }
                                   },
                                   "imaginary": {
                                     "type": "array",
                                     "items": {
-                                      "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema21"
+                                      "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema22"
                                     }
                                   },
                                   "semantics": {
-                                    "type": "object",
-                                    "properties": {
-                                      "valueKind": {
-                                        "type": "string",
-                                        "enum": [
-                                          "real",
-                                          "complex",
-                                          "unknown"
-                                        ]
-                                      },
-                                      "quantity": {
-                                        "type": "string"
-                                      },
-                                      "origin": {
-                                        "type": "string",
-                                        "enum": [
-                                          "raw",
-                                          "expression"
-                                        ]
-                                      },
-                                      "expression": {
-                                        "type": "string"
-                                      }
-                                    },
-                                    "required": [
-                                      "valueKind",
-                                      "quantity",
-                                      "origin"
-                                    ],
-                                    "additionalProperties": false
+                                    "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema23"
                                   }
                                 },
                                 "required": [
@@ -34503,31 +34489,16 @@
                                 "additionalProperties": false
                               }
                             },
+                            "scalars": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema24"
+                              }
+                            },
                             "integrated": {
                               "type": "array",
                               "items": {
-                                "type": "object",
-                                "properties": {
-                                  "id": {
-                                    "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema1"
-                                  },
-                                  "label": {
-                                    "type": "string"
-                                  },
-                                  "unit": {
-                                    "type": "string"
-                                  },
-                                  "value": {
-                                    "type": "number"
-                                  }
-                                },
-                                "required": [
-                                  "id",
-                                  "label",
-                                  "unit",
-                                  "value"
-                                ],
-                                "additionalProperties": false
+                                "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema24"
                               }
                             }
                           },
@@ -35026,7 +34997,7 @@
                     "maxItems": 16,
                     "type": "array",
                     "items": {
-                      "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema22"
+                      "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema25"
                     }
                   }
                 },
@@ -36137,12 +36108,42 @@
             "maximum": 9007199254740991
           },
           "__schema18": {
-            "type": "string"
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema19"
+                },
+                "quantity": {
+                  "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema20"
+                },
+                "unit": {
+                  "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema21"
+                },
+                "value": {
+                  "type": "number"
+                },
+                "imaginary": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "name",
+                "quantity",
+                "unit",
+                "value"
+              ],
+              "additionalProperties": false
+            }
           },
           "__schema19": {
             "type": "string"
           },
           "__schema20": {
+            "type": "string"
+          },
+          "__schema21": {
             "anyOf": [
               {
                 "type": "string"
@@ -36152,7 +36153,7 @@
               }
             ]
           },
-          "__schema21": {
+          "__schema22": {
             "anyOf": [
               {
                 "type": "number"
@@ -36162,7 +36163,69 @@
               }
             ]
           },
-          "__schema22": {
+          "__schema23": {
+            "type": "object",
+            "properties": {
+              "valueKind": {
+                "type": "string",
+                "enum": [
+                  "real",
+                  "complex",
+                  "unknown"
+                ]
+              },
+              "quantity": {
+                "type": "string"
+              },
+              "origin": {
+                "type": "string",
+                "enum": [
+                  "raw",
+                  "expression"
+                ]
+              },
+              "expression": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "valueKind",
+              "quantity",
+              "origin"
+            ],
+            "additionalProperties": false
+          },
+          "__schema24": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema1"
+              },
+              "label": {
+                "type": "string"
+              },
+              "unit": {
+                "type": "string"
+              },
+              "value": {
+                "type": "number"
+              },
+              "imaginary": {
+                "type": "number"
+              },
+              "semantics": {
+                "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema23"
+              }
+            },
+            "required": [
+              "id",
+              "label",
+              "unit",
+              "value"
+            ],
+            "additionalProperties": false
+          },
+          "__schema25": {
             "type": "object",
             "properties": {
               "id": {

--- a/fixtures/agent-api/agent-circuit.openapi.json
+++ b/fixtures/agent-api/agent-circuit.openapi.json
@@ -34321,6 +34321,76 @@
                         "type": "number",
                         "const": 1
                       },
+                      "nativeMeasurements": {
+                        "type": "array",
+                        "items": {
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "occurrence": {
+                                  "type": "integer",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 9007199254740991
+                                },
+                                "status": {
+                                  "type": "string",
+                                  "const": "available"
+                                },
+                                "value": {
+                                  "type": "number"
+                                },
+                                "logLine": {
+                                  "type": "integer",
+                                  "exclusiveMinimum": 0,
+                                  "maximum": 9007199254740991
+                                },
+                                "detail": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "occurrence",
+                                "status",
+                                "value",
+                                "logLine",
+                                "detail"
+                              ],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "occurrence": {
+                                  "type": "number",
+                                  "const": 0
+                                },
+                                "status": {
+                                  "type": "string",
+                                  "const": "unavailable"
+                                },
+                                "detail": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "occurrence",
+                                "status",
+                                "detail"
+                              ],
+                              "additionalProperties": false
+                            }
+                          ]
+                        }
+                      },
                       "analyses": {
                         "type": "array",
                         "items": {
@@ -34390,6 +34460,38 @@
                                     "items": {
                                       "$ref": "#/components/schemas/agentSimulationResourceResponse/$defs/__schema21"
                                     }
+                                  },
+                                  "semantics": {
+                                    "type": "object",
+                                    "properties": {
+                                      "valueKind": {
+                                        "type": "string",
+                                        "enum": [
+                                          "real",
+                                          "complex",
+                                          "unknown"
+                                        ]
+                                      },
+                                      "quantity": {
+                                        "type": "string"
+                                      },
+                                      "origin": {
+                                        "type": "string",
+                                        "enum": [
+                                          "raw",
+                                          "expression"
+                                        ]
+                                      },
+                                      "expression": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "valueKind",
+                                      "quantity",
+                                      "origin"
+                                    ],
+                                    "additionalProperties": false
                                   }
                                 },
                                 "required": [
@@ -35486,23 +35588,23 @@
                               "vgs",
                               "vds",
                               "vbs",
-                              "id"
+                              "id",
+                              "gm",
+                              "gds",
+                              "gmbs",
+                              "vth",
+                              "vdsat"
                             ]
                           },
                           "label": {
-                            "type": "string",
-                            "enum": [
-                              "VGS",
-                              "VDS",
-                              "VBS",
-                              "ID"
-                            ]
+                            "type": "string"
                           },
                           "unit": {
                             "type": "string",
                             "enum": [
                               "V",
-                              "A"
+                              "A",
+                              "S"
                             ]
                           },
                           "expression": {

--- a/fixtures/ngspice-rawfile/native-scalars-ac.raw
+++ b/fixtures/ngspice-rawfile/native-scalars-ac.raw
@@ -1,0 +1,32 @@
+Title: * scalar shape contract (synthetic arithmetic fixture)
+Date: Sun Sep 13 00:00:00 2026
+Command: ngspice-46
+Plotname: AC Analysis
+Flags: complex
+No. Variables: 5
+No. Points: 3
+Variables:
+ 0 frequency frequency grid=3
+ 1 gain_db decibel
+ 2 peak_gain_db notype dims=1
+ 3 scalar_phasor notype dims=1
+ 4 v(reference) voltage
+Values:
+ 0 100,0
+ 1,0
+ 4,0
+ 3,4
+ 1,0
+
+ 1 200,0
+ 4,0
+ 0,0
+ 0,0
+ 1,0
+
+ 2 300,0
+ 2,0
+ 0,0
+ 0,0
+ 1,0
+

--- a/fixtures/projects/compatibility-corpus.json
+++ b/fixtures/projects/compatibility-corpus.json
@@ -6,7 +6,8 @@
     "fixtures/projects/phase-1-manual/project.icproj.json",
     "fixtures/projects/phase-3-routing/project.icproj.json",
     "fixtures/projects/phase-5-dense-analog/project.icproj.json",
-    "fixtures/projects/instance-value-display/project.icproj.json"
+    "fixtures/projects/instance-value-display/project.icproj.json",
+    "netlists/native-ota/source.icproj.json"
   ],
   "rejected": [
     {

--- a/fixtures/simulation-acceptance/README.md
+++ b/fixtures/simulation-acceptance/README.md
@@ -1,0 +1,83 @@
+# Simulation acceptance Projects
+
+The existing `hosted-*.json` acceptance manifests and `ota-5t*` inputs are
+retained as service-level regression fixtures. They are not the human-importable
+native Code examples below and are not silently replaced.
+
+## Native Code Project examples
+
+From the repository root, build workspace packages, then run:
+
+```powershell
+node scripts/build-native-simulation-examples.mjs
+```
+
+The output directory is `output/native-simulation-examples`. Import one of its
+four `.icproj.json` files with File → Import in Preview, open Code, select an
+experiment folder, and run. Each Project includes its Canvas circuits and
+source files; no file from the author's Downloads directory is needed.
+
+| Project            | Experiments | Electrical intent                                                                  |
+| ------------------ | ----------- | ---------------------------------------------------------------------------------- |
+| `01-rc-filters`    | 4           | Low/high-pass AC and step response; 10 kΩ, 10 nF, 1.59155 kHz cutoff               |
+| `02-rlc-filter`    | 3           | AC plus transient at under/critical/over damping; 10 mH, 100 nF                    |
+| `03-common-source` | 4           | SKY130 bias/device OP, DC transfer, AC, small/large-signal native loop             |
+| `04-sky130-ota`    | 8           | Preserved user OTA, OP/DC, TT/FF/SS AC, open-loop transient, noise, unity feedback |
+
+Inputs live in separate `netlists/native-*/` directories. The OTA source is a
+canonicalized copy of the user-supplied Five-Transistor OTA Project, with its six-transistor
+drawing (five core devices plus bias device) and model parameters preserved.
+The closed-loop experiment binds the same DUT with an explicit text testbench;
+the open-loop Canvas testbench is not misrepresented as a feedback schematic.
+
+Experiments use source setup v4, config v2 and the pinned
+`sky130-core-continuous-ngspice46-v1` environment. SPICE owns `.temp`, `.lib`,
+`save`, `let`, `meas`, analyses and loops. There are no legacy managed outputs,
+measurements or sweep settings. Models are the declared SKY130 dependency, not
+illustrative substitutes. Temperature is 27 °C; OTA AC covers TT, FF and SS,
+and the other MOS analyses use TT. This is representative coverage, not a claim
+that every product feature, process corner or analog specification is tested.
+
+## Live MCP acceptance
+
+The runner opens isolated temporary Preview browser contexts, imports through
+the GUI, obtains a fresh full-authority claim for each temporary Project, and
+runs prepare/start/read batch and artifact export through stdio MCP. It does
+not use a user's open browser Project, restart their MCP, publish a Project,
+call simulation HTTP endpoints directly, or substitute mocked simulator data.
+
+The currently published 0.7.0 bundle predates parts of the native result
+contract. Use a genuinely recompiled current-source MCP (a fresh build-info
+path avoids an old bundled `dist/main.js` masquerading as a source build):
+
+```powershell
+pnpm --filter @icm/mcp-server... build
+pnpm exec tsc -p apps/mcp-server/tsconfig.json --tsBuildInfoFile output/native-mcp-rebuild.tsbuildinfo
+node scripts/run-native-simulation-examples.mjs
+node scripts/analyze-native-simulation-examples.mjs
+```
+
+The runner defaults to current source and records the Git revision and entry
+digest. It does not install or release a new MCP. Optional argument 2 changes
+the output directory and argument 3 selects one exact Project slug. For an
+explicit published-bundle regression, set `ICM_EXAMPLE_MCP_SOURCE=0` and place
+the manifest-verified release archive and extracted package under
+`output/mcp-published-0.7.0/`; this is expected to expose the compatibility issue
+until the release is updated.
+
+`results/<project>/<folder>/` contains immutable rawfiles, logs, result JSON,
+native measurements, CSV exports and evidence manifests with verified SHA-256
+digests. Multi-group plot exports are ZIPs. `mcp-export.icproj.json` is a
+round-trip export, not a container for run history. Run history is intentionally
+separate from portable Projects: an importing user must run again to populate
+Results. The analyzer checks finite captured values and native measurements,
+RC/RLC theory, the common-source load line and small-signal model, and nominal
+OTA bias/feedback behavior. Treat missing results or failed checks as incomplete
+acceptance, even if a simulator process exited successfully.
+
+The generator contract test checks importable structure, clean diagnostics,
+source-only experiment configuration and preservation of the user's OTA DUT:
+
+```powershell
+pnpm test:local scripts/build-native-simulation-examples.test.mjs
+```

--- a/netlists/native-common-source/circuit.spi
+++ b/netlists/native-common-source/circuit.spi
@@ -1,0 +1,7 @@
+* Resistor-loaded SKY130 common-source amplifier; model supplied by hosted Profile.
+VDD vdd 0 1.8
+VIN in 0 0.7
+RD vdd out 10k
+XM1 out in 0 0 sky130_fd_pr__nfet_01v8 W=10 L=1 nf=1
+CL out 0 1p
+.end

--- a/netlists/native-ota/source.icproj.json
+++ b/netlists/native-ota/source.icproj.json
@@ -1,0 +1,3028 @@
+{
+  "documents": [
+    {
+      "annotations": [
+        {
+          "alignment": "middle",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 615,
+              "y": 400
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 55,
+              "y": 80
+            },
+            "objectId": "XDUT"
+          },
+          "binding": {
+            "instanceId": "XDUT",
+            "kind": "instance-reference"
+          },
+          "id": "instance-label-XDUT",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "middle",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 460,
+              "y": 115
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -30,
+              "y": -45
+            },
+            "objectId": "VDD"
+          },
+          "binding": {
+            "instanceId": "VDD",
+            "kind": "instance-reference"
+          },
+          "id": "instance-label-VDD",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "middle",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 500,
+              "y": 115
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 10,
+              "y": -45
+            },
+            "objectId": "VDD"
+          },
+          "binding": {
+            "instanceId": "VDD",
+            "kind": "instance-value"
+          },
+          "id": "instance-value-VDD",
+          "kind": "instance-value",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "middle",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 375,
+              "y": 265
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -25,
+              "y": -35
+            },
+            "objectId": "VINP"
+          },
+          "binding": {
+            "instanceId": "VINP",
+            "kind": "instance-reference"
+          },
+          "id": "instance-label-VINP",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "middle",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 420,
+              "y": 265
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": -35
+            },
+            "objectId": "VINP"
+          },
+          "binding": {
+            "instanceId": "VINP",
+            "kind": "instance-value"
+          },
+          "id": "instance-value-VINP",
+          "kind": "instance-value",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "middle",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 380,
+              "y": 390
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -20,
+              "y": 40
+            },
+            "objectId": "VINN"
+          },
+          "binding": {
+            "instanceId": "VINN",
+            "kind": "instance-reference"
+          },
+          "id": "instance-label-VINN",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "middle",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 425,
+              "y": 390
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 25,
+              "y": 40
+            },
+            "objectId": "VINN"
+          },
+          "binding": {
+            "instanceId": "VINN",
+            "kind": "instance-value"
+          },
+          "id": "instance-value-VINN",
+          "kind": "instance-value",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 500,
+              "y": 205
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -50,
+              "y": -5
+            },
+            "objectId": "IBIAS"
+          },
+          "binding": {
+            "instanceId": "IBIAS",
+            "kind": "instance-reference"
+          },
+          "id": "instance-label-IBIAS",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 500,
+              "y": 230
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -50,
+              "y": 20
+            },
+            "objectId": "IBIAS"
+          },
+          "binding": {
+            "instanceId": "IBIAS",
+            "kind": "instance-value"
+          },
+          "id": "instance-value-IBIAS",
+          "kind": "instance-value",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 750,
+              "y": 355
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": -5
+            },
+            "objectId": "CL"
+          },
+          "binding": {
+            "instanceId": "CL",
+            "kind": "instance-reference"
+          },
+          "id": "instance-label-CL",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 775,
+              "y": 355
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 45,
+              "y": -5
+            },
+            "objectId": "CL"
+          },
+          "binding": {
+            "instanceId": "CL",
+            "kind": "instance-value"
+          },
+          "id": "instance-value-CL",
+          "kind": "instance-value",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "middle",
+          "anchor": {
+            "direction": "forward",
+            "fallbackPosition": {
+              "x": 685,
+              "y": 310
+            },
+            "kind": "route",
+            "legId": "route-leg-9cbad225568967f9",
+            "normalOffset": -10,
+            "orientation": "follow",
+            "routeId": "tb-vout-route",
+            "t": 0.5
+          },
+          "binding": {
+            "kind": "net-name",
+            "netId": "tb-vout-net"
+          },
+          "id": "net-label-tb-vout-route",
+          "kind": "net-label",
+          "locked": false,
+          "netId": "tb-vout-net",
+          "rotation": 0
+        }
+      ],
+      "connectivityEvidence": [
+        {
+          "id": "connectivity-evidence-33dd40c74ee1950d",
+          "kind": "name-claim",
+          "name": "0",
+          "netId": "net-split-a810f1946a2e3084",
+          "owner": {
+            "kind": "power-marker",
+            "objectId": "GND1"
+          },
+          "powerDomain": "ground",
+          "scope": "global"
+        },
+        {
+          "id": "connectivity-evidence-4fd51303c6ed3225",
+          "kind": "name-claim",
+          "name": "0",
+          "netId": "net-split-f3cbcac420d93ece",
+          "owner": {
+            "kind": "power-marker",
+            "objectId": "GND2"
+          },
+          "powerDomain": "ground",
+          "scope": "global"
+        },
+        {
+          "id": "connectivity-evidence-97019202b6a994e5",
+          "kind": "name-claim",
+          "name": "0",
+          "netId": "net-power-gnd3",
+          "owner": {
+            "kind": "power-marker",
+            "objectId": "GND3"
+          },
+          "powerDomain": "ground",
+          "scope": "global"
+        },
+        {
+          "id": "connectivity-evidence-d2bb87eae3b4a1c5",
+          "kind": "name-claim",
+          "name": "0",
+          "netId": "net-power-gnd4",
+          "owner": {
+            "kind": "power-marker",
+            "objectId": "GND4"
+          },
+          "powerDomain": "ground",
+          "scope": "global"
+        },
+        {
+          "id": "connectivity-evidence-7ec67ce55c90646d",
+          "kind": "name-claim",
+          "name": "0",
+          "netId": "net-power-gnd5",
+          "owner": {
+            "kind": "power-marker",
+            "objectId": "GND5"
+          },
+          "powerDomain": "ground",
+          "scope": "global"
+        },
+        {
+          "id": "connectivity-evidence-db342e0a821d20d0",
+          "kind": "name-claim",
+          "name": "vout",
+          "netId": "tb-vout-net",
+          "owner": {
+            "annotationId": "net-label-tb-vout-route",
+            "kind": "net-label"
+          },
+          "scope": "local"
+        }
+      ],
+      "constraints": [],
+      "drafting": {
+        "objects": []
+      },
+      "id": "document-ota-5t-testbench",
+      "instances": [
+        {
+          "id": "XDUT",
+          "netlist": {
+            "binding": {
+              "childDocumentId": "document-ota-5t",
+              "kind": "subcircuit"
+            },
+            "parameters": {}
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 560,
+              "y": 320
+            },
+            "rotation": 0
+          },
+          "reference": "XDUT",
+          "symbolId": "hierarchical-symbol-72404fc79d737213"
+        },
+        {
+          "id": "VDD",
+          "netlist": {
+            "binding": {
+              "deviceClass": "voltage-source",
+              "kind": "primitive"
+            },
+            "parameters": {
+              "dc": "1.8"
+            }
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 490,
+              "y": 160
+            },
+            "rotation": 90
+          },
+          "reference": "VDD",
+          "symbolId": "voltage-source"
+        },
+        {
+          "id": "VINP",
+          "netlist": {
+            "binding": {
+              "deviceClass": "voltage-source",
+              "kind": "primitive"
+            },
+            "parameters": {
+              "acMagnitude": "1",
+              "dc": "0.9",
+              "delay": "1u",
+              "fall": "1n",
+              "high": "0.91",
+              "low": "0.9",
+              "period": "3u",
+              "rise": "1n",
+              "waveform": "pulse",
+              "width": "1u"
+            }
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 400,
+              "y": 300
+            },
+            "rotation": 90
+          },
+          "reference": "VINP",
+          "symbolId": "voltage-source"
+        },
+        {
+          "id": "VINN",
+          "netlist": {
+            "binding": {
+              "deviceClass": "voltage-source",
+              "kind": "primitive"
+            },
+            "parameters": {
+              "dc": "0.9"
+            }
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 400,
+              "y": 350
+            },
+            "rotation": 90
+          },
+          "reference": "VINN",
+          "symbolId": "voltage-source"
+        },
+        {
+          "id": "IBIAS",
+          "netlist": {
+            "binding": {
+              "deviceClass": "current-source",
+              "kind": "primitive"
+            },
+            "parameters": {
+              "dc": "15u"
+            }
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 550,
+              "y": 210
+            },
+            "rotation": 0
+          },
+          "reference": "IBIAS",
+          "symbolId": "current-source"
+        },
+        {
+          "id": "CL",
+          "netlist": {
+            "binding": {
+              "deviceClass": "capacitor",
+              "kind": "primitive"
+            },
+            "parameters": {
+              "value": "1p"
+            }
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 730,
+              "y": 360
+            },
+            "rotation": 0
+          },
+          "reference": "CL",
+          "symbolId": "capacitor"
+        },
+        {
+          "id": "GND1",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 430,
+              "y": 160
+            },
+            "rotation": 90
+          },
+          "symbolId": "ground"
+        },
+        {
+          "id": "GND2",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 340,
+              "y": 300
+            },
+            "rotation": 90
+          },
+          "symbolId": "ground"
+        },
+        {
+          "id": "GND3",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 340,
+              "y": 350
+            },
+            "rotation": 90
+          },
+          "symbolId": "ground"
+        },
+        {
+          "id": "GND4",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 560,
+              "y": 420
+            },
+            "rotation": 0
+          },
+          "symbolId": "ground"
+        },
+        {
+          "id": "GND5",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 730,
+              "y": 400
+            },
+            "rotation": 0
+          },
+          "symbolId": "ground"
+        }
+      ],
+      "junctions": [
+        {
+          "id": "junction-canonical-fa66a02887bbb6d9",
+          "netId": "net-tb-vdd",
+          "position": {
+            "x": 550,
+            "y": 160
+          },
+          "role": "branch"
+        }
+      ],
+      "layoutGroups": [],
+      "name": "Testbench",
+      "netlist": {
+        "formalParameters": [],
+        "name": "Testbench",
+        "terminals": []
+      },
+      "nets": [
+        {
+          "id": "net-power-gnd3",
+          "terminals": [
+            {
+              "instanceId": "GND3",
+              "pinName": "0"
+            },
+            {
+              "instanceId": "VINN",
+              "pinName": "-"
+            }
+          ]
+        },
+        {
+          "id": "net-power-gnd4",
+          "terminals": [
+            {
+              "instanceId": "GND4",
+              "pinName": "0"
+            },
+            {
+              "instanceId": "XDUT",
+              "pinName": "vss"
+            }
+          ]
+        },
+        {
+          "id": "net-power-gnd5",
+          "terminals": [
+            {
+              "instanceId": "GND5",
+              "pinName": "0"
+            },
+            {
+              "instanceId": "CL",
+              "pinName": "2"
+            }
+          ]
+        },
+        {
+          "id": "net-tb-vdd",
+          "terminals": [
+            {
+              "instanceId": "VDD",
+              "pinName": "+"
+            },
+            {
+              "instanceId": "IBIAS",
+              "pinName": "+"
+            },
+            {
+              "instanceId": "XDUT",
+              "pinName": "vdd"
+            }
+          ]
+        },
+        {
+          "id": "tb-ibias-net",
+          "terminals": [
+            {
+              "instanceId": "IBIAS",
+              "pinName": "-"
+            },
+            {
+              "instanceId": "XDUT",
+              "pinName": "ibias"
+            }
+          ]
+        },
+        {
+          "id": "tb-vinp-net",
+          "terminals": [
+            {
+              "instanceId": "VINP",
+              "pinName": "+"
+            },
+            {
+              "instanceId": "XDUT",
+              "pinName": "vinp"
+            }
+          ]
+        },
+        {
+          "id": "tb-vinn-net",
+          "terminals": [
+            {
+              "instanceId": "VINN",
+              "pinName": "+"
+            },
+            {
+              "instanceId": "XDUT",
+              "pinName": "vinn"
+            }
+          ]
+        },
+        {
+          "id": "tb-vout-net",
+          "terminals": [
+            {
+              "instanceId": "XDUT",
+              "pinName": "vout"
+            },
+            {
+              "instanceId": "CL",
+              "pinName": "1"
+            }
+          ]
+        },
+        {
+          "id": "net-split-a810f1946a2e3084",
+          "terminals": [
+            {
+              "instanceId": "GND1",
+              "pinName": "0"
+            },
+            {
+              "instanceId": "VDD",
+              "pinName": "-"
+            }
+          ]
+        },
+        {
+          "id": "net-split-f3cbcac420d93ece",
+          "terminals": [
+            {
+              "instanceId": "GND2",
+              "pinName": "0"
+            },
+            {
+              "instanceId": "VINP",
+              "pinName": "-"
+            }
+          ]
+        }
+      ],
+      "noConnects": [],
+      "presentation": {
+        "compactness": "normal",
+        "grid": 10,
+        "styleProfileId": "razavi-textbook-v1"
+      },
+      "revision": 161,
+      "routes": [
+        {
+          "id": "tb-gnd-vinn-route",
+          "legs": [
+            {
+              "id": "route-leg-34fd6882297027f4",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "GND3",
+                  "kind": "terminal",
+                  "pinName": "0"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-power-gnd3",
+          "start": {
+            "instanceId": "VINN",
+            "kind": "terminal",
+            "pinName": "-"
+          }
+        },
+        {
+          "id": "tb-gnd-dut-route",
+          "legs": [
+            {
+              "id": "route-leg-ac185f3591d27db9",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "XDUT",
+                  "kind": "terminal",
+                  "pinName": "vss"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-power-gnd4",
+          "start": {
+            "instanceId": "GND4",
+            "kind": "terminal",
+            "pinName": "0"
+          }
+        },
+        {
+          "id": "tb-gnd-cl-route",
+          "legs": [
+            {
+              "id": "route-leg-af02721fb438a990",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "GND5",
+                  "kind": "terminal",
+                  "pinName": "0"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-power-gnd5",
+          "start": {
+            "instanceId": "CL",
+            "kind": "terminal",
+            "pinName": "2"
+          }
+        },
+        {
+          "id": "tb-ibias-route",
+          "legs": [
+            {
+              "id": "route-leg-9c7f13cc644db106",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "XDUT",
+                  "kind": "terminal",
+                  "pinName": "ibias"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "tb-ibias-net",
+          "start": {
+            "instanceId": "IBIAS",
+            "kind": "terminal",
+            "pinName": "-"
+          }
+        },
+        {
+          "id": "tb-vinp-route",
+          "legs": [
+            {
+              "id": "route-leg-db9df07a18d56c80",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "XDUT",
+                  "kind": "terminal",
+                  "pinName": "vinp"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "tb-vinp-net",
+          "start": {
+            "instanceId": "VINP",
+            "kind": "terminal",
+            "pinName": "+"
+          }
+        },
+        {
+          "id": "tb-vinn-route",
+          "legs": [
+            {
+              "id": "route-leg-42de77b6b7306ba2",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "XDUT",
+                  "kind": "terminal",
+                  "pinName": "vinn"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "tb-vinn-net",
+          "start": {
+            "instanceId": "VINN",
+            "kind": "terminal",
+            "pinName": "+"
+          }
+        },
+        {
+          "id": "tb-vout-route",
+          "legs": [
+            {
+              "id": "route-leg-9cbad225568967f9",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-9cbad225568967f9",
+                "kind": "bend",
+                "position": {
+                  "x": 730,
+                  "y": 320
+                }
+              }
+            },
+            {
+              "id": "route-leg-9cbad12556896646",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "CL",
+                  "kind": "terminal",
+                  "pinName": "1"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "tb-vout-net",
+          "start": {
+            "instanceId": "XDUT",
+            "kind": "terminal",
+            "pinName": "vout"
+          }
+        },
+        {
+          "id": "route-ui-1",
+          "legs": [
+            {
+              "id": "route-leg-ace29482c237b3d7",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "VDD",
+                  "kind": "terminal",
+                  "pinName": "-"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-a810f1946a2e3084",
+          "start": {
+            "instanceId": "GND1",
+            "kind": "terminal",
+            "pinName": "0"
+          }
+        },
+        {
+          "id": "route-35e042e11550de52",
+          "legs": [
+            {
+              "id": "route-leg-94c48a25d3985fe6",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "VINP",
+                  "kind": "terminal",
+                  "pinName": "-"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-f3cbcac420d93ece",
+          "start": {
+            "instanceId": "GND2",
+            "kind": "terminal",
+            "pinName": "0"
+          }
+        },
+        {
+          "id": "route-ui-3",
+          "legs": [
+            {
+              "id": "route-leg-950eb45aec291af5",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-canonical-fa66a02887bbb6d9",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-tb-vdd",
+          "start": {
+            "instanceId": "VDD",
+            "kind": "terminal",
+            "pinName": "+"
+          }
+        },
+        {
+          "id": "tb-vdd-dut-route-a-2",
+          "legs": [
+            {
+              "id": "route-leg-624f4d1edaa3951c",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "IBIAS",
+                  "kind": "terminal",
+                  "pinName": "+"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-tb-vdd",
+          "start": {
+            "junctionId": "junction-canonical-fa66a02887bbb6d9",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "tb-vdd-dut-route-b-2",
+          "legs": [
+            {
+              "id": "route-leg-c64a8aa78eb2d60f",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-624f4d1edaa3951c",
+                "kind": "bend",
+                "position": {
+                  "x": 590,
+                  "y": 160
+                }
+              }
+            },
+            {
+              "id": "route-leg-624f4e1edaa396cf",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "XDUT",
+                  "kind": "terminal",
+                  "pinName": "vdd"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-tb-vdd",
+          "start": {
+            "junctionId": "junction-canonical-fa66a02887bbb6d9",
+            "kind": "junction"
+          }
+        }
+      ],
+      "sourceStatus": "connectivity-modified"
+    },
+    {
+      "annotations": [
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 300,
+              "y": 560
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 10,
+              "y": 20
+            },
+            "objectId": "PVSS"
+          },
+          "binding": {
+            "kind": "cell-terminal-name",
+            "terminalId": "terminal-pvss"
+          },
+          "id": "instance-label-PVSS",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 245,
+              "y": 355
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -45,
+              "y": -5
+            },
+            "objectId": "PIBIAS"
+          },
+          "binding": {
+            "kind": "cell-terminal-name",
+            "terminalId": "terminal-pibias"
+          },
+          "id": "instance-label-PIBIAS",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 305,
+              "y": 85
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -5,
+              "y": -15
+            },
+            "objectId": "PVDD"
+          },
+          "binding": {
+            "kind": "cell-terminal-name",
+            "terminalId": "terminal-pvdd"
+          },
+          "id": "instance-label-PVDD",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 630,
+              "y": 270
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": -10
+            },
+            "objectId": "PVINN"
+          },
+          "binding": {
+            "kind": "cell-terminal-name",
+            "terminalId": "terminal-pvinn"
+          },
+          "id": "instance-label-PVINN",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 310,
+              "y": 270
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -20,
+              "y": -10
+            },
+            "objectId": "PVINP"
+          },
+          "binding": {
+            "kind": "cell-terminal-name",
+            "terminalId": "terminal-pvinp"
+          },
+          "id": "instance-label-PVINP",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 645,
+              "y": 220
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 15,
+              "y": 0
+            },
+            "objectId": "PVOUT"
+          },
+          "binding": {
+            "kind": "cell-terminal-name",
+            "terminalId": "terminal-pvout"
+          },
+          "id": "instance-label-PVOUT",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "middle",
+          "anchor": {
+            "direction": "forward",
+            "fallbackPosition": {
+              "x": 436,
+              "y": 200
+            },
+            "kind": "route",
+            "legId": "route-leg-220f44782704e593",
+            "normalOffset": -10,
+            "orientation": "follow",
+            "routeId": "dut-nleft-trunk-route",
+            "t": 0.625
+          },
+          "binding": {
+            "kind": "net-name",
+            "netId": "net-dut-nleft"
+          },
+          "id": "net-label-dut-nleft-trunk-route",
+          "kind": "net-label",
+          "locked": false,
+          "netId": "net-dut-nleft",
+          "rotation": 0
+        },
+        {
+          "alignment": "middle",
+          "anchor": {
+            "direction": "forward",
+            "fallbackPosition": {
+              "x": 0,
+              "y": 0
+            },
+            "kind": "route",
+            "legId": "route-leg-ada2b726f49de050",
+            "normalOffset": -14,
+            "orientation": "follow",
+            "routeId": "dut-tail-m1s-route",
+            "t": 0.9
+          },
+          "binding": {
+            "kind": "net-name",
+            "netId": "net-dut-tail"
+          },
+          "id": "net-label-dut-tail-m1s-route",
+          "kind": "net-label",
+          "locked": false,
+          "netId": "net-dut-tail",
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 345,
+              "y": 315
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -25,
+              "y": 35
+            },
+            "objectId": "M1"
+          },
+          "binding": {
+            "instanceId": "M1",
+            "kind": "instance-reference"
+          },
+          "id": "instance-label-M1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 390,
+              "y": 275
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": -5
+            },
+            "objectId": "M1"
+          },
+          "binding": {
+            "instanceId": "M1",
+            "kind": "instance-value"
+          },
+          "id": "instance-value-M1",
+          "kind": "instance-value",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 605,
+              "y": 310
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 35,
+              "y": 30
+            },
+            "objectId": "M2"
+          },
+          "binding": {
+            "instanceId": "M2",
+            "kind": "instance-reference"
+          },
+          "id": "instance-label-M2",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 555,
+              "y": 285
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -15,
+              "y": 5
+            },
+            "objectId": "M2"
+          },
+          "binding": {
+            "instanceId": "M2",
+            "kind": "instance-value"
+          },
+          "id": "instance-value-M2",
+          "kind": "instance-value",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 420,
+              "y": 135
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 30,
+              "y": -25
+            },
+            "objectId": "M3"
+          },
+          "binding": {
+            "instanceId": "M3",
+            "kind": "instance-reference"
+          },
+          "id": "instance-label-M3",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 370,
+              "y": 165
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -20,
+              "y": 5
+            },
+            "objectId": "M3"
+          },
+          "binding": {
+            "instanceId": "M3",
+            "kind": "instance-value"
+          },
+          "id": "instance-value-M3",
+          "kind": "instance-value",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 520,
+              "y": 140
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -30,
+              "y": -20
+            },
+            "objectId": "M4"
+          },
+          "binding": {
+            "instanceId": "M4",
+            "kind": "instance-reference"
+          },
+          "id": "instance-label-M4",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 570,
+              "y": 170
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "M4"
+          },
+          "binding": {
+            "instanceId": "M4",
+            "kind": "instance-value"
+          },
+          "id": "instance-value-M4",
+          "kind": "instance-value",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 440,
+              "y": 465
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -30,
+              "y": 25
+            },
+            "objectId": "M5"
+          },
+          "binding": {
+            "instanceId": "M5",
+            "kind": "instance-reference"
+          },
+          "id": "instance-label-M5",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 490,
+              "y": 450
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "M5"
+          },
+          "binding": {
+            "instanceId": "M5",
+            "kind": "instance-value"
+          },
+          "id": "instance-value-M5",
+          "kind": "instance-value",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 335,
+              "y": 465
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 35,
+              "y": 25
+            },
+            "objectId": "M6"
+          },
+          "binding": {
+            "instanceId": "M6",
+            "kind": "instance-reference"
+          },
+          "id": "instance-label-M6",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 275,
+              "y": 450
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -25,
+              "y": 10
+            },
+            "objectId": "M6"
+          },
+          "binding": {
+            "instanceId": "M6",
+            "kind": "instance-value"
+          },
+          "id": "instance-value-M6",
+          "kind": "instance-value",
+          "locked": false,
+          "rotation": 0
+        }
+      ],
+      "connectivityEvidence": [
+        {
+          "id": "connectivity-evidence-9f1ce905a5db8772",
+          "kind": "name-claim",
+          "name": "nleft",
+          "netId": "net-dut-nleft",
+          "owner": {
+            "annotationId": "net-label-dut-nleft-trunk-route",
+            "kind": "net-label"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-ca7bbcf380650530",
+          "kind": "name-claim",
+          "name": "tail",
+          "netId": "net-dut-tail",
+          "owner": {
+            "annotationId": "net-label-dut-tail-m1s-route",
+            "kind": "net-label"
+          },
+          "scope": "local"
+        }
+      ],
+      "constraints": [],
+      "drafting": {
+        "objects": []
+      },
+      "id": "document-ota-5t",
+      "instances": [
+        {
+          "id": "M1",
+          "mosBulkBinding": {
+            "netId": "net-cell-pin-pvss",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "binding": {
+              "definitionId": "external-subcircuit-e5ee3d17d0c7c89a",
+              "kind": "external-subcircuit"
+            },
+            "parameters": {
+              "l": "1u",
+              "nf": "12",
+              "w": "96u"
+            }
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 370,
+              "y": 280
+            },
+            "rotation": 0
+          },
+          "reference": "XM1",
+          "symbolId": "nmos"
+        },
+        {
+          "id": "M2",
+          "mosBulkBinding": {
+            "netId": "net-cell-pin-pvss",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "binding": {
+              "definitionId": "external-subcircuit-e5ee3d17d0c7c89a",
+              "kind": "external-subcircuit"
+            },
+            "parameters": {
+              "l": "1u",
+              "nf": "12",
+              "w": "96u"
+            }
+          },
+          "placement": {
+            "mirror": "x",
+            "position": {
+              "x": 570,
+              "y": 280
+            },
+            "rotation": 0
+          },
+          "reference": "XM2",
+          "symbolId": "nmos"
+        },
+        {
+          "id": "M3",
+          "mosBulkBinding": {
+            "netId": "net-cell-pin-pvdd",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "binding": {
+              "definitionId": "external-subcircuit-27f716b14d59fc10",
+              "kind": "external-subcircuit"
+            },
+            "parameters": {
+              "l": "1u",
+              "nf": "8",
+              "w": "64u"
+            }
+          },
+          "placement": {
+            "mirror": "x",
+            "position": {
+              "x": 390,
+              "y": 160
+            },
+            "rotation": 0
+          },
+          "reference": "XM3",
+          "symbolId": "pmos"
+        },
+        {
+          "id": "M4",
+          "mosBulkBinding": {
+            "netId": "net-cell-pin-pvdd",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "binding": {
+              "definitionId": "external-subcircuit-27f716b14d59fc10",
+              "kind": "external-subcircuit"
+            },
+            "parameters": {
+              "l": "1u",
+              "nf": "8",
+              "w": "64u"
+            }
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 550,
+              "y": 160
+            },
+            "rotation": 0
+          },
+          "reference": "XM4",
+          "symbolId": "pmos"
+        },
+        {
+          "id": "M5",
+          "mosBulkBinding": {
+            "netId": "net-cell-pin-pvss",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "binding": {
+              "definitionId": "external-subcircuit-e5ee3d17d0c7c89a",
+              "kind": "external-subcircuit"
+            },
+            "parameters": {
+              "l": "3u",
+              "nf": "20",
+              "w": "100u"
+            }
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 470,
+              "y": 440
+            },
+            "rotation": 0
+          },
+          "reference": "XM5",
+          "symbolId": "nmos"
+        },
+        {
+          "id": "M6",
+          "mosBulkBinding": {
+            "netId": "net-cell-pin-pvss",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "binding": {
+              "definitionId": "external-subcircuit-e5ee3d17d0c7c89a",
+              "kind": "external-subcircuit"
+            },
+            "parameters": {
+              "l": "3u",
+              "nf": "6",
+              "w": "60u"
+            }
+          },
+          "placement": {
+            "mirror": "x",
+            "position": {
+              "x": 300,
+              "y": 440
+            },
+            "rotation": 0
+          },
+          "reference": "XM6",
+          "symbolId": "nmos"
+        },
+        {
+          "id": "PVSS",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 290,
+              "y": 540
+            },
+            "rotation": 270
+          },
+          "symbolId": "port"
+        },
+        {
+          "id": "PIBIAS",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 290,
+              "y": 360
+            },
+            "rotation": 90
+          },
+          "symbolId": "port"
+        },
+        {
+          "id": "PVDD",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 310,
+              "y": 100
+            },
+            "rotation": 0
+          },
+          "symbolId": "port"
+        },
+        {
+          "id": "PVINN",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 610,
+              "y": 280
+            },
+            "rotation": 180
+          },
+          "symbolId": "port"
+        },
+        {
+          "id": "PVINP",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 330,
+              "y": 280
+            },
+            "rotation": 0
+          },
+          "symbolId": "port"
+        },
+        {
+          "id": "PVOUT",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 630,
+              "y": 220
+            },
+            "rotation": 180
+          },
+          "symbolId": "port"
+        }
+      ],
+      "junctions": [
+        {
+          "id": "junction-dut-vdd",
+          "netId": "net-cell-pin-pvdd",
+          "position": {
+            "x": 380,
+            "y": 100
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-dut-vout",
+          "netId": "net-cell-pin-pvout",
+          "position": {
+            "x": 560,
+            "y": 220
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-dut-nleft-a",
+          "netId": "net-dut-nleft",
+          "position": {
+            "x": 380,
+            "y": 210
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-dut-nleft-b",
+          "netId": "net-dut-nleft",
+          "position": {
+            "x": 470,
+            "y": 160
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-dut-tail",
+          "netId": "net-dut-tail",
+          "position": {
+            "x": 480,
+            "y": 340
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-canonical-a69a92ac5a85be8f",
+          "netId": "net-cell-pin-pibias",
+          "position": {
+            "x": 290,
+            "y": 400
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-canonical-3993d1302f152696",
+          "netId": "net-cell-pin-pvss",
+          "position": {
+            "x": 290,
+            "y": 490
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-canonical-0fddbcfe7d216a81",
+          "netId": "net-cell-pin-pibias",
+          "position": {
+            "x": 380,
+            "y": 440
+          },
+          "role": "branch"
+        }
+      ],
+      "layoutGroups": [],
+      "mosBulkDefaults": {
+        "nmosNetId": "net-cell-pin-pvss",
+        "pmosNetId": "net-cell-pin-pvdd"
+      },
+      "name": "ota_5t",
+      "netlist": {
+        "formalParameters": [],
+        "name": "ota_5t",
+        "terminals": [
+          {
+            "direction": "passive",
+            "id": "terminal-pvss",
+            "interfaceInstanceIds": [
+              "PVSS"
+            ],
+            "name": "vss",
+            "netId": "net-cell-pin-pvss"
+          },
+          {
+            "direction": "input",
+            "id": "terminal-pibias",
+            "interfaceInstanceIds": [
+              "PIBIAS"
+            ],
+            "name": "ibias",
+            "netId": "net-cell-pin-pibias"
+          },
+          {
+            "direction": "passive",
+            "id": "terminal-pvdd",
+            "interfaceInstanceIds": [
+              "PVDD"
+            ],
+            "name": "vdd",
+            "netId": "net-cell-pin-pvdd"
+          },
+          {
+            "direction": "input",
+            "id": "terminal-pvinn",
+            "interfaceInstanceIds": [
+              "PVINN"
+            ],
+            "name": "vinn",
+            "netId": "net-cell-pin-pvinn"
+          },
+          {
+            "direction": "input",
+            "id": "terminal-pvinp",
+            "interfaceInstanceIds": [
+              "PVINP"
+            ],
+            "name": "vinp",
+            "netId": "net-cell-pin-pvinp"
+          },
+          {
+            "direction": "output",
+            "id": "terminal-pvout",
+            "interfaceInstanceIds": [
+              "PVOUT"
+            ],
+            "name": "vout",
+            "netId": "net-cell-pin-pvout"
+          }
+        ]
+      },
+      "nets": [
+        {
+          "id": "net-cell-pin-pvss",
+          "terminals": [
+            {
+              "instanceId": "PVSS",
+              "pinName": "P"
+            },
+            {
+              "instanceId": "M6",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "M5",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "M1",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "M2",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "M5",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "M6",
+              "pinName": "B"
+            }
+          ]
+        },
+        {
+          "id": "net-cell-pin-pibias",
+          "terminals": [
+            {
+              "instanceId": "PIBIAS",
+              "pinName": "P"
+            },
+            {
+              "instanceId": "M6",
+              "pinName": "G"
+            },
+            {
+              "instanceId": "M6",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "M5",
+              "pinName": "G"
+            }
+          ]
+        },
+        {
+          "id": "net-cell-pin-pvdd",
+          "terminals": [
+            {
+              "instanceId": "PVDD",
+              "pinName": "P"
+            },
+            {
+              "instanceId": "M3",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "M4",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "M3",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "M4",
+              "pinName": "B"
+            }
+          ]
+        },
+        {
+          "id": "net-cell-pin-pvinn",
+          "terminals": [
+            {
+              "instanceId": "PVINN",
+              "pinName": "P"
+            },
+            {
+              "instanceId": "M2",
+              "pinName": "G"
+            }
+          ]
+        },
+        {
+          "id": "net-cell-pin-pvinp",
+          "terminals": [
+            {
+              "instanceId": "PVINP",
+              "pinName": "P"
+            },
+            {
+              "instanceId": "M1",
+              "pinName": "G"
+            }
+          ]
+        },
+        {
+          "id": "net-cell-pin-pvout",
+          "terminals": [
+            {
+              "instanceId": "PVOUT",
+              "pinName": "P"
+            },
+            {
+              "instanceId": "M4",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "M2",
+              "pinName": "D"
+            }
+          ]
+        },
+        {
+          "id": "net-dut-nleft",
+          "terminals": [
+            {
+              "instanceId": "M3",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "M1",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "M3",
+              "pinName": "G"
+            },
+            {
+              "instanceId": "M4",
+              "pinName": "G"
+            }
+          ]
+        },
+        {
+          "id": "net-dut-tail",
+          "terminals": [
+            {
+              "instanceId": "M5",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "M1",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "M2",
+              "pinName": "S"
+            }
+          ]
+        }
+      ],
+      "noConnects": [],
+      "presentation": {
+        "cellSymbol": {
+          "minimumBodySize": {
+            "height": 120,
+            "width": 140
+          },
+          "pinPlacements": [
+            {
+              "offset": 30,
+              "side": "north",
+              "terminalId": "terminal-pvdd"
+            },
+            {
+              "offset": 30,
+              "side": "west",
+              "terminalId": "terminal-pvinn"
+            },
+            {
+              "offset": 0,
+              "side": "east",
+              "terminalId": "terminal-pvout"
+            },
+            {
+              "offset": 0,
+              "side": "south",
+              "terminalId": "terminal-pvss"
+            },
+            {
+              "offset": -20,
+              "side": "west",
+              "terminalId": "terminal-pvinp"
+            },
+            {
+              "offset": -10,
+              "side": "north",
+              "terminalId": "terminal-pibias"
+            }
+          ]
+        },
+        "compactness": "normal",
+        "grid": 10,
+        "styleProfileId": "razavi-textbook-v1"
+      },
+      "revision": 162,
+      "routes": [
+        {
+          "id": "dut-vdd-port-route",
+          "legs": [
+            {
+              "id": "route-leg-a720db58bbd8e3ad",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-dut-vdd",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-cell-pin-pvdd",
+          "start": {
+            "instanceId": "PVDD",
+            "kind": "terminal",
+            "pinName": "P"
+          }
+        },
+        {
+          "id": "dut-vdd-m3-route",
+          "legs": [
+            {
+              "id": "route-leg-e029990b3e5d06bc",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-dut-vdd",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-cell-pin-pvdd",
+          "start": {
+            "instanceId": "M3",
+            "kind": "terminal",
+            "pinName": "S"
+          }
+        },
+        {
+          "id": "dut-vdd-m4-route",
+          "legs": [
+            {
+              "id": "route-leg-5b9805254e937a59",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-5b9805254e937a59",
+                "kind": "bend",
+                "position": {
+                  "x": 560,
+                  "y": 100
+                }
+              }
+            },
+            {
+              "id": "route-leg-5b9804254e9378a6",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-dut-vdd",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-cell-pin-pvdd",
+          "start": {
+            "instanceId": "M4",
+            "kind": "terminal",
+            "pinName": "S"
+          }
+        },
+        {
+          "id": "dut-vout-port-route",
+          "legs": [
+            {
+              "id": "route-leg-6043a3e9d6720b4e",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-dut-vout",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-cell-pin-pvout",
+          "start": {
+            "instanceId": "PVOUT",
+            "kind": "terminal",
+            "pinName": "P"
+          }
+        },
+        {
+          "id": "dut-vout-m4-route",
+          "legs": [
+            {
+              "id": "route-leg-ae091c386561f66a",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-dut-vout",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-cell-pin-pvout",
+          "start": {
+            "instanceId": "M4",
+            "kind": "terminal",
+            "pinName": "D"
+          }
+        },
+        {
+          "id": "dut-vout-m2-route",
+          "legs": [
+            {
+              "id": "route-leg-109a650f1a292f40",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-dut-vout",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-cell-pin-pvout",
+          "start": {
+            "instanceId": "M2",
+            "kind": "terminal",
+            "pinName": "D"
+          }
+        },
+        {
+          "id": "dut-vinp-route",
+          "legs": [
+            {
+              "id": "route-leg-a72f03f468a1d2f4",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "M1",
+                  "kind": "terminal",
+                  "pinName": "G"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-cell-pin-pvinp",
+          "start": {
+            "instanceId": "PVINP",
+            "kind": "terminal",
+            "pinName": "P"
+          }
+        },
+        {
+          "id": "dut-vinn-route",
+          "legs": [
+            {
+              "id": "route-leg-d16ea816ee4bf8ce",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "M2",
+                  "kind": "terminal",
+                  "pinName": "G"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-cell-pin-pvinn",
+          "start": {
+            "instanceId": "PVINN",
+            "kind": "terminal",
+            "pinName": "P"
+          }
+        },
+        {
+          "id": "dut-nleft-m3d-route",
+          "legs": [
+            {
+              "id": "route-leg-f449712ee4a17702",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-dut-nleft-a",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-dut-nleft",
+          "start": {
+            "instanceId": "M3",
+            "kind": "terminal",
+            "pinName": "D"
+          }
+        },
+        {
+          "id": "dut-nleft-m1d-route",
+          "legs": [
+            {
+              "id": "route-leg-4449fdaa3f37ea4c",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-dut-nleft-a",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-dut-nleft",
+          "start": {
+            "instanceId": "M1",
+            "kind": "terminal",
+            "pinName": "D"
+          }
+        },
+        {
+          "id": "dut-nleft-trunk-route",
+          "legs": [
+            {
+              "id": "route-leg-220f44782704e593",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-adb5e8be6b3344d6",
+                "kind": "bend",
+                "position": {
+                  "x": 470,
+                  "y": 210
+                }
+              }
+            },
+            {
+              "id": "route-leg-c5b2e6b4e8fd7635",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-dut-nleft-b",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-dut-nleft",
+          "start": {
+            "junctionId": "junction-dut-nleft-a",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "dut-nleft-m3g-route",
+          "legs": [
+            {
+              "id": "route-leg-a7d85c5a0e43f8af",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-dut-nleft-b",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-dut-nleft",
+          "start": {
+            "instanceId": "M3",
+            "kind": "terminal",
+            "pinName": "G"
+          }
+        },
+        {
+          "id": "dut-nleft-m4g-route",
+          "legs": [
+            {
+              "id": "route-leg-5dee764c63230748",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-dut-nleft-b",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-dut-nleft",
+          "start": {
+            "instanceId": "M4",
+            "kind": "terminal",
+            "pinName": "G"
+          }
+        },
+        {
+          "id": "dut-tail-m5d-route",
+          "legs": [
+            {
+              "id": "route-leg-beabd8e3dedf141e",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-dut-tail",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-dut-tail",
+          "start": {
+            "instanceId": "M5",
+            "kind": "terminal",
+            "pinName": "D"
+          }
+        },
+        {
+          "id": "dut-tail-m1s-route",
+          "legs": [
+            {
+              "id": "route-leg-ada2b826f49de203",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-ada2b826f49de203",
+                "kind": "bend",
+                "position": {
+                  "x": 380,
+                  "y": 340
+                }
+              }
+            },
+            {
+              "id": "route-leg-ada2b726f49de050",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-dut-tail",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-dut-tail",
+          "start": {
+            "instanceId": "M1",
+            "kind": "terminal",
+            "pinName": "S"
+          }
+        },
+        {
+          "id": "dut-tail-m2s-route",
+          "legs": [
+            {
+              "id": "route-leg-a525c367f98f1f50",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-a525c367f98f1f50",
+                "kind": "bend",
+                "position": {
+                  "x": 560,
+                  "y": 340
+                }
+              }
+            },
+            {
+              "id": "route-leg-a525c467f98f2103",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-dut-tail",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-dut-tail",
+          "start": {
+            "instanceId": "M2",
+            "kind": "terminal",
+            "pinName": "S"
+          }
+        },
+        {
+          "id": "dut-vss-m5-route",
+          "legs": [
+            {
+              "id": "route-leg-1fd2cacc728a5fec",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-canonical-3993d1302f152696",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-cell-pin-pvss",
+          "start": {
+            "instanceId": "M6",
+            "kind": "terminal",
+            "pinName": "S"
+          }
+        },
+        {
+          "id": "dut-vss-port-route",
+          "legs": [
+            {
+              "id": "route-leg-9a243a8749f3f47b",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "PVSS",
+                  "kind": "terminal",
+                  "pinName": "P"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-cell-pin-pvss",
+          "start": {
+            "junctionId": "junction-canonical-3993d1302f152696",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-canonical-e161f2c6f556c327",
+          "legs": [
+            {
+              "id": "route-leg-6406fbb3dde68137",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-6406fbb3dde68137",
+                "kind": "bend",
+                "position": {
+                  "x": 480,
+                  "y": 490
+                }
+              }
+            },
+            {
+              "id": "route-leg-6406fab3dde67f84",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "M5",
+                  "kind": "terminal",
+                  "pinName": "S"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-cell-pin-pvss",
+          "start": {
+            "junctionId": "junction-canonical-3993d1302f152696",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "dut-ibias-port-route",
+          "legs": [
+            {
+              "id": "route-leg-df9387cdaaaab728",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-canonical-a69a92ac5a85be8f",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-cell-pin-pibias",
+          "start": {
+            "instanceId": "PIBIAS",
+            "kind": "terminal",
+            "pinName": "P"
+          }
+        },
+        {
+          "id": "dut-ibias-m6d-route",
+          "legs": [
+            {
+              "id": "route-leg-dfa853aaa4309a7e",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "M6",
+                  "kind": "terminal",
+                  "pinName": "D"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-cell-pin-pibias",
+          "start": {
+            "junctionId": "junction-canonical-a69a92ac5a85be8f",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "dut-ibias-m5g-route",
+          "legs": [
+            {
+              "id": "route-leg-7172d946242cfd98",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-9351f6029255a2bb",
+                "kind": "bend",
+                "position": {
+                  "x": 380,
+                  "y": 400
+                }
+              }
+            },
+            {
+              "id": "route-leg-a63007ca9d22b9cc",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-canonical-0fddbcfe7d216a81",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-cell-pin-pibias",
+          "start": {
+            "junctionId": "junction-canonical-a69a92ac5a85be8f",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "dut-ibias-m6g-route",
+          "legs": [
+            {
+              "id": "route-leg-36accc90d5a60eab",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-canonical-0fddbcfe7d216a81",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-cell-pin-pibias",
+          "start": {
+            "instanceId": "M6",
+            "kind": "terminal",
+            "pinName": "G"
+          }
+        },
+        {
+          "id": "route-canonical-781ca20d250b5d82",
+          "legs": [
+            {
+              "id": "route-leg-77da2da4eeb4e9de",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "M5",
+                  "kind": "terminal",
+                  "pinName": "G"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-cell-pin-pibias",
+          "start": {
+            "junctionId": "junction-canonical-0fddbcfe7d216a81",
+            "kind": "junction"
+          }
+        }
+      ],
+      "sourceStatus": "connectivity-modified"
+    }
+  ],
+  "externalSubcircuitDefinitions": [
+    {
+      "formalParameters": [
+        {
+          "defaultValue": "1",
+          "name": "w"
+        },
+        {
+          "defaultValue": "0.15",
+          "name": "l"
+        },
+        {
+          "defaultValue": "1",
+          "name": "nf"
+        },
+        {
+          "defaultValue": "1",
+          "name": "m"
+        }
+      ],
+      "id": "external-subcircuit-e5ee3d17d0c7c89a",
+      "interfaceStatus": "declared",
+      "name": "sky130_fd_pr__nfet_01v8",
+      "terminals": [
+        {
+          "direction": "passive",
+          "id": "external-subcircuit-terminal-353df4da271bcc2b",
+          "name": "D"
+        },
+        {
+          "direction": "passive",
+          "id": "external-subcircuit-terminal-353df3da271bca78",
+          "name": "G"
+        },
+        {
+          "direction": "passive",
+          "id": "external-subcircuit-terminal-353df6da271bcf91",
+          "name": "S"
+        },
+        {
+          "direction": "passive",
+          "id": "external-subcircuit-terminal-353df5da271bcdde",
+          "name": "B"
+        }
+      ]
+    },
+    {
+      "formalParameters": [
+        {
+          "defaultValue": "1",
+          "name": "w"
+        },
+        {
+          "defaultValue": "0.15",
+          "name": "l"
+        },
+        {
+          "defaultValue": "1",
+          "name": "nf"
+        },
+        {
+          "defaultValue": "1",
+          "name": "m"
+        }
+      ],
+      "id": "external-subcircuit-27f716b14d59fc10",
+      "interfaceStatus": "declared",
+      "name": "sky130_fd_pr__pfet_01v8",
+      "terminals": [
+        {
+          "direction": "passive",
+          "id": "external-subcircuit-terminal-7921a0096089118d",
+          "name": "D"
+        },
+        {
+          "direction": "passive",
+          "id": "external-subcircuit-terminal-79219f0960890fda",
+          "name": "G"
+        },
+        {
+          "direction": "passive",
+          "id": "external-subcircuit-terminal-79219e0960890e27",
+          "name": "S"
+        },
+        {
+          "direction": "passive",
+          "id": "external-subcircuit-terminal-79219d0960890c74",
+          "name": "B"
+        }
+      ]
+    }
+  ],
+  "id": "project-five-transistor-ota-sky130",
+  "name": "Five-Transistor OTA (Sky130)",
+  "schemaVersion": 51,
+  "simulationFolders": [
+    {
+      "id": "simulation-setup-ota-op-ac",
+      "input": {
+        "circuitBindings": [
+          {
+            "documentId": "document-ota-5t-testbench",
+            "emission": "top-level",
+            "id": "simulation-circuit-binding-43c930b6671663fa",
+            "path": "circuit.spice"
+          }
+        ],
+        "configPath": "experiment.json",
+        "dependencies": [],
+        "entry": "run.cir",
+        "files": [
+          {
+            "path": "run.cir",
+            "text": "* OTA OP, DC, AC, and TRAN — migrated authored experiment\n.temp 27\n.include \"circuit.spice\"\n.control\nset filetype=ascii\nset appendwrite\nop\nwrite out.raw\ndc VINP 0.88 0.92 0.005\nwrite out.raw\nac dec 10 1 1000000000\nwrite out.raw\ntran 2e-8 0.000004\nwrite out.raw\n.endc\n.end\n"
+          },
+          {
+            "path": "experiment.json",
+            "text": "{\n  \"version\": 1,\n  \"environment\": {\n    \"profileId\": \"sky130-core-continuous-ngspice46-v1\",\n    \"corner\": \"tt\"\n  },\n  \"runPlan\": {\n    \"mode\": \"nominal\"\n  },\n  \"variables\": [],\n  \"outputs\": [\n    {\n      \"id\": \"probe-vout\",\n      \"label\": \"vout\",\n      \"expression\": {\n        \"documentId\": \"document-ota-5t-testbench\",\n        \"anchor\": {\n          \"kind\": \"terminal\",\n          \"instanceId\": \"XDUT\",\n          \"pinName\": \"vout\"\n        },\n        \"occurrence\": [],\n        \"kind\": \"voltage\",\n        \"circuit\": {\n          \"bindingId\": \"simulation-circuit-binding-43c930b6671663fa\",\n          \"callPath\": []\n        }\n      }\n    },\n    {\n      \"id\": \"probe-ibias\",\n      \"label\": \"ibias\",\n      \"expression\": {\n        \"documentId\": \"document-ota-5t-testbench\",\n        \"anchor\": {\n          \"kind\": \"terminal\",\n          \"instanceId\": \"IBIAS\",\n          \"pinName\": \"-\"\n        },\n        \"occurrence\": [],\n        \"kind\": \"voltage\",\n        \"circuit\": {\n          \"bindingId\": \"simulation-circuit-binding-43c930b6671663fa\",\n          \"callPath\": []\n        }\n      }\n    },\n    {\n      \"id\": \"probe-tail\",\n      \"label\": \"tail\",\n      \"expression\": {\n        \"documentId\": \"document-ota-5t\",\n        \"anchor\": {\n          \"kind\": \"terminal\",\n          \"instanceId\": \"M5\",\n          \"pinName\": \"D\"\n        },\n        \"occurrence\": [\n          \"XDUT\"\n        ],\n        \"kind\": \"voltage\",\n        \"circuit\": {\n          \"bindingId\": \"simulation-circuit-binding-43c930b6671663fa\",\n          \"callPath\": []\n        }\n      }\n    },\n    {\n      \"id\": \"probe-nleft\",\n      \"label\": \"nleft\",\n      \"expression\": {\n        \"documentId\": \"document-ota-5t\",\n        \"anchor\": {\n          \"kind\": \"terminal\",\n          \"instanceId\": \"M3\",\n          \"pinName\": \"D\"\n        },\n        \"occurrence\": [\n          \"XDUT\"\n        ],\n        \"kind\": \"voltage\",\n        \"circuit\": {\n          \"bindingId\": \"simulation-circuit-binding-43c930b6671663fa\",\n          \"callPath\": []\n        }\n      }\n    }\n  ],\n  \"deviceOperatingPoints\": [],\n  \"measurements\": [],\n  \"collection\": {\n    \"rawfile\": \"out.raw\"\n  }\n}\n"
+          }
+        ],
+        "kind": "source"
+      },
+      "name": "OTA OP, DC, AC, and TRAN",
+      "version": 4
+    },
+    {
+      "id": "simulation-setup-ota-bias-tt",
+      "input": {
+        "circuitBindings": [
+          {
+            "documentId": "document-ota-5t-testbench",
+            "emission": "top-level",
+            "id": "simulation-circuit-binding-54bc9080fdbafada",
+            "path": "circuit.spice"
+          }
+        ],
+        "configPath": "experiment.json",
+        "dependencies": [],
+        "entry": "run.cir",
+        "files": [
+          {
+            "path": "run.cir",
+            "text": "* Bias point (TT) — migrated authored experiment\n.temp 27\n.include \"circuit.spice\"\n.control\nset filetype=ascii\nset appendwrite\nop\nwrite out.raw\n.endc\n.end\n"
+          },
+          {
+            "path": "experiment.json",
+            "text": "{\n  \"version\": 1,\n  \"environment\": {\n    \"profileId\": \"sky130-core-continuous-ngspice46-v1\",\n    \"corner\": \"tt\"\n  },\n  \"runPlan\": {\n    \"mode\": \"nominal\"\n  },\n  \"variables\": [],\n  \"outputs\": [\n    {\n      \"id\": \"probe-vout\",\n      \"label\": \"vout\",\n      \"expression\": {\n        \"documentId\": \"document-ota-5t-testbench\",\n        \"anchor\": {\n          \"kind\": \"terminal\",\n          \"instanceId\": \"XDUT\",\n          \"pinName\": \"vout\"\n        },\n        \"occurrence\": [],\n        \"kind\": \"voltage\",\n        \"circuit\": {\n          \"bindingId\": \"simulation-circuit-binding-54bc9080fdbafada\",\n          \"callPath\": []\n        }\n      }\n    },\n    {\n      \"id\": \"probe-ibias\",\n      \"label\": \"ibias\",\n      \"expression\": {\n        \"documentId\": \"document-ota-5t-testbench\",\n        \"anchor\": {\n          \"kind\": \"terminal\",\n          \"instanceId\": \"IBIAS\",\n          \"pinName\": \"-\"\n        },\n        \"occurrence\": [],\n        \"kind\": \"voltage\",\n        \"circuit\": {\n          \"bindingId\": \"simulation-circuit-binding-54bc9080fdbafada\",\n          \"callPath\": []\n        }\n      }\n    },\n    {\n      \"id\": \"probe-tail\",\n      \"label\": \"tail\",\n      \"expression\": {\n        \"documentId\": \"document-ota-5t\",\n        \"anchor\": {\n          \"kind\": \"terminal\",\n          \"instanceId\": \"M5\",\n          \"pinName\": \"D\"\n        },\n        \"occurrence\": [\n          \"XDUT\"\n        ],\n        \"kind\": \"voltage\",\n        \"circuit\": {\n          \"bindingId\": \"simulation-circuit-binding-54bc9080fdbafada\",\n          \"callPath\": []\n        }\n      }\n    },\n    {\n      \"id\": \"probe-nleft\",\n      \"label\": \"nleft\",\n      \"expression\": {\n        \"documentId\": \"document-ota-5t\",\n        \"anchor\": {\n          \"kind\": \"terminal\",\n          \"instanceId\": \"M3\",\n          \"pinName\": \"D\"\n        },\n        \"occurrence\": [\n          \"XDUT\"\n        ],\n        \"kind\": \"voltage\",\n        \"circuit\": {\n          \"bindingId\": \"simulation-circuit-binding-54bc9080fdbafada\",\n          \"callPath\": []\n        }\n      }\n    },\n    {\n      \"id\": \"probe-supply-current\",\n      \"label\": \"I_supply\",\n      \"expression\": {\n        \"kind\": \"negate\",\n        \"operand\": {\n          \"kind\": \"current\",\n          \"documentId\": \"document-ota-5t-testbench\",\n          \"instanceId\": \"VDD\",\n          \"pinName\": \"+\",\n          \"occurrence\": [],\n          \"circuit\": {\n            \"bindingId\": \"simulation-circuit-binding-54bc9080fdbafada\",\n            \"callPath\": []\n          }\n        }\n      }\n    }\n  ],\n  \"deviceOperatingPoints\": [],\n  \"measurements\": [],\n  \"collection\": {\n    \"rawfile\": \"out.raw\"\n  }\n}\n"
+          }
+        ],
+        "kind": "source"
+      },
+      "name": "Bias point (TT)",
+      "version": 4
+    },
+    {
+      "id": "simulation-setup-ota-dc-transfer-tt",
+      "input": {
+        "circuitBindings": [
+          {
+            "documentId": "document-ota-5t-testbench",
+            "emission": "top-level",
+            "id": "simulation-circuit-binding-aff95ba8645ee65e",
+            "path": "circuit.spice"
+          }
+        ],
+        "configPath": "experiment.json",
+        "dependencies": [],
+        "entry": "run.cir",
+        "files": [
+          {
+            "path": "run.cir",
+            "text": "* DC transfer (TT) — migrated authored experiment\n.temp 27\n.include \"circuit.spice\"\n.control\nset filetype=ascii\nset appendwrite\ndc VINP 0.86 0.94 0.001\nwrite out.raw\n.endc\n.end\n"
+          },
+          {
+            "path": "experiment.json",
+            "text": "{\n  \"version\": 1,\n  \"environment\": {\n    \"profileId\": \"sky130-core-continuous-ngspice46-v1\",\n    \"corner\": \"tt\"\n  },\n  \"runPlan\": {\n    \"mode\": \"nominal\"\n  },\n  \"variables\": [],\n  \"outputs\": [\n    {\n      \"id\": \"probe-vout\",\n      \"label\": \"vout\",\n      \"expression\": {\n        \"documentId\": \"document-ota-5t-testbench\",\n        \"anchor\": {\n          \"kind\": \"terminal\",\n          \"instanceId\": \"XDUT\",\n          \"pinName\": \"vout\"\n        },\n        \"occurrence\": [],\n        \"kind\": \"voltage\",\n        \"circuit\": {\n          \"bindingId\": \"simulation-circuit-binding-aff95ba8645ee65e\",\n          \"callPath\": []\n        }\n      }\n    },\n    {\n      \"id\": \"probe-vinp\",\n      \"label\": \"vinp\",\n      \"expression\": {\n        \"documentId\": \"document-ota-5t-testbench\",\n        \"anchor\": {\n          \"kind\": \"terminal\",\n          \"instanceId\": \"VINP\",\n          \"pinName\": \"+\"\n        },\n        \"occurrence\": [],\n        \"kind\": \"voltage\",\n        \"circuit\": {\n          \"bindingId\": \"simulation-circuit-binding-aff95ba8645ee65e\",\n          \"callPath\": []\n        }\n      }\n    },\n    {\n      \"id\": \"probe-tail\",\n      \"label\": \"tail\",\n      \"expression\": {\n        \"documentId\": \"document-ota-5t\",\n        \"anchor\": {\n          \"kind\": \"terminal\",\n          \"instanceId\": \"M5\",\n          \"pinName\": \"D\"\n        },\n        \"occurrence\": [\n          \"XDUT\"\n        ],\n        \"kind\": \"voltage\",\n        \"circuit\": {\n          \"bindingId\": \"simulation-circuit-binding-aff95ba8645ee65e\",\n          \"callPath\": []\n        }\n      }\n    }\n  ],\n  \"deviceOperatingPoints\": [],\n  \"measurements\": [],\n  \"collection\": {\n    \"rawfile\": \"out.raw\"\n  }\n}\n"
+          }
+        ],
+        "kind": "source"
+      },
+      "name": "DC transfer (TT)",
+      "version": 4
+    },
+    {
+      "id": "simulation-setup-ota-ac-tt",
+      "input": {
+        "circuitBindings": [
+          {
+            "documentId": "document-ota-5t-testbench",
+            "emission": "top-level",
+            "id": "simulation-circuit-binding-33a7174fa9bb1375",
+            "path": "circuit.spice"
+          }
+        ],
+        "configPath": "experiment.json",
+        "dependencies": [],
+        "entry": "run.cir",
+        "files": [
+          {
+            "path": "run.cir",
+            "text": "* AC response (TT) — migrated authored experiment\n.temp 27\n.include \"circuit.spice\"\n.control\nset filetype=ascii\nset appendwrite\nac dec 40 1 1000000000\nwrite out.raw\n.endc\n.end\n"
+          },
+          {
+            "path": "experiment.json",
+            "text": "{\n  \"version\": 1,\n  \"environment\": {\n    \"profileId\": \"sky130-core-continuous-ngspice46-v1\",\n    \"corner\": \"tt\"\n  },\n  \"runPlan\": {\n    \"mode\": \"nominal\"\n  },\n  \"variables\": [],\n  \"outputs\": [\n    {\n      \"id\": \"probe-vout\",\n      \"label\": \"vout (A_v for AC=1 V)\",\n      \"expression\": {\n        \"documentId\": \"document-ota-5t-testbench\",\n        \"anchor\": {\n          \"kind\": \"terminal\",\n          \"instanceId\": \"XDUT\",\n          \"pinName\": \"vout\"\n        },\n        \"occurrence\": [],\n        \"kind\": \"voltage\",\n        \"circuit\": {\n          \"bindingId\": \"simulation-circuit-binding-33a7174fa9bb1375\",\n          \"callPath\": []\n        }\n      }\n    },\n    {\n      \"id\": \"probe-tail\",\n      \"label\": \"tail\",\n      \"expression\": {\n        \"documentId\": \"document-ota-5t\",\n        \"anchor\": {\n          \"kind\": \"terminal\",\n          \"instanceId\": \"M5\",\n          \"pinName\": \"D\"\n        },\n        \"occurrence\": [\n          \"XDUT\"\n        ],\n        \"kind\": \"voltage\",\n        \"circuit\": {\n          \"bindingId\": \"simulation-circuit-binding-33a7174fa9bb1375\",\n          \"callPath\": []\n        }\n      }\n    }\n  ],\n  \"deviceOperatingPoints\": [],\n  \"measurements\": [],\n  \"collection\": {\n    \"rawfile\": \"out.raw\"\n  }\n}\n"
+          }
+        ],
+        "kind": "source"
+      },
+      "name": "AC response (TT)",
+      "version": 4
+    },
+    {
+      "id": "simulation-setup-ota-ac-ff",
+      "input": {
+        "circuitBindings": [
+          {
+            "documentId": "document-ota-5t-testbench",
+            "emission": "top-level",
+            "id": "simulation-circuit-binding-87bfa2a46e9c045d",
+            "path": "circuit.spice"
+          }
+        ],
+        "configPath": "experiment.json",
+        "dependencies": [],
+        "entry": "run.cir",
+        "files": [
+          {
+            "path": "run.cir",
+            "text": "* AC response (FF) — migrated authored experiment\n.temp 27\n.include \"circuit.spice\"\n.control\nset filetype=ascii\nset appendwrite\nac dec 40 1 1000000000\nwrite out.raw\n.endc\n.end\n"
+          },
+          {
+            "path": "experiment.json",
+            "text": "{\n  \"version\": 1,\n  \"environment\": {\n    \"profileId\": \"sky130-core-continuous-ngspice46-v1\",\n    \"corner\": \"ff\"\n  },\n  \"runPlan\": {\n    \"mode\": \"nominal\"\n  },\n  \"variables\": [],\n  \"outputs\": [\n    {\n      \"id\": \"probe-vout\",\n      \"label\": \"vout (A_v for AC=1 V)\",\n      \"expression\": {\n        \"documentId\": \"document-ota-5t-testbench\",\n        \"anchor\": {\n          \"kind\": \"terminal\",\n          \"instanceId\": \"XDUT\",\n          \"pinName\": \"vout\"\n        },\n        \"occurrence\": [],\n        \"kind\": \"voltage\",\n        \"circuit\": {\n          \"bindingId\": \"simulation-circuit-binding-87bfa2a46e9c045d\",\n          \"callPath\": []\n        }\n      }\n    },\n    {\n      \"id\": \"probe-tail\",\n      \"label\": \"tail\",\n      \"expression\": {\n        \"documentId\": \"document-ota-5t\",\n        \"anchor\": {\n          \"kind\": \"terminal\",\n          \"instanceId\": \"M5\",\n          \"pinName\": \"D\"\n        },\n        \"occurrence\": [\n          \"XDUT\"\n        ],\n        \"kind\": \"voltage\",\n        \"circuit\": {\n          \"bindingId\": \"simulation-circuit-binding-87bfa2a46e9c045d\",\n          \"callPath\": []\n        }\n      }\n    }\n  ],\n  \"deviceOperatingPoints\": [],\n  \"measurements\": [],\n  \"collection\": {\n    \"rawfile\": \"out.raw\"\n  }\n}\n"
+          }
+        ],
+        "kind": "source"
+      },
+      "name": "AC response (FF)",
+      "version": 4
+    },
+    {
+      "id": "simulation-setup-ota-ac-ss",
+      "input": {
+        "circuitBindings": [
+          {
+            "documentId": "document-ota-5t-testbench",
+            "emission": "top-level",
+            "id": "simulation-circuit-binding-069b639e7112bc97",
+            "path": "circuit.spice"
+          }
+        ],
+        "configPath": "experiment.json",
+        "dependencies": [],
+        "entry": "run.cir",
+        "files": [
+          {
+            "path": "run.cir",
+            "text": "* AC response (SS) — migrated authored experiment\n.temp 27\n.include \"circuit.spice\"\n.control\nset filetype=ascii\nset appendwrite\nac dec 40 1 1000000000\nwrite out.raw\n.endc\n.end\n"
+          },
+          {
+            "path": "experiment.json",
+            "text": "{\n  \"version\": 1,\n  \"environment\": {\n    \"profileId\": \"sky130-core-continuous-ngspice46-v1\",\n    \"corner\": \"ss\"\n  },\n  \"runPlan\": {\n    \"mode\": \"nominal\"\n  },\n  \"variables\": [],\n  \"outputs\": [\n    {\n      \"id\": \"probe-vout\",\n      \"label\": \"vout (A_v for AC=1 V)\",\n      \"expression\": {\n        \"documentId\": \"document-ota-5t-testbench\",\n        \"anchor\": {\n          \"kind\": \"terminal\",\n          \"instanceId\": \"XDUT\",\n          \"pinName\": \"vout\"\n        },\n        \"occurrence\": [],\n        \"kind\": \"voltage\",\n        \"circuit\": {\n          \"bindingId\": \"simulation-circuit-binding-069b639e7112bc97\",\n          \"callPath\": []\n        }\n      }\n    },\n    {\n      \"id\": \"probe-tail\",\n      \"label\": \"tail\",\n      \"expression\": {\n        \"documentId\": \"document-ota-5t\",\n        \"anchor\": {\n          \"kind\": \"terminal\",\n          \"instanceId\": \"M5\",\n          \"pinName\": \"D\"\n        },\n        \"occurrence\": [\n          \"XDUT\"\n        ],\n        \"kind\": \"voltage\",\n        \"circuit\": {\n          \"bindingId\": \"simulation-circuit-binding-069b639e7112bc97\",\n          \"callPath\": []\n        }\n      }\n    }\n  ],\n  \"deviceOperatingPoints\": [],\n  \"measurements\": [],\n  \"collection\": {\n    \"rawfile\": \"out.raw\"\n  }\n}\n"
+          }
+        ],
+        "kind": "source"
+      },
+      "name": "AC response (SS)",
+      "version": 4
+    },
+    {
+      "id": "simulation-setup-ota-tran-tt",
+      "input": {
+        "circuitBindings": [
+          {
+            "documentId": "document-ota-5t-testbench",
+            "emission": "top-level",
+            "id": "simulation-circuit-binding-bbdb56d73eaee0ba",
+            "path": "circuit.spice"
+          }
+        ],
+        "configPath": "experiment.json",
+        "dependencies": [],
+        "entry": "run.cir",
+        "files": [
+          {
+            "path": "run.cir",
+            "text": "* Transient step (TT) — migrated authored experiment\n.temp 27\n.include \"circuit.spice\"\n.control\nset filetype=ascii\nset appendwrite\ntran 1e-8 0.000006 0 1e-8\nwrite out.raw\n.endc\n.end\n"
+          },
+          {
+            "path": "experiment.json",
+            "text": "{\n  \"version\": 1,\n  \"environment\": {\n    \"profileId\": \"sky130-core-continuous-ngspice46-v1\",\n    \"corner\": \"tt\"\n  },\n  \"runPlan\": {\n    \"mode\": \"nominal\"\n  },\n  \"variables\": [],\n  \"outputs\": [\n    {\n      \"id\": \"probe-vinp\",\n      \"label\": \"vinp\",\n      \"expression\": {\n        \"documentId\": \"document-ota-5t-testbench\",\n        \"anchor\": {\n          \"kind\": \"terminal\",\n          \"instanceId\": \"VINP\",\n          \"pinName\": \"+\"\n        },\n        \"occurrence\": [],\n        \"kind\": \"voltage\",\n        \"circuit\": {\n          \"bindingId\": \"simulation-circuit-binding-bbdb56d73eaee0ba\",\n          \"callPath\": []\n        }\n      }\n    },\n    {\n      \"id\": \"probe-vout\",\n      \"label\": \"vout\",\n      \"expression\": {\n        \"documentId\": \"document-ota-5t-testbench\",\n        \"anchor\": {\n          \"kind\": \"terminal\",\n          \"instanceId\": \"XDUT\",\n          \"pinName\": \"vout\"\n        },\n        \"occurrence\": [],\n        \"kind\": \"voltage\",\n        \"circuit\": {\n          \"bindingId\": \"simulation-circuit-binding-bbdb56d73eaee0ba\",\n          \"callPath\": []\n        }\n      }\n    }\n  ],\n  \"deviceOperatingPoints\": [],\n  \"measurements\": [],\n  \"collection\": {\n    \"rawfile\": \"out.raw\"\n  }\n}\n"
+          }
+        ],
+        "kind": "source"
+      },
+      "name": "Transient step (TT)",
+      "version": 4
+    }
+  ],
+  "source": {
+    "dialect": "none",
+    "entry": null,
+    "files": [],
+    "sourcePolicy": "copy"
+  },
+  "structureRevision": 85,
+  "symbolLibrary": {
+    "hash": "razavi-reference-v1",
+    "id": "razavi-symbols",
+    "version": "1"
+  },
+  "topDocumentId": "document-ota-5t-testbench"
+}

--- a/netlists/native-rc-filters/circuit.spi
+++ b/netlists/native-rc-filters/circuit.spi
@@ -1,0 +1,5 @@
+* First-order RC low-pass. High-pass is the complementary C-series/R-shunt Cell.
+V1 in 0 0
+R1 in out 10k
+C1 out 0 10n
+.end

--- a/netlists/native-rlc-filter/circuit.spi
+++ b/netlists/native-rlc-filter/circuit.spi
@@ -1,0 +1,6 @@
+* Series RLC, output across C. f0 = 5032.921 Hz; Rcrit = 632.456 ohm.
+V1 in 0 0
+R1 in mid 200
+L1 mid out 10m
+C1 out 0 100n
+.end

--- a/packages/simulation-service/src/contract.ts
+++ b/packages/simulation-service/src/contract.ts
@@ -206,6 +206,8 @@ export const EvaluatedScalarSchema = z.strictObject({
   label: z.string(),
   unit: z.string(),
   value: z.number().finite(),
+  imaginary: z.number().finite().optional(),
+  semantics: OutputSemanticsSchema.optional(),
 });
 export const EvaluatedAnalysisSchema = z.strictObject({
   rawPlotOrdinals: SimulationRawPlotOrdinalsSchema.optional(),
@@ -219,6 +221,8 @@ export const EvaluatedAnalysisSchema = z.strictObject({
     })
     .optional(),
   outputs: z.array(EvaluatedOutputSchema),
+  /** Captured single values, not sweep samples or automatic waveform measurements. */
+  scalars: z.array(EvaluatedScalarSchema).optional(),
   /** Analysis-owned scalar results, such as integrated input/output noise. */
   integrated: z.array(EvaluatedScalarSchema).optional(),
 });

--- a/packages/simulation-service/src/contract.ts
+++ b/packages/simulation-service/src/contract.ts
@@ -185,12 +185,21 @@ export const PreparedSchema = z.strictObject({
 });
 export type Prepared = z.infer<typeof PreparedSchema>;
 export const OutputPointSchema = z.number().finite().nullable();
+/** Meaning is distinct from raw AC storage (a real expression may have zero imaginary samples). */
+export const OutputSemanticsSchema = z.strictObject({
+  valueKind: z.enum(["real", "complex", "unknown"]),
+  quantity: z.string(),
+  origin: z.enum(["raw", "expression"]),
+  expression: z.string().optional(),
+});
+export type OutputSemantics = z.infer<typeof OutputSemanticsSchema>;
 export const EvaluatedOutputSchema = z.strictObject({
   id: Id,
   label: z.string(),
   unit: z.string(),
   values: z.array(OutputPointSchema),
   imaginary: z.array(OutputPointSchema).optional(),
+  semantics: OutputSemanticsSchema.optional(),
 });
 export const EvaluatedScalarSchema = z.strictObject({
   id: Id,

--- a/packages/simulation-service/src/hosted-executor.test.ts
+++ b/packages/simulation-service/src/hosted-executor.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { createHostedExecutor } from "./hosted-executor.js";
+import { readFileSync } from "node:fs";
+import { readSimulationData } from "@icm/spice-run";
+import {
+  createHostedExecutor,
+  decodeHostedExecutionPayload,
+} from "./hosted-executor.js";
 import type { ExecutionInput } from "./executor.js";
 const input: ExecutionInput = {
   mode: "raw",
@@ -11,6 +16,61 @@ const input: ExecutionInput = {
   environment: { profileId: "p" },
 };
 describe("hosted executor recovery", () => {
+  it("normalizes scalar dimensions from an older executor without losing raw evidence or reviving withheld data", () => {
+    const rawfile = readFileSync(
+      new URL(
+        "../../../fixtures/ngspice-rawfile/native-scalars-ac.raw",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+    const old = readSimulationData(rawfile.replaceAll(" dims=1", ""));
+    if (old.status !== "read") throw Error("read expected");
+    const payload = {
+      outcome: { status: "completed" },
+      diagnostics: [],
+      log: "done",
+      durationMs: 1,
+      metadata: {
+        schemaVersion: 1,
+        input: {
+          inputRevision: "rev",
+          netlistSha256: "a".repeat(64),
+          testbenchSha256: "b".repeat(64),
+          deckSha256: "c".repeat(64),
+        },
+        configuration: { modelLibrary: null },
+        environment: {
+          executor: "hosted-container",
+          reproducibility: "pinned",
+          profileId: "p",
+          platform: "linux/x64",
+          simulator: { name: "ngspice", version: "46", binarySha256: null },
+          models: null,
+          startupSha256: null,
+          fingerprint: "fixture",
+        },
+      },
+      data: old.data,
+      rawfile,
+    };
+    const normalized = decodeHostedExecutionPayload(input, payload);
+    expect(normalized.result.data?.analyses[0]?.scalars?.[0]?.value).toBe(4);
+    expect(normalized.result.data?.analyses[0]?.probes).toHaveLength(2);
+    expect(normalized.rawfile).toBe(rawfile);
+    expect(normalized.result.outcome.status).toBe("completed");
+    const { data: _data, ...withheld } = payload;
+    expect(
+      decodeHostedExecutionPayload(input, withheld).result.data,
+    ).toBeUndefined();
+    const invalid = decodeHostedExecutionPayload(input, {
+      ...payload,
+      rawfile: rawfile.replace("dims=1", "dims=2"),
+    });
+    expect(invalid.result.outcome.status).toBe("failed");
+    expect(invalid.result.data).toBeUndefined();
+    expect(invalid.rawfile).toContain("dims=2");
+  });
   it("preserves cancellation uncertainty and the executor retry delay", async () => {
     const executor = createHostedExecutor(async () =>
       Response.json({ error: "cancel-response-unknown" }, { status: 502 }),

--- a/packages/simulation-service/src/hosted-executor.test.ts
+++ b/packages/simulation-service/src/hosted-executor.test.ts
@@ -56,7 +56,9 @@ describe("hosted executor recovery", () => {
     };
     const normalized = decodeHostedExecutionPayload(input, payload);
     expect(normalized.result.data?.analyses[0]?.scalars?.[0]?.value).toBe(4);
-    expect(normalized.result.data?.analyses[0]?.probes).toHaveLength(2);
+    const analysis = normalized.result.data?.analyses[0];
+    if (analysis?.analysis !== "ac") throw Error("AC expected");
+    expect(analysis.probes).toHaveLength(2);
     expect(normalized.rawfile).toBe(rawfile);
     expect(normalized.result.outcome.status).toBe("completed");
     const { data: _data, ...withheld } = payload;

--- a/packages/simulation-service/src/hosted-executor.ts
+++ b/packages/simulation-service/src/hosted-executor.ts
@@ -1,5 +1,5 @@
 import { CapabilitiesSchema } from "./contract.js";
-import { SimulationResultSchema } from "@icm/spice-run";
+import { SimulationResultSchema, readSimulationData } from "@icm/spice-run";
 import {
   ExecutionFailure,
   type Executor,
@@ -36,6 +36,30 @@ export function decodeHostedExecutionPayload(
       stage: "read",
       recovery: "not-retryable",
     });
+  // Older executor images projected padded short vectors as sweep samples.
+  // Re-read explicit dimension declarations with the shared reader, without
+  // promoting a result the executor withheld (for example a truncated file).
+  if (
+    parsed.data.data &&
+    typeof rawfile === "string" &&
+    /^\s*\d+\s+\S+\s+\S+[^\r\n]*\bdims=/mu.test(rawfile)
+  ) {
+    const reading = readSimulationData(rawfile);
+    parsed.data.diagnostics.push(
+      ...reading.diagnostics.filter(
+        (d) =>
+          !parsed.data.diagnostics.some((existing) => existing.text === d.text),
+      ),
+    );
+    if (reading.status === "read")
+      parsed.data.data = SimulationResultSchema.shape.data.parse(reading.data);
+    else delete parsed.data.data;
+    if (
+      reading.diagnostics.some((d) => d.severity === "error") &&
+      parsed.data.outcome.status !== "timed-out"
+    )
+      parsed.data.outcome = { status: "failed" };
+  }
   return {
     result: parsed.data,
     cancelled: cancelled === true,

--- a/packages/simulation-service/src/native-measurements.test.ts
+++ b/packages/simulation-service/src/native-measurements.test.ts
@@ -3,6 +3,25 @@ import { nativeMeasurementResults } from "./native-measurements.js";
 import { SimulationOutputDataSchema } from "./contract.js";
 
 describe("native measurement reports", () => {
+  it("ignores unreachable measurement declarations and follows included source", () => {
+    const result = nativeMeasurementResults(
+      [
+        { path: "run.cir", text: '* entry\n.include "active.spice"\n.end\n' },
+        {
+          path: "active.spice",
+          text: ".control\nmeas ac peak MAX v(out)\n.endc\n",
+        },
+        {
+          path: "unused.spice",
+          text: ".control\nmeas ac ghost MAX v(out)\n.endc\n",
+        },
+      ],
+      "run.cir",
+      "peak = 4\nghost = 999\n",
+    );
+    expect(result).toMatchObject([{ name: "peak", value: 4 }]);
+    expect(result).toHaveLength(1);
+  });
   const files = [
     {
       path: "run.cir",

--- a/packages/simulation-service/src/native-measurements.ts
+++ b/packages/simulation-service/src/native-measurements.ts
@@ -1,4 +1,4 @@
-import { parseSpiceSource } from "@icm/spice";
+import { inspectSimulationSourceGraph } from "@icm/netlist";
 import type { SimulationOutputData } from "./contract.js";
 
 /**
@@ -11,30 +11,26 @@ export function nativeMeasurementResults(
   log: string,
 ): NonNullable<SimulationOutputData["nativeMeasurements"]> {
   const declarations = new Map<string, string>();
-  for (const file of files) {
-    if (file.path.endsWith(".json")) continue;
-    for (const statement of parseSpiceSource(
-      {
-        id: file.path,
-        path: file.path,
-        text: file.text,
-        hash: "",
-        encoding: "utf-8",
-      },
-      { titleLine: file.path === entry },
-    ).statements) {
-      const command =
-        statement.kind === "control_command"
-          ? statement.command
-          : statement.kind === "directive"
-            ? statement.name
-            : "";
-      if (!["meas", "measure"].includes(command.toLowerCase())) continue;
-      const args = "arguments" in statement ? statement.arguments : [];
-      const name = args[1];
-      if (name && /^[A-Za-z_][A-Za-z0-9_]*$/u.test(name))
-        declarations.set(name.toLowerCase(), name);
-    }
+  const graph = inspectSimulationSourceGraph({
+    kind: "source",
+    entry,
+    configPath: "experiment.json",
+    files: [...files],
+    circuitBindings: [],
+    dependencies: [],
+  });
+  for (const { statement } of graph.statements) {
+    const command =
+      statement.kind === "control_command"
+        ? statement.command
+        : statement.kind === "directive"
+          ? statement.name
+          : "";
+    if (!["meas", "measure"].includes(command.toLowerCase())) continue;
+    const args = "arguments" in statement ? statement.arguments : [];
+    const name = args[1];
+    if (name && /^[A-Za-z_][A-Za-z0-9_]*$/u.test(name))
+      declarations.set(name.toLowerCase(), name);
   }
   const result: NonNullable<SimulationOutputData["nativeMeasurements"]> = [];
   const counts = new Map<string, number>();

--- a/packages/simulation-service/src/native-output-semantics.test.ts
+++ b/packages/simulation-service/src/native-output-semantics.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import {
+  nativeOutputDeclarations,
+  nativeProbeMeaning,
+} from "./native-output-semantics.js";
+import { evaluateSimulationOutputs } from "./output-evaluation.js";
+
+const declarations = (code: string) =>
+  nativeOutputDeclarations(
+    [{ path: "run.cir", text: `* test\n.control\n${code}\n.endc\n.end\n` }],
+    "run.cir",
+  );
+const probes = [
+  { name: "v(in)", quantity: "voltage", unit: "V", real: [1, 1], imag: [0, 0] },
+  {
+    name: "v(out)",
+    quantity: "voltage",
+    unit: "V",
+    real: [0.5, 0.01],
+    imag: [-0.5, -0.1],
+  },
+  {
+    name: "gain_db",
+    quantity: "decibel",
+    unit: null,
+    real: [-3.0103, -20],
+    imag: [0, 0],
+  },
+  {
+    name: "phase_deg",
+    quantity: "notype",
+    unit: null,
+    real: [-45, -84.3],
+    imag: [0, 0],
+  },
+];
+describe("native result meaning (not AC storage shape)", () => {
+  it("bounds alias depth and memoizes repeated semantic dependencies", () => {
+    const code = [
+      "let x0 = v(out)",
+      ...Array.from({ length: 64 }, (_, i) => `let x${i + 1} = x${i} + x${i}`),
+    ].join("\n");
+    const source = declarations(code);
+    expect(
+      nativeProbeMeaning({ ...probes[3]!, name: "x24" }, probes, true, source),
+    ).toMatchObject({ unit: "V", semantics: { valueKind: "complex" } });
+    expect(
+      nativeProbeMeaning({ ...probes[3]!, name: "x64" }, probes, true, source)
+        .semantics.valueKind,
+    ).toBe("unknown");
+  });
+  it("keeps RC dB/degree expressions real while retaining complex zero-imaginary input", () => {
+    const source = declarations(
+      "let gain_db = db(v(out)/v(in))\nlet phase_deg = 180/PI*cph(v(out)/v(in))",
+    );
+    const result = evaluateSimulationOutputs(
+      {
+        schemaVersion: 1,
+        analyses: [
+          {
+            analysis: "ac",
+            plotName: "AC Analysis",
+            frequencyHz: [1591.55, 1e4],
+            probes,
+          },
+        ],
+      },
+      [],
+      [],
+      [],
+      [],
+      true,
+      {},
+      source,
+    );
+    const out = result.analyses[0]!.outputs;
+    expect(out[0]).toMatchObject({
+      imaginary: [0, 0],
+      semantics: { valueKind: "complex" },
+    });
+    expect(out[2]).toMatchObject({
+      unit: "dB",
+      values: [-3.0103, -20],
+      semantics: { valueKind: "real", origin: "expression" },
+    });
+    expect(out[3]).toMatchObject({
+      unit: "deg",
+      values: [-45, -84.3],
+      semantics: { valueKind: "real" },
+    });
+    expect(out[2]).not.toHaveProperty("imaginary");
+    expect(out[3]).not.toHaveProperty("imaginary");
+    expect(probes[3]!.imag).toEqual([0, 0]);
+  });
+  it("uses expressions and aliases, never suggestive names", () => {
+    const source = declarations(
+      "let H = v(out)/v(in)\nlet funny = 180/PI*cph(H)\nlet gain_db = H\nlet r = real(v(out))",
+    );
+    expect(
+      nativeProbeMeaning(
+        { ...probes[3]!, name: "funny" },
+        probes,
+        true,
+        source,
+      ),
+    ).toMatchObject({ unit: "deg", semantics: { valueKind: "real" } });
+    expect(nativeProbeMeaning(probes[2]!, probes, true, source)).toMatchObject({
+      unit: "1",
+      semantics: { valueKind: "complex" },
+    });
+    expect(
+      nativeProbeMeaning({ ...probes[1]!, name: "r" }, probes, true, source),
+    ).toMatchObject({ unit: "V", semantics: { valueKind: "real" } });
+    expect(
+      nativeProbeMeaning(
+        { ...probes[3]!, name: "mystery_deg" },
+        probes,
+        true,
+        source,
+      ),
+    ).toMatchObject({ unit: "", semantics: { valueKind: "unknown" } });
+  });
+  it("does not guess repeated assignments or evaluate recursive/unsupported programs", () => {
+    const source = declarations(
+      "let x = db(v(out))\nlet x = cph(v(out))\nlet y = z\nlet z = y\nlet custom = user_function(v(out))",
+    );
+    for (const name of ["x", "y", "z", "custom"])
+      expect(
+        nativeProbeMeaning({ ...probes[3]!, name }, probes, true, source)
+          .semantics.valueKind,
+      ).toBe("unknown");
+  });
+  it("ignores an unreferenced source file", () => {
+    const source = nativeOutputDeclarations(
+      [
+        {
+          path: "run.cir",
+          text: "* test\n.control\nlet a = real(v(out))\n.endc",
+        },
+        { path: "unused.cir", text: ".control\nlet a = db(v(out))\n.endc" },
+      ],
+      "run.cir",
+    );
+    expect(source.get("a")).toBe("real(v(out))");
+  });
+  it("does not reinterpret an earlier alias or a conditional program", () => {
+    for (const code of [
+      "let x = later\nlet later = db(v(out))",
+      "if flag\nlet x = db(v(out))\nend",
+    ]) {
+      expect(
+        nativeProbeMeaning(
+          { ...probes[3]!, name: "x" },
+          probes,
+          true,
+          declarations(code),
+        ).semantics.valueKind,
+      ).toBe("unknown");
+    }
+  });
+});

--- a/packages/simulation-service/src/native-output-semantics.ts
+++ b/packages/simulation-service/src/native-output-semantics.ts
@@ -1,0 +1,241 @@
+import { inspectSimulationSourceGraph } from "@icm/netlist";
+import { parseSpiceNumber } from "@icm/spice";
+import type { SimulationProbe } from "@icm/spice-run";
+import type { OutputSemantics } from "./contract.js";
+
+type Meaning = {
+  valueKind: OutputSemantics["valueKind"];
+  unit: string;
+  constant?: number;
+};
+export type NativeDeclarations = ReadonlyMap<string, string | null>;
+const unknown = (): Meaning => ({ valueKind: "unknown", unit: "" });
+
+/** Only reached source is evidence. Conflicting assignments are deliberately ambiguous:
+ * we do not pretend to execute loops, branches, setplot or the ngspice interpreter. */
+export function nativeOutputDeclarations(
+  files: readonly { path: string; text: string }[],
+  entry: string,
+): NativeDeclarations {
+  const graph = inspectSimulationSourceGraph({
+    kind: "source",
+    entry,
+    configPath: "experiment.json",
+    files: [...files],
+    circuitBindings: [],
+    dependencies: [],
+  });
+  const declarations = new Map<string, string | null>();
+  const firstAssignments = new Map<string, number>();
+  let dynamic = false;
+  for (const { statement } of graph.statements) {
+    if (statement.kind !== "control_command") continue;
+    const command = statement.command.toLowerCase();
+    if (
+      [
+        "if",
+        "while",
+        "dowhile",
+        "repeat",
+        "foreach",
+        "goto",
+        "settype",
+        "destroy",
+        "unset",
+      ].includes(command)
+    )
+      dynamic = true;
+    if (command !== "let") continue;
+    const match = /^([a-z_][a-z0-9_]*)\s*=\s*(.+)$/iu.exec(
+      statement.arguments.join(" "),
+    );
+    if (!match) continue;
+    const key = match[1]!.toLowerCase(),
+      expression = match[2]!.trim();
+    if (!firstAssignments.has(key))
+      firstAssignments.set(key, firstAssignments.size);
+    declarations.set(
+      key,
+      declarations.has(key) && declarations.get(key) !== expression
+        ? null
+        : expression,
+    );
+  }
+  for (const [name, expression] of declarations) {
+    // A future declaration is not evidence for a value captured earlier.
+    const forwardReference = expression
+      ?.match(/[a-z_][a-z0-9_]*/giu)
+      ?.some(
+        (token) =>
+          (firstAssignments.get(token.toLowerCase()) ?? -1) >=
+          firstAssignments.get(name)!,
+      );
+    if (dynamic || forwardReference) declarations.set(name, null);
+  }
+  return declarations;
+}
+
+/** A bounded semantic reader, never a second numeric evaluator. Unsupported syntax
+ * stays unknown, and vector spellings (_db, _deg, etc.) carry no authority. */
+export function inferNativeExpression(
+  text: string,
+  resolve: (name: string) => Meaning,
+  depth = 0,
+): Meaning {
+  if (depth > 32 || text.length > 8192) return unknown();
+  const expression = text.trim();
+  if (!expression) return unknown();
+  const recurse = (s: string) => inferNativeExpression(s, resolve, depth + 1);
+  let nesting = 0;
+  const splits: { index: number; operator: string }[] = [];
+  for (let i = 0; i < expression.length; i++) {
+    const c = expression[i]!;
+    if (c === "(") nesting++;
+    else if (c === ")") {
+      if (--nesting < 0) return unknown();
+    } else if (!nesting && "+-*/".includes(c)) {
+      const prefix = expression.slice(0, i).trimEnd();
+      if (!prefix || /[+\-*/(]$/u.test(prefix) || /\d[eE]$/u.test(prefix))
+        continue;
+      splits.push({ index: i, operator: c });
+    }
+  }
+  if (nesting) return unknown();
+  const split =
+    splits.filter((s) => "+-".includes(s.operator)).at(-1) ?? splits.at(-1);
+  if (split) {
+    const left = recurse(expression.slice(0, split.index)),
+      right = recurse(expression.slice(split.index + 1));
+    const op = split.operator;
+    if (left.constant !== undefined && right.constant !== undefined) {
+      const n =
+        op === "+"
+          ? left.constant + right.constant
+          : op === "-"
+            ? left.constant - right.constant
+            : op === "*"
+              ? left.constant * right.constant
+              : left.constant / right.constant;
+      return Number.isFinite(n)
+        ? { valueKind: "real", unit: "1", constant: n }
+        : unknown();
+    }
+    const valueKind =
+      left.valueKind === "unknown" || right.valueKind === "unknown"
+        ? "unknown"
+        : left.valueKind === "complex" || right.valueKind === "complex"
+          ? "complex"
+          : "real";
+    if (!left.unit || !right.unit) return { valueKind, unit: "" };
+    if (op === "+" || op === "-")
+      return { valueKind, unit: left.unit === right.unit ? left.unit : "" };
+    // The conventional explicit radians-to-degrees conversion, not a name heuristic.
+    if (
+      op === "*" &&
+      ((left.unit === "rad" &&
+        right.constant !== undefined &&
+        Math.abs(right.constant - 180 / Math.PI) < 1e-10) ||
+        (right.unit === "rad" &&
+          left.constant !== undefined &&
+          Math.abs(left.constant - 180 / Math.PI) < 1e-10))
+    )
+      return { valueKind, unit: "deg" };
+    if (op === "*")
+      return {
+        valueKind,
+        unit:
+          left.unit === "1"
+            ? right.unit
+            : right.unit === "1"
+              ? left.unit
+              : `${left.unit}·${right.unit}`,
+      };
+    return {
+      valueKind,
+      unit:
+        left.unit === right.unit
+          ? "1"
+          : right.unit === "1"
+            ? left.unit
+            : `${left.unit}/${right.unit}`,
+    };
+  }
+  if (expression.startsWith("(") && expression.endsWith(")"))
+    return recurse(expression.slice(1, -1));
+  if (/^[+-]/u.test(expression)) {
+    const value = recurse(expression.slice(1));
+    return value.constant === undefined
+      ? value
+      : {
+          ...value,
+          constant: expression[0] === "-" ? -value.constant : value.constant,
+        };
+  }
+  const numeric = parseSpiceNumber(expression);
+  if (numeric && !numeric.trailingUnit)
+    return { valueKind: "real", unit: "1", constant: numeric.value };
+  if (expression.toLowerCase() === "pi")
+    return { valueKind: "real", unit: "1", constant: Math.PI };
+  const call = /^([a-z_][a-z0-9_]*)\((.*)\)$/iu.exec(expression);
+  if (call) {
+    const name = call[1]!.toLowerCase(),
+      operandText = call[2]!;
+    if (name === "v" || name === "i") return resolve(expression.toLowerCase());
+    const operand = recurse(operandText);
+    if (name === "db") return { valueKind: "real", unit: "dB" };
+    if (name === "ph" || name === "cph")
+      return { valueKind: "real", unit: "rad" };
+    if (["real", "imag", "mag", "abs"].includes(name))
+      return { valueKind: "real", unit: operand.unit };
+    return unknown();
+  }
+  return /^[a-z_][a-z0-9_]*$/iu.test(expression)
+    ? resolve(expression.toLowerCase())
+    : unknown();
+}
+
+export function nativeProbeMeaning(
+  probe: SimulationProbe,
+  probes: readonly SimulationProbe[],
+  ac: boolean,
+  declarations: NativeDeclarations,
+): { unit: string; semantics: OutputSemantics } {
+  const visited = new Set<string>();
+  const meanings = new Map<string, Meaning>();
+  const byName = new Map(probes.map((p) => [p.name.toLowerCase(), p]));
+  function resolve(name: string): Meaning {
+    const cached = meanings.get(name);
+    if (cached) return cached;
+    if (visited.has(name) || visited.size >= 32) return unknown();
+    if (declarations.has(name)) {
+      const expression = declarations.get(name);
+      if (!expression) return unknown();
+      visited.add(name);
+      const value = inferNativeExpression(expression, resolve);
+      visited.delete(name);
+      meanings.set(name, value);
+      return value;
+    }
+    const raw = byName.get(name);
+    if (!raw) return unknown();
+    const quantity = raw.quantity.toLowerCase();
+    if (quantity === "decibel") return { valueKind: "real", unit: "dB" };
+    if (quantity === "phase") return { valueKind: "real", unit: "rad" };
+    if (!ac) return { valueKind: "real", unit: raw.unit ?? "" };
+    // Physical acquisitions remain complex even with an entirely zero imaginary array.
+    if (/^(?:v|i)\(.+\)$/iu.test(name) || name.startsWith("@"))
+      return { valueKind: "complex", unit: raw.unit ?? "" };
+    return unknown();
+  }
+  const expression = declarations.get(probe.name.toLowerCase());
+  const meaning = resolve(probe.name.toLowerCase());
+  return {
+    unit: meaning.unit,
+    semantics: {
+      valueKind: meaning.valueKind,
+      quantity: probe.quantity,
+      origin: declarations.has(probe.name.toLowerCase()) ? "expression" : "raw",
+      ...(expression ? { expression } : {}),
+    },
+  };
+}

--- a/packages/simulation-service/src/output-evaluation.ts
+++ b/packages/simulation-service/src/output-evaluation.ts
@@ -435,7 +435,13 @@ export function evaluateSimulationOutputs(
                 return {
                   id: `native:${scalar.name.toLowerCase()}`,
                   label: scalar.name,
-                  unit: meaning.unit,
+                  // Cardinality and complex interpretation do not erase a
+                  // declared raw unit. Unsupported expressions remain unknown.
+                  unit:
+                    meaning.unit ||
+                    (meaning.semantics.origin === "raw"
+                      ? (scalar.unit ?? "")
+                      : ""),
                   value: scalar.value,
                   ...(scalar.imaginary !== undefined &&
                   (meaning.semantics.valueKind !== "real" ||

--- a/packages/simulation-service/src/output-evaluation.ts
+++ b/packages/simulation-service/src/output-evaluation.ts
@@ -423,6 +423,38 @@ export function evaluateSimulationOutputs(
         plotName: analysis.plotName,
         ...(domain ? { domain } : {}),
         outputs: evaluated,
+        ...(includeNative && analysis.scalars?.length
+          ? {
+              scalars: analysis.scalars.map((scalar) => {
+                const meaning = nativeProbeMeaning(
+                  scalar,
+                  [...analysis.probes, ...analysis.scalars!],
+                  analysis.analysis === "ac",
+                  declarations,
+                );
+                return {
+                  id: `native:${scalar.name.toLowerCase()}`,
+                  label: scalar.name,
+                  unit: meaning.unit,
+                  value: scalar.value,
+                  ...(scalar.imaginary !== undefined &&
+                  (meaning.semantics.valueKind !== "real" ||
+                    scalar.imaginary !== 0)
+                    ? { imaginary: scalar.imaginary }
+                    : {}),
+                  semantics: {
+                    ...meaning.semantics,
+                    valueKind:
+                      meaning.semantics.valueKind === "real" &&
+                      scalar.imaginary !== undefined &&
+                      scalar.imaginary !== 0
+                        ? "unknown"
+                        : meaning.semantics.valueKind,
+                  },
+                };
+              }),
+            }
+          : {}),
       };
     },
   );
@@ -573,8 +605,23 @@ export function simulationOutputAnalysisToCsv(
         : [output.values[index] ?? null],
     ),
   ]);
-  const series =
+  let series =
     [headers, ...rows].map((row) => row.map(quote).join(",")).join("\n") + "\n";
+  if (analysis.scalars?.length)
+    series +=
+      "\n" +
+      [
+        ["Captured scalar", "Real value", "Imaginary value", "Unit"],
+        ...analysis.scalars.map((s) => [
+          s.label,
+          s.value,
+          s.imaginary ?? null,
+          s.unit,
+        ]),
+      ]
+        .map((row) => row.map(quote).join(","))
+        .join("\n") +
+      "\n";
   if (!analysis.integrated?.length) return series;
   return (
     series +

--- a/packages/simulation-service/src/output-evaluation.ts
+++ b/packages/simulation-service/src/output-evaluation.ts
@@ -14,6 +14,10 @@ import type { SimulationMeasurementSpec } from "@icm/model";
 import type { SimulationOutputData } from "./contract.js";
 import { deriveAutomaticMeasurements } from "./automatic-measurements.js";
 import { deriveAuthoredMeasurements } from "./authored-measurements.js";
+import {
+  nativeProbeMeaning,
+  type NativeDeclarations,
+} from "./native-output-semantics.js";
 
 interface ComplexSeries {
   readonly real: readonly (number | null)[];
@@ -200,6 +204,7 @@ function sourceSeries(
     { analysis: "noise" }
   >,
   vectors: readonly CompiledSimulationVector[],
+  declarations: NativeDeclarations = new Map(),
 ): Map<string, ComplexSeries> {
   const byName = new Map(
     analysis.probes.map((probe) => [probe.name.toLowerCase(), probe]),
@@ -215,9 +220,15 @@ function sourceSeries(
         ? (byName.get(`i(${name})`) ?? byName.get(`v(${name})`))
         : undefined);
     if (!source) continue;
+    const meaning = nativeProbeMeaning(
+      source,
+      analysis.probes,
+      analysis.analysis === "ac",
+      declarations,
+    );
     const unit =
       vector.quantity === "native"
-        ? (source.unit ?? "")
+        ? meaning.unit
         : vector.quantity === "voltage"
           ? "V"
           : "A";
@@ -226,7 +237,10 @@ function sourceSeries(
         unit,
         real: source.real,
         imaginary: source.imag,
-        complex: true,
+        complex:
+          vector.quantity !== "native" ||
+          meaning.semantics.valueKind !== "real" ||
+          source.imag.some((v) => v !== 0),
       });
     } else {
       const value = "value" in source ? source.value : [];
@@ -251,6 +265,7 @@ export function evaluateSimulationOutputs(
   deviceOperatingPointSpecs: readonly CompiledSimulationDeviceOperatingPoint[] = [],
   includeNative = false,
   signalNames: Readonly<Record<string, string>> = {},
+  declarations: NativeDeclarations = new Map(),
 ): SimulationOutputData {
   const diagnostics: SimulationOutputData["diagnostics"] = [];
   const analyses: SimulationOutputData["analyses"] = data.analyses.map(
@@ -298,7 +313,7 @@ export function evaluateSimulationOutputs(
           ],
         };
       }
-      const acquisitions = sourceSeries(analysis, vectors);
+      const acquisitions = sourceSeries(analysis, vectors, declarations);
       const pointCount =
         analysis.analysis === "op"
           ? 1
@@ -307,30 +322,42 @@ export function evaluateSimulationOutputs(
             : analysis.analysis === "tran"
               ? analysis.timeSeconds.length
               : analysis.sweep.values.length;
-      const evaluated = outputs.flatMap((output) => {
-        try {
-          const series = evaluate(output.expression, acquisitions, pointCount);
-          return [
-            {
-              id: output.id,
-              label: output.label,
-              unit: series.unit,
-              values: [...series.real],
-              ...(series.complex ? { imaginary: [...series.imaginary] } : {}),
-            },
-          ];
-        } catch (error) {
-          diagnostics.push({
-            analysisIndex,
-            ...rawOrigin,
-            outputId: output.id,
-            code: "SIMULATION_OUTPUT_EVALUATION_FAILED",
-            message:
-              error instanceof Error ? error.message : "Evaluation failed",
-          });
-          return [];
-        }
-      });
+      const evaluated: SimulationOutputData["analyses"][number]["outputs"] =
+        outputs.flatMap((output) => {
+          try {
+            const series = evaluate(
+              output.expression,
+              acquisitions,
+              pointCount,
+            );
+            return [
+              {
+                id: output.id,
+                label: output.label,
+                unit: series.unit,
+                values: [...series.real],
+                ...(series.complex ? { imaginary: [...series.imaginary] } : {}),
+                semantics: {
+                  valueKind: series.complex
+                    ? ("complex" as const)
+                    : ("real" as const),
+                  quantity: series.unit,
+                  origin: "expression" as const,
+                },
+              },
+            ];
+          } catch (error) {
+            diagnostics.push({
+              analysisIndex,
+              ...rawOrigin,
+              outputId: output.id,
+              code: "SIMULATION_OUTPUT_EVALUATION_FAILED",
+              message:
+                error instanceof Error ? error.message : "Evaluation failed",
+            });
+            return [];
+          }
+        });
       if (includeNative) {
         const represented = new Set(
           outputs.flatMap(({ expression }) =>
@@ -348,7 +375,15 @@ export function evaluateSimulationOutputs(
             vector: probe.name,
             quantity: "native" as const,
           };
-          const series = sourceSeries(analysis, [native]).get(native.probeId)!;
+          const meaning = nativeProbeMeaning(
+            probe,
+            analysis.probes,
+            analysis.analysis === "ac",
+            declarations,
+          );
+          const series = sourceSeries(analysis, [native], declarations).get(
+            native.probeId,
+          )!;
           const friendly = signalNames[probe.name.toLowerCase()];
           evaluated.push({
             id: native.probeId,
@@ -356,6 +391,13 @@ export function evaluateSimulationOutputs(
             unit: series.unit,
             values: [...series.real],
             ...(series.complex ? { imaginary: [...series.imaginary] } : {}),
+            semantics: {
+              ...meaning.semantics,
+              valueKind:
+                meaning.semantics.valueKind === "real" && series.complex
+                  ? "unknown"
+                  : meaning.semantics.valueKind,
+            },
           });
         }
       }
@@ -392,7 +434,7 @@ export function evaluateSimulationOutputs(
     deviceOperatingPointSpecs.flatMap((device) => {
       const operatingPoint = record?.analysis;
       const acquisitions = operatingPoint
-        ? sourceSeries(operatingPoint, vectors)
+        ? sourceSeries(operatingPoint, vectors, declarations)
         : new Map();
       const native = device.id.startsWith("native-op:");
       const values = native

--- a/packages/simulation-service/src/scalar-results.test.ts
+++ b/packages/simulation-service/src/scalar-results.test.ts
@@ -7,6 +7,27 @@ import {
 } from "./output-evaluation.js";
 import { SimulationOutputDataSchema } from "./contract.js";
 describe("scalar output projection", () => {
+  it("retains an explicit captured Hz unit through evaluation and CSV without guessing a complex view", () => {
+    const raw = readFileSync(
+      new URL(
+        "../../../fixtures/ngspice-rawfile/native-scalars-ac.raw",
+        import.meta.url,
+      ),
+      "utf8",
+    ).replace("peak_gain_db notype", "peak_frequency frequency");
+    const r = readSimulationData(raw);
+    if (r.status !== "read") throw Error("read expected");
+    const data = evaluateSimulationOutputs(r.data, [], [], [], [], true);
+    expect(data.analyses[0]?.scalars?.[0]).toMatchObject({
+      label: "peak_frequency",
+      value: 4,
+      unit: "Hz",
+      semantics: { valueKind: "unknown", origin: "raw" },
+    });
+    expect(simulationOutputAnalysisToCsv(data.analyses[0]!)).toContain(
+      '"peak_frequency","4","0","Hz"',
+    );
+  });
   it("never derives curve measurements from raw scalar padding and preserves scalars in export", () => {
     const raw = readFileSync(
       new URL(

--- a/packages/simulation-service/src/scalar-results.test.ts
+++ b/packages/simulation-service/src/scalar-results.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from "node:fs";
+import { describe, it, expect } from "vitest";
+import { readSimulationData } from "@icm/spice-run";
+import {
+  evaluateSimulationOutputs,
+  simulationOutputAnalysisToCsv,
+} from "./output-evaluation.js";
+import { SimulationOutputDataSchema } from "./contract.js";
+describe("scalar output projection", () => {
+  it("never derives curve measurements from raw scalar padding and preserves scalars in export", () => {
+    const raw = readFileSync(
+      new URL(
+        "../../../fixtures/ngspice-rawfile/native-scalars-ac.raw",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+    const r = readSimulationData(raw);
+    if (r.status !== "read") throw Error("read expected");
+    const data = evaluateSimulationOutputs(r.data, [], [], [], [], true);
+    expect(SimulationOutputDataSchema.safeParse(data).success).toBe(true);
+    const a = data.analyses[0]!;
+    expect(a.outputs.map((o) => o.id)).toEqual([
+      "native:gain_db",
+      "native:v(reference)",
+    ]);
+    expect(a.scalars).toMatchObject([
+      { label: "peak_gain_db", value: 4 },
+      { label: "scalar_phasor", value: 3, imaginary: 4 },
+    ]);
+    expect(
+      data.measurements?.some((m) => m.outputId === "native:peak_gain_db"),
+    ).toBe(false);
+    const csv = simulationOutputAnalysisToCsv(a);
+    expect(csv.split("\n")[0]).not.toContain("peak_gain_db");
+    expect(csv).toContain('"Captured scalar"');
+    expect(csv).toContain('"peak_gain_db","4"');
+    const contradictory = structuredClone(r.data);
+    const phasor = contradictory.analyses[0]?.scalars?.[1];
+    if (!phasor) throw Error("scalar expected");
+    const changed = {
+      ...contradictory,
+      analyses: contradictory.analyses.map((analysis) => ({
+        ...analysis,
+        scalars: analysis.scalars?.map((s) =>
+          s.name === "scalar_phasor"
+            ? { ...s, quantity: "decibel", unit: "dB" }
+            : s,
+        ),
+      })),
+    };
+    const projected = evaluateSimulationOutputs(changed, [], [], [], [], true);
+    expect(projected.analyses[0]?.scalars?.[1]).toMatchObject({
+      imaginary: 4,
+      semantics: { valueKind: "unknown" },
+    });
+  });
+});

--- a/packages/simulation-service/src/service.ts
+++ b/packages/simulation-service/src/service.ts
@@ -18,6 +18,7 @@ import {
 } from "./output-evaluation.js";
 import { automaticMeasurementsToCsv } from "./automatic-measurements.js";
 import { nativeMeasurementResults } from "./native-measurements.js";
+import { nativeOutputDeclarations } from "./native-output-semantics.js";
 
 import {
   ExecutionFailure,
@@ -769,6 +770,7 @@ export class SimulationService {
           run.prepared.deviceOperatingPoints,
           true,
           run.prepared.signalNames,
+          nativeOutputDeclarations(input.files, input.entryPath ?? "run.cir"),
         );
       }
       const nativeMeasurements = nativeMeasurementResults(

--- a/packages/spice-run/src/result-data.ts
+++ b/packages/spice-run/src/result-data.ts
@@ -53,6 +53,12 @@ export interface OperatingPointProbe extends SimulationProbe {
 export interface SimulationRawPlotOrigin {
   /** Optional only for archived results created before native multi-record support. */
   readonly rawPlotOrdinals?: readonly number[] | undefined;
+  /** Explicit short vectors of length one, never inferred from a flat waveform. */
+  readonly scalars?: readonly CapturedScalar[] | undefined;
+}
+export interface CapturedScalar extends SimulationProbe {
+  readonly value: number;
+  readonly imaginary?: number | undefined;
 }
 export interface OperatingPointResult extends SimulationRawPlotOrigin {
   readonly analysis: "op";
@@ -317,6 +323,74 @@ export function readSimulationData(rawfile: string): SimulationDataReading {
 }
 
 function readPlot(plot: RawfilePlot): PlotReading {
+  if (
+    [
+      "ac analysis",
+      "transient analysis",
+      "dc transfer characteristic",
+    ].includes(plot.plotName.trim().toLowerCase())
+  ) {
+    const scalars: CapturedScalar[] = [];
+    const vectors: RawfileVector[] = [];
+    for (const vector of plot.vectors) {
+      const dimensions = vector.variable.qualifiers.filter((q) =>
+        q.startsWith("dims="),
+      );
+      if (!dimensions.length) {
+        vectors.push(vector);
+        continue;
+      }
+      const spelling = dimensions[0]!.slice(5);
+      if (
+        dimensions.length !== 1 ||
+        !/^[1-9]\d*(?:,[1-9]\d*)*$/u.test(spelling)
+      )
+        return {
+          diagnostic: error(
+            `Invalid dimensions for "${vector.variable.name}": ${dimensions.join(" ")}.`,
+          ),
+        };
+      if (spelling.includes(","))
+        return {
+          diagnostic: error(
+            `"${vector.variable.name}" declares multidimensional data (${spelling}); it cannot be flattened onto a one-dimensional sweep axis. Inspect the rawfile.`,
+          ),
+        };
+      const length = Number(spelling);
+      if (!Number.isSafeInteger(length) || length > plot.pointCount)
+        return {
+          diagnostic: error(
+            `Dimensions for "${vector.variable.name}" exceed the recorded point count.`,
+          ),
+        };
+      if (
+        length === 1 &&
+        (plot.pointCount > 1 ||
+          (!["frequency", "time"].includes(
+            vector.variable.quantity.toLowerCase(),
+          ) &&
+            !vector.variable.name.toLowerCase().endsWith("-sweep")))
+      ) {
+        scalars.push({
+          ...probeOf(vector),
+          value: vector.real[0]!,
+          ...(vector.imag ? { imaginary: vector.imag[0]! } : {}),
+        });
+      } else if (length === plot.pointCount) vectors.push(vector);
+      else
+        return {
+          diagnostic: error(
+            `"${vector.variable.name}" has ${length} valid values, not ${plot.pointCount} sweep samples. A shorter vector cannot be placed on this axis; inspect the rawfile.`,
+          ),
+        };
+    }
+    if (scalars.length) {
+      const reading = readPlot({ ...plot, vectors });
+      return "analysis" in reading
+        ? { analysis: { ...reading.analysis, scalars } }
+        : reading;
+    }
+  }
   const name = plot.plotName.trim().toLowerCase();
   if (plot.vectors.length === 0 || plot.pointCount === 0) {
     return {
@@ -663,6 +737,17 @@ export function simulationAnalysisToCsv(
           : analysis.analysis === "tran"
             ? transientRows(analysis)
             : noiseRows(analysis);
+  if (analysis.scalars?.length)
+    rows.push(
+      [],
+      ["Captured scalar", "Real value", "Imaginary value", "Unit"],
+      ...analysis.scalars.map((s) => [
+        s.name,
+        String(s.value),
+        s.imaginary === undefined ? "" : String(s.imaginary),
+        s.unit ?? "",
+      ]),
+    );
   return rows.map((row) => row.map(csvField).join(",")).join("\n") + "\n";
 }
 

--- a/packages/spice-run/src/result-data.ts
+++ b/packages/spice-run/src/result-data.ts
@@ -187,6 +187,8 @@ const UNIT_BY_QUANTITY = new Map<string, string>([
   ["resistance", "Ω"],
   ["time", "s"],
   ["frequency", "Hz"],
+  ["decibel", "dB"],
+  ["phase", "rad"],
   ["temp-sweep", "°C"],
   ["res-sweep", "Ω"],
 ]);

--- a/packages/spice-run/src/result-schema.ts
+++ b/packages/spice-run/src/result-schema.ts
@@ -26,11 +26,21 @@ const SimulationProbeShape = {
   quantity: z.string(),
   unit: z.string().nullable(),
 };
+const CapturedScalarsSchema = z
+  .array(
+    z.strictObject({
+      ...SimulationProbeShape,
+      value: z.number().finite(),
+      imaginary: z.number().finite().optional(),
+    }),
+  )
+  .optional();
 
 const SimulationAnalysisResultSchema = z.discriminatedUnion("analysis", [
   z.strictObject({
     rawPlotOrdinals: SimulationRawPlotOrdinalsSchema.optional(),
     analysis: z.literal("op"),
+    scalars: CapturedScalarsSchema,
     plotName: z.string(),
     probes: z.array(
       z.strictObject({ ...SimulationProbeShape, value: z.number() }),
@@ -38,6 +48,7 @@ const SimulationAnalysisResultSchema = z.discriminatedUnion("analysis", [
   }),
   z.strictObject({
     analysis: z.literal("ac"),
+    scalars: CapturedScalarsSchema,
     rawPlotOrdinals: SimulationRawPlotOrdinalsSchema.optional(),
     plotName: z.string(),
     frequencyHz: z.array(z.number()),
@@ -54,6 +65,7 @@ const SimulationAnalysisResultSchema = z.discriminatedUnion("analysis", [
   }),
   z.strictObject({
     analysis: z.literal("dc"),
+    scalars: CapturedScalarsSchema,
     rawPlotOrdinals: SimulationRawPlotOrdinalsSchema.optional(),
     plotName: z.string(),
     sweep: z.strictObject({
@@ -66,6 +78,7 @@ const SimulationAnalysisResultSchema = z.discriminatedUnion("analysis", [
   }),
   z.strictObject({
     analysis: z.literal("tran"),
+    scalars: CapturedScalarsSchema,
     rawPlotOrdinals: SimulationRawPlotOrdinalsSchema.optional(),
     plotName: z.string(),
     timeSeconds: z.array(z.number()),
@@ -75,6 +88,7 @@ const SimulationAnalysisResultSchema = z.discriminatedUnion("analysis", [
   }),
   z.strictObject({
     analysis: z.literal("noise"),
+    scalars: CapturedScalarsSchema,
     rawPlotOrdinals: SimulationRawPlotOrdinalsSchema.optional(),
     plotName: z.literal("Noise Analysis"),
     frequencyHz: z.array(z.number()),

--- a/packages/spice-run/src/scalar-results.test.ts
+++ b/packages/spice-run/src/scalar-results.test.ts
@@ -1,0 +1,97 @@
+import { readFileSync } from "node:fs";
+import { describe, it, expect } from "vitest";
+import { readSimulationData, simulationAnalysisToCsv } from "./result-data.js";
+const source = readFileSync(
+  new URL(
+    "../../../fixtures/ngspice-rawfile/native-scalars-ac.raw",
+    import.meta.url,
+  ),
+  "utf8",
+);
+describe("captured scalar cardinality", () => {
+  it("separates explicit singletons, preserving signed/complex values and constant waveforms", () => {
+    const result = readSimulationData(source);
+    expect(result.status).toBe("read");
+    if (result.status !== "read") return;
+    const a = result.data.analyses[0]!;
+    if (a.analysis !== "ac") throw Error("AC expected");
+    expect(a.probes.map((p) => p.name)).toEqual(["gain_db", "v(reference)"]);
+    expect(a.probes[1]?.real).toEqual([1, 1, 1]);
+    expect(a.scalars).toMatchObject([
+      { name: "peak_gain_db", value: 4, imaginary: 0 },
+      { name: "scalar_phasor", value: 3, imaginary: 4 },
+    ]);
+    const csv = simulationAnalysisToCsv(a);
+    expect(csv.split("\n")[0]).not.toContain("peak_gain_db");
+    expect(csv).toContain("peak_gain_db,4,0,");
+    expect(csv).toContain("scalar_phasor,3,4,");
+  });
+  it("does not infer a scalar from zero padding without a declaration", () => {
+    const r = readSimulationData(source.replaceAll(" dims=1", ""));
+    if (r.status !== "read") throw Error("read expected");
+    expect(r.data.analyses[0]?.scalars).toBeUndefined();
+  });
+  it("does not mistake a captured frequency for a second frequency axis", () => {
+    const r = readSimulationData(
+      source.replace("peak_gain_db notype", "peak_frequency frequency"),
+    );
+    if (r.status !== "read") throw Error(JSON.stringify(r));
+    expect(r.data.analyses[0]?.scalars?.[0]).toMatchObject({
+      name: "peak_frequency",
+      value: 4,
+      unit: "Hz",
+    });
+  });
+  it("preserves a negative singleton without taking magnitude", () => {
+    const r = readSimulationData(source.replace("4,0\n 3,4", "-4,0\n 3,4"));
+    if (r.status !== "read") throw Error("read expected");
+    expect(r.data.analyses[0]?.scalars?.[0]?.value).toBe(-4);
+  });
+  it("keeps an unqualified one-point AC acquisition as a waveform", () => {
+    const onePoint = source
+      .slice(0, source.indexOf("\n 1 200"))
+      .replace("No. Points: 3", "No. Points: 1");
+    const r = readSimulationData(onePoint);
+    if (r.status !== "read") throw Error("read expected");
+    expect(r.data.analyses[0]?.probes.map((p) => p.name)).toEqual([
+      "gain_db",
+      "v(reference)",
+    ]);
+  });
+  it.each(["dims=2", "dims=99", "dims=x", "dims=1 dims=1", "dims=1,3"])(
+    "refuses ambiguous or unsupported axis alignment: %s",
+    (dims) => {
+      const r = readSimulationData(source.replace("dims=1", dims));
+      expect(r.status).toBe("unusable");
+      expect(r.diagnostics.length).toBeGreaterThan(0);
+    },
+  );
+  it("keeps repeated captured values attached to their raw plot", () => {
+    const r = readSimulationData(
+      source + "\n" + source.replace("4,0\n 3,4", "7,0\n 3,4"),
+    );
+    if (r.status !== "read") throw Error("read expected");
+    expect(
+      r.data.analyses.map((a) => [a.rawPlotOrdinals, a.scalars?.[0]?.value]),
+    ).toEqual([
+      [[0], 4],
+      [[1], 7],
+    ]);
+  });
+  it.each([
+    ["Transient Analysis", "time", "time", "tran"],
+    ["DC transfer characteristic", "v-sweep", "voltage", "dc"],
+  ])(
+    "separates real scalar padding in %s",
+    (plotName, axis, quantity, kind) => {
+      const raw = `Title: synthetic real scalar\nPlotname: ${plotName}\nFlags: real\nNo. Variables: 2\nNo. Points: 2\nVariables:\n0 ${axis} ${quantity}\n1 captured voltage dims=1\nValues:\n0 0\n-2\n\n1 1\n0\n\n`;
+      const r = readSimulationData(raw);
+      if (r.status !== "read") throw Error(JSON.stringify(r));
+      expect(r.data.analyses[0]).toMatchObject({
+        analysis: kind,
+        probes: [],
+        scalars: [{ name: "captured", value: -2, unit: "V" }],
+      });
+    },
+  );
+});

--- a/packages/spice-run/src/scalar-results.test.ts
+++ b/packages/spice-run/src/scalar-results.test.ts
@@ -53,10 +53,9 @@ describe("captured scalar cardinality", () => {
       .replace("No. Points: 3", "No. Points: 1");
     const r = readSimulationData(onePoint);
     if (r.status !== "read") throw Error("read expected");
-    expect(r.data.analyses[0]?.probes.map((p) => p.name)).toEqual([
-      "gain_db",
-      "v(reference)",
-    ]);
+    const a = r.data.analyses[0];
+    if (a?.analysis !== "ac") throw Error("AC expected");
+    expect(a.probes.map((p) => p.name)).toEqual(["gain_db", "v(reference)"]);
   });
   it.each(["dims=2", "dims=99", "dims=x", "dims=1 dims=1", "dims=1,3"])(
     "refuses ambiguous or unsupported axis alignment: %s",

--- a/scripts/analyze-native-simulation-examples.mjs
+++ b/scripts/analyze-native-simulation-examples.mjs
@@ -1,0 +1,305 @@
+import assert from "node:assert/strict";
+import { readFile, writeFile, rename } from "node:fs/promises";
+import { resolve, join } from "node:path";
+import { createHash } from "node:crypto";
+import { parseProject } from "../packages/project-protocol/dist/index.js";
+import { compileSourceSimulation } from "../packages/netlist/dist/index.js";
+
+const root = resolve(process.argv[2] ?? "output/native-simulation-examples");
+const read = async (path) => JSON.parse(await readFile(path, "utf8"));
+const manifest = await read(join(root, "manifest.json"));
+const runs = new Map();
+const checks = [];
+function check(name, actual, expected, tolerance) {
+  checks.push({
+    name,
+    actual,
+    expected,
+    tolerance,
+    passed: Number.isFinite(actual) && Math.abs(actual - expected) <= tolerance,
+  });
+}
+for (const project of manifest.projects) {
+  const currentProject = parseProject(await readFile(project.file, "utf8"));
+  const receipt = await read(
+    join(root, "results", project.slug, "receipt.json"),
+  );
+  assert.equal(receipt.status, "passed", `${project.slug}: incomplete MCP run`);
+  for (const folder of project.folders) {
+    const dir = join(root, "results", project.slug, folder.id);
+    const runReceipt = await read(join(dir, "run.json"));
+    assert.equal(
+      receipt.runs.find((r) => r.folderId === folder.id)?.runId,
+      runReceipt.id,
+      `${folder.id}: result must belong to this batch`,
+    );
+    assert(runReceipt.artifacts.some((a) => a.name === "result.json"));
+    for (const artifact of runReceipt.artifacts) {
+      const bytes = await readFile(join(dir, artifact.name));
+      assert.equal(
+        createHash("sha256").update(bytes).digest("hex"),
+        artifact.sha256,
+        `${folder.id}: stale or corrupt ${artifact.name}`,
+      );
+    }
+    const compiled = compileSourceSimulation(
+      currentProject,
+      currentProject.simulationFolders.find((f) => f.id === folder.id),
+    );
+    assert(compiled.ok, `${folder.id}: current Project does not compile`);
+    for (const file of compiled.files)
+      assert.equal(
+        await readFile(join(dir, file.path), "utf8"),
+        file.text,
+        `${folder.id}/${file.path}: delivered Project must match the simulated electrical input`,
+      );
+    const result = await read(join(dir, "result.json"));
+    assert.equal(result.outcome.status, "completed", folder.id);
+    const analyses = result.data?.analyses ?? [];
+    assert(analyses.length > 0, `${folder.id}: no captured results`);
+    const measurements = await read(
+      join(dir, "native-measurements.json"),
+    ).catch(() => []);
+    assert(
+      measurements.every((m) => m.status === "available"),
+      `${folder.id}: failed native measurement`,
+    );
+    for (const a of analyses)
+      for (const p of a.probes ?? []) {
+        for (const values of [p.value, p.real, p.imag]) {
+          if (values !== undefined)
+            assert(
+              (Array.isArray(values) ? values : [values]).every(
+                Number.isFinite,
+              ),
+              `${folder.id}: nonfinite ${p.name}`,
+            );
+        }
+      }
+    // The Results exporter returns a ZIP when a record has multiple plot groups.
+    for (let i = 0; i < analyses.length; i++) {
+      const plot = join(dir, `plot-${i}.svg`);
+      const bytes = await readFile(plot).catch(() => null);
+      if (bytes?.subarray(0, 2).toString() === "PK")
+        await rename(plot, join(dir, `plot-${i}.zip`));
+    }
+    runs.set(folder.id, {
+      project: project.slug,
+      name: folder.name,
+      result,
+      analyses,
+      measurements,
+    });
+  }
+}
+const meas = (id, name, occurrence = 1) =>
+  runs
+    .get(id)
+    .measurements.find((m) => m.name === name && m.occurrence === occurrence)
+    ?.value;
+const analysis = (id, kind) =>
+  runs.get(id).analyses.find((a) => a.analysis === kind);
+const probe = (a, name) => {
+  const p = a.probes.find((p) => p.name === name);
+  assert(p, `missing ${name}`);
+  return p;
+};
+const scalar = (p) => (Array.isArray(p.value) ? p.value[0] : p.value);
+for (const [id, run] of runs) {
+  if (id === "ota-noise" || id.endsWith("-op")) continue;
+  const pair = id.startsWith("ota-")
+    ? ["v(vinp)", "v(vout)"]
+    : ["v(in)", "v(out)"];
+  for (const a of run.analyses) for (const name of pair) probe(a, name);
+}
+for (const kind of ["lp", "hp"])
+  check(
+    `RC ${kind} cutoff dB`,
+    meas(`rc-${kind}-ac`, "gain_at_fc"),
+    -10 * Math.log10(2),
+    0.005,
+  );
+check(
+  "RC LP one time constant",
+  meas("rc-lp-tran", "at_one_tau"),
+  1 - Math.exp(-1),
+  0.001,
+);
+check(
+  "RC HP one time constant",
+  meas("rc-hp-tran", "at_one_tau"),
+  Math.exp(-1),
+  0.001,
+);
+const zeta = (200 / 2) * Math.sqrt(100e-9 / 10e-3);
+check(
+  "RLC underdamped peak",
+  meas("rlc-1", "peak_output"),
+  1 + Math.exp((-Math.PI * zeta) / Math.sqrt(1 - zeta * zeta)),
+  0.002,
+);
+check(
+  "RLC resonance dB",
+  meas("rlc-1", "peak_gain_db"),
+  20 * Math.log10(1 / (2 * zeta * Math.sqrt(1 - zeta * zeta))),
+  0.01,
+);
+for (const id of ["rlc-2", "rlc-3"])
+  check(`${id} monotonic step peak`, meas(id, "peak_output"), 1, 0.001);
+
+const cs = analysis("cs-op", "op");
+const csOut = scalar(probe(cs, "v(out)"));
+const csCurrent = -scalar(probe(cs, "i(vdd)"));
+check("Common-source load line", csOut + csCurrent * 10000, 1.8, 1e-5);
+const csGm = scalar(cs.probes.find((p) => p.name.endsWith("[gm]")));
+const csGds = scalar(cs.probes.find((p) => p.name.endsWith("[gds]")));
+const gainEstimate = csGm / (1 / 10000 + csGds);
+check(
+  "Common-source AC versus gm/(1/R+gds)",
+  meas("cs-ac", "gain_db_1khz"),
+  20 * Math.log10(gainEstimate),
+  0.05,
+);
+check(
+  "Common-source small signal p-p",
+  meas("cs-tran", "output_pp", 1),
+  0.02 * gainEstimate,
+  0.02 * gainEstimate * 0.05,
+);
+const csAc = analysis("cs-ac", "ac");
+const csVout = probe(csAc, "v(out)");
+assert(csVout.real[0] < 0, "common source must invert");
+const csDistortion = runs.get("cs-tran").analyses.map((a) => {
+  const t = a.timeSeconds,
+    y = probe(a, "v(out)").value;
+  const n = 2048,
+    samples = [];
+  let k = 0;
+  for (let j = 0; j < n; j++) {
+    const at = 200e-6 + (j * 200e-6) / n;
+    while (k + 1 < t.length - 1 && t[k + 1] < at) k++;
+    const f = (at - t[k]) / (t[k + 1] - t[k]);
+    samples.push(y[k] + f * (y[k + 1] - y[k]));
+  }
+  const harmonics = Array.from({ length: 5 }, (_, i) => {
+    let re = 0,
+      im = 0;
+    for (let j = 0; j < n; j++) {
+      const phase = (2 * Math.PI * (i + 1) * 2 * j) / n;
+      re += samples[j] * Math.cos(phase);
+      im += samples[j] * Math.sin(phase);
+    }
+    return (2 * Math.hypot(re, im)) / n;
+  });
+  return {
+    minV: Math.min(...samples),
+    maxV: Math.max(...samples),
+    harmonicsV: harmonics,
+    thd2to5: Math.hypot(...harmonics.slice(1)) / harmonics[0],
+  };
+});
+assert(
+  csDistortion[1].thd2to5 > csDistortion[0].thd2to5,
+  "large signal should show greater distortion",
+);
+
+const otaOp = analysis("ota-op", "op");
+const otaOut = scalar(probe(otaOp, "v(vout)"));
+check("OTA nominal output bias", otaOut, 0.75898, 0.005);
+const otaAC = [];
+for (const corner of ["tt", "ff", "ss"]) {
+  assert(meas(`ota-ac-${corner}`, "dc_gain_db") > 20);
+  assert(meas(`ota-ac-${corner}`, "unity_gain_hz") > 0);
+  const a = analysis(`ota-ac-${corner}`, "ac"),
+    unity = meas(`ota-ac-${corner}`, "unity_gain_hz");
+  const phase = probe(a, "phase_deg").real;
+  const i = a.frequencyHz.findIndex((f) => f >= unity);
+  assert(i > 0);
+  const fraction =
+    Math.log(unity / a.frequencyHz[i - 1]) /
+    Math.log(a.frequencyHz[i] / a.frequencyHz[i - 1]);
+  otaAC.push({
+    corner,
+    gainDb: meas(`ota-ac-${corner}`, "dc_gain_db"),
+    unityHz: unity,
+    nominalPhaseMarginDeg:
+      180 + phase[i - 1] + fraction * (phase[i] - phase[i - 1]),
+  });
+}
+check(
+  "OTA unity follower low frequency",
+  meas("ota-closed", "closed_gain_db"),
+  20 * Math.log10(120.1227 / (1 + 120.1227)),
+  0.04,
+);
+check(
+  "OTA closed-loop step target",
+  meas("ota-closed", "output_at_2us"),
+  0.91,
+  0.003,
+);
+const noise = runs.get("ota-noise").analyses;
+const noiseRecord = noise.find((a) => a.analysis === "noise");
+assert(
+  noiseRecord?.rawPlotOrdinals.length === 2,
+  "capture noise spectrum and integrated noise",
+);
+for (const density of [
+  noiseRecord.inputNoiseDensity,
+  noiseRecord.outputNoiseDensity,
+])
+  assert(density.every((v) => Number.isFinite(v) && v > 0));
+assert(
+  noiseRecord.integratedInputNoise > 0 && noiseRecord.integratedOutputNoise > 0,
+);
+
+const summary = {
+  environment: runs.get("ota-op").result.metadata.environment,
+  checks,
+  commonSource: {
+    outputV: csOut,
+    supplyA: csCurrent,
+    gm: csGm,
+    gds: csGds,
+    gainEstimate,
+    smallSignalPP: meas("cs-tran", "output_pp", 1),
+    largeSignalPP: meas("cs-tran", "output_pp", 2),
+    distortion: csDistortion,
+  },
+  ota: {
+    ac: otaAC,
+    outputV: otaOut,
+    supplyA: -scalar(probe(otaOp, "i(vdd)")),
+    deviceValues: otaOp.probes.filter((p) => p.name.includes("[")),
+    noise: {
+      integratedInputV: noiseRecord.integratedInputNoise,
+      integratedOutputV: noiseRecord.integratedOutputNoise,
+      minFrequencyHz: noiseRecord.frequencyHz[0],
+      maxFrequencyHz: noiseRecord.frequencyHz.at(-1),
+      inputAt1Hz: noiseRecord.inputNoiseDensity[0],
+      outputAt1Hz: noiseRecord.outputNoiseDensity[0],
+    },
+  },
+  measurements: Object.fromEntries(
+    [...runs].map(([id, r]) => [id, r.measurements]),
+  ),
+};
+await writeFile(
+  join(root, "acceptance.json"),
+  JSON.stringify(summary, null, 2) + "\n",
+);
+console.log(
+  JSON.stringify(
+    {
+      checks,
+      commonSource: summary.commonSource,
+      ota: { outputV: summary.ota.outputV, supplyA: summary.ota.supplyA },
+    },
+    null,
+    2,
+  ),
+);
+assert(
+  checks.every((c) => c.passed),
+  "Electrical acceptance failed; inspect acceptance.json",
+);

--- a/scripts/build-native-simulation-examples.mjs
+++ b/scripts/build-native-simulation-examples.mjs
@@ -1,0 +1,738 @@
+import assert from "node:assert/strict";
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { resolve, join } from "node:path";
+import { importSpiceSources } from "../packages/spice/dist/index.js";
+import {
+  parseProject,
+  serializeProject,
+} from "../packages/project-protocol/dist/index.js";
+import {
+  createSimulationFolder,
+  createRoutePath,
+  CircuitProjectSchema,
+} from "../packages/model/dist/index.js";
+import { executeTransaction } from "../packages/edit-engine/dist/index.js";
+import {
+  builtInSymbols,
+  createProjectSymbolResolver,
+} from "../packages/symbols/dist/index.js";
+import { renderDocumentSvg } from "../packages/render-svg/dist/index.js";
+import { createFormalExportSource } from "../packages/exporters/dist/index.js";
+import { exportFormalArtifacts } from "../packages/exporters/dist/node.js";
+import { buildAgentSessionSnapshot } from "../packages/agent-adapter/dist/index.js";
+import {
+  compileSourceSimulation,
+  nativeSimulationDevices,
+  nativeDeviceOpVectors,
+} from "../packages/netlist/dist/index.js";
+
+const output = resolve(process.argv[2] ?? "output/native-simulation-examples");
+const otaInput = process.argv[3] ?? "netlists/native-ota/source.icproj.json";
+const profile = JSON.parse(
+  await readFile("containers/ngspice/hosted-sky130-profile.json", "utf8"),
+);
+await mkdir(output, { recursive: true });
+const manifest = [];
+let sequence = 0;
+const pt = (x, y) => ({ x, y });
+const terminal = (instanceId, pinName) => ({
+  kind: "terminal",
+  instanceId,
+  pinName,
+});
+function tx(project, doc, edits) {
+  const result = executeTransaction(
+    doc,
+    {
+      transactionId: `example-${++sequence}`,
+      documentId: doc.id,
+      expectedRevision: doc.revision,
+      actor: { kind: "agent", id: "native-examples" },
+      edits,
+    },
+    { symbolResolver: createProjectSymbolResolver(project, builtInSymbols) },
+  );
+  assert(
+    result.ok,
+    JSON.stringify({ error: result.error, diagnostics: result.diagnostics }),
+  );
+  project.documents[project.documents.findIndex((d) => d.id === doc.id)] =
+    result.document;
+  return result.document;
+}
+function label(instance, x, y, kind = "instance-label") {
+  return {
+    kind: "upsert_schematic_annotation",
+    annotation: {
+      id: `${kind}-${instance.id}`,
+      kind,
+      binding: {
+        kind:
+          kind === "instance-label" ? "instance-reference" : "instance-value",
+        instanceId: instance.id,
+      },
+      anchor: { kind: "free", position: pt(x, y) },
+      alignment: "start",
+      rotation: 0,
+      locked: false,
+    },
+  };
+}
+function note(id, text, x, y) {
+  return {
+    kind: "upsert_drafting_object",
+    object: {
+      id,
+      kind: "text",
+      content: { runs: [{ kind: "text", value: text }] },
+      anchor: { kind: "free", position: pt(x, y) },
+      alignment: "start",
+      rotation: 0,
+      locked: false,
+      zIndex: 0,
+    },
+  };
+}
+async function imported(slug, name, text, placements, wires, descriptions) {
+  const input = await importSpiceSources(
+    [{ path: "circuit.spi", bytes: new TextEncoder().encode(text) }],
+    "circuit.spi",
+  );
+  assert(
+    input.project && !input.diagnostics.some((d) => d.severity === "error"),
+    JSON.stringify(input.diagnostics),
+  );
+  const project = input.project;
+  project.id = `project-${slug}`;
+  project.name = name;
+  let doc = project.documents[0];
+  doc.id = `cell-${slug}`;
+  doc.name = name;
+  doc.netlist.name = slug.replaceAll("-", "_");
+  doc.sourceBinding.cellName = doc.netlist.name;
+  project.topDocumentId = doc.id;
+  const edit = [];
+  for (const instance of doc.instances) {
+    const [x, y, rotation = 0] = placements[instance.id];
+    edit.push({
+      kind: "place_instance",
+      instanceId: instance.id,
+      placement: { position: pt(x, y), rotation, mirror: "none" },
+    });
+    const mos = instance.symbolId === "nmos" || instance.symbolId === "pmos";
+    edit.push(
+      label(
+        instance,
+        mos ? x + 70 : x + (rotation ? -20 : 25),
+        y + (rotation ? -55 : mos ? -35 : -15),
+      ),
+    );
+    edit.push(
+      label(
+        instance,
+        mos ? x + 90 : x + (rotation ? -20 : 25),
+        y + (rotation ? -25 : 15),
+        "instance-value",
+      ),
+    );
+  }
+  // Each supply return has its own real ground marker; no invisible connectivity substitute.
+  const grounds = wires.filter((w) => w[1] === "ground");
+  for (const [from, , [x, y], id] of grounds) {
+    edit.push({
+      kind: "add_instance",
+      instance: {
+        id,
+        symbolId: "ground",
+        placement: { position: pt(x, y), rotation: 0, mirror: "none" },
+      },
+    });
+  }
+  descriptions.forEach((text, i) =>
+    edit.push(note(`description-${i}`, text, 20, 20 + i * 25)),
+  );
+  doc = tx(project, doc, edit);
+  for (const [a, b, bendsOrPos, id] of wires) {
+    const from = terminal(...a),
+      to = b === "ground" ? terminal(id, "0") : terminal(...b);
+    const net = doc.nets.find((n) =>
+      n.terminals.some((t) => t.instanceId === a[0] && t.pinName === a[1]),
+    );
+    assert(net, JSON.stringify(a));
+    if (b === "ground")
+      doc = tx(project, doc, [{ kind: "connect_endpoints", from, to }]);
+    const bends = b === "ground" ? [] : (bendsOrPos ?? []).map((p) => pt(...p));
+    doc = tx(project, doc, [
+      {
+        kind: "set_route_path",
+        route: createRoutePath({
+          id: `wire-${++sequence}`,
+          netId: net.id,
+          start: from,
+          end: to,
+          bends,
+          modes: Array(bends.length + 1).fill("manual"),
+        }),
+      },
+    ]);
+  }
+  const netLabels = [];
+  for (const name of ["in", "out"]) {
+    const netId = doc.connectivityEvidence.find(
+      (e) => e.kind === "net-name-hint" && e.sourceName === name,
+    )?.netId;
+    if (!netId) continue;
+    const [x, y] =
+      name === "in"
+        ? (placements.VIN ?? placements.V1)
+        : (placements.CL ?? placements[slug === "rc-highpass" ? "R1" : "C1"]);
+    netLabels.push({
+      kind: "upsert_schematic_annotation",
+      annotation: {
+        id: `net-${name}`,
+        kind: "net-label",
+        netId,
+        binding: { kind: "net-name", netId },
+        anchor: {
+          kind: "free",
+          position: pt(name === "in" ? x - 50 : x + 20, y - 65),
+        },
+        alignment: "start",
+        rotation: 0,
+        locked: false,
+      },
+    });
+    netLabels.push({
+      kind: "upsert_connectivity_evidence",
+      evidence: {
+        id: `name-${name}`,
+        kind: "name-claim",
+        netId,
+        name,
+        scope: "local",
+        owner: { kind: "net-label", annotationId: `net-${name}` },
+      },
+    });
+  }
+  doc = tx(project, doc, netLabels);
+  return project;
+}
+function source(project, docId, id, parameters) {
+  const doc = project.documents.find((d) => d.id === docId);
+  tx(project, doc, [
+    {
+      kind: "patch_instance_netlist_parameters",
+      instanceId: id,
+      set: parameters,
+    },
+  ]);
+}
+const pulse = {
+  dc: "0",
+  acMagnitude: "1",
+  waveform: "pulse",
+  low: "0",
+  high: "1",
+  delay: "100u",
+  rise: "100n",
+  fall: "100n",
+  width: "2m",
+  period: "4m",
+};
+function experiment(project, id, name, commands, options = {}) {
+  const folder = createSimulationFolder({
+    id,
+    name,
+    profileId: profile.id,
+    documentId: options.docId ?? project.topDocumentId,
+    ...(options.dut ? { dut: options.dut } : {}),
+  });
+  if (options.model)
+    folder.input.dependencies = [
+      {
+        id: profile.models.id,
+        sha256: profile.models.contentSha256,
+        mountPath: "icm-models.lib",
+      },
+    ];
+  const model = options.model
+    ? `.lib "icm-models.lib" ${options.corner ?? "tt"}\n`
+    : "";
+  const head = `* ${name}\n* Native Code owns all electrical intent. Run without legacy settings.\n.temp 27\n${model}.include "circuit.spice"\n${options.dut ? '.include "testbench.spice"\n' : ""}${options.pre ?? ""}`;
+  if (options.tb)
+    folder.input.files.find((f) => f.path === "testbench.spice").text =
+      options.tb;
+  folder.input.files.find((f) => f.path === "run.cir").text =
+    head +
+    ".control\nset filetype=ascii\nset appendwrite\n" +
+    commands.join("\n") +
+    "\n.endc\n.end\n";
+  project.simulationFolders.push(folder);
+  return folder;
+}
+async function deliver(project, slug, description) {
+  project = CircuitProjectSchema.parse(project);
+  for (const folder of project.simulationFolders) {
+    assert.equal(
+      JSON.parse(
+        folder.input.files.find((f) => f.path === folder.input.configPath).text,
+      ).version,
+      2,
+    );
+    const compiled = compileSourceSimulation(project, folder);
+    assert(
+      compiled.ok,
+      JSON.stringify({
+        folder: folder.name,
+        diagnostics: compiled.diagnostics,
+      }),
+    );
+  }
+  const file = join(output, `${slug}.icproj.json`);
+  await writeFile(file, serializeProject(project));
+  const resolver = createProjectSymbolResolver(project, builtInSymbols);
+  for (const doc of project.documents) {
+    await writeFile(
+      join(output, `${slug}-${doc.id}.svg`),
+      renderDocumentSvg(doc, resolver),
+    );
+    const artifacts = await exportFormalArtifacts(
+      createFormalExportSource(doc, resolver, { title: doc.name }),
+      2,
+    );
+    await writeFile(join(output, `${slug}-${doc.id}.png`), artifacts.png.bytes);
+    const snap = buildAgentSessionSnapshot({
+      project,
+      document: doc,
+      resolver,
+    });
+    await writeFile(
+      join(output, `${slug}-${doc.id}-inspection.json`),
+      JSON.stringify(snap, null, 2),
+    );
+    console.log(doc.name, JSON.stringify(snap.document.diagnostics));
+  }
+  for (const folder of project.simulationFolders) {
+    const dir = join(output, "source", slug, folder.id);
+    await mkdir(dir, { recursive: true });
+    for (const f of folder.input.files)
+      await writeFile(join(dir, f.path), f.text);
+  }
+  manifest.push({
+    slug,
+    file,
+    name: project.name,
+    description,
+    projectId: project.id,
+    folders: project.simulationFolders.map((f) => ({ id: f.id, name: f.name })),
+    documents: project.documents.map((d) => ({ id: d.id, name: d.name })),
+  });
+}
+
+const rcText = await readFile("netlists/native-rc-filters/circuit.spi", "utf8");
+const rc = await imported(
+  "rc-lowpass",
+  "RC Filters — Low-pass & High-pass",
+  rcText,
+  { V1: [100, 260], R1: [260, 160, 270], C1: [420, 260] },
+  [
+    [["V1", "+"], ["R1", "1"], [[100, 160]]],
+    [["R1", "2"], ["C1", "1"], [[420, 160]]],
+    [["V1", "-"], "ground", [100, 310], "GND1"],
+    [["C1", "2"], "ground", [420, 310], "GND2"],
+  ],
+  [
+    "RC low-pass: R = 10 kohm, C = 10 nF",
+    "Expected fc = 1591.55 Hz; tau = 100 us.",
+  ],
+);
+const hp = await imported(
+  "rc-highpass",
+  "RC High-pass",
+  rcText.replace("R1 in out 10k\nC1 out 0 10n", "C1 in out 10n\nR1 out 0 10k"),
+  { V1: [100, 260], C1: [260, 160, 270], R1: [420, 260] },
+  [
+    [["V1", "+"], ["C1", "1"], [[100, 160]]],
+    [["C1", "2"], ["R1", "1"], [[420, 160]]],
+    [["V1", "-"], "ground", [100, 310], "GND1"],
+    [["R1", "2"], "ground", [420, 310], "GND2"],
+  ],
+  [
+    "RC high-pass: complementary first-order response",
+    "Expected fc = 1591.55 Hz; step response decays to zero.",
+  ],
+);
+rc.documents.push(hp.documents[0]);
+for (const doc of rc.documents) {
+  source(rc, doc.id, "V1", pulse);
+  const high = doc.id.includes("highpass"),
+    prefix = high ? "hp" : "lp";
+  experiment(
+    rc,
+    `rc-${prefix}-ac`,
+    `${high ? "03" : "01"} ${high ? "High" : "Low"}-pass | AC`,
+    [
+      "save v(in) v(out) i(v1)",
+      "ac dec 80 10 1Meg",
+      "let gain_db = db(v(out)/v(in))",
+      "let phase_deg = 180/PI*cph(v(out)/v(in))",
+      "meas ac gain_at_fc FIND gain_db AT=1591.549431",
+      "write out.raw v(in) v(out) gain_db phase_deg",
+    ],
+    { docId: doc.id },
+  );
+  experiment(
+    rc,
+    `rc-${prefix}-tran`,
+    `${high ? "04" : "02"} ${high ? "High" : "Low"}-pass | Step`,
+    [
+      "save v(in) v(out) i(v1)",
+      "tran 1u 1m 0 1u",
+      "meas tran at_one_tau FIND v(out) AT=200.05u",
+      "meas tran final_value FIND v(out) AT=1m",
+      "write out.raw",
+    ],
+    { docId: doc.id },
+  );
+}
+await deliver(
+  rc,
+  "01-rc-filters",
+  "Complementary RC filters, independent frequency/time-domain expectations.",
+);
+
+const rlc = await imported(
+  "rlc-filter",
+  "RLC Filter — Damping Laboratory",
+  await readFile("netlists/native-rlc-filter/circuit.spi", "utf8"),
+  { V1: [100, 300], R1: [240, 180, 270], L1: [400, 180, 270], C1: [540, 300] },
+  [
+    [["V1", "+"], ["R1", "1"], [[100, 180]]],
+    [["R1", "2"], ["L1", "1"], []],
+    [["L1", "2"], ["C1", "1"], [[540, 180]]],
+    [["V1", "-"], "ground", [100, 350], "GND1"],
+    [["C1", "2"], "ground", [540, 350], "GND2"],
+  ],
+  [
+    "RLC low-pass: L = 10 mH, C = 100 nF",
+    "f0 = 5032.92 Hz; critical R = 632.456 ohm.",
+    "Each experiment explicitly alters R1 for its damping case.",
+  ],
+);
+source(rlc, rlc.topDocumentId, "V1", pulse);
+for (const [index, label, resistance] of [
+  [1, "Underdamped", 200],
+  [2, "Critical", 632.455532],
+  [3, "Overdamped", 1000],
+])
+  experiment(rlc, `rlc-${index}`, `0${index} ${label} | AC + Step`, [
+    `alter R1 ${resistance}`,
+    "save v(in) v(out) i(l1)",
+    "ac dec 100 100 1Meg",
+    "let gain_db = db(v(out))",
+    "meas ac peak_gain_db MAX gain_db",
+    "write out.raw",
+    "tran 0.5u 1m 0 0.5u",
+    "meas tran peak_output MAX v(out)",
+    "meas tran final_value FIND v(out) AT=1m",
+    "write out.raw",
+  ]);
+await deliver(
+  rlc,
+  "02-rlc-filter",
+  "Same Canvas circuit, three explicit native damping experiments; select all folders for Batch.",
+);
+
+const cs = await imported(
+  "common-source",
+  "SKY130 Common-source Amplifier",
+  await readFile("netlists/native-common-source/circuit.spi", "utf8"),
+  {
+    VDD: [100, 190],
+    VIN: [100, 400],
+    RD: [350, 190],
+    XM1: [340, 400],
+    CL: [540, 400],
+  },
+  [
+    [
+      ["VDD", "+"],
+      ["RD", "1"],
+      [
+        [100, 110],
+        [350, 110],
+      ],
+    ],
+    [["RD", "2"], ["XM1", "D"], []],
+    [
+      ["VIN", "+"],
+      ["XM1", "G"],
+      [
+        [100, 340],
+        [260, 340],
+        [260, 400],
+      ],
+    ],
+    [
+      ["XM1", "D"],
+      ["CL", "1"],
+      [
+        [350, 300],
+        [540, 300],
+      ],
+    ],
+    [["VDD", "-"], "ground", [100, 240], "GND1"],
+    [["VIN", "-"], "ground", [100, 450], "GND2"],
+    [["XM1", "S"], "ground", [350, 470], "GND3"],
+    [
+      ["XM1", "B"],
+      ["XM1", "S"],
+      [
+        [400, 400],
+        [400, 440],
+        [350, 440],
+      ],
+    ],
+    [["CL", "2"], "ground", [540, 450], "GND4"],
+  ],
+  [
+    "SKY130 NMOS resistor-loaded common-source amplifier",
+    "VDD = 1.8 V; Vbias = 0.7 V; RD = 10 kohm; CL = 1 pF",
+    "Small/large signals use native alter commands, not hidden JSON overrides.",
+  ],
+);
+source(cs, cs.topDocumentId, "VIN", {
+  dc: "0.7",
+  acMagnitude: "1",
+  waveform: "sin",
+  offset: "0.7",
+  amplitude: "10m",
+  frequency: "10k",
+});
+const bias = experiment(
+  cs,
+  "cs-op",
+  "01 Bias | Native Device OP",
+  ["op", "write out.raw"],
+  { model: true },
+);
+const vectors = nativeSimulationDevices(cs, bias.input).flatMap(
+  nativeDeviceOpVectors,
+);
+bias.input.files.find((f) => f.path === "run.cir").text = bias.input.files
+  .find((f) => f.path === "run.cir")
+  .text.replace(
+    "\nop\n",
+    `\nsave v(in) v(out) i(vdd) ${vectors.join(" ")}\nop\n`,
+  );
+experiment(
+  cs,
+  "cs-dc",
+  "02 DC transfer",
+  ["save v(in) v(out) i(vdd)", "dc VIN 0.3 1.2 0.005", "write out.raw"],
+  { model: true },
+);
+experiment(
+  cs,
+  "cs-ac",
+  "03 AC gain and bandwidth",
+  [
+    "save v(in) v(out)",
+    "ac dec 80 10 1G",
+    "let gain_db = db(v(out)/v(in))",
+    "let phase_deg = 180/PI*cph(v(out)/v(in))",
+    "meas ac gain_db_1khz FIND gain_db AT=1k",
+    "write out.raw",
+  ],
+  { model: true },
+);
+experiment(
+  cs,
+  "cs-tran",
+  "04 Small and large signal | Native loop",
+  [
+    "save v(in) v(out)",
+    "foreach amplitude 0.01 0.2",
+    "alter @VIN[sin] = [ 0.7 $amplitude 10k ]",
+    "tran 0.2u 400u 0 0.2u",
+    "meas tran output_pp PP v(out) FROM=200u TO=400u",
+    "write out.raw",
+    "end",
+  ],
+  { model: true },
+);
+await deliver(
+  cs,
+  "03-common-source",
+  "DC, small-signal gain, native device values, and two transient amplitudes in one control loop.",
+);
+
+const ota = parseProject(await readFile(otaInput, "utf8"));
+ota.id = "project-native-ota-laboratory";
+ota.name = "SKY130 OTA — Open & Closed Loop";
+ota.simulationFolders = [];
+const tb = "document-ota-5t-testbench";
+ota.topDocumentId = tb;
+for (const [name, x, y] of [
+  ["vinp", 450, 285],
+  ["vinn", 450, 340],
+  ["vdd", 580, 150],
+  ["ibias", 570, 245],
+]) {
+  const doc = ota.documents.find((d) => d.id === tb);
+  const netId = doc.nets.find((n) =>
+    n.terminals.some((t) => t.instanceId === "XDUT" && t.pinName === name),
+  )?.id;
+  assert(netId, `OTA testbench pin ${name} must resolve to a real Net`);
+  const annotationId = `native-net-${name}`;
+  tx(ota, doc, [
+    {
+      kind: "upsert_schematic_annotation",
+      annotation: {
+        id: annotationId,
+        kind: "net-label",
+        netId,
+        binding: { kind: "net-name", netId },
+        anchor: { kind: "free", position: pt(x, y) },
+        alignment: "start",
+        rotation: 0,
+        locked: false,
+      },
+    },
+    {
+      kind: "upsert_connectivity_evidence",
+      evidence: {
+        id: `native-name-${name}`,
+        kind: "name-claim",
+        netId,
+        name,
+        scope: "local",
+        owner: { kind: "net-label", annotationId },
+      },
+    },
+  ]);
+}
+tx(
+  ota,
+  ota.documents.find((d) => d.id === tb),
+  [
+    note(
+      "native-guide-1",
+      "Native OTA laboratory: bias, DC, AC corners, transient, noise and feedback.",
+      280,
+      30,
+    ),
+    note(
+      "native-guide-2",
+      "Five-transistor core plus bias transistor XM6. Open-loop pulse is not settling time.",
+      280,
+      55,
+    ),
+  ],
+);
+const op = experiment(
+  ota,
+  "ota-op",
+  "01 Bias | Native Device OP",
+  ["op", "write out.raw"],
+  { docId: tb, model: true },
+);
+const otaVectors = nativeSimulationDevices(ota, op.input).flatMap(
+  nativeDeviceOpVectors,
+);
+op.input.files.find((f) => f.path === "run.cir").text = op.input.files
+  .find((f) => f.path === "run.cir")
+  .text.replace(
+    "\nop\n",
+    `\nsave v(vout) v(ibias) v(xdut.tail) v(xdut.nleft) i(vdd) ${otaVectors.join(" ")}\nop\nlet supply_current = -i(vdd)\nprint supply_current\n`,
+  );
+experiment(
+  ota,
+  "ota-dc",
+  "02 DC transfer",
+  [
+    "save v(vinp) v(vout) v(xdut.tail)",
+    "dc VINP 0.86 0.94 0.001",
+    "write out.raw",
+  ],
+  { docId: tb, model: true },
+);
+for (const [i, corner] of ["tt", "ff", "ss"].entries())
+  experiment(
+    ota,
+    `ota-ac-${corner}`,
+    `0${i + 3} Open-loop AC | ${corner.toUpperCase()}`,
+    [
+      "save v(vinp) v(vout)",
+      "ac dec 60 1 1G",
+      "let gain_db = db(v(vout)/v(vinp))",
+      "let phase_deg = 180/PI*cph(v(vout)/v(vinp))",
+      "meas ac dc_gain_db FIND gain_db AT=1",
+      "meas ac unity_gain_hz WHEN gain_db=0 FALL=1",
+      "write out.raw",
+    ],
+    { docId: tb, model: true, corner },
+  );
+experiment(
+  ota,
+  "ota-tran",
+  "06 Open-loop input pulse",
+  [
+    "save v(vinp) v(vout)",
+    "tran 2n 6u 0 2n",
+    "meas tran output_max MAX v(vout)",
+    "meas tran output_min MIN v(vout)",
+    "write out.raw",
+  ],
+  { docId: tb, model: true },
+);
+experiment(
+  ota,
+  "ota-noise",
+  "07 Input and output noise",
+  ["noise v(vout) VINP dec 30 1 1G", "write out.raw noise1.all noise2.all"],
+  { docId: tb, model: true },
+);
+const closedTb =
+  "* Unity follower: vout feeds VINN; only the DUT is generated from Canvas.\nVDD vdd 0 1.8\nVINP vinp 0 DC 0.9 AC 1 PULSE(0.9 0.91 1u 1n 1n 2u 5u)\nIBIAS vdd ibias 15u\nXDUT 0 ibias vdd vout vinp vout ota_5t\nCL vout 0 1p\n";
+experiment(
+  ota,
+  "ota-closed",
+  "08 Unity feedback | AC + Step",
+  [
+    "save v(vinp) v(vout) i(vdd)",
+    "ac dec 60 1 1G",
+    "let gain_db = db(v(vout))",
+    "meas ac closed_gain_db FIND gain_db AT=1",
+    "write out.raw",
+    "tran 1n 6u 0 1n",
+    "meas tran output_at_2us FIND v(vout) AT=2u",
+    "meas tran output_peak MAX v(vout) FROM=1u TO=3u",
+    "write out.raw",
+  ],
+  {
+    docId: "document-ota-5t",
+    dut: {
+      name: "ota_5t",
+      ports: ["0", "ibias", "vdd", "vinn", "vinp", "vout"],
+    },
+    tb: closedTb,
+    model: true,
+  },
+);
+await deliver(
+  ota,
+  "04-sky130-ota",
+  "Preserved user OTA drawing with native experiments and an explicit text-authored unity-feedback TB.",
+);
+await writeFile(
+  join(output, "manifest.json"),
+  JSON.stringify({ profileId: profile.id, projects: manifest }, null, 2) + "\n",
+);
+console.log(
+  JSON.stringify(
+    manifest.map((p) => ({ file: p.file, experiments: p.folders.length })),
+    null,
+    2,
+  ),
+);

--- a/scripts/build-native-simulation-examples.test.mjs
+++ b/scripts/build-native-simulation-examples.test.mjs
@@ -1,0 +1,99 @@
+import { test, expect, beforeAll } from "vitest";
+import { execFileSync, execSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+beforeAll(() => {
+  // Exercise the actual standalone CLI, including on a clean CI checkout.
+  // Unit CI intentionally does not prebuild workspace dist artifacts.
+  execSync(
+    "pnpm --filter @icm/agent-adapter... --filter @icm/exporters... build",
+    {
+      stdio: "pipe",
+      timeout: 180000,
+    },
+  );
+}, 190000);
+
+test("complete example Projects preserve their circuits and use native source-only experiments", () => {
+  const directory = mkdtempSync(join(tmpdir(), "icm-native-projects-test-"));
+  try {
+    execFileSync(
+      process.execPath,
+      ["scripts/build-native-simulation-examples.mjs", directory],
+      { stdio: "pipe", timeout: 60000 },
+    );
+    const manifest = JSON.parse(
+      readFileSync(join(directory, "manifest.json"), "utf8"),
+    );
+    expect(manifest.projects.map((p) => p.folders.length)).toEqual([
+      4, 3, 4, 8,
+    ]);
+    for (const item of manifest.projects) {
+      const project = JSON.parse(readFileSync(item.file, "utf8"));
+      for (const document of project.documents) {
+        if (item.slug !== "04-sky130-ota")
+          for (const name of ["in", "out"])
+            expect(document.connectivityEvidence).toContainEqual(
+              expect.objectContaining({ kind: "name-claim", name }),
+            );
+        expect(document.instances.every((i) => i.placement !== null)).toBe(
+          true,
+        );
+        const inspection = JSON.parse(
+          readFileSync(
+            join(directory, `${item.slug}-${document.id}-inspection.json`),
+            "utf8",
+          ),
+        );
+        expect(inspection.document.diagnostics).toEqual([]);
+      }
+      for (const folder of project.simulationFolders) {
+        const config = JSON.parse(
+          folder.input.files.find((f) => f.path === folder.input.configPath)
+            .text,
+        );
+        expect(config).toEqual({
+          version: 2,
+          environment: { profileId: manifest.profileId },
+        });
+        const source = folder.input.files.find(
+          (f) => f.path === folder.input.entry,
+        ).text;
+        expect(source).toContain("write out.raw");
+        expect(source).not.toContain("/opt/");
+        expect(folder.input.circuitBindings).toHaveLength(1);
+      }
+    }
+    const original = JSON.parse(
+      readFileSync("netlists/native-ota/source.icproj.json", "utf8"),
+    );
+    const ota = JSON.parse(readFileSync(manifest.projects[3].file, "utf8"));
+    const before = original.documents.find((d) => d.id === "document-ota-5t");
+    const after = ota.documents.find((d) => d.id === "document-ota-5t");
+    expect(after.netlist.terminals.map((t) => t.name)).toEqual(
+      before.netlist.terminals.map((t) => t.name),
+    );
+    expect(
+      after.instances.map((i) => ({ id: i.id, netlist: i.netlist })),
+    ).toEqual(before.instances.map((i) => ({ id: i.id, netlist: i.netlist })));
+    const closed = ota.simulationFolders.find((f) => f.id === "ota-closed");
+    const testbench = ota.documents.find(
+      (d) => d.id === "document-ota-5t-testbench",
+    );
+    for (const name of ["vinp", "vinn", "vdd", "ibias"]) {
+      const net = testbench.nets.find((n) =>
+        n.terminals.some((t) => t.instanceId === "XDUT" && t.pinName === name),
+      );
+      expect(testbench.connectivityEvidence).toContainEqual(
+        expect.objectContaining({ kind: "name-claim", netId: net.id, name }),
+      );
+    }
+    expect(
+      closed.input.files.find((f) => f.path === "testbench.spice").text,
+    ).toContain("XDUT 0 ibias vdd vout vinp vout ota_5t");
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}, 90000);

--- a/scripts/run-native-simulation-examples.mjs
+++ b/scripts/run-native-simulation-examples.mjs
@@ -1,0 +1,332 @@
+import assert from "node:assert/strict";
+import { spawn, execFileSync } from "node:child_process";
+import { createInterface } from "node:readline";
+import {
+  readFile,
+  writeFile,
+  mkdir,
+  mkdtemp,
+  rm,
+  rename,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve, basename } from "node:path";
+import { createHash, randomUUID } from "node:crypto";
+import { chromium } from "@playwright/test";
+
+const root = resolve(process.argv[2] ?? "output/native-simulation-examples");
+const selected = process.argv[3];
+const base = "https://analog-canvas-preview.tokenzhang.com";
+const manifest = JSON.parse(
+  await readFile(join(root, "manifest.json"), "utf8"),
+);
+const distribution = await (
+  await fetch(base + "/api/agent/mcp-manifest.json")
+).json();
+assert.equal(
+  distribution.version,
+  "0.7.0",
+  "Requalify the runner when the published MCP version changes.",
+);
+const sourceBuild = process.env.ICM_EXAMPLE_MCP_SOURCE !== "0";
+const executable = resolve(
+  sourceBuild
+    ? "apps/mcp-server/dist/main.js"
+    : "output/mcp-published-0.7.0/package/bin/analog-canvas-mcp.mjs",
+);
+const executableBytes = await readFile(executable);
+if (sourceBuild)
+  assert(
+    !executableBytes.includes(Buffer.from("//#region")),
+    "Recompile apps/mcp-server with a fresh tsBuildInfoFile; this entry is a packaged bundle, not current source.",
+  );
+if (!sourceBuild) {
+  const tarball = await readFile(
+    resolve("output/mcp-published-0.7.0/analog-canvas-mcp-server-0.7.0.tgz"),
+  );
+  assert.equal(
+    createHash("sha256").update(tarball).digest("hex"),
+    distribution.distribution.sha256,
+  );
+}
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const browser = await chromium.launch({ headless: true });
+const summary = [];
+for (const project of manifest.projects.filter(
+  (p) => !selected || p.slug === selected,
+)) {
+  const dir = join(root, "results", project.slug);
+  await mkdir(dir, { recursive: true });
+  const temporary = await mkdtemp(join(tmpdir(), "native-examples-mcp-"));
+  const context = await browser.newContext({
+    viewport: { width: 1440, height: 1000 },
+  });
+  const page = await context.newPage();
+  const browserErrors = [];
+  page.on("pageerror", (e) => browserErrors.push(e.message));
+  let child,
+    paired = false,
+    seq = 0;
+  const pending = new Map();
+  function rpc(method, params = {}) {
+    const id = ++seq;
+    return new Promise((resolveReply, reject) => {
+      const timer = setTimeout(() => {
+        pending.delete(id);
+        reject(Error("MCP timeout: " + method));
+      }, 150000);
+      pending.set(id, {
+        resolve: (r) => {
+          clearTimeout(timer);
+          resolveReply(r);
+        },
+        reject: (e) => {
+          clearTimeout(timer);
+          reject(e);
+        },
+      });
+      child.stdin.write(
+        JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n",
+      );
+    });
+  }
+  async function tool(name, args = {}) {
+    for (let attempt = 0; ; attempt++) {
+      const reply = await rpc("tools/call", { name, arguments: args });
+      const value = JSON.parse(
+        reply.content.find((c) => c.type === "text").text,
+      );
+      if (value.error?.code === "RATE_LIMITED" && attempt < 10) {
+        await sleep(Math.max(value.error.retryAfterMs ?? 5000, 1000));
+        continue;
+      }
+      assert(
+        !reply.isError && value.ok !== false,
+        JSON.stringify({ tool: name, response: value }),
+      );
+      return value;
+    }
+  }
+  const report = {
+    project: project.slug,
+    startedAt: new Date().toISOString(),
+    mcpVersion: distribution.version,
+    mcpExecutableSha256: createHash("sha256")
+      .update(executableBytes)
+      .digest("hex"),
+    mcpBuild: sourceBuild ? "current-source" : "published",
+    mcpSourceCommit: sourceBuild
+      ? execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim()
+      : undefined,
+    mcpSha256: sourceBuild ? undefined : distribution.distribution.sha256,
+    runs: [],
+  };
+  try {
+    await page.goto(base + "/editor");
+    await page.getByTestId("project-file").setInputFiles(project.file);
+    await page
+      .locator("summary")
+      .filter({ hasText: /^Agent$/ })
+      .click();
+    await page
+      .getByRole("button", { name: "Connect Agent", exact: true })
+      .click();
+    await page.getByTestId("agent-preset-full").click();
+    await page
+      .getByTestId("agent-claim-code")
+      .waitFor({ state: "attached", timeout: 30000 });
+    const claimCode = await page.getByTestId("agent-claim-code").textContent();
+    child = spawn(process.execPath, [executable], {
+      env: {
+        ...process.env,
+        ANALOG_CANVAS_API_URL: base,
+        ANALOG_CANVAS_MCP_CONNECTOR: join(temporary, "connector.json"),
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    createInterface({ input: child.stdout }).on("line", (line) => {
+      try {
+        const r = JSON.parse(line);
+        const p = pending.get(r.id);
+        if (p) {
+          pending.delete(r.id);
+          r.error
+            ? p.reject(Error(JSON.stringify(r.error)))
+            : p.resolve(r.result);
+        }
+      } catch {}
+    });
+    child.stderr.on("data", () => {});
+    child.on("exit", (code) => {
+      for (const p of pending.values()) p.reject(Error("MCP exited " + code));
+      pending.clear();
+    });
+    const initialized = await rpc("initialize", {
+      protocolVersion: "2025-06-18",
+      capabilities: {},
+      clientInfo: { name: "native-example-acceptance", version: "1" },
+    });
+    assert.equal(initialized.serverInfo.version, "0.7.0");
+    child.stdin.write(
+      JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }) +
+        "\n",
+    );
+    await tool("connect", { claimCode });
+    paired = true;
+    await rpc("resources/read", {
+      uri: "analog-canvas://reference/quickstart",
+    });
+    await page
+      .getByTestId("agent-status")
+      .filter({ hasText: "Connected" })
+      .waitFor({ state: "visible", timeout: 30000 });
+    report.context = await tool("get_context");
+    report.capabilities = (
+      await tool("simulation", { request: { operation: "capabilities" } })
+    ).capabilities;
+    console.log(project.slug, "connected; native files verified");
+    for (const folder of project.folders) {
+      const listed = await tool("simulation_files", {
+        request: {
+          action: "read",
+          owner: { kind: "project-folder", folderId: folder.id },
+          path: "experiment.json",
+        },
+      });
+      assert.equal(JSON.parse(listed.text).version, 2);
+    }
+    const config = await tool("simulation_files", {
+      request: {
+        action: "read",
+        owner: { kind: "project-folder", folderId: project.folders[0].id },
+        path: "experiment.json",
+      },
+    });
+    const prepared = await tool("simulation", {
+      request: {
+        operation: "prepare-batch",
+        expectedStructureRevision: config.revision,
+        items: project.folders.map((f) => ({ id: f.id, folderId: f.id })),
+      },
+    });
+    await tool("simulation", {
+      requestId: randomUUID(),
+      request: { operation: "start-batch", batchId: prepared.batch.id },
+    });
+    let batch;
+    for (let i = 0; i < 400; i++) {
+      batch = (
+        await tool("simulation", {
+          request: { operation: "read-batch", batchId: prepared.batch.id },
+        })
+      ).batch;
+      if (!["running", "cancelling", "prepared"].includes(batch.state)) break;
+      await sleep(2000);
+    }
+    report.batch = batch;
+    assert.deepEqual(
+      batch.items.map((i) => i.id).sort(),
+      project.folders.map((f) => f.id).sort(),
+      "Batch must cover exactly the selected experiments",
+    );
+    for (const item of batch.items) {
+      const runDir = join(dir, item.id);
+      await mkdir(runDir, { recursive: true });
+      if (!item.runId) {
+        report.runs.push({
+          folderId: item.id,
+          state: item.state,
+          error: item.error,
+        });
+        continue;
+      }
+      const run = (
+        await tool("simulation", {
+          request: { operation: "read", runId: item.runId },
+        })
+      ).run;
+      await writeFile(join(runDir, "run.json"), JSON.stringify(run, null, 2));
+      const artifacts = [];
+      for (const artifact of run.artifacts ?? []) {
+        // Immutable service artifacts, no arbitrary host paths from simulator output.
+        const path = join(runDir, basename(artifact.name));
+        await tool("simulation_files", {
+          request: { action: "artifact", artifactId: artifact.id },
+          outputPath: path,
+        });
+        assert.equal(
+          createHash("sha256")
+            .update(await readFile(path))
+            .digest("hex"),
+          artifact.sha256,
+        );
+        artifacts.push({ name: artifact.name, sha256: artifact.sha256 });
+      }
+      const analyses =
+        run.outputData?.analyses ?? run.result?.data?.analyses ?? [];
+      for (let index = 0; index < analyses.length; index++) {
+        if (analyses[index].analysis === "op") continue;
+        try {
+          await tool("export_file", {
+            artifact: "simulation-plot",
+            simulation: { runId: run.id, analysisIndex: index, format: "svg" },
+            outputPath: join(runDir, `plot-${index}.svg`),
+          });
+          const plot = join(runDir, `plot-${index}.svg`);
+          if ((await readFile(plot)).subarray(0, 2).toString() === "PK") {
+            await rename(plot, join(runDir, `plot-${index}.zip`));
+          }
+        } catch (e) {
+          report.exportWarnings ??= [];
+          report.exportWarnings.push({ folder: item.id, message: e.message });
+        }
+      }
+      report.runs.push({
+        folderId: item.id,
+        runId: run.id,
+        state: run.state,
+        outcome: run.result?.outcome,
+        artifacts,
+      });
+      console.log(
+        project.slug,
+        item.id,
+        run.state,
+        run.result?.outcome?.status,
+      );
+    }
+    await tool("export_file", {
+      artifact: "project",
+      outputPath: join(dir, "mcp-export.icproj.json"),
+    });
+    report.status = report.runs.every((r) => r.outcome?.status === "completed")
+      ? "passed"
+      : "failed";
+    await page.screenshot({ path: join(dir, "editor.png"), fullPage: true });
+  } catch (e) {
+    report.status = "failed";
+    report.error = e.message;
+    console.error(project.slug, e.message);
+    await page.screenshot({ path: join(dir, "failure.png") }).catch(() => {});
+  } finally {
+    report.browserErrors = browserErrors;
+    report.completedAt = new Date().toISOString();
+    if (paired) await tool("disconnect").catch(() => {});
+    if (child) {
+      child.stdin.end();
+      await sleep(1000);
+      if (child.exitCode === null) child.kill();
+    }
+    await context.close();
+    await rm(temporary, { recursive: true, force: true });
+    await writeFile(join(dir, "receipt.json"), JSON.stringify(report, null, 2));
+    summary.push({
+      project: project.slug,
+      status: report.status,
+      error: report.error,
+    });
+  }
+}
+await browser.close();
+console.log(JSON.stringify(summary, null, 2));
+if (summary.some((s) => s.status !== "passed")) process.exitCode = 1;


### PR DESCRIPTION
## Summary

- Separate result meaning (real, complex, unknown), captured cardinality, and presentation. Preserve signed native dB/phase results instead of applying magnitude twice; retain complex physical AC acquisitions even when their imaginary samples are zero.
- Group compatible waveform units, isolate unknown units, allow separate traces, and share X ranges/cursors within one raw analysis record while retaining independent Y axes. Keep view controls outside the waveform layout grid and fit logarithmic viewports in the same coordinate space used to draw lines.
- Preserve explicit raw `dims=1` captures as record-local scalar values, not zero-padded waveforms. Show/export scalar values separately, exclude them from waveform summaries, and retain declared raw units without guessing from variable names.
- Reconcile the generated Agent OpenAPI contract and add four complete native simulation example Projects with recorded acceptance tooling. No Project electrical data is rewritten by plot preferences.

## Validation

Candidate `14b187c7` includes main `952dd8f9`. Frozen dependency installation and preflight passed. Integrated static checks, 3274 unit tests (31 existing skips), build, performance budgets, visual/export/PWA goldens, production smoke, and packaged MCP/release smoke passed. The local full browser stage completed with 407 passing and one existing Helper test timing failure. All seven required GitHub checks passed for this SHA, including all four full-browser shards.

The Helper trace shows ArrowDown arriving about 11ms after autocomplete opened, within CodeMirror's default 75ms interaction guard. The unchanged failing case subsequently passed five repetitions on the same SHA. Final head `884f43c3` adds only a documented 100ms test synchronization wait; it does not change product behavior, assertion timeouts, or assertions. The full Code Editor spec passed five repetitions (45 tests). Delta preflight/static/typecheck and affected gates completed successfully: 3274 unit tests and all 30 browser tests in the six analog specs passed. The original failed full-gate result is retained, not relabelled as a pass. The final worktree is clean and `git diff --check` passed. All seven required GitHub checks passed for this exact final head in CI run `34707669631`, including the four full-browser shards. Full merge-queue validation remains required before merge.

Evidence already available: replay of 19 recorded ngspice runs retains 24 analyses and 142 probe arrays/values while separating 27 captured scalars. The 401-point RC low-pass gain and phase retain exactly their original numeric arrays, now labelled signed dB and degrees. These replays are historical simulator evidence, not a new hosted execution.

Regression coverage includes native dB/phase signs, unknown-unit isolation, scalar dimensions and CSV, repeated-record separation, linked waveform view state, logarithmic autoscale, raw-only archive fallback, maximized layout, and the complete human simulation/export journey.

## Delivery boundary

Merge deploys Preview only. No Production promotion, MCP registry publication, simulator-host deployment, or client restart is included. Clients that strictly validate the old result schema need a rebuilt adapter to consume new optional semantics/scalar fields. Existing archives remain readable; missing historical dimension evidence is not reconstructed from zero padding.

Test-Impact: tests-updated
