### PR TITLE
chore(release): align production core with preview

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -68,6 +68,11 @@ jobs:
           # Timing simulation remains a localhost development surface until
           # its interaction and presentation contracts are ready to publish.
           VITE_ICM_TIMING_UI: disabled
+          # Production promotes the same main commit as Preview, but keeps the
+          # unreleased human Simulation and Agent surfaces out of its editor.
+          # Their persisted data and HTTP APIs remain available independently.
+          VITE_ICM_SIMULATION_UI: disabled
+          VITE_ICM_AGENT_UI: disabled
       # The version serving right now, captured BEFORE anything changes.
       # Read afterwards it would already describe the deploy under test, and
       # a rollback would restore the very thing it is meant to undo.

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -43,6 +43,10 @@ jobs:
       - run: pnpm --filter @icm/editor... build
         env:
           VITE_ICM_TIMING_UI: disabled
+          # Preview is the acceptance surface for the human Simulation
+          # workspace. Production builds the same commit with this UI off;
+          # persisted data and HTTP APIs do not depend on the flag.
+          VITE_ICM_SIMULATION_UI: enabled
           # The preview is the channel that simulates (ADR 0057) and simulation
           # is Agent-first (ADR 0055): an Agent must be able to pair with the
           # preview editor, so its Connect Agent surface is enabled here.

--- a/apps/editor/src/agent/public-agent-ui.ts
+++ b/apps/editor/src/agent/public-agent-ui.ts
@@ -1,3 +1,5 @@
+import { resolvePublicUiFeatureEnabled } from "../deployment/public-ui-feature";
+
 /**
  * Controls whether the browser exposes the human-facing Agent connection UI.
  *
@@ -9,9 +11,7 @@ export function resolvePublicAgentUiEnabled(input: {
   production: boolean;
   configured?: string;
 }): boolean {
-  if (input.configured === "enabled") return true;
-  if (input.configured === "disabled") return false;
-  return !input.production;
+  return resolvePublicUiFeatureEnabled(input);
 }
 
 export const PUBLIC_AGENT_UI_ENABLED = resolvePublicAgentUiEnabled({

--- a/apps/editor/src/app/App.test.tsx
+++ b/apps/editor/src/app/App.test.tsx
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
-import { createEmptyProject } from "@icm/model";
+import { createEmptyProject, createSimulationFolder } from "@icm/model";
 import { serializeProject } from "@icm/project-protocol";
 import { EditTransactionSchema } from "@icm/edit-engine";
 import { renderToStaticMarkup } from "react-dom/server";
@@ -105,6 +105,7 @@ describe("editor shell", () => {
     expect(markup).toContain('data-testid="edit-manage-cells"');
     expect(markup).not.toContain('data-testid="cell-command-menu"');
     expect(markup).toContain("Manage Cells…");
+    expect(markup).toContain("New Testbench Cell…");
     expect(markup).toContain("Instance Table…");
     const netlistStart = markup.indexOf("<summary>Netlist</summary>");
     const netlistEnd = markup.indexOf("</details>", netlistStart);
@@ -209,6 +210,25 @@ describe("editor shell", () => {
     expect(markup).not.toContain("agent-shelf-indicator");
     expect(markup).not.toContain("Agent:");
     expect(markup).not.toContain("Approve Agent file import");
+  });
+
+  it("keeps analog Simulation authoring out of a production editor without changing project data", () => {
+    const project = createEmptyProject("simulation-ui-dormant", "Dormant");
+    project.simulationFolders.push(
+      createSimulationFolder({
+        id: "saved-simulation",
+        name: "Saved Simulation",
+        profileId: "hosted-sky130-v1",
+      }),
+    );
+    const persistedSimulation = structuredClone(project.simulationFolders);
+    const markup = renderToStaticMarkup(
+      <App project={project} publicSimulationUiEnabled={false} />,
+    );
+
+    expect(markup).not.toContain('data-testid="open-analog-simulation"');
+    expect(markup).not.toContain("New Testbench Cell…");
+    expect(project.simulationFolders).toEqual(persistedSimulation);
   });
 
   it("keeps the timing surface behind its deployment flag", () => {

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -128,6 +128,7 @@ import {
 } from "../features/simulation/terminal-current-pick";
 import { TimingSimulationPanel } from "../features/simulation/timing-simulation-panel";
 import { TIMING_UI_ENABLED } from "../features/simulation/timing-ui";
+import { PUBLIC_SIMULATION_UI_ENABLED } from "../features/simulation/public-simulation-ui";
 import { updateComponentParameterValues } from "../features/component-insert/component-parameters";
 import {
   waveformDraftingObjects,
@@ -371,6 +372,8 @@ export interface AppProps {
   visitStats?: { pv: number; uv: number } | null;
   /** Test/staging seam; production defaults to a human-only editor. */
   publicAgentUiEnabled?: boolean;
