### PR TITLE
Fix duplicate scalar measurements and OP result scoping

### DIFF
--- a/apps/editor/e2e/simulation-workspace.spec.ts
+++ b/apps/editor/e2e/simulation-workspace.spec.ts
@@ -818,7 +818,7 @@ test("human simulation uses saved folder, survives minimizing, recovers a bad in
       json: {
         outcome: { status: "completed" },
         diagnostics: [],
-        log: "ngspice OP",
+        log: "ngspice OP\nat_one_tau = 5.00000e-01\n",
         durationMs: 1,
         data: {
           ...reading.data,
@@ -852,6 +852,14 @@ test("human simulation uses saved folder, survives minimizing, recovers a bad in
               analysis: "tran",
               plotName: "Transient response",
               timeSeconds: [0, 1e-9, 10e-9],
+              scalars: [
+                {
+                  name: "at_one_tau",
+                  quantity: "voltage",
+                  unit: "V",
+                  value: 0.5,
+                },
+              ],
               probes: [
                 {
                   name: requestedVector,
@@ -950,6 +958,7 @@ test("human simulation uses saved folder, survives minimizing, recovers a bad in
     "ac dec 10 1 1e6",
     "write out.raw",
     "tran 1e-9 1e-6 0 5e-10",
+    "meas tran at_one_tau FIND v(vout) AT=1e-9",
     "write out.raw",
     "noise v(vout) VINP dec 10 1 1e6",
     "write out.raw",
@@ -1018,7 +1027,12 @@ test("human simulation uses saved folder, survives minimizing, recovers a bad in
   await expect(panel.locator(".simulation-console-summary")).toHaveCount(0);
   await expect(panel.locator(".simulation-console-view > pre")).toBeVisible();
   await panel.getByRole("tab", { name: "Plot", exact: true }).click();
+  await expect(panel.getByText("at_one_tau", { exact: true })).toHaveCount(1);
+  await expect(
+    panel.getByRole("region", { name: "Native measurements", exact: true }),
+  ).toHaveCount(0);
   await panel.getByRole("tab", { name: "Operating Point" }).click();
+  await expect(panel.getByText("at_one_tau", { exact: true })).toHaveCount(0);
   await expect(panel.getByRole("region", { name: "OP results" })).toContainText(
     "0.500000",
   );

--- a/apps/editor/src/features/simulation/captured-scalar-results.tsx
+++ b/apps/editor/src/features/simulation/captured-scalar-results.tsx
@@ -13,11 +13,7 @@ export function CapturedScalarResults({
       aria-label={`Captured scalars record ${record}`}
       className="simulation-measurement-results"
     >
-      <h4>Captured values · Record {record}</h4>
-      <p>
-        Single values stored in this raw plot. These are not samples along its
-        sweep axis. Console measurement reports are listed separately.
-      </p>
+      <h4>Measurements · Record {record}</h4>
       <table>
         <thead>
           <tr>

--- a/apps/editor/src/features/simulation/measurement-presentation.test.tsx
+++ b/apps/editor/src/features/simulation/measurement-presentation.test.tsx
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { SimulationOutputData } from "@icm/simulation-service/contract";
+import { unrepresentedConsoleMeasurements } from "./measurement-presentation";
+import { SimulationOutputResults } from "./simulation-output-results";
+
+function fixture(): SimulationOutputData {
+  return {
+    schemaVersion: 1,
+    diagnostics: [],
+    analyses: [
+      {
+        analysis: "tran",
+        plotName: "Transient Analysis",
+        rawPlotOrdinals: [0],
+        domain: { name: "Time", unit: "s", values: [0, 0.001] },
+        outputs: [],
+        scalars: [
+          {
+            id: "native:at_one_tau",
+            label: "at_one_tau",
+            value: 0.3678778,
+            unit: "",
+          },
+        ],
+      },
+    ],
+    nativeMeasurements: [
+      {
+        name: "at_one_tau",
+        occurrence: 1,
+        status: "available",
+        value: 0.367878,
+        logLine: 10,
+        detail: "at_one_tau = 3.67878e-01",
+      },
+    ],
+  };
+}
+describe("measurement presentation", () => {
+  it("shows the high-pass Step scalar once while retaining its original Console evidence", () => {
+    const data = fixture();
+    const before = structuredClone(data);
+    expect(unrepresentedConsoleMeasurements(data)).toEqual([]);
+    const html = renderToStaticMarkup(
+      <SimulationOutputResults
+        resultKey="hp-step"
+        data={data}
+        outputs={[]}
+        view="waveform"
+      />,
+    );
+    expect(html.match(/>at_one_tau</gu)).toHaveLength(1);
+    expect(html).toContain("0.3678778");
+    expect(html).not.toContain("Code measurements");
+    expect(html).not.toContain("These are not samples");
+    expect(data).toEqual(before);
+  });
+  it("keeps Console-only and failed measurements available", () => {
+    const data = fixture();
+    data.analyses[0]!.scalars = [];
+    data.nativeMeasurements!.push({
+      name: "failed",
+      occurrence: 0,
+      status: "unavailable",
+      detail: "No crossing",
+    });
+    expect(unrepresentedConsoleMeasurements(data)).toEqual(
+      data.nativeMeasurements,
+    );
+    const html = renderToStaticMarkup(
+      <SimulationOutputResults resultKey="reports" data={data} outputs={[]} />,
+    );
+    expect(html).toContain("at_one_tau");
+    expect(html).toContain("Unavailable");
+  });
+  it.each([
+    "changed",
+    "complex",
+    "repeated reports",
+    "repeated records",
+    "insufficient precision",
+  ])("does not merge %s", (kind) => {
+    const data = fixture();
+    if (kind === "changed") data.analyses[0]!.scalars![0]!.value = 0.5;
+    if (kind === "complex") data.analyses[0]!.scalars![0]!.imaginary = 1;
+    if (kind === "repeated reports")
+      data.nativeMeasurements!.push({
+        ...data.nativeMeasurements![0]!,
+        occurrence: 2,
+      } as NonNullable<SimulationOutputData["nativeMeasurements"]>[number]);
+    if (kind === "repeated records")
+      data.analyses.push({ ...data.analyses[0]!, rawPlotOrdinals: [1] });
+    if (kind === "insufficient precision")
+      data.nativeMeasurements![0]!.detail = "at_one_tau = 0.36787800";
+    expect(unrepresentedConsoleMeasurements(data)).toEqual(
+      data.nativeMeasurements,
+    );
+  });
+  it("does not show TRAN reports or captures in an empty or populated OP view", () => {
+    const data = fixture();
+    data.diagnostics = [
+      {
+        analysisIndex: 0,
+        outputId: "tran-only",
+        code: "UNAVAILABLE",
+        message: "Transient-only diagnostic",
+      },
+    ];
+    data.nativeMeasurements!.push({
+      name: "console_only",
+      occurrence: 1,
+      status: "available",
+      value: 2,
+      logLine: 11,
+      detail: "console_only = 2",
+    });
+    for (const addOp of [false, true]) {
+      if (addOp)
+        data.analyses.push({
+          analysis: "op",
+          plotName: "Operating Point",
+          outputs: [
+            { id: "v(out)", label: "v(out)", unit: "V", values: [0.1] },
+          ],
+        });
+      const html = renderToStaticMarkup(
+        <SimulationOutputResults
+          resultKey="op-view"
+          data={data}
+          outputs={[]}
+          view="op"
+        />,
+      );
+      expect(html).not.toContain("at_one_tau");
+      expect(html).not.toContain("console_only");
+      expect(html).not.toContain("Transient-only diagnostic");
+      if (addOp) expect(html).toContain("v(out)");
+    }
+  });
+  it("retains original record indices when the waveform view hides OP", () => {
+    const data = fixture();
+    data.analyses.unshift({
+      analysis: "op",
+      plotName: "Operating Point",
+      outputs: [],
+    });
+    const html = renderToStaticMarkup(
+      <SimulationOutputResults
+        resultKey="mixed"
+        data={data}
+        outputs={[]}
+        view="waveform"
+      />,
+    );
+    expect(html).toContain('aria-label="Captured scalars record 2"');
+    expect(html).not.toContain('aria-label="OP results"');
+  });
+});

--- a/apps/editor/src/features/simulation/measurement-presentation.ts
+++ b/apps/editor/src/features/simulation/measurement-presentation.ts
@@ -1,0 +1,47 @@
+import type { SimulationOutputData } from "@icm/simulation-service/contract";
+
+type Report = NonNullable<SimulationOutputData["nativeMeasurements"]>[number];
+
+/** Presentation only: retain the original reports in the Run/Console/artifacts.
+ * Only suppress a unique scalar's corroborating report. Repeated names, changed
+ * values and complex values are not evidence of a unique matching capture. */
+export function unrepresentedConsoleMeasurements(
+  data: SimulationOutputData,
+): Report[] {
+  const reports = data.nativeMeasurements ?? [];
+  const scalars = data.analyses.flatMap((analysis) => analysis.scalars ?? []);
+  return reports.filter((report) => {
+    if (report.status !== "available") return true;
+    const name = report.name.toLowerCase();
+    if (reports.filter((r) => r.name.toLowerCase() === name).length !== 1)
+      return true;
+    const captures = scalars.filter(
+      (s) => s.id.toLowerCase() === `native:${name}`,
+    );
+    if (captures.length !== 1) return true;
+    const capture = captures[0]!;
+    if (capture.imaginary !== undefined && capture.imaginary !== 0) return true;
+    if (capture.value === report.value) return false;
+    // ngspice's Console commonly rounds more aggressively than its rawfile.
+    // Match only the precision explicitly printed in this report, not an epsilon.
+    const token =
+      /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*([+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?)(?=\s|$)/u.exec(
+        report.detail,
+      );
+    if (
+      !token ||
+      token[1]!.toLowerCase() !== name ||
+      Number(token[2]) !== report.value
+    )
+      return true;
+    const digits = token[2]!
+      .split(/[eE]/u)[0]!
+      .replace(/[^\d]/gu, "")
+      .replace(/^0+/u, "").length;
+    return (
+      digits < 1 ||
+      digits > 100 ||
+      Number(capture.value.toPrecision(digits)) !== report.value
+    );
+  });
+}

--- a/apps/editor/src/features/simulation/native-measurement-results.tsx
+++ b/apps/editor/src/features/simulation/native-measurement-results.tsx
@@ -11,11 +11,7 @@ export function NativeMeasurementResults({
       className="simulation-measurement-results"
       aria-label="Native measurements"
     >
-      <h4>Code measurements</h4>
-      <p>
-        Scalars reported by ngspice. Repeated names retain their report order;
-        units and plot associations are not inferred.
-      </p>
+      <h4>Measurements</h4>
       <table>
         <thead>
           <tr>

--- a/apps/editor/src/features/simulation/simulation-output-results.tsx
+++ b/apps/editor/src/features/simulation/simulation-output-results.tsx
@@ -19,6 +19,7 @@ import { ScalarResultsExplorer } from "./transient-results-explorer";
 import { SimulationMeasurementResults } from "./simulation-measurement-results";
 import { NativeMeasurementResults } from "./native-measurement-results";
 import { CapturedScalarResults } from "./captured-scalar-results";
+import { unrepresentedConsoleMeasurements } from "./measurement-presentation";
 import { NoiseResultsExplorer } from "./noise-results-explorer";
 import { planResultOutput } from "./result-plot-plan";
 import { ResultRecordView, ResultPlotControls } from "./result-plot-controls";
@@ -231,10 +232,12 @@ export function SimulationOutputResults({
   outputs,
   signalTargets,
   onFocusProbe,
+  view = "all",
 }: {
   resultKey: string;
   data: SimulationOutputData;
   outputs: readonly SimulationOutputSpec[];
+  view?: "all" | "waveform" | "op";
   signalTargets?: Prepared["signalTargets"];
   onFocusProbe?(probe: SimulationFocusTarget): void;
 }) {
@@ -256,12 +259,21 @@ export function SimulationOutputResults({
       anchor: { kind: "base-net", netId: target.netId },
     });
   }
+  const isVisible = (analysis: SimulationOutputData["analyses"][number]) =>
+    view === "all" ||
+    (view === "op" ? analysis.analysis === "op" : analysis.analysis !== "op");
   const visibleAnalyses = new Set(
-    data.analyses.map((analysis) => analysis.analysis),
+    data.analyses.filter(isVisible).map((a) => a.analysis),
   );
+  const visibleDiagnostics = data.diagnostics.filter((diagnostic) => {
+    if (diagnostic.analysisIndex === undefined) return view !== "op";
+    const analysis = data.analyses[diagnostic.analysisIndex];
+    return analysis ? isVisible(analysis) : view !== "op";
+  });
   return (
     <div className="simulation-output-results">
       {data.analyses.map((analysis, analysisIndex) => {
+        if (!isVisible(analysis)) return null;
         if (analysis.analysis === "op")
           return (
             <SimulationAnalysisCard key={`op-${analysisIndex}`} kind="op">
@@ -495,9 +507,9 @@ export function SimulationOutputResults({
           </ResultRecordView>
         );
       })}
-      {data.diagnostics.length > 0 ? (
+      {visibleDiagnostics.length > 0 ? (
         <div className="simulation-output-diagnostics" role="status">
-          {data.diagnostics.map((diagnostic, index) => (
+          {visibleDiagnostics.map((diagnostic, index) => (
             <p key={`${index}:${diagnostic.outputId}:${diagnostic.code}`}>
               <strong>
                 {authored.get(diagnostic.outputId)?.label ??
@@ -513,7 +525,11 @@ export function SimulationOutputResults({
           visibleAnalyses.has(measurement.analysis),
         )}
       />
-      <NativeMeasurementResults measurements={data.nativeMeasurements ?? []} />
+      {view !== "op" ? (
+        <NativeMeasurementResults
+          measurements={unrepresentedConsoleMeasurements(data)}
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -1198,12 +1198,8 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
             {run?.outputData ? (
               <SimulationOutputResults
                 resultKey={run.id}
-                data={{
-                  ...run.outputData,
-                  analyses: run.outputData.analyses.filter(
-                    (analysis) => analysis.analysis !== "op",
-                  ),
-                }}
+                data={run.outputData}
+                view="waveform"
                 outputs={runPresentation?.outputs ?? []}
                 signalTargets={runPresentation?.prepared.signalTargets}
                 {...(props.onFocusProbe
@@ -1387,12 +1383,8 @@ function SimulationSurface(props: SpiceSimulationSurfaceProps) {
                 />
                 <SimulationOutputResults
                   resultKey={`${run.id}:op`}
-                  data={{
-                    ...run.outputData,
-                    analyses: run.outputData.analyses.filter(
-                      (analysis) => analysis.analysis === "op",
-                    ),
-                  }}
+                  data={run.outputData}
+                  view="op"
                   outputs={runPresentation?.outputs ?? []}
                 />
               </>

--- a/docs/specs/simulation-results.md
+++ b/docs/specs/simulation-results.md
@@ -213,7 +213,7 @@ remain waveforms. Unsupported short arrays and malformed dimensions produce
 diagnostics instead of being plotted against the wrong axis.
 
 The evaluated record also carries `scalars`, separate from curve `outputs`.
-Results shows these in a **Captured values** table per record, preserving signed
+Results shows these in a compact **Measurements** table per record, preserving signed
 and complex numbers. They do not generate curve min/max/span/RMS summaries and
 are not image-export traces. Both raw and evaluated CSV append a separately
 headed scalar table. Unknown units stay explicitly unknown; a variable suffix
@@ -222,8 +222,14 @@ such as `_db` does not establish a unit.
 Console measurement reports remain separate evidence: only declarations reached
 from the executed entry/include graph participate, and repeated report names
 retain Console order. The UI does not invent an association between Console
-lines and raw records. A value may therefore appear as both a captured scalar
-and a Console report, with their different provenance made explicit.
+lines and raw records. A unique raw scalar is preferred over a unique same-name
+Console report when their real values agree at the Console's explicitly printed
+precision. This only suppresses a redundant presentation row; both original
+sources remain in the Run, Console and exported artifacts. Repeated names,
+multiple captures, differing values and complex captures are not collapsed.
+Console-only and failed reports remain visible. The OP view never renders
+run-wide Console measurements from other analyses. View filtering retains the
+original record indices and scopes analysis diagnostics as well as summaries.
 
 Hosted responses with numeric data and explicit rawfile dimensions are re-read
 by the same canonical reader to handle executor-image version skew. Missing


### PR DESCRIPTION
## Changes
- Prefer a unique raw scalar over a corroborating unique same-name Console report at its printed precision. Keep ambiguous repeated names, different values, complex captures, failed measurements and Console-only results; original Run/Console/CSV evidence is untouched.
- OP no longer renders run-wide Console reports from TRAN/AC. Keep original record indices and scope analysis diagnostics correctly.
- Use compact Measurements headings and remove explanatory paragraphs.

## Validation
- Local gate preflight passed (static, typecheck, Test-Impact).
- Local gate affected passed: 485 unit files, 3283 tests passed (31 existing skips), and all 30 browser tests across six analog simulation specs.
- The human simulation journey asserts at_one_tau appears once in Plot and never in OP; the presentation contract covers the actual high-pass rounded pair 0.3678778 / 3.67878e-01.
- All seven required GitHub checks passed on 089bcdcc (run 34729403927), including release/performance and all four focused browser shards.
- git diff --check passed; worktree clean.

No electrical Project/model data, numeric results, API/MCP contracts, Production release or deployment changes. Original evidence is retained; unknown associations are not guessed.

Test-Impact: tests-updated