### PR TITLE
Unify every component Properties surface

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -975,11 +975,14 @@ test("renames one supply marker without changing its same-name peer", async ({
 
   await page.getByTestId("hit-VDD1").click();
   await openSelectionShelf(page);
-  const name = page.getByRole("textbox", { name: "Supply name" });
-  await name.fill("AVDD");
-  await name.press("Tab");
+  await expect(page.getByRole("textbox", { name: "Supply name" })).toHaveCount(
+    0,
+  );
+  await editComponentPropertyCode(page, (code) => {
+    code.netName = "AVDD";
+  });
 
-  await expect(page.getByTestId("status")).toContainText("Supply named AVDD");
+  await expectComponentCodeField(page, "netName", "AVDD");
   await expect(
     canvas.locator('[data-object-id="power-label-vdd1"]'),
   ).toContainText("AVDD");

--- a/apps/editor/e2e/component-properties-catalog.spec.ts
+++ b/apps/editor/e2e/component-properties-catalog.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "@playwright/test";
+import { expandedDeviceSymbols, razaviProductSymbols } from "@icm/symbols";
+
+import { chooseComponent } from "./editor-fixtures.js";
+
+// These are the two canonical sources of placeable Instance tiles. Editor-only
+// Annotation tools and the two-click Power Rail intentionally do not appear in
+// either list because they own drawing-specific Properties rather than a
+// component Instance.
+const componentSymbolIds = [
+  ...razaviProductSymbols,
+  ...expandedDeviceSymbols,
+].map((symbol) => symbol.id);
+
+for (const symbolId of componentSymbolIds) {
+  test(`${symbolId} uses the one text-first component Properties surface`, async ({
+    page,
+  }) => {
+    await page.goto("/editor");
+    await chooseComponent(page, symbolId);
+    const canvas = page.getByTestId("schematic-canvas");
+    await canvas.click({ position: { x: 520, y: 350 } });
+    await page.keyboard.press("Escape");
+
+    const instance = page.locator('[data-canvas-hit-kind="instance"]');
+    await expect(instance).toHaveCount(1);
+    await instance.click();
+    const shelf = page.getByTestId("selection-shelf");
+    if ((await shelf.getAttribute("aria-expanded")) === "true") {
+      await shelf.click();
+    }
+    await page.keyboard.press("q");
+
+    const properties = page.getByRole("region", {
+      name: "Component properties",
+    });
+    await expect(properties).toBeVisible();
+    await expect(
+      properties.getByLabel("Editable Canvas property code"),
+    ).toBeVisible();
+    await expect(properties.locator(":scope > *")).toHaveCount(1);
+    await expect(properties.locator(":scope > :only-child")).toHaveAttribute(
+      "aria-label",
+      "Canvas property code",
+    );
+  });
+}

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -4365,7 +4365,7 @@ test("Properties keeps component and Annotation text colors independent", async 
   expect(savedLabel).not.toHaveProperty("textColor");
 });
 
-test("shows fixed and variable capacitor plate terminals as read-only Properties", async ({
+test("keeps fixed and variable capacitor Properties on the shared code surface", async ({
   page,
 }) => {
   await page.goto("/editor");
@@ -4375,33 +4375,26 @@ test("shows fixed and variable capacitor plate terminals as read-only Properties
   await page.getByTestId("hit-C1").click();
   await openSelectionShelf(page);
   const properties = page.getByRole("complementary", { name: "Properties" });
-  let plateCard = properties.getByRole("group", {
-    name: "Capacitor plate terminals",
+  const componentProperties = properties.getByRole("region", {
+    name: "Component properties",
   });
   await expect(
-    plateCard.getByText("Electrical terminals", { exact: true }),
+    componentProperties.getByLabel("Editable Canvas property code"),
   ).toBeVisible();
-  await expect(plateCard.getByLabel("Top plate terminal")).toHaveText(
-    "Pin 1 · Unconnected",
-  );
-  await expect(plateCard.getByLabel("Bottom plate terminal")).toHaveText(
-    "Pin 2 · Unconnected",
-  );
-  await expect(plateCard.locator("input, select, button")).toHaveCount(0);
-  await expect(plateCard).not.toContainText(
-    "Plate roles are defined by the device",
-  );
+  await expect(componentProperties.locator(":scope > *")).toHaveCount(1);
+  await expect(
+    properties.getByRole("group", { name: "Capacitor plate terminals" }),
+  ).toHaveCount(0);
 
   await page.getByTestId("hit-C2").click();
-  plateCard = properties.getByRole("group", {
-    name: "Capacitor plate terminals",
-  });
-  await expect(plateCard.getByLabel("Top plate terminal")).toHaveText(
-    "Pin P1 · Unconnected",
-  );
-  await expect(plateCard.getByLabel("Bottom plate terminal")).toHaveText(
-    "Pin P2 · Unconnected",
-  );
+  await expect(properties).toContainText("C2 · variable-capacitor");
+  await expect(
+    componentProperties.getByLabel("Editable Canvas property code"),
+  ).toBeVisible();
+  await expect(componentProperties.locator(":scope > *")).toHaveCount(1);
+  await expect(
+    properties.getByRole("group", { name: "Capacitor plate terminals" }),
+  ).toHaveCount(0);
 });
 
 test("value display projects MOS W/L and passive values beside the reference", async ({

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -23,6 +23,7 @@ import {
   planSetCellSymbolPresentation,
   planSetDeviceModelTarget,
   planInstanceUnplacement,
+  gateRoutingOperationPlan,
   type ProjectStructureEdit,
   type CellResetPlan,
   type SchematicEdit,
@@ -146,6 +147,7 @@ import { deriveWireUnderSymbolWarnings } from "../canvas/wire-under-symbol";
 import { createPlacementTrayCommands } from "../features/component-insert/placement-tray-commands";
 import { componentTargetDescription } from "../features/properties/component-identity-properties";
 import { componentSourceCode } from "../features/properties/component-source-code";
+import { planElectricalMarkerName } from "../features/properties/electrical-marker-name";
 import {
   endpointTestId,
   instanceLabelAnnotationFor,
@@ -5737,6 +5739,9 @@ export function App({
                           ? selectedInstanceValue !== null &&
                             selectedInstanceValue.visible !== false
                           : null,
+                        netName: selectedSupplyMarker
+                          ? (selectedPortLogicalName ?? "")
+                          : null,
                         onApply: (value: ComponentPropertyCodeValue) => {
                           try {
                             const edits: SchematicEdit[] =
@@ -5844,6 +5849,36 @@ export function App({
                                   desiredValue,
                                 ),
                               );
+                            }
+                            if (
+                              value.netName !== undefined &&
+                              value.netName !== selectedPortLogicalName
+                            ) {
+                              const markerPlan = planElectricalMarkerName(
+                                document,
+                                selectedInstance.id,
+                                value.netName,
+                              );
+                              if (markerPlan.status === "rejected") {
+                                return {
+                                  ok: false as const,
+                                  message: markerPlan.message,
+                                };
+                              }
+                              if (markerPlan.status === "ready") {
+                                const gate = gateRoutingOperationPlan(
+                                  document,
+                                  markerPlan.operationPlan,
+                                  { symbolResolver: resolver },
+                                );
+                                if (!gate.ok) {
+                                  return {
+                                    ok: false as const,
+                                    message: gate.message,
+                                  };
+                                }
+                                edits.push(...gate.edits);
+                              }
                             }
                             const currentTarget =
                               selectedInstance.netlist?.binding?.kind ===

--- a/apps/editor/src/app/editor-properties-dock.tsx
+++ b/apps/editor/src/app/editor-properties-dock.tsx
@@ -151,9 +151,7 @@ export function EditorPropertiesDock({
               {component.cellSymbolLayout ? (
                 <CellSymbolLayoutProperties {...component.cellSymbolLayout} />
               ) : null}
-              {component.identity.portNet ||
-              component.identity.propertyTerminal ||
-              component.identity.capacitorPlateRows ? (
+              {component.identity.propertyTerminal ? (
                 <ComponentIdentityProperties
                   {...component.identity}
                   fieldsMovedToCode

--- a/apps/editor/src/features/properties/component-property-code-editor.tsx
+++ b/apps/editor/src/features/properties/component-property-code-editor.tsx
@@ -28,6 +28,7 @@ export interface ComponentPropertyCodeEditorProps {
   revision: number;
   referenceVisible: boolean | null;
   valueVisible: boolean | null;
+  netName?: string | null;
   defaultForeground?: string;
   details?: ComponentPropertyCodeContext["details"];
   focusRequest?: number;
@@ -42,6 +43,7 @@ export function ComponentPropertyCodeEditor({
   revision,
   referenceVisible,
   valueVisible,
+  netName,
   defaultForeground = "#000000",
   details,
   focusRequest = 0,
@@ -52,9 +54,10 @@ export function ComponentPropertyCodeEditor({
       instance,
       referenceVisible,
       valueVisible,
+      ...(netName !== undefined ? { netName } : {}),
       ...(details ? { details } : {}),
     }),
-    [instance, referenceVisible, valueVisible, details],
+    [instance, referenceVisible, valueVisible, netName, details],
   );
   const baseline = useMemo(
     () => formatComponentPropertyCode(context),

--- a/apps/editor/src/features/properties/component-property-code.test.ts
+++ b/apps/editor/src/features/properties/component-property-code.test.ts
@@ -97,6 +97,29 @@ describe("component property code", () => {
     expect(parseComponentPropertyCode(source, noDisplayContext).ok).toBe(true);
   });
 
+  it("keeps a supply marker's Net name in the same editable code surface", () => {
+    const supplyContext = {
+      instance: { ...instance, symbolId: "vdd-port", reference: undefined },
+      referenceVisible: null,
+      valueVisible: null,
+      netName: "VDD",
+    };
+    const decoded = JSON.parse(formatComponentPropertyCode(supplyContext));
+    expect(decoded.netName).toBe("VDD");
+    decoded.netName = " AVDD ";
+    expect(
+      parseComponentPropertyCode(JSON.stringify(decoded), supplyContext),
+    ).toMatchObject({ ok: true, value: { netName: "AVDD" } });
+
+    delete decoded.netName;
+    expect(
+      parseComponentPropertyCode(JSON.stringify(decoded), supplyContext),
+    ).toEqual({
+      ok: false,
+      message: "netName is required for this component",
+    });
+  });
+
   it("keeps tray membership outside free-form property edits", () => {
     const source = formatComponentPropertyCode(context).replace(
       /"placement": \{[\s\S]*?\n  \},\n  "appearance"/u,

--- a/apps/editor/src/features/properties/component-property-code.ts
+++ b/apps/editor/src/features/properties/component-property-code.ts
@@ -34,6 +34,8 @@ export interface ComponentPropertyDisplayCode {
 }
 
 export interface ComponentPropertyCodeValue extends ComponentPropertyDetailsValue {
+  /** Global Net name owned by a supply marker. */
+  netName?: string;
   placement: ComponentPropertyPlacementCode | null;
   display?: ComponentPropertyDisplayCode;
   appearance: {
@@ -47,6 +49,8 @@ export interface ComponentPropertyCodeContext {
   instance: Instance;
   referenceVisible: boolean | null;
   valueVisible: boolean | null;
+  /** Null when this component does not own an editable electrical marker name. */
+  netName?: string | null;
   details?: ComponentPropertyDetailsContext;
 }
 
@@ -58,6 +62,7 @@ const ROOT_KEYS = new Set([
   "placement",
   "display",
   "appearance",
+  "netName",
   "reference",
   "parameters",
   "netlistTarget",
@@ -217,6 +222,9 @@ export function componentPropertyCodeValue(
   }
   if (context.valueVisible !== null) display.value = context.valueVisible;
   return {
+    ...(context.netName !== undefined && context.netName !== null
+      ? { netName: context.netName }
+      : {}),
     ...componentPropertyDetailsValue(instance, context.details),
     placement: instance.placement
       ? {
@@ -301,9 +309,31 @@ export function parseComponentPropertyCode(
     );
     if (appearanceUnknown) throw new Error(appearanceUnknown);
     const display = parseDisplay(decoded.display, context);
+    const netNameAvailable =
+      context.netName !== undefined && context.netName !== null;
+    if (!netNameAvailable && "netName" in decoded) {
+      throw new Error("netName is not available for this component");
+    }
+    if (netNameAvailable) {
+      if (!("netName" in decoded)) {
+        throw new Error("netName is required for this component");
+      }
+      if (
+        typeof decoded.netName !== "string" ||
+        !decoded.netName.trim() ||
+        decoded.netName.length > 128
+      ) {
+        throw new Error(
+          "netName must be a nonempty string of at most 128 characters",
+        );
+      }
+    }
     return {
       ok: true,
       value: {
+        ...(netNameAvailable
+          ? { netName: (decoded.netName as string).trim() }
+          : {}),
         ...parseComponentPropertyDetails(
           decoded,
           context.instance,

--- a/config/validation-gates.json
+++ b/config/validation-gates.json
@@ -101,7 +101,8 @@
     ],
     "componentInsert": [
       "apps/editor/src/features/component-insert/**",
-      "apps/editor/e2e/component-insert.spec.ts"
+      "apps/editor/e2e/component-insert.spec.ts",
+      "apps/editor/e2e/component-properties-catalog.spec.ts"
     ],
     "hierarchy": [
       "apps/editor/src/features/hierarchy/**",
@@ -249,9 +250,15 @@
       "command": [
         "pnpm",
         "test:e2e:local",
-        "apps/editor/e2e/component-insert.spec.ts"
+        "apps/editor/e2e/component-insert.spec.ts",
+        "apps/editor/e2e/component-properties-catalog.spec.ts"
       ],
-      "ci": { "e2eArgs": ["apps/editor/e2e/component-insert.spec.ts"] }
+      "ci": {
+        "e2eArgs": [
+          "apps/editor/e2e/component-insert.spec.ts",
+          "apps/editor/e2e/component-properties-catalog.spec.ts"
+        ]
+      }
     },
     {
       "id": "hierarchy-browser",

--- a/scripts/lib/ci-validation-plan.test.mjs
+++ b/scripts/lib/ci-validation-plan.test.mjs
@@ -58,6 +58,7 @@ describe("CI validation planning", () => {
       mode: "focused",
       e2eArgs: [
         "apps/editor/e2e/component-insert.spec.ts",
+        "apps/editor/e2e/component-properties-catalog.spec.ts",
         "apps/editor/e2e/gallery.spec.ts",
       ],
     });


### PR DESCRIPTION
## Summary
- remove the remaining legacy capacitor and supply-marker cards from component Properties
- edit supply marker Net names through the shared text-first property document
- verify every one of the 55 insertable component symbols opens exactly one shared code surface after `Q`
- register that exhaustive browser contract in the focused CI routing policy

## Local validation
- visually reviewed local screenshots for resistor, capacitor, variable capacitor, VDD, op amp, and reset D flip-flop
- focused unit: 18 passed
- catalog/property browser checks: 57 passed
- workspace unit: 3,361 passed, 7 skipped
- build, performance, visual/export goldens, production smoke, release smoke: passed
- full browser run: 455/466 passed; the retired capacitor-card assertion was updated and now passes; the other 10 failures reproduce unchanged in four pre-existing Analog Simulation specs on macOS/Node 26, with no Simulation source changes in this PR. Remote required checks are the delivery authority for that environment-specific limitation.
