### PR TITLE
Put black first in the line color palette

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -429,6 +429,20 @@ for (const width of [300, 540]) {
     }
     await color.click();
 
+    expect(
+      await page
+        .getByLabel("Line presets")
+        .getByRole("button")
+        .evaluateAll((buttons) =>
+          buttons.map((button) => button.getAttribute("aria-label")),
+        ),
+    ).toEqual([
+      "Use Black for line",
+      "Use Light gray for line",
+      "Use Red for line",
+      "Use Green for line",
+      "Use Blue for line",
+    ]);
     await expect(
       page.getByRole("button", { name: "Use Light gray for line" }),
     ).toBeVisible();

--- a/apps/editor/src/features/properties/component-property-json-editor.tsx
+++ b/apps/editor/src/features/properties/component-property-json-editor.tsx
@@ -79,8 +79,8 @@ interface Props {
 const externalUpdate = Annotation.define<boolean>();
 const refreshDecorations = StateEffect.define<null>();
 const LINE_COLOR_PRESETS = [
-  ...COMMON_COLOR_PRESETS,
   { label: "Black", value: "#000000" },
+  ...COMMON_COLOR_PRESETS,
 ] as const;
 
 /** Lazy loaded: selecting a component does not make the canvas shell depend on CodeMirror. */


### PR DESCRIPTION
## Summary\n- order inline component line-color presets as black, light gray, red, green, blue\n- protect the exact palette order at both supported Properties widths\n\n## Validation\n- pnpm gate:preflight -- --base origin/main\n- pnpm gate:affected -- --base origin/main\n  - 3,363 unit tests passed; 7 skipped\n  - 156 editor browser tests passed\n