### PR TITLE
Fix mixed text and component dragging

### DIFF
--- a/apps/editor/e2e/context-menu.spec.ts
+++ b/apps/editor/e2e/context-menu.spec.ts
@@ -141,6 +141,66 @@ test("drafting text shares device additive selection and context alignment", asy
   );
 });
 
+test("dragging drafting text carries its mixed component selection as one body", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await placeComponent(page, "resistor", { x: 300, y: 220 });
+  await clickDrawTool(page, "text");
+  const input = page.getByRole("textbox", { name: "Canvas text editor" });
+  await input.fill("BIAS");
+  await page.getByRole("button", { name: "Apply text changes" }).click();
+
+  const instance = page.locator('[data-canvas-hit-kind="instance"]').first();
+  const text = page.locator('[data-canvas-hit-kind="drafting"]').first();
+  await instance.click();
+  await text.click({ modifiers: ["Shift"] });
+  await expect(instance).toHaveClass(/selected/);
+  await expect(text).toHaveClass(/selected/);
+
+  const instanceBefore = await instance.boundingBox();
+  const textBefore = await text.boundingBox();
+  if (!instanceBefore || !textBefore)
+    throw new Error("Selection is not measurable");
+  const start = {
+    x: textBefore.x + textBefore.width / 2,
+    y: textBefore.y + textBefore.height / 2,
+  };
+  await page.mouse.move(start.x, start.y);
+  await page.mouse.down();
+  await page.mouse.move(start.x + 80, start.y + 60, { steps: 4 });
+  await page.mouse.up();
+
+  const instanceAfter = await instance.boundingBox();
+  const textAfter = await text.boundingBox();
+  if (!instanceAfter || !textAfter)
+    throw new Error("Moved selection is not measurable");
+  const instanceDelta = {
+    x: instanceAfter.x - instanceBefore.x,
+    y: instanceAfter.y - instanceBefore.y,
+  };
+  const textDelta = {
+    x: textAfter.x - textBefore.x,
+    y: textAfter.y - textBefore.y,
+  };
+  // Smart Snap may keep either axis aligned with nearby geometry. The
+  // contract here is one non-zero translation shared by every selected
+  // member, not a promise that both axes must change.
+  expect(Math.hypot(instanceDelta.x, instanceDelta.y)).toBeGreaterThan(0);
+  expect(textDelta.x).toBeCloseTo(instanceDelta.x, 0);
+  expect(textDelta.y).toBeCloseTo(instanceDelta.y, 0);
+  await expect(instance).toHaveClass(/selected/);
+  await expect(text).toHaveClass(/selected/);
+
+  await page.keyboard.press("ControlOrMeta+Z");
+  const instanceUndone = await instance.boundingBox();
+  const textUndone = await text.boundingBox();
+  expect(instanceUndone?.x).toBeCloseTo(instanceBefore.x, 0);
+  expect(instanceUndone?.y).toBeCloseTo(instanceBefore.y, 0);
+  expect(textUndone?.x).toBeCloseTo(textBefore.x, 0);
+  expect(textUndone?.y).toBeCloseTo(textBefore.y, 0);
+});
+
 test("drafting shapes join device selection from either order", async ({
   page,
 }) => {

--- a/apps/editor/src/canvas/canvas-hit-controller.ts
+++ b/apps/editor/src/canvas/canvas-hit-controller.ts
@@ -111,7 +111,13 @@ export function createCanvasHitController({
   },
 }: CanvasHitControllerDependencies) {
   const compositeSelectionOwnsHit = (
-    kind: "instance" | "instance-label" | "annotation" | "route" | "junction",
+    kind:
+      | "instance"
+      | "instance-label"
+      | "annotation"
+      | "drafting"
+      | "route"
+      | "junction",
     id: string,
   ): boolean => {
     const hasCompositeSelection =
@@ -135,6 +141,9 @@ export function createCanvasHitController({
         selection.junctionIds.includes(id) ||
         selectedInternalJunctionIds.has(id)
       );
+    }
+    if (kind === "drafting") {
+      return selection.draftingIds.includes(id);
     }
     const annotation = document.annotations.find(
       (candidate) => candidate.id === id,
@@ -194,7 +203,6 @@ export function createCanvasHitController({
     const compositeOwnsHit = Boolean(
       hit &&
       hit.kind !== "handle" &&
-      hit.kind !== "drafting" &&
       compositeSelectionOwnsHit(hit.kind, hit.id),
     );
     const primaryInstanceId = selection.instanceIds.at(-1) ?? null;

--- a/apps/editor/src/canvas/pointer-down-router.test.ts
+++ b/apps/editor/src/canvas/pointer-down-router.test.ts
@@ -202,6 +202,22 @@ describe("who owns one press on the canvas", () => {
     expect(resolvePointerDownAction(facts(composite))).toEqual({
       kind: "begin-visual-selection-move",
     });
+
+    // Drafting text and shapes are ordinary members of the same selection.
+    // Pressing one must not fall back to its single-object drag controller.
+    const draftingComposite = {
+      hit: hitOf("drafting", "note-1"),
+      compositeSelectionOwnsHit: true,
+      compositeMovePlanHasPreview: true,
+    };
+    expect(
+      resolvePointerDownAction(
+        facts({ ...draftingComposite, primaryInstanceId: "R1" }),
+      ),
+    ).toEqual({ kind: "begin-instance-move", instanceId: "R1" });
+    expect(resolvePointerDownAction(facts(draftingComposite))).toEqual({
+      kind: "begin-visual-selection-move",
+    });
   });
 
   it("lets a modifier compose the selection instead of moving it", () => {

--- a/apps/editor/src/canvas/pointer-down-router.ts
+++ b/apps/editor/src/canvas/pointer-down-router.ts
@@ -73,6 +73,7 @@ const COMPOSITE_KINDS: readonly CanvasHitKind[] = [
   "instance",
   "instance-label",
   "annotation",
+  "drafting",
   "route",
   "junction",
 ];


### PR DESCRIPTION
## Summary
- route selected drafting text and shapes through the existing composite-move protocol
- preserve mixed instance, route, junction, annotation, and drafting selection when dragging from text
- cover drafting-led mixed movement, equal preview/commit translation, and atomic undo

## Validation
- 3348 unit tests passed (31 skipped)
- 22 focused selection/canvas unit tests passed
- 16 context-menu, command, and thin-target browser tests passed
- 8 focused manual-editor movement tests passed
- preflight static contracts, typecheck, formatting, and test-impact passed