### PR TITLE
Fix connected 45-degree component rotation

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -1863,6 +1863,49 @@ test("authors components and connectivity manually from an empty canvas", async 
   await expect(page.locator('[data-layer="routes"] polyline')).toHaveCount(0);
 });
 
+test("component property code turns a connected part by 45 degrees", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await placeComponent(page, "resistor", { x: 340, y: 220 });
+  await placeComponent(page, "nmos", { x: 560, y: 220 });
+  await clickDrawTool(page, "wire");
+  await page.getByTestId("terminal-R1-2").click();
+  await page.getByTestId("terminal-M1-G").click();
+  await page.keyboard.press("Escape");
+
+  await page.getByTestId("hit-R1").click();
+  await openSelectionShelf(page);
+  await editComponentPropertyCode(page, (code) => {
+    code.placement.rotation = 45;
+  });
+
+  await expectComponentCodeField(page, "placement.rotation", 45);
+  await expect(page.getByTestId("revision")).toHaveText("4");
+  await expect(page.getByTestId("status")).toHaveText(
+    "Applied Canvas property code to R1",
+  );
+  await expect(page.locator('[data-layer="routes"] polyline')).toHaveCount(1);
+  const saved = JSON.parse(
+    (await downloadBytes(page, "File", "Export Project File…")).toString(
+      "utf8",
+    ),
+  ) as { documents: SchematicDocument[] };
+  expect(saved.documents[0]!.instances[0]!.placement?.rotation).toBe(45);
+  const persistedBends = saved.documents[0]!.routes[0]!.legs.flatMap((leg) =>
+    leg.to.kind === "bend" ? [leg.to.position] : [],
+  );
+  expect(
+    persistedBends.every(
+      (point) =>
+        Number.isInteger(point.x) &&
+        Number.isInteger(point.y) &&
+        point.x % saved.documents[0]!.presentation.grid === 0 &&
+        point.y % saved.documents[0]!.presentation.grid === 0,
+    ),
+  ).toBe(true);
+});
+
 test("splices a two-terminal device into one wire and reconnects its halves after deletion", async ({
   page,
 }) => {

--- a/packages/edit-engine/src/endpoint-connection.integration.test.ts
+++ b/packages/edit-engine/src/endpoint-connection.integration.test.ts
@@ -138,6 +138,51 @@ function gateRouteDocument(symbolId: "nmos" | "pmos") {
 
 describe("EndpointConnection transform lifecycle", () => {
   it.each(["nmos", "pmos"] as const)(
+    "keeps a connected %s Route persistable after a direct 45-degree turn",
+    (symbolId) => {
+      const document = gateRouteDocument(symbolId);
+      const result = executeTransaction(
+        document,
+        {
+          transactionId: `turn-${symbolId}-45`,
+          documentId: document.id,
+          expectedRevision: document.revision,
+          actor: { kind: "human", id: "test" },
+          edits: [
+            {
+              kind: "rotate_instance",
+              instanceId: "M1",
+              rotation: 45,
+            },
+          ],
+        },
+        { symbolResolver: resolver },
+      );
+
+      expect(
+        result,
+        result.ok
+          ? ""
+          : JSON.stringify({
+              error: result.error,
+              diagnostics: result.diagnostics,
+            }),
+      ).toMatchObject({ ok: true });
+      if (!result.ok) return;
+      expect(result.document.instances[0]!.placement?.rotation).toBe(45);
+      expect(
+        routeBends(result.document.routes[0]!).every(
+          (point) =>
+            Number.isInteger(point.x) &&
+            Number.isInteger(point.y) &&
+            point.x % document.presentation.grid === 0 &&
+            point.y % document.presentation.grid === 0,
+        ),
+      ).toBe(true);
+    },
+  );
+
+  it.each(["nmos", "pmos"] as const)(
     "follows a connected %s Route once at the final reflected pose",
     (symbolId) => {
       const document = gateRouteDocument(symbolId);

--- a/packages/edit-engine/src/transaction-route-follow.ts
+++ b/packages/edit-engine/src/transaction-route-follow.ts
@@ -1,4 +1,9 @@
-import { createRoutePath, routeEnd, routeModes } from "@icm/model";
+import {
+  createRoutePath,
+  routeEnd,
+  routeModes,
+  snapGridPoint,
+} from "@icm/model";
 import type {
   Point,
   RouteBranch,
@@ -312,7 +317,23 @@ export function applyInstancesRouteFollow(
       continue;
     }
 
-    const normalized = normalizeRouteGeometry(points, modes);
+    let normalized = normalizeRouteGeometry(points, modes);
+    if (normalized.points.length >= 2) {
+      // Rotated terminal contacts are exact derived geometry and may be
+      // fractional. Endpoint stretch uses those contacts to preserve the pin
+      // lead, but every intermediate point becomes a persisted Route bend and
+      // therefore must return to the document grid before commit.
+      normalized = normalizeRouteGeometry(
+        [
+          normalized.points[0]!,
+          ...normalized.points
+            .slice(1, -1)
+            .map((point) => snapGridPoint(point, draft.presentation.grid)),
+          normalized.points.at(-1)!,
+        ],
+        normalized.segmentModes,
+      );
+    }
     if (normalized.points.length < 2) {
       // A transformed endpoint can land exactly on the Route's other
       // endpoint. Persisting that direct contact as a zero-length Route would


### PR DESCRIPTION
## Summary
- snap route-follow bends to the document grid after exact terminal transforms
- keep wired components editable at 45-degree rotation through Canvas property code
- add edit-engine and browser regressions that validate exported integer route bends

## Validation
- focused 45-degree browser regression passed
- edit-engine transaction/routing/endpoint tests: 121 passed
- static checks, full unit suite: 3,363 passed, build, release verification, and production smoke passed
- full browser suite passed the new regression; 10 unrelated simulation workspace/editor tests remain red and reproduced identically in a focused rerun

Test-Impact: tests-updated