### PR TITLE
feat(editor): disambiguate netlist identity and visual annotation properties

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -162,7 +162,7 @@ test("writes an Instance Reference through post-placement Properties", async ({
   await page.getByTestId("hit-R1").click();
   await page.getByTestId("selection-shelf").click();
   await editComponentPropertyCode(page, (code) => {
-    code.reference = "R7";
+    code.netlistName = "R7";
   });
 
   await expect
@@ -1255,7 +1255,7 @@ test("carries a default and manual Value through placement and Q property editin
     "R1 · resistor",
   );
   await expect(page.getByLabel("Component display toggles")).toHaveCount(0);
-  await expect(propertyCode).toContainText(/"reference": true/u);
+  await expect(propertyCode).toContainText(/"visualAnnotation": true/u);
   await expect(propertyCode).toContainText(/"value": false/u);
   await expect(page.getByText("Actions", { exact: true })).toHaveCount(0);
   // Opening focuses the shelf header, never the first field: Q stays a pure
@@ -1296,13 +1296,13 @@ test("carries a default and manual Value through placement and Q property editin
     "aria-label",
     "Canvas property code",
   );
-  await expectComponentCodeField(page, "reference", "R1");
+  await expectComponentCodeField(page, "netlistName", "R1");
   await editComponentPropertyCode(page, (code) => {
-    code.reference = "R7";
+    code.netlistName = "R7";
     code.parameters.tc = "0.1";
   });
   await expect(page.getByTestId("revision")).toHaveText("4");
-  await expectComponentCodeField(page, "reference", "R7");
+  await expectComponentCodeField(page, "netlistName", "R7");
   await expectComponentCodeField(page, "parameters.tc", "0.1");
 });
 
@@ -1593,7 +1593,7 @@ test("sets MOS parameters and orientation through the ghost and Properties", asy
   await setComponentParameter(page, "m", "4");
 
   await editComponentPropertyCode(page, (value) => {
-    value.display.reference = false;
+    value.display.visualAnnotation = false;
   });
   await expect(
     page.locator('[data-object-id="instance-label-M1"]'),

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -43,11 +43,11 @@ test("live JSON properties update controls immediately and round-trip raw parame
   await expect(panel.getByRole("button", { name: "Apply code" })).toHaveCount(
     0,
   );
-  await expect(panel.locator(".cm-property-hint")).toHaveCount(0);
-  await expect(panel.locator(".cm-property-assist")).toHaveCount(0);
+  await expect(panel.locator(".cm-property-unit")).toHaveCount(2);
+  await expect(panel.getByLabel("Target netlist options")).toBeVisible();
   await editComponentPropertyCode(page, (code) => {
     code.placement.rotation = 90;
-    code.display.reference = false;
+    code.display.visualAnnotation = false;
   });
   await expect(page.getByTestId("revision")).toHaveText(
     String(Number(revision) + 1),
@@ -59,7 +59,7 @@ test("live JSON properties update controls immediately and round-trip raw parame
   );
   const draft = JSON.parse(await readComponentPropertyCode(page));
   expect(draft.placement.rotation).toBe(90);
-  expect(draft.display.reference).toBe(false);
+  expect(draft.display.visualAnnotation).toBe(false);
   expect(draft.appearance.foreground).toEqual([220, 38, 38]);
   draft.parameters.w = "EV";
   draft.parameters.l = "L";
@@ -131,7 +131,9 @@ test("live Defaults are undoable and invalid drafts never change the canvas", as
     page.getByRole("button", { name: "Edit line color" }),
   ).toBeDisabled();
   await expect(
-    page.getByRole("switch", { name: "Toggle reference visibility" }),
+    page.getByRole("switch", {
+      name: "Toggle visual annotation visibility",
+    }),
   ).toBeDisabled();
   await expect(
     page.getByRole("switch", { name: "Toggle value visibility" }),
@@ -162,15 +164,15 @@ test("one live JSON edit combines model, dimensions and appearance in one undo b
     code.parameters.w = "5u";
     code.appearance.foreground = [20, 30, 40];
   });
-  await expectComponentCodeField(page, "reference", "XM1");
+  await expectComponentCodeField(page, "netlistName", "XM1");
   await expectComponentCodeField(page, "parameters.w", "5u");
   await expectComponentCodeField(page, "appearance.foreground", [20, 30, 40]);
   await clickCommand(page, "Edit", "Undo");
-  await expectComponentCodeField(page, "reference", "M1");
+  await expectComponentCodeField(page, "netlistName", "M1");
   await expectComponentCodeField(page, "parameters.w", "1u");
   await expectComponentCodeField(page, "appearance.foreground", "auto");
   await clickCommand(page, "Edit", "Redo");
-  await expectComponentCodeField(page, "reference", "XM1");
+  await expectComponentCodeField(page, "netlistName", "XM1");
   await expectComponentCodeField(page, "parameters.w", "5u");
 });
 
@@ -320,7 +322,7 @@ for (const width of [300, 540]) {
 
     const color = editor.getByRole("button", { name: "Edit line color" });
     const reference = editor.getByRole("switch", {
-      name: "Toggle reference visibility",
+      name: "Toggle visual annotation visibility",
     });
     const value = editor.getByRole("switch", {
       name: "Toggle value visibility",
@@ -355,7 +357,9 @@ for (const width of [300, 540]) {
     );
     expect(
       await reference.evaluate((element) =>
-        element.closest(".cm-line")?.textContent?.includes('"reference"'),
+        element
+          .closest(".cm-line")
+          ?.textContent?.includes('"visualAnnotation"'),
       ),
     ).toBe(true);
     expect(
@@ -402,7 +406,7 @@ for (const width of [300, 540]) {
     await reference.click();
     await value.click();
     await rotation.click();
-    await expectComponentCodeField(page, "display.reference", false);
+    await expectComponentCodeField(page, "display.visualAnnotation", false);
     await expectComponentCodeField(page, "display.value", true);
     await expectComponentCodeField(page, "placement.rotation", 45);
     await mirrorLeftRight.click();
@@ -1241,18 +1245,18 @@ test("a part with no designator offers no Reference toggle", async ({
   await placeComponent(page, "resistor", { x: 500, y: 200 });
   await openSelectionShelf(page);
   const code = properties.getByLabel("Editable Canvas property code");
-  await expect(code).toContainText(/"reference": true/u);
+  await expect(code).toContainText(/"visualAnnotation": true/u);
   await expect(code).toContainText(/"value": false/u);
   const drawnLabel = page.locator(
     '[data-layer="annotations"] [data-object-id="instance-label-R1"]',
   );
   await expect(drawnLabel).toHaveCount(1);
   await editComponentPropertyCode(page, (value) => {
-    value.display.reference = false;
+    value.display.visualAnnotation = false;
   });
   await expect(drawnLabel).toHaveCount(0);
   await editComponentPropertyCode(page, (value) => {
-    value.display.reference = true;
+    value.display.visualAnnotation = true;
   });
   await expect(drawnLabel).toHaveCount(1);
 });
@@ -4038,7 +4042,7 @@ test("Properties offers no dead Reference controls for a schematic-only block", 
   await page.getByTestId("hit-R1").click();
   await expect(referenceField).toHaveCount(0);
   await expect(parametersCard).toHaveCount(0);
-  await expectComponentCodeField(page, "reference", "R1");
+  await expectComponentCodeField(page, "netlistName", "R1");
   await expect(
     properties.getByLabel("Editable Canvas property code"),
   ).toContainText(/"display"/u);
@@ -4109,7 +4113,7 @@ test("resizes Properties and applies component presentation as editable code", a
   edited.placement.at = [420, 280];
   edited.placement.rotation = 90;
   edited.placement.mirror = "horizontal";
-  edited.display.reference = false;
+  edited.display.visualAnnotation = false;
   edited.appearance.foreground = "#DC2626";
   await code.fill(JSON.stringify(edited, null, 2));
 
@@ -4179,7 +4183,7 @@ test("Properties toggles reference label visibility for one or many components",
   ).toHaveCount(0);
   await expectComponentCodeField(page, "netlistTarget", "");
   await editComponentPropertyCode(page, (value) => {
-    value.display.reference = false;
+    value.display.visualAnnotation = false;
   });
   await expect(
     page.getByTestId("annotation-hit-instance-label-R1"),
@@ -4192,13 +4196,13 @@ test("Properties toggles reference label visibility for one or many components",
   ).toHaveCount(1);
   // Hiding is recoverable: the annotation is still in the project.
   await editComponentPropertyCode(page, (value) => {
-    value.display.reference = true;
+    value.display.visualAnnotation = true;
   });
   await expect(
     page.getByTestId("annotation-hit-instance-label-R1"),
   ).toHaveCount(1);
   await editComponentPropertyCode(page, (value) => {
-    value.display.reference = false;
+    value.display.visualAnnotation = false;
   });
 
   // Marquee both components and edit the shared code surface. The left-to-right
@@ -4217,12 +4221,12 @@ test("Properties toggles reference label visibility for one or many components",
   ).toBeVisible();
   await expect(page.getByText("Canvas labels", { exact: true })).toHaveCount(0);
   const groupToggle = groupEditor.getByRole("switch", {
-    name: "Toggle reference visibility",
+    name: "Toggle visual annotation visibility",
   });
   await expect(groupToggle).toBeVisible();
   await expect(groupToggle).toHaveAttribute("data-mixed", "true");
   expect(
-    JSON.parse(await readComponentPropertyCode(page)).display.reference,
+    JSON.parse(await readComponentPropertyCode(page)).display.visualAnnotation,
   ).toBe("mixed");
   await groupToggle.click();
   await expect(
@@ -4265,7 +4269,7 @@ test("Select All shows one batch code surface instead of object-specific forms",
   await expect(batch).toBeVisible();
   await expect(batch.getByText("2 selected", { exact: true })).toBeVisible();
   expect(JSON.parse(await readComponentPropertyCode(page))).toEqual({
-    display: { reference: true, value: false },
+    display: { visualAnnotation: true, value: false },
     appearance: { foreground: "auto" },
   });
   await expect(
@@ -5825,7 +5829,7 @@ test("exports structural SPICE and Spectre netlists while exposing instance auth
   const properties = page.getByRole("complementary", { name: "Properties" });
   await expect(properties.getByLabel("Cell netlist name")).toHaveCount(0);
   await expect(properties.getByLabel("Cell netlist port order")).toHaveCount(0);
-  await expectComponentCodeField(page, "reference", "M1");
+  await expectComponentCodeField(page, "netlistName", "M1");
   await expectComponentCodeField(page, "netlistTarget", "");
   await expect(properties.getByText(/^Model:/u)).toHaveCount(0);
 });
@@ -5943,7 +5947,7 @@ test("edits a formula-capable Signal Flow block with undo, redo, and Reset defau
   ).toHaveCount(0);
 });
 
-test("selects a reviewed SKY130 MOS through the existing Model field", async ({
+test("selects a reviewed SKY130 MOS through the inline Target netlist field", async ({
   page,
 }) => {
   await page.goto("/editor");
@@ -5954,23 +5958,25 @@ test("selects a reviewed SKY130 MOS through the existing Model field", async ({
   await expect(
     properties.getByRole("button", { name: "Need help?", exact: true }),
   ).toHaveCount(0);
-  await setComponentCodeField(page, "netlistTarget", "sky130_fd_pr__nfet_01v8");
+  await properties
+    .getByLabel("Target netlist options")
+    .selectOption("sky130_fd_pr__nfet_01v8");
 
   await expectComponentCodeField(
     page,
     "netlistTarget",
     "sky130_fd_pr__nfet_01v8",
   );
-  await expectComponentCodeField(page, "reference", "XM1");
+  await expectComponentCodeField(page, "netlistName", "XM1");
   await expectComponentCodeField(page, "parameters.nf", "1");
   await expectComponentCodeField(page, "parameters.m", "1");
 
   await setComponentCodeField(page, "netlistTarget", "");
   await expectComponentCodeField(page, "netlistTarget", "");
-  await expectComponentCodeField(page, "reference", "M1");
+  await expectComponentCodeField(page, "netlistName", "M1");
   await setComponentCodeField(page, "netlistTarget", "generic_nmos");
   await expectComponentCodeField(page, "netlistTarget", "generic_nmos");
-  await expectComponentCodeField(page, "reference", "M1");
+  await expectComponentCodeField(page, "netlistName", "M1");
 
   await setComponentCodeField(page, "netlistTarget", "sky130_fd_pr__nfet_01v8");
   await expectComponentCodeField(
@@ -5978,7 +5984,7 @@ test("selects a reviewed SKY130 MOS through the existing Model field", async ({
     "netlistTarget",
     "sky130_fd_pr__nfet_01v8",
   );
-  await expectComponentCodeField(page, "reference", "XM1");
+  await expectComponentCodeField(page, "netlistName", "XM1");
 
   const saved = JSON.parse(
     (await downloadBytes(page, "File", "Export Project File…")).toString(
@@ -6024,7 +6030,7 @@ test("keeps the exact SKY130 PNP on its three-terminal model interface", async (
     "sky130_fd_pr__pnp_05v5_W0p68L0p68",
   );
   await expect(properties.getByLabel("Substrate Net")).toHaveCount(0);
-  await expectComponentCodeField(page, "reference", "XQ1");
+  await expectComponentCodeField(page, "netlistName", "XQ1");
 
   const saved = JSON.parse(
     (await downloadBytes(page, "File", "Export Project File…")).toString(
@@ -6038,7 +6044,7 @@ test("keeps the exact SKY130 PNP on its three-terminal model interface", async (
 
   await setComponentCodeField(page, "netlistTarget", "");
   await expect(properties.getByLabel("Substrate Net")).toHaveCount(0);
-  await expectComponentCodeField(page, "reference", "Q1");
+  await expectComponentCodeField(page, "netlistName", "Q1");
 });
 
 test("derives NPN substrate from its exact Model", async ({ page }) => {
@@ -6056,7 +6062,7 @@ test("derives NPN substrate from its exact Model", async ({ page }) => {
     "sky130_fd_pr__npn_05v5_W1p00L1p00",
   );
   await expect(properties.getByLabel("Substrate Net")).toBeVisible();
-  await expectComponentCodeField(page, "reference", "XQ1");
+  await expectComponentCodeField(page, "netlistName", "XQ1");
 
   const saved = JSON.parse(
     (await downloadBytes(page, "File", "Export Project File…")).toString(
@@ -6070,7 +6076,7 @@ test("derives NPN substrate from its exact Model", async ({ page }) => {
 
   await setComponentCodeField(page, "netlistTarget", "");
   await expect(properties.getByLabel("Substrate Net")).toHaveCount(0);
-  await expectComponentCodeField(page, "reference", "Q1");
+  await expectComponentCodeField(page, "netlistName", "Q1");
 });
 
 for (const fixture of [
@@ -6101,7 +6107,7 @@ for (const fixture of [
     await setComponentCodeField(page, "netlistTarget", fixture.model);
     await expectComponentCodeField(
       page,
-      "reference",
+      "netlistName",
       fixture.externalReference,
     );
     expect(
@@ -6115,7 +6121,11 @@ for (const fixture of [
 
     await setComponentCodeField(page, "netlistTarget", "");
     await expectComponentCodeField(page, "netlistTarget", "");
-    await expectComponentCodeField(page, "reference", fixture.nativeReference);
+    await expectComponentCodeField(
+      page,
+      "netlistName",
+      fixture.nativeReference,
+    );
     await expectComponentCodeField(
       page,
       `parameters.${fixture.primitiveParameter}`,

--- a/apps/editor/e2e/reference-label.spec.ts
+++ b/apps/editor/e2e/reference-label.spec.ts
@@ -119,26 +119,26 @@ test("Properties renames the electrical identity explicitly; restore is an in-pl
   await page.getByTestId("hit-R1").click();
   await page.getByTestId("selection-shelf").click();
   const properties = page.getByRole("complementary", { name: "Properties" });
-  await expectComponentCodeField(page, "reference", "R1");
+  await expectComponentCodeField(page, "netlistName", "R1");
   await expect(properties.getByLabel("Component label")).toHaveCount(0);
   await editComponentPropertyCode(page, (code) => {
-    code.reference = "R7";
+    code.netlistName = "R7";
   });
-  await expectComponentCodeField(page, "reference", "R7");
+  await expectComponentCodeField(page, "netlistName", "R7");
   await expect(visual(page)).toContainText("load");
   // Prefix validation still applies to this explicitly electrical field.
   await editComponentPropertyCode(page, (code) => {
-    code.reference = "gm";
+    code.netlistName = "gm";
   });
   await expect(properties).toContainText("Canvas property code was rejected");
   await properties.getByRole("button", { name: "Discard draft" }).click();
-  await expectComponentCodeField(page, "reference", "R7");
+  await expectComponentCodeField(page, "netlistName", "R7");
   await editComponentPropertyCode(page, (value) => {
-    value.display.reference = false;
+    value.display.visualAnnotation = false;
   });
   await expect(visual(page)).toHaveCount(0);
   await editComponentPropertyCode(page, (value) => {
-    value.display.reference = true;
+    value.display.visualAnnotation = true;
   });
   await expect(visual(page)).toContainText("load");
 

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -5664,13 +5664,14 @@ export function App({
                 onApply: (value: GroupPropertyCodeValue) => {
                   const edits: SchematicEdit[] = [];
                   if (
-                    value.display.reference !== "mixed" &&
-                    value.display.reference !== selectedGroupReferenceVisibility
+                    value.display.visualAnnotation !== "mixed" &&
+                    value.display.visualAnnotation !==
+                      selectedGroupReferenceVisibility
                   )
                     edits.push(
                       ...referenceLabelVisibilityEdits(
                         selectedIds,
-                        value.display.reference,
+                        value.display.visualAnnotation,
                       ),
                     );
                   if (
@@ -5808,7 +5809,8 @@ export function App({
                                   : instance,
                               ),
                             };
-                            const desiredReference = value.display?.reference;
+                            const desiredReference =
+                              value.display?.visualAnnotation;
                             const currentReference =
                               selectedInstanceLabel !== undefined &&
                               selectedInstanceLabel.visible !== false;

--- a/apps/editor/src/features/properties/component-property-code-assists.test.ts
+++ b/apps/editor/src/features/properties/component-property-code-assists.test.ts
@@ -82,7 +82,7 @@ describe("Canvas property assistance", () => {
   it("addresses all available fields by syntax path and preserves unrelated draft bytes", () => {
     const source = formatComponentPropertyCode(context);
     expect(propertyCodeSpans(source).map((span) => span.field.path)).toEqual([
-      "display.reference",
+      "display.visualAnnotation",
       "display.value",
       "placement.at",
       "placement.rotation",

--- a/apps/editor/src/features/properties/component-property-code-edits.test.ts
+++ b/apps/editor/src/features/properties/component-property-code-edits.test.ts
@@ -21,7 +21,7 @@ describe("planComponentPropertyCodeEdits", () => {
     expect(
       planComponentPropertyCodeEdits(document, instance, {
         placement: { at: [123, 177], rotation: 90, mirror: "horizontal" },
-        display: { reference: true, value: false },
+        display: { visualAnnotation: true, value: false },
         appearance: { foreground: "#DC2626" },
       }),
     ).toEqual([
@@ -56,7 +56,7 @@ describe("planComponentPropertyCodeEdits", () => {
     expect(
       planComponentPropertyCodeEdits(document, instance, {
         placement: { at: [100, 100], rotation: 0, mirror: "none" },
-        display: { reference: true, value: false },
+        display: { visualAnnotation: true, value: false },
         appearance: { foreground: "auto" },
       }),
     ).toEqual([]);

--- a/apps/editor/src/features/properties/component-property-code-edits.ts
+++ b/apps/editor/src/features/properties/component-property-code-edits.ts
@@ -32,11 +32,14 @@ export function planComponentPropertyCodeEdits(
   value: ComponentPropertyCodeValue,
 ): SchematicEdit[] {
   const edits: SchematicEdit[] = [];
-  if (value.reference !== undefined && value.reference !== instance.reference)
+  if (
+    value.netlistName !== undefined &&
+    value.netlistName !== instance.reference
+  )
     edits.push({
       kind: "set_instance_reference",
       instanceId: instance.id,
-      reference: value.reference,
+      reference: value.netlistName,
     });
   if (value.parameters && instance.netlist) {
     const set = Object.fromEntries(

--- a/apps/editor/src/features/properties/component-property-code.test.ts
+++ b/apps/editor/src/features/properties/component-property-code.test.ts
@@ -35,7 +35,7 @@ describe("component property code", () => {
   it("formats placement as one coordinate and makes display/style explicit", () => {
     expect(formatComponentPropertyCode(context)).toBe(`{
   "display": {
-    "reference": true,
+    "visualAnnotation": true,
     "value": false
   },
   "placement": {
@@ -49,6 +49,32 @@ describe("component property code", () => {
 }`);
   });
 
+  it("rejects the former ambiguous Reference surface names", () => {
+    const identityContext = { ...context, details: { parameters: [] } };
+    const source = formatComponentPropertyCode(identityContext);
+    expect(source).toContain('"netlistName": "R1"');
+    expect(source).toContain('"visualAnnotation": true');
+    expect(source).not.toMatch(/"reference"/u);
+    expect(
+      parseComponentPropertyCode(
+        source.replace('"netlistName"', '"reference"'),
+        identityContext,
+      ),
+    ).toEqual({
+      ok: false,
+      message: "component.reference is not a supported property",
+    });
+    expect(
+      parseComponentPropertyCode(
+        source.replace('"visualAnnotation"', '"reference"'),
+        identityContext,
+      ),
+    ).toEqual({
+      ok: false,
+      message: "display.reference is not a supported property",
+    });
+  });
+
   it("round-trips edited coordinates, orientation, display, and colors", () => {
     const source = formatComponentPropertyCode(context)
       .replace("360", "420")
@@ -60,7 +86,7 @@ describe("component property code", () => {
       ok: true,
       value: {
         placement: { at: [420, 240], rotation: 180, mirror: "horizontal" },
-        display: { reference: true, value: true },
+        display: { visualAnnotation: true, value: true },
         appearance: { foreground: "#DC2626" },
       },
     });

--- a/apps/editor/src/features/properties/component-property-code.ts
+++ b/apps/editor/src/features/properties/component-property-code.ts
@@ -29,7 +29,7 @@ export interface ComponentPropertyPlacementCode {
 }
 
 export interface ComponentPropertyDisplayCode {
-  reference?: boolean;
+  visualAnnotation?: boolean;
   value?: boolean;
 }
 
@@ -63,7 +63,7 @@ const ROOT_KEYS = new Set([
   "display",
   "appearance",
   "netName",
-  "reference",
+  "netlistName",
   "parameters",
   "netlistTarget",
   "symbol",
@@ -150,7 +150,7 @@ function parseDisplay(
   context: ComponentPropertyCodeContext,
 ): ComponentPropertyDisplayCode | undefined {
   const supported = new Set<string>();
-  if (context.referenceVisible !== null) supported.add("reference");
+  if (context.referenceVisible !== null) supported.add("visualAnnotation");
   if (context.valueVisible !== null) supported.add("value");
   if (supported.size === 0) {
     if (value !== undefined) {
@@ -218,7 +218,7 @@ export function componentPropertyCodeValue(
   const inputPolarity = componentInputPolarity(instance.symbolId);
   const display: ComponentPropertyDisplayCode = {};
   if (context.referenceVisible !== null) {
-    display.reference = context.referenceVisible;
+    display.visualAnnotation = context.referenceVisible;
   }
   if (context.valueVisible !== null) display.value = context.valueVisible;
   return {

--- a/apps/editor/src/features/properties/component-property-details.test.ts
+++ b/apps/editor/src/features/properties/component-property-details.test.ts
@@ -47,15 +47,16 @@ describe("unified component property details", () => {
       expect(
         fields.find((field) => field.path === `parameters.${key}`)?.description,
       ).toBe("m");
-    expect(
-      fields.find((field) => field.path === "reference")?.description,
-    ).toBe("Netlist name");
+    expect(fields.find((field) => field.path === "netlistName")?.label).toBe(
+      "Netlist name",
+    );
   });
   it("retains reviewed model choices outside the short comment", () => {
     const field = componentDetailFields(instance, context.details).find(
       (item) => item.path === "netlistTarget",
     )!;
     expect(field.kind).toBe("choice");
+    expect(field.label).toBe("Target netlist");
     expect(field.options).toEqual([
       { value: "", label: "None" },
       { value: "model_a", label: "model_a" },
@@ -65,7 +66,7 @@ describe("unified component property details", () => {
   it("round-trips authored strings, overrides, and model target without unit conversion", () => {
     const source = formatComponentPropertyCode(context);
     expect(JSON.parse(source)).toMatchObject({
-      reference: "M1",
+      netlistName: "M1",
       parameters: instance.netlist!.parameters,
       netlistTarget: "model_a",
     });
@@ -93,7 +94,7 @@ describe("unified component property details", () => {
   });
   it("plans parameter set/unset, identity and placement as ordinary atomic edits", () => {
     const decoded = JSON.parse(formatComponentPropertyCode(context));
-    decoded.reference = "M2";
+    decoded.netlistName = "M2";
     decoded.parameters.w = "3u";
     decoded.parameters.custom = "";
     delete decoded.parameters.nf;
@@ -133,7 +134,7 @@ describe("unified component property details", () => {
   it("loads real descriptor defaults but preserves placement coordinates, identity, target and unknown overrides", () => {
     const defaults = JSON.parse(defaultComponentPropertyCode(context));
     expect(defaults).toMatchObject({
-      reference: "M1",
+      netlistName: "M1",
       netlistTarget: "model_a",
       placement: { at: [200, 160], rotation: 0, mirror: "none" },
       parameters: { custom: "{x+1}" },

--- a/apps/editor/src/features/properties/component-property-details.ts
+++ b/apps/editor/src/features/properties/component-property-details.ts
@@ -22,7 +22,7 @@ export interface ComponentPropertyDetailsContext {
 }
 
 export interface ComponentPropertyDetailsValue {
-  reference?: string;
+  netlistName?: string;
   parameters?: Record<string, string>;
   netlistTarget?: string;
   symbol?: string;
@@ -49,7 +49,7 @@ export function componentPropertyDetailsValue(
 ): ComponentPropertyDetailsValue {
   if (!context) return {};
   return {
-    ...(instance.reference ? { reference: instance.reference } : {}),
+    ...(instance.reference ? { netlistName: instance.reference } : {}),
     ...(instance.netlist
       ? {
           parameters: {
@@ -85,7 +85,7 @@ export function parseComponentPropertyDetails(
   const baseline = componentPropertyDetailsValue(instance, context);
   const result: ComponentPropertyDetailsValue = {};
   for (const key of [
-    "reference",
+    "netlistName",
     "parameters",
     "netlistTarget",
     "symbol",
@@ -178,10 +178,10 @@ export function componentDetailFields(
       description: "",
     },
     {
-      path: "reference",
-      label: "Reference",
+      path: "netlistName",
+      label: "Netlist name",
       kind: "text",
-      description: "Netlist name",
+      description: "",
       help: "Unique electrical instance name in this Cell. Double-click the drawing label to edit its visual text independently.",
     },
     {
@@ -199,7 +199,7 @@ export function componentDetailFields(
     })),
     {
       path: "netlistTarget",
-      label: "Model",
+      label: "Target netlist",
       kind: context.modelTarget?.suggestions.length ? "choice" : "text",
       options: [
         ...new Set([
@@ -208,7 +208,7 @@ export function componentDetailFields(
           context.modelTarget?.defaultValue ?? "",
         ]),
       ].map((value) => ({ value, label: value || "None" })),
-      description: 'Model name · "": clear',
+      description: "",
       help: "Choose a suggested model or type a custom model name in JSON. An empty string clears the target; model compatibility checks still apply.",
     },
     {
@@ -219,7 +219,7 @@ export function componentDetailFields(
         value,
         label: value,
       })),
-      description: "Pin-compatible variant",
+      description: "",
     },
     ...(componentInternalMark(instance) === undefined
       ? [
@@ -227,7 +227,7 @@ export function componentDetailFields(
             path: "signalFlow",
             label: "Signal flow",
             kind: "text" as const,
-            description: "Presentation only",
+            description: "",
           },
         ]
       : []),

--- a/apps/editor/src/features/properties/component-property-fields.test.ts
+++ b/apps/editor/src/features/properties/component-property-fields.test.ts
@@ -6,10 +6,12 @@ import {
 } from "./component-property-fields";
 
 describe("property color picker transport", () => {
-  it("keeps comments out of the plain editor while retaining validation guidance", () => {
+  it("names visual annotation explicitly while retaining validation guidance", () => {
     expect(
-      CANVAS_PROPERTY_FIELDS.every((field) => field.description === ""),
-    ).toBe(true);
+      CANVAS_PROPERTY_FIELDS.find(
+        (field) => field.path === "display.visualAnnotation",
+      )?.label,
+    ).toBe("Visual annotation");
     expect(
       CANVAS_PROPERTY_FIELDS.find(
         (field) => field.path === "appearance.background",

--- a/apps/editor/src/features/properties/component-property-fields.ts
+++ b/apps/editor/src/features/properties/component-property-fields.ts
@@ -60,11 +60,11 @@ export const CANVAS_PROPERTY_FIELDS: readonly CanvasPropertyField[] = [
     help: "Horizontal flips left/right; vertical flips top/bottom. Mirror directions are independent and never rewrite rotation.",
   },
   {
-    path: "display.reference",
-    label: "Reference",
+    path: "display.visualAnnotation",
+    label: "Visual annotation",
     kind: "boolean",
     description: "",
-    help: "Show or hide the instance reference label without renaming its electrical identity.",
+    help: "Show or hide the visual instance annotation without changing its netlist name.",
   },
   {
     path: "display.value",

--- a/apps/editor/src/features/properties/component-property-json-editor.tsx
+++ b/apps/editor/src/features/properties/component-property-json-editor.tsx
@@ -287,7 +287,7 @@ function jsonDecorations(state: EditorState, read: () => Props): DecorationSet {
   const spans = editorSpans(source, read());
   const documentValid = editorParse(source, read()).ok;
   for (const field of [
-    { path: "display.reference", label: "reference" },
+    { path: "display.visualAnnotation", label: "visual annotation" },
     { path: "display.value", label: "value" },
     { path: "appearance.inputPolarity", label: "input polarity" },
   ] as const) {
@@ -407,14 +407,109 @@ function jsonDecorations(state: EditorState, read: () => Props): DecorationSet {
       }).range(foreground.to),
     );
   }
+  for (const span of spans) {
+    const at = source[span.to] === "," ? span.to + 1 : span.to;
+    if (span.field.description)
+      ranges.push(
+        Decoration.widget({
+          widget: new PropertyUnit(span.field.description),
+          side: 2,
+        }).range(at),
+      );
+    if (span.field.path === "netlistTarget" && span.field.kind === "choice")
+      ranges.push(
+        Decoration.widget({
+          widget: new NetlistTargetSelect(span, documentValid, read),
+          side: 1,
+        }).range(at),
+      );
+  }
   return Decoration.set(ranges, true);
+}
+
+class PropertyUnit extends WidgetType {
+  constructor(private readonly unit: string) {
+    super();
+  }
+
+  override eq(other: PropertyUnit): boolean {
+    return this.unit === other.unit;
+  }
+
+  toDOM(): HTMLElement {
+    const unit = document.createElement("span");
+    unit.className = "cm-property-unit";
+    unit.contentEditable = "false";
+    unit.textContent = ` // ${this.unit}`;
+    return unit;
+  }
+
+  override ignoreEvent(): boolean {
+    return true;
+  }
+}
+
+class NetlistTargetSelect extends WidgetType {
+  constructor(
+    private readonly span: PropertyCodeSpan,
+    private readonly enabled: boolean,
+    private readonly read: () => Props,
+  ) {
+    super();
+  }
+
+  override eq(other: NetlistTargetSelect): boolean {
+    return (
+      JSON.stringify(this.span.field.options) ===
+        JSON.stringify(other.span.field.options) &&
+      this.span.value === other.span.value &&
+      this.enabled === other.enabled
+    );
+  }
+
+  toDOM(view: EditorView): HTMLElement {
+    const select = document.createElement("select");
+    select.className = "cm-netlist-target-select";
+    select.contentEditable = "false";
+    select.setAttribute("aria-label", "Target netlist options");
+    select.disabled = !this.enabled;
+    const options = this.span.field.options ?? [];
+    for (const option of options) {
+      const element = document.createElement("option");
+      element.value = option.value;
+      element.textContent = option.label;
+      select.append(element);
+    }
+    if (
+      typeof this.span.value === "string" &&
+      !options.some((option) => option.value === this.span.value)
+    ) {
+      const authored = document.createElement("option");
+      authored.value = this.span.value;
+      authored.textContent = this.span.value;
+      select.append(authored);
+    }
+    select.value = String(this.span.value);
+    select.addEventListener("change", () => {
+      const changes = editorChanges(view.state.doc.toString(), this.read(), {
+        netlistTarget: select.value,
+      });
+      if (changes.length)
+        view.dispatch({ changes, userEvent: "input.property-control" });
+    });
+    return select;
+  }
+
+  override ignoreEvent(): boolean {
+    return true;
+  }
 }
 
 class DisplayToggleWidget extends WidgetType {
   constructor(
     private readonly path:
-      "display.reference" | "display.value" | "appearance.inputPolarity",
-    private readonly label: "reference" | "value" | "input polarity",
+      "display.visualAnnotation" | "display.value" | "appearance.inputPolarity",
+    private readonly label: "visual annotation" | "value" | "input polarity",
     private readonly checked: boolean | "mixed",
     private readonly disabled: boolean,
     private readonly read: () => Props,
@@ -457,8 +552,8 @@ class DisplayToggleWidget extends WidgetType {
       : `${
           this.path === "appearance.inputPolarity"
             ? "Input polarity marks"
-            : this.label === "reference"
-              ? "Reference"
+            : this.label === "visual annotation"
+              ? "Visual annotation"
               : "Value"
         } · ${
           this.checked === "mixed" ? "Mixed" : this.checked ? "Shown" : "Hidden"

--- a/apps/editor/src/features/properties/group-property-code.test.ts
+++ b/apps/editor/src/features/properties/group-property-code.test.ts
@@ -30,7 +30,7 @@ describe("batch component property code", () => {
   it("represents differing selection values explicitly", () => {
     const source = formatGroupPropertyCode(context);
     expect(JSON.parse(source)).toEqual({
-      display: { reference: "mixed", value: false },
+      display: { visualAnnotation: "mixed", value: false },
       appearance: { foreground: "mixed" },
     });
     expect(parseGroupPropertyCode(source, context).ok).toBe(true);
@@ -41,18 +41,18 @@ describe("batch component property code", () => {
     const changed = apply(
       source,
       groupPropertyCodeChanges(source, context, {
-        "display.reference": true,
+        "display.visualAnnotation": true,
         "appearance.foreground": [220, 38, 38],
       }),
     );
     expect(JSON.parse(changed)).toEqual({
-      display: { reference: true, value: false },
+      display: { visualAnnotation: true, value: false },
       appearance: { foreground: [220, 38, 38] },
     });
     expect(parseGroupPropertyCode(changed, context)).toEqual({
       ok: true,
       value: {
-        display: { reference: true, value: false },
+        display: { visualAnnotation: true, value: false },
         appearance: { foreground: "#dc2626" },
       },
     });
@@ -61,12 +61,14 @@ describe("batch component property code", () => {
   it("omits an unavailable value field and rejects unsupported properties", () => {
     const withoutValue = { ...context, value: null };
     const source = formatGroupPropertyCode(withoutValue);
-    expect(JSON.parse(source).display).toEqual({ reference: "mixed" });
+    expect(JSON.parse(source).display).toEqual({
+      visualAnnotation: "mixed",
+    });
     expect(
       parseGroupPropertyCode(
         source.replace(
-          '"reference": "mixed"',
-          '"reference": "mixed", "value": true',
+          '"visualAnnotation": "mixed"',
+          '"visualAnnotation": "mixed", "value": true',
         ),
         withoutValue,
       ),

--- a/apps/editor/src/features/properties/group-property-code.ts
+++ b/apps/editor/src/features/properties/group-property-code.ts
@@ -9,7 +9,7 @@ export type GroupPropertyColor = "auto" | `#${string}` | "mixed";
 
 export interface GroupPropertyCodeValue {
   display: {
-    reference: GroupPropertyMixedValue;
+    visualAnnotation: GroupPropertyMixedValue;
     value?: GroupPropertyMixedValue;
   };
   appearance: {
@@ -64,15 +64,17 @@ export function parseGroupPropertyCode(
     if (!isRecord(decoded.display))
       throw new Error("display must be an object");
     const displayKeys =
-      context.value === null ? ["reference"] : ["reference", "value"];
+      context.value === null
+        ? ["visualAnnotation"]
+        : ["visualAnnotation", "value"];
     assertKeys(decoded.display, displayKeys, "display");
-    if (!("reference" in decoded.display))
-      throw new Error("display.reference is required");
+    if (!("visualAnnotation" in decoded.display))
+      throw new Error("display.visualAnnotation is required");
     const display: GroupPropertyCodeValue["display"] = {
-      reference: parseMixedBoolean(
-        decoded.display.reference,
+      visualAnnotation: parseMixedBoolean(
+        decoded.display.visualAnnotation,
         context.reference,
-        "display.reference",
+        "display.visualAnnotation",
       ),
     };
     if (context.value !== null) {
@@ -111,7 +113,7 @@ export function groupPropertyCodeValue(
 ): GroupPropertyCodeValue {
   return {
     display: {
-      reference: context.reference,
+      visualAnnotation: context.reference,
       ...(context.value === null ? {} : { value: context.value }),
     },
     appearance: { foreground: context.foreground },

--- a/apps/editor/src/styles/editor-properties.css
+++ b/apps/editor/src/styles/editor-properties.css
@@ -506,6 +506,21 @@
 .component-json-editor .cm-json-bracket {
   color: #6e40a6;
 }
+.component-json-editor .cm-property-unit {
+  margin-left: 0.45rem;
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+  user-select: none;
+}
+.component-json-editor .cm-netlist-target-select {
+  width: auto;
+  max-width: 9rem;
+  min-height: 1.35rem;
+  margin-left: 0.45rem;
+  padding: 0 1.2rem 0 0.25rem;
+  font: inherit;
+  vertical-align: middle;
+}
 .cm-property-inline-toggle {
   position: relative;
   display: inline-block;

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -68,7 +68,7 @@ properties together as strict, editable JSON. For example, a resistor:
 
 ```json
 {
-  "reference": "R1",
+  "netlistName": "R1",
   "parameters": { "value": "10k", "tc": "0.1" },
   "netlistTarget": "",
   "placement": {
@@ -77,7 +77,7 @@ properties together as strict, editable JSON. For example, a resistor:
     "mirror": "none"
   },
   "display": {
-    "reference": true,
+    "visualAnnotation": true,
     "value": false
   },
   "appearance": {
@@ -86,7 +86,9 @@ properties together as strict, editable JSON. For example, a resistor:
 }
 ```
 
-`placement.at` is the `[x, y]` grid coordinate, rotation is restricted to
+`netlistName` is the electrical instance name used by netlist export;
+`display.visualAnnotation` only controls whether its drawing annotation is
+visible. `placement.at` is the `[x, y]` grid coordinate, rotation is restricted to
 45-degree steps, and mirror is `"none"`, `"horizontal"`, `"vertical"`, or
 `"both"`. Display keys appear only for
 annotations supported by that Symbol; when present, the `display` object is
@@ -109,7 +111,9 @@ root keys and invalid values are rejected without changing the Document.
 `parameters` contains descriptor-owned values and arbitrary model/dialect
 overrides as raw strings; empty values or removed keys unset a parameter.
 `netlistTarget` accepts model names, including reviewed external targets, and
-an empty string clears it. A target switch composes the existing structural
+an empty string clears it. Its JSON value carries a compact inline selector
+populated from reviewed targets while preserving authored custom values. A
+target switch composes the existing structural
 planner with the rest of the draft into one project transaction. No new
 project format or parallel netlist authority is introduced.
 
@@ -121,10 +125,12 @@ and Cell-level interface/layout operations retain their existing typed
 authoring surfaces; removing a component remains an explicit Delete action.
 
 The lazy JSON editor provides syntax highlighting, bracket matching, JSON
-diagnostics and local text undo. Its document is ordinary selectable text with
-no injected comments or control values. Canvas-layer field metadata still owns
+diagnostics and local text undo. Its document remains ordinary selectable raw
+JSON. Descriptor-owned parameter values show their declared unit as a non-data
+line annotation, and `netlistTarget` carries a compact non-data selector.
+Canvas-layer field metadata still owns
 validation of rotation, mirror, color channels, and other bounded values. A
-small, non-text switch is visually decorated after each `display.reference` and
+small, non-text switch is visually decorated after each `display.visualAnnotation` and
 `display.value` boolean for immediate visibility toggling. Compact action
 buttons after `placement.rotation` and `placement.mirror` cycle clockwise
 through the eight 45-degree orientations and reflect left/right or top/bottom. Horizontal
@@ -143,7 +149,7 @@ editor without applying legacy form drafts or discarding incomplete text.
 **Discard draft** restores the last accepted state when
 the draft is invalid or rejected, without changing the circuit.
 **Defaults** loads known parameter, orientation, color, and formula defaults
-immediately and remains undoable; it preserves coordinates, reference, model
+immediately and remains undoable; it preserves coordinates, netlist name, model
 target, display flags, and unknown overrides. Defaults sits in the Properties
 header with Copy and conditional Discard; there is no Apply button.
 **Copy JSON** copies

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -48,12 +48,15 @@ is defined.
   only the drawn route.
 - Select a component and press `Q` to open **Properties**. Its editable
   JSON keeps raw parameters (W/L/NF/M and additional
-  netlist overrides), reference and model target together with position as
+  netlist overrides), `netlistName` and target netlist together with position as
   `"at": [x, y]`, plus 45-degree-step
-  rotation, mirror, supported Reference/Value visibility, and line color.
+  rotation, mirror, supported Visual annotation/Value visibility, and line color.
   The `display` block appears first for quick access. The code area is ordinary
-  selectable text with no injected comments. Type
-  values directly, use the small switches after `display.reference` and
+  selectable raw JSON. `netlistName` is the exported electrical instance name;
+  `display.visualAnnotation` only controls the drawing label. Declared parameter
+  units appear beside their JSON values without becoming data, and
+  `netlistTarget` has a compact inline selector. Type values directly, use the
+  small switches after `display.visualAnnotation` and
   `display.value` to toggle label visibility, click the buttons after
   `placement.rotation` and `placement.mirror` to rotate clockwise, mirror
   left/right, or mirror top/bottom. Mirror is written as `"horizontal"`,


### PR DESCRIPTION
Rename the editor-local JSON keys from reference to netlistName and from display.reference to display.visualAnnotation so electrical identity and drawing visibility cannot be confused. Persisted project and netlist contracts remain unchanged. Restore a compact Target netlist selector beside netlistTarget using reviewed suggestions while retaining authored custom values. Show only descriptor-declared units beside parameter values as non-data decorations; copied JSON remains raw.

Rebase this surface onto the unified component Properties controls so rotation, both mirror actions, display toggles, and line color remain available for single and grouped selections.

Validation: gate:preflight passed formatting, documentation links, catalog contracts, typecheck, and test-impact checks. gate:affected passed 489 unit files (3,349 tests; 2 files and 31 tests skipped), 91 component/catalog browser tests, and 156 manual-editor browser tests.

Test-Impact: tests-updated