+  /** Test/Preview seam; production hides human-facing analog simulation. */
+  publicSimulationUiEnabled?: boolean;
   /** Test/staging seam; production Cloudflare builds keep timing tools hidden. */
   timingUiEnabled?: boolean;
   /** `/g/<id>` deep link: load this gallery entry after boot. */
@@ -381,6 +384,7 @@ export function App({
   project: initialProject,
   visitStats,
   publicAgentUiEnabled = PUBLIC_AGENT_UI_ENABLED,
+  publicSimulationUiEnabled = PUBLIC_SIMULATION_UI_ENABLED,
   timingUiEnabled = TIMING_UI_ENABLED,
   initialGalleryEntryId = null,
 }: AppProps) {
@@ -873,26 +877,36 @@ export function App({
   const analogSimulationMaximized = analogSimulationState === "maximized";
   const humanSimulationSession = useMemo(
     () =>
-      new BrowserSimulationSession({
-        getProjectSessionId: () => editorDocumentController.projectSessionId,
-        getProject: () => editorDocumentController.project,
-        projectFiles: createSimulationProjectFileHost({
-          getProject: () => editorDocumentController.project,
-          getProjectSessionId: () => editorDocumentController.projectSessionId,
-          dispatch: (request) => dispatchProjectTransaction(request),
-          actor: { kind: "human", id: "human-local" },
-        }),
-        transport: releaseChannel === "preview" ? "managed" : "direct",
-      }),
-    [editorDocumentController, projectSessionId, releaseChannel],
+      analogSimulationOpened
+        ? new BrowserSimulationSession({
+            getProjectSessionId: () =>
+              editorDocumentController.projectSessionId,
+            getProject: () => editorDocumentController.project,
+            projectFiles: createSimulationProjectFileHost({
+              getProject: () => editorDocumentController.project,
+              getProjectSessionId: () =>
+                editorDocumentController.projectSessionId,
+              dispatch: (request) => dispatchProjectTransaction(request),
+              actor: { kind: "human", id: "human-local" },
+            }),
+            transport: releaseChannel === "preview" ? "managed" : "direct",
+          })
+        : null,
+    [
+      analogSimulationOpened,
+      editorDocumentController,
+      projectSessionId,
+      releaseChannel,
+    ],
   );
   useEffect(
     () => () => {
-      void humanSimulationSession.clear();
+      void humanSimulationSession?.clear();
     },
     [humanSimulationSession],
   );
   const openAnalogSimulation = (): void => {
+    if (!publicSimulationUiEnabled) return;
     simulationPropertiesOpenBeforeRef.current = selectionOpen;
     setSelectionOpen(false);
     setAnalogSimulationState("open");
@@ -909,7 +923,7 @@ export function App({
   };
   const exitAnalogSimulation = (): void => {
     setSimulationPickModeState(null);
-    void humanSimulationSession.clear();
+    void humanSimulationSession?.clear();
     setAnalogSimulationState("closed");
     setSimulationDraftContext(null);
     setSelectionOpen(simulationPropertiesOpenBeforeRef.current);
@@ -3385,6 +3399,7 @@ export function App({
   }
 
   function openNewTestbenchDialog(dutDocumentId = document.id): void {
+    if (!publicSimulationUiEnabled) return;
     cancelAllTransientInteraction();
     setCanvasContextMenu(null);
     setNewTestbenchDutId(dutDocumentId);
@@ -4501,7 +4516,12 @@ export function App({
     <main className="app-shell">
       {renderCrashRequested() ? <RenderCrashProbe /> : null}
       <EditorAppChrome
-        simulationAction={openAnalogSimulation}
+        {...(publicSimulationUiEnabled
+          ? {
+              simulationAction: openAnalogSimulation,
+              onNewTestbench: () => openNewTestbenchDialog(),
+            }
+          : {})}
         simulationState={analogSimulationState}
         releaseChannel={releaseChannel}
         projectName={project.name}
@@ -4572,7 +4592,6 @@ export function App({
         searchOpen={searchOpen}
         selectionFilterOpen={selectionFilterOpen}
         onManageCells={() => setCellManagerOpen(true)}
-        onNewTestbench={() => openNewTestbenchDialog()}
         placeProjectCell={{
           enabled: cellInsertCandidates.length > 0,
           execute: placeCellInstance,
@@ -5020,7 +5039,7 @@ export function App({
             : null
         }
         newTestbench={
-          newTestbenchDutId
+          publicSimulationUiEnabled && newTestbenchDutId
             ? {
                 documents: project.documents,
                 initialDutDocumentId: newTestbenchDutId,
@@ -5363,7 +5382,7 @@ export function App({
             setSelectionOpen(open);
           }}
           code={
-            analogSimulationOpened ? (
+            analogSimulationOpened && humanSimulationSession ? (
               <Suspense fallback={null}>
                 <LazySpiceSimulationSurface
                   key={projectSessionId}

--- a/apps/editor/src/app/editor-app-chrome.tsx
+++ b/apps/editor/src/app/editor-app-chrome.tsx
@@ -44,7 +44,7 @@ export interface EditorAppChromeProps {
   fileCommands: ComponentProps<typeof FileCommandMenu>;
   searchOpen: boolean;
   onManageCells: () => void;
-  onNewTestbench: () => void;
+  onNewTestbench?: () => void;
   placeProjectCell: CommandAction;
   selectionFilterOpen: boolean;
   onOpenSelectionFilter: () => void;
@@ -219,9 +219,11 @@ export function EditorAppChrome({
                 >
                   Manage Cells…
                 </button>
-                <button type="button" onClick={onNewTestbench}>
-                  New Testbench Cell…
-                </button>
+                {onNewTestbench ? (
+                  <button type="button" onClick={onNewTestbench}>
+                    New Testbench Cell…
+                  </button>
+                ) : null}
                 <button
                   type="button"
                   onClick={placeProjectCell.execute}

--- a/apps/editor/src/deployment/public-ui-feature.test.ts
+++ b/apps/editor/src/deployment/public-ui-feature.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { resolvePublicUiFeatureEnabled } from "./public-ui-feature";
+
+describe("resolvePublicUiFeatureEnabled", () => {
+  it("fails closed for production and stays available in development", () => {
+    expect(resolvePublicUiFeatureEnabled({ production: true })).toBe(false);
+    expect(resolvePublicUiFeatureEnabled({ production: false })).toBe(true);
+  });
+
+  it("honors an explicit channel build choice", () => {
+    expect(
+      resolvePublicUiFeatureEnabled({
+        production: true,
+        configured: "enabled",
+      }),
+    ).toBe(true);
+    expect(
+      resolvePublicUiFeatureEnabled({
+        production: false,
+        configured: "disabled",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not treat an unknown value as an opt-in", () => {
+    expect(
+      resolvePublicUiFeatureEnabled({
+        production: true,
+        configured: "yes",
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/editor/src/deployment/public-ui-feature.ts
+++ b/apps/editor/src/deployment/public-ui-feature.ts
@@ -1,0 +1,16 @@
+export interface PublicUiFeatureConfiguration {
+  production: boolean;
+  configured?: string;
+}
+
+/**
+ * Public UI capabilities fail closed in production builds. Preview and local
+ * development opt in explicitly or inherit the development default.
+ */
+export function resolvePublicUiFeatureEnabled(
+  input: PublicUiFeatureConfiguration,
+): boolean {
+  if (input.configured === "enabled") return true;
+  if (input.configured === "disabled") return false;
+  return !input.production;
+}

--- a/apps/editor/src/features/simulation/public-simulation-ui.ts
+++ b/apps/editor/src/features/simulation/public-simulation-ui.ts
@@ -1,0 +1,18 @@
+import { resolvePublicUiFeatureEnabled } from "../../deployment/public-ui-feature";
+
+/**
+ * Controls the human-facing analog Simulation workspace and authoring entry
+ * points. Persisted simulation data and HTTP APIs are separate contracts and
+ * deliberately do not depend on this build flag.
+ */
+export function resolvePublicSimulationUiEnabled(input: {
+  production: boolean;
+  configured?: string;
+}): boolean {
+  return resolvePublicUiFeatureEnabled(input);
+}
+
+export const PUBLIC_SIMULATION_UI_ENABLED = resolvePublicSimulationUiEnabled({
+  production: import.meta.env.PROD,
+  configured: import.meta.env.VITE_ICM_SIMULATION_UI,
+});

--- a/apps/editor/src/features/simulation/timing-ui.ts
+++ b/apps/editor/src/features/simulation/timing-ui.ts
@@ -1,3 +1,5 @@
+import { resolvePublicUiFeatureEnabled } from "../../deployment/public-ui-feature";
+
 /**
  * Controls the experimental human-facing digital timing tools.
  *
@@ -10,9 +12,7 @@ export function resolveTimingUiEnabled(input: {
   production: boolean;
   configured?: string;
 }): boolean {
-  if (input.configured === "enabled") return true;
-  if (input.configured === "disabled") return false;
-  return !input.production;
+  return resolvePublicUiFeatureEnabled(input);
 }
 
 export const TIMING_UI_ENABLED = resolveTimingUiEnabled({

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -20,6 +20,23 @@ build artifact: the workflows build their selected checkout. Channel-controlled
 features and runtime bindings may differ.
 [ADR 0057](adr/0057-release-channels-preview-and-production.md) explains the choice.
 
+The release build keeps ordinary editor behavior at the promoted `main`
+commit. Human-facing Simulation and Agent controls are explicit channel
+capabilities rather than a reason to hold back unrelated editor work:
+
+| Browser capability                                               | Preview  | Production |
+| ---------------------------------------------------------------- | -------- | ---------- |
+| Core editor, project format, Gallery and account UI              | Enabled  | Enabled    |
+| Analog Simulation workspace and Testbench authoring entry points | Enabled  | Disabled   |
+| Agent connection controls                                        | Enabled  | Disabled   |
+| Digital Timing UI                                                | Disabled | Disabled   |
+
+These are browser presentation choices. Persisted Simulation data remains
+round-trippable on both channels, and the Agent and Simulation HTTP APIs keep
+their independently deployed contracts. Production therefore promotes the
+same source revision without exposing unfinished human-facing workflows or
+discarding data authored on Preview.
+
 The deployed cross-Project journey receives a repository secret as a
 host-scoped HttpOnly cookie. Only `/api/projects` recognizes that identity, and
 only when `ICM_CHANNEL=preview`; Gallery, account, moderation and Production

--- a/scripts/preview-workflow.test.mjs
+++ b/scripts/preview-workflow.test.mjs
@@ -79,6 +79,7 @@ describe("the preview deploy", () => {
     expect(preview).toContain(
       'node scripts/preview-simulation-smoke.mjs "$PREVIEW_URL"',
     );
+    expect(preview).toContain("VITE_ICM_SIMULATION_UI: enabled");
     expect(preview).toContain("VITE_ICM_AGENT_UI: enabled");
     expect(preview).toContain("pnpm --filter @icm/mcp-server... build");
     expect(preview).toContain("playwright install --with-deps chromium");
@@ -108,7 +109,11 @@ describe("the preview deploy", () => {
   it("does not leak into the production workflow", () => {
     expect(production).not.toContain("wrangler.preview.jsonc");
     expect(production).not.toContain("VITE_ICM_AGENT_UI: enabled");
+    expect(production).toContain("VITE_ICM_SIMULATION_UI: disabled");
+    expect(production).toContain("VITE_ICM_AGENT_UI: disabled");
     expect(production).not.toContain("preview-agent-simulation-journey.mjs");
+    // UI release controls do not retire the shared machine contracts.
+    expect(production).toContain("/api/agent/mcp-manifest.json");
   });
 
   it("injects its recoverable failure through the current authored-output contract", () => {


### PR DESCRIPTION
## Summary

- make the Analog Simulation and Agent browser surfaces explicit release-channel capabilities
- keep Production on the same promoted main revision while hiding Simulation/Testbench and Agent controls
- preserve persisted Simulation data and leave Agent/Simulation HTTP APIs unchanged
- defer human Simulation session allocation until the workspace is opened

## Channel contract

| Browser surface | Preview | Production |
| --- | --- | --- |
| Core editor / project / Gallery / account | enabled | enabled |
| Analog Simulation and Testbench authoring | enabled | disabled |
| Agent connection controls | enabled | disabled |
| Digital Timing | disabled | disabled |

## Validation

- pnpm gate:preflight -- --base origin/main
- focused Vitest: 30 tests
- pnpm gate:full: formatting, docs, generated contracts, typecheck, 3,352 unit tests, workspace build, performance/goldens, production/release smoke passed
- the local full Playwright server exited after 109/467 cases; all three pre-exit failures plus affected narrow-layout and Simulation/Testbench journeys passed in focused reruns (6 tests)
- require all remote checks and Preview acceptance before Production promotion

Test-Impact: tests-updated