### PR TITLE
Preserve supply marker ownership across edits and legacy imports

### DIFF
--- a/apps/editor/e2e/project-file.spec.ts
+++ b/apps/editor/e2e/project-file.spec.ts
@@ -351,7 +351,7 @@ test("normalizes legacy overlapping Wire topology on Project import", async ({
     buffer: Buffer.from(JSON.stringify(source)),
   });
   await expect(page.getByTestId("status")).toContainText(
-    "normalized Wire topology in 1 Cell",
+    "normalized connectivity and Wire topology in 1 Cell",
   );
   const exported = JSON.parse(
     (await downloadBytes(page, "File", "Export Project File…")).toString(
@@ -363,6 +363,76 @@ test("normalizes legacy overlapping Wire topology on Project import", async ({
     sourceStatus: "geometry-only-changed",
   });
   expect(exported.documents[0]!.routes).toHaveLength(3);
+});
+
+test("imports split source-ground markers with independent owners and saves the repair", async ({
+  page,
+}) => {
+  const source = createEmptyProject("split-ground", "Split ground");
+  const document = source.documents[0]!;
+  for (const [index, id] of ["G1", "G2"].entries()) {
+    document.instances.push({
+      id,
+      symbolId: "ground",
+      placement: {
+        position: { x: 200 + index * 200, y: 300 },
+        rotation: 0,
+        mirror: "none",
+      },
+    });
+    document.nets.push({
+      id: `net-${id}`,
+      terminals: [{ instanceId: id, pinName: "0" }],
+    });
+    document.connectivityEvidence.push({
+      id: `source-${id}`,
+      kind: "spice-source",
+      netId: `net-${id}`,
+      sourceNetId: "original-0",
+    });
+  }
+  document.connectivityEvidence.push({
+    id: "global",
+    kind: "name-claim",
+    netId: "net-G1",
+    name: "0",
+    scope: "global",
+    powerDomain: "ground",
+    owner: { kind: "global-declaration", sourceNetId: "original-0" },
+  });
+  await page.goto("/editor");
+  await page.getByTestId("project-file").setInputFiles({
+    name: "split-ground.icproj.json",
+    mimeType: "application/json",
+    buffer: Buffer.from(JSON.stringify(source)),
+  });
+  await expect(page.getByTestId("status")).toContainText(
+    "save to Cloud or export to keep the repair",
+  );
+  const exported = JSON.parse(
+    (await downloadBytes(page, "File", "Export Project File…")).toString(
+      "utf8",
+    ),
+  ) as typeof source;
+  const repaired = exported.documents[0]!;
+  expect(repaired.nets).toEqual(document.nets);
+  expect(repaired.routes).toEqual([]);
+  expect(repaired.sourceStatus).toBe("connectivity-modified");
+  expect(
+    repaired.connectivityEvidence.filter(
+      (e) => e.kind === "name-claim" && e.owner.kind === "power-marker",
+    ),
+  ).toEqual(
+    expect.arrayContaining(
+      ["G1", "G2"].map((objectId) =>
+        expect.objectContaining({
+          name: "0",
+          scope: "global",
+          owner: { kind: "power-marker", objectId },
+        }),
+      ),
+    ),
+  );
 });
 
 test("rejects invalid imports without replacing live or recovered work", async ({

--- a/apps/editor/src/document/project-conductor-normalization.test.ts
+++ b/apps/editor/src/document/project-conductor-normalization.test.ts
@@ -3,10 +3,52 @@ import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
 import { describe, expect, it } from "vitest";
 
 import { normalizeImportedProjectConductors } from "./project-conductor-normalization";
+import { resolveDocumentLogicalNets } from "@icm/derived";
+import { parseProject, serializeProject } from "@icm/project-protocol";
 
 const resolver = new InMemorySymbolResolver(builtInSymbols);
 
 describe("imported Project conductor normalization", () => {
+  it("repairs proven split Ground markers once, preserves geometry, and survives save/reopen", () => {
+    const project = createEmptyProject("split-ground", "Ground");
+    const document = project.documents[0]!;
+    for (const id of ["G1", "G2"]) {
+      document.instances.push({ id, symbolId: "ground", placement: null });
+      document.nets.push({
+        id: `net-${id}`,
+        terminals: [{ instanceId: id, pinName: "0" }],
+      });
+      document.connectivityEvidence.push({
+        id: `source-${id}`,
+        kind: "spice-source",
+        netId: `net-${id}`,
+        sourceNetId: "original-0",
+      });
+    }
+    document.connectivityEvidence.push({
+      id: "global",
+      kind: "name-claim",
+      netId: "net-G1",
+      name: "0",
+      scope: "global",
+      powerDomain: "ground",
+      owner: { kind: "global-declaration", sourceNetId: "original-0" },
+    });
+    const repaired = normalizeImportedProjectConductors(project, resolver);
+    expect(repaired.changedDocumentIds).toEqual([document.id]);
+    expect(repaired.project.documents[0]!.nets).toEqual(document.nets);
+    expect(repaired.project.documents[0]!.sourceStatus).toBe(
+      "connectivity-modified",
+    );
+    expect(
+      resolveDocumentLogicalNets(repaired.project.documents[0]!).groups,
+    ).toHaveLength(1);
+    const reopened = parseProject(serializeProject(repaired.project));
+    expect(
+      normalizeImportedProjectConductors(reopened, resolver).changedDocumentIds,
+    ).toEqual([]);
+    expect(document.connectivityEvidence).toHaveLength(3);
+  });
   it("repairs every legacy overlap in the imported copy only", () => {
     const project = createEmptyProject("legacy-overlap", "Legacy overlap");
     const document = project.documents[0]!;

--- a/apps/editor/src/document/project-conductor-normalization.ts
+++ b/apps/editor/src/document/project-conductor-normalization.ts
@@ -1,6 +1,7 @@
 import {
   normalizeRedundantDirectContactRoutes,
   normalizeSameNetConductorTopology,
+  missingPowerMarkerClaims,
 } from "@icm/edit-engine";
 import { CircuitProjectSchema } from "@icm/model";
 import type { CircuitProject } from "@icm/model";
@@ -12,12 +13,13 @@ export interface ImportedConductorNormalization {
 }
 
 /**
- * Canonicalize legacy ordinary-Wire geometry in one explicitly imported copy.
+ * Canonicalize legacy conductors and supply-marker ownership in an imported copy.
  *
  * Project parsing remains byte-preserving and Cloud/recovery opens remain
  * exact. The local File import boundary is the intentional equivalent of an
  * EDA check-and-save repair: changed Documents advance once and advertise a
- * geometry-only source delta without changing electrical Net membership.
+ * source delta. Marker repair preserves Base-Net membership; proven legacy
+ * split Ground markers regain logical node 0 without drawing or merging wires.
  */
 export function normalizeImportedProjectConductors(
   project: CircuitProject,
@@ -26,14 +28,25 @@ export function normalizeImportedProjectConductors(
   const candidate = structuredClone(project);
   const changedDocumentIds: string[] = [];
   for (const document of candidate.documents) {
+    const markerClaims = missingPowerMarkerClaims(document, {
+      recoverImportedGround: true,
+    });
+    document.connectivityEvidence.push(...markerClaims);
     const directContacts = normalizeRedundantDirectContactRoutes(
       document,
       resolver,
     );
     const topology = normalizeSameNetConductorTopology(document, resolver);
-    if (!directContacts.changed && !topology.changed) continue;
+    if (
+      !directContacts.changed &&
+      !topology.changed &&
+      markerClaims.length === 0
+    )
+      continue;
     document.revision += 1;
-    if (document.sourceStatus === "in-sync") {
+    if (markerClaims.length > 0) {
+      document.sourceStatus = "connectivity-modified";
+    } else if (document.sourceStatus === "in-sync") {
       document.sourceStatus = "geometry-only-changed";
     }
     changedDocumentIds.push(document.id);

--- a/apps/editor/src/document/use-project-file-lifecycle.ts
+++ b/apps/editor/src/document/use-project-file-lifecycle.ts
@@ -609,9 +609,9 @@ export function useProjectFileLifecycle({
       });
       setStatus(
         staged.migrated
-          ? `Imported and upgraded ${staged.fileName} from schema ${staged.sourceSchemaVersion} to schema ${openedProject.schemaVersion}${normalizedDocumentCount > 0 ? ` and normalized Wire topology in ${normalizedDocumentCount} Cell${normalizedDocumentCount === 1 ? "" : "s"}` : ""} — save to Cloud or export to keep the upgrade`
+          ? `Imported and upgraded ${staged.fileName} from schema ${staged.sourceSchemaVersion} to schema ${openedProject.schemaVersion}${normalizedDocumentCount > 0 ? ` and normalized connectivity and Wire topology in ${normalizedDocumentCount} Cell${normalizedDocumentCount === 1 ? "" : "s"}` : ""} — save to Cloud or export to keep the upgrade`
           : normalizedDocumentCount > 0
-            ? `Opened ${staged.fileName} and normalized Wire topology in ${normalizedDocumentCount} Cell${normalizedDocumentCount === 1 ? "" : "s"} — save to Cloud or export to keep the repair`
+            ? `Opened ${staged.fileName} and normalized connectivity and Wire topology in ${normalizedDocumentCount} Cell${normalizedDocumentCount === 1 ? "" : "s"} — save to Cloud or export to keep the repair`
             : `Opened ${staged.fileName} at revision ${staged.topDocumentRevision}`,
       );
     };

--- a/apps/editor/src/features/clipboard/clipboard.test.ts
+++ b/apps/editor/src/features/clipboard/clipboard.test.ts
@@ -28,6 +28,64 @@ import {
 const resolver = new InMemorySymbolResolver(builtInSymbols);
 
 describe("schematic clipboard", () => {
+  it("copies inherited Ground authority onto the selected marker's new Base Net", () => {
+    const document = createEmptyDocument("legacy-gnd", "Ground");
+    document.instances.push(
+      {
+        id: "G1",
+        symbolId: "ground",
+        placement: { position: { x: 0, y: 0 }, rotation: 0, mirror: "none" },
+      },
+      {
+        id: "G2",
+        symbolId: "ground",
+        placement: { position: { x: 100, y: 0 }, rotation: 0, mirror: "none" },
+      },
+    );
+    document.nets.push({
+      id: "gnd",
+      terminals: ["G1", "G2"].map((instanceId) => ({
+        instanceId,
+        pinName: "0",
+      })),
+    });
+    document.connectivityEvidence.push({
+      id: "owner",
+      kind: "name-claim",
+      netId: "gnd",
+      name: "0",
+      scope: "global",
+      powerDomain: "ground",
+      owner: { kind: "power-marker", objectId: "G1" },
+    });
+    const copied = copySelection(document, ["G2"])!;
+    expect(copied.connectivityEvidence).toEqual([
+      expect.objectContaining({
+        name: "0",
+        owner: { kind: "power-marker", objectId: "G2" },
+      }),
+    ]);
+    const proposal = proposePaste(document, copied, { x: 300, y: 0 }, 1);
+    const pasted = executeTransaction(
+      document,
+      {
+        transactionId: "paste-ground",
+        documentId: document.id,
+        expectedRevision: 0,
+        actor: { kind: "human", id: "test" },
+        edits: proposal.edits,
+      },
+      { symbolResolver: resolver },
+    );
+    expect(pasted.ok, JSON.stringify(pasted)).toBe(true);
+    if (!pasted.ok) return;
+    const grounds = resolveDocumentLogicalNets(pasted.document).groups.filter(
+      (group) => group.name === "0",
+    );
+    expect(grounds).toHaveLength(1);
+    expect(grounds[0]!.baseNetIds).toHaveLength(2);
+    expect(document.connectivityEvidence).toHaveLength(1);
+  });
   it.each(["fallback", "dry-run"])(
     "keeps %s drawing previews at the same coordinates as the paste",
     (mode) => {

--- a/apps/editor/src/features/clipboard/clipboard.ts
+++ b/apps/editor/src/features/clipboard/clipboard.ts
@@ -6,6 +6,7 @@ import {
 } from "@icm/devices";
 import {
   captureRoutingCopyFragment,
+  withPowerMarkerOwnership,
   createRoutingOperationPlan,
   executeTransaction,
   gridAlignmentDiagnostics,
@@ -706,6 +707,7 @@ export function clipboardPreviewDocument(
 export function captureDocumentComposition(
   document: SchematicDocument,
 ): SchematicClipboard | null {
+  document = withPowerMarkerOwnership(document);
   const draftingObjects = document.drafting?.objects ?? [];
   if (
     document.instances.length === 0 &&
@@ -778,6 +780,7 @@ export function copySelection(
   draftingIds: readonly string[] = [],
   routingSelection?: ExplicitCopyRoutingSelection,
 ): SchematicClipboard | null {
+  document = withPowerMarkerOwnership(document);
   const selectedIds = new Set(instanceIds);
   const instances = document.instances.filter((instance) =>
     selectedIds.has(instance.id),

--- a/docs/specs/connectivity-and-routing.md
+++ b/docs/specs/connectivity-and-routing.md
@@ -201,6 +201,24 @@ VDD markers on that Net do not require a drawn trunk or matching label and do
 not produce a flightline. Named local Nets still require route, contact, or
 label evidence for their visible connectivity.
 
+Legacy Projects may have several supply markers sharing one inherited claim.
+Before a Wire cut, each marker on the affected Base Net materializes the
+unambiguous current supply name and scope as its own claim. Copy and flattened
+composition capture the same owner-complete view without mutating the source.
+Existing explicit marker claims and conflicting identities are never replaced.
+When visible Ground owners take over node `0`, the cut retires the redundant
+source-wide ground declaration: a genuinely detached unmarked terminal must
+not remain grounded merely because it retains the original Base-Net ID.
+
+File and Gallery import copies also materialize these owners. They may recover
+an unnamed Ground marker on a split imported Base Net only when that Net's
+source identity is backed by a surviving explicit global `0` declaration in
+the Document. A bare device, arbitrary source name, conflicting current name,
+or unknown supply is not recovered. The import is marked dirty and advances
+the repaired Document revision once; parsing, Cloud opens and recovery remain
+exact. This is a bounded legacy import repair, not a runtime source-equivalence
+rule. Physical membership and authored geometry are never joined by it.
+
 ## Imported routing guidance
 
 SPICE import creates electrical membership before drawing and persists one

--- a/docs/specs/edit-engine.md
+++ b/docs/specs/edit-engine.md
@@ -277,6 +277,10 @@ Topology operations have these preconditions:
   authoring uses the name-first power and named-Net planners; a transaction
   cannot silently add a canonical name, change scope, or repair a duplicate
   Net after the caller's explicit edits have run.
+  The bounded legacy marker-ownership capture before a cut preserves an
+  already-resolved supply identity on each marker; it does not infer a new
+  supply or normalize physical Nets. See the connectivity contract for
+  source-backed Ground repair at the explicit import boundary.
 - `move_junction` preserves topology and must be paired with `set_route_path`
   edits for every incident Route whose geometry changes in the same
   transaction. GUI movement planners always author those Route edits; Routes

--- a/packages/edit-engine/src/index.ts
+++ b/packages/edit-engine/src/index.ts
@@ -5,6 +5,7 @@ export * from "./route-operations.js";
 export * from "./routing-planner.js";
 export * from "./series-splice-planner.js";
 export * from "./power-net-planner.js";
+export * from "./power-marker-ownership.js";
 export * from "./named-net-planner.js";
 export * from "./direct-contact-planner.js";
 export * from "./instance-contact-planner.js";

--- a/packages/edit-engine/src/power-marker-ownership.test.ts
+++ b/packages/edit-engine/src/power-marker-ownership.test.ts
@@ -1,0 +1,164 @@
+import { createEmptyDocument, createRoutePath } from "@icm/model";
+import {
+  resolveDocumentLogicalNets,
+  deriveImportedRoutingGuidance,
+} from "@icm/derived";
+import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
+import { describe, expect, it } from "vitest";
+import {
+  missingPowerMarkerClaims,
+  withPowerMarkerOwnership,
+} from "./power-marker-ownership.js";
+import { executeTransaction } from "./transaction.js";
+import { captureRoutingCopyFragment } from "./routing-copy-fragment.js";
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
+function fixture() {
+  const document = createEmptyDocument("ground", "Ground");
+  for (const [index, x] of [0, 200, 400].entries()) {
+    const r = `R${index}`,
+      g = `G${index}`;
+    document.instances.push(
+      {
+        id: r,
+        symbolId: "resistor",
+        placement: { position: { x, y: 0 }, rotation: 0, mirror: "none" },
+      },
+      {
+        id: g,
+        symbolId: "ground",
+        placement: { position: { x, y: 80 }, rotation: 0, mirror: "none" },
+      },
+    );
+    document.routes.push(
+      createRoutePath({
+        id: `wire${index}`,
+        netId: "source-ground",
+        start: { kind: "terminal", instanceId: r, pinName: "2" },
+        end: { kind: "terminal", instanceId: g, pinName: "0" },
+        bends: [],
+        modes: ["manual"],
+      }),
+    );
+  }
+  document.nets.push({
+    id: "source-ground",
+    terminals: document.instances.map((i) => ({
+      instanceId: i.id,
+      pinName: i.symbolId === "ground" ? "0" : "2",
+    })),
+  });
+  document.connectivityEvidence.push(
+    {
+      id: "source",
+      kind: "spice-source",
+      netId: "source-ground",
+      sourceNetId: "original-0",
+    },
+    {
+      id: "global",
+      kind: "name-claim",
+      netId: "source-ground",
+      name: "0",
+      scope: "global",
+      powerDomain: "ground",
+      owner: { kind: "global-declaration", sourceNetId: "original-0" },
+    },
+  );
+  return document;
+}
+
+describe("power marker ownership across physical editing", () => {
+  it("keeps untouched ground branches logically joined but releases the actually cut pin", () => {
+    const document = fixture();
+    const before = structuredClone(document);
+    const result = executeTransaction(
+      document,
+      {
+        transactionId: "cut",
+        documentId: document.id,
+        expectedRevision: 0,
+        actor: { kind: "human", id: "test" },
+        edits: [{ kind: "cut_connection", routeId: "wire0" }],
+      },
+      { symbolResolver: resolver },
+    );
+    expect(result.ok, JSON.stringify(result)).toBe(true);
+    if (!result.ok) return;
+    const groups = resolveDocumentLogicalNets(result.document);
+    const netFor = (id: string) =>
+      result.document.nets.find((n) =>
+        n.terminals.some((t) => t.instanceId === id),
+      )!;
+    expect(groups.byBaseNetId.get(netFor("R0").id)?.name).toBeUndefined();
+    for (const id of ["G0", "G1", "G2", "R1", "R2"]) {
+      expect(groups.byBaseNetId.get(netFor(id).id)).toMatchObject({
+        name: "0",
+        scope: "global",
+      });
+    }
+    expect(new Set(["G0", "R1", "R2"].map((id) => netFor(id).id)).size).toBe(3);
+    expect(document).toEqual(before);
+    // Only the genuinely cut pin may remain a source-routing candidate.
+    expect(deriveImportedRoutingGuidance(result.document, resolver)).toEqual(
+      [],
+    );
+  });
+
+  it("captures a legacy marker as a named copy owner without mutating its source", () => {
+    const document = fixture();
+    const capture = captureRoutingCopyFragment(document, {
+      instanceIds: ["G1"],
+      routeIds: [],
+      junctionIds: [],
+    });
+    expect(capture.ownerNetIds).toEqual(["source-ground"]);
+    const prepared = withPowerMarkerOwnership(document);
+    expect(missingPowerMarkerClaims(prepared)).toEqual([]);
+    expect(
+      prepared.connectivityEvidence.filter(
+        (e) => e.kind === "name-claim" && e.owner.kind === "power-marker",
+      ),
+    ).toHaveLength(3);
+    expect(document.connectivityEvidence).toHaveLength(2);
+  });
+
+  it("recovers a source-backed split Ground only at import, never a bare detached device", () => {
+    const document = fixture();
+    document.nets[0]!.terminals = document.nets[0]!.terminals.filter(
+      (t) => t.instanceId !== "G1" && t.instanceId !== "R1",
+    );
+    document.nets.push(
+      { id: "split", terminals: [{ instanceId: "G1", pinName: "0" }] },
+      { id: "detached", terminals: [{ instanceId: "R1", pinName: "2" }] },
+    );
+    for (const netId of ["split", "detached"])
+      document.connectivityEvidence.push({
+        id: `source-${netId}`,
+        kind: "spice-source",
+        netId,
+        sourceNetId: "original-0",
+      });
+    expect(
+      missingPowerMarkerClaims(document).some((c) => c.netId === "split"),
+    ).toBe(false);
+    const repairs = missingPowerMarkerClaims(document, {
+      recoverImportedGround: true,
+    });
+    expect(repairs.some((c) => c.netId === "split")).toBe(true);
+    expect(repairs.some((c) => c.netId === "detached")).toBe(false);
+    document.connectivityEvidence.push({
+      id: "bias",
+      kind: "name-claim",
+      netId: "split",
+      name: "BIAS",
+      scope: "local",
+      owner: { kind: "power-marker", objectId: "G1" },
+    });
+    expect(
+      missingPowerMarkerClaims(document, { recoverImportedGround: true }).some(
+        (c) => c.netId === "split",
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/edit-engine/src/power-marker-ownership.ts
+++ b/packages/edit-engine/src/power-marker-ownership.ts
@@ -1,0 +1,115 @@
+import { resolveDocumentLogicalNets } from "@icm/derived";
+import { deriveStableId } from "@icm/model";
+import type { ConnectivityEvidence, SchematicDocument } from "@icm/model";
+
+/**
+ * Materialize an existing supply identity on each visible marker before a
+ * topology operation separates its Base Net. This never invents a supply
+ * from artwork, copies source spelling, or changes physical membership.
+ * Source-backed ground recovery is restricted to the explicit import boundary.
+ */
+export function missingPowerMarkerClaims(
+  document: SchematicDocument,
+  options: { netId?: string; recoverImportedGround?: boolean } = {},
+): ConnectivityEvidence[] {
+  const resolution = resolveDocumentLogicalNets(document);
+  const groundSources = new Set(
+    document.connectivityEvidence.flatMap((evidence) =>
+      evidence.kind === "name-claim" &&
+      evidence.owner.kind === "global-declaration" &&
+      evidence.name === "0" &&
+      evidence.scope === "global"
+        ? [evidence.owner.sourceNetId]
+        : [],
+    ),
+  );
+  const claims: ConnectivityEvidence[] = [];
+  for (const instance of document.instances) {
+    if (instance.symbolId !== "ground" && instance.symbolId !== "vdd-port")
+      continue;
+    if (
+      document.connectivityEvidence.some(
+        (evidence) =>
+          evidence.kind === "name-claim" &&
+          evidence.owner.kind === "power-marker" &&
+          evidence.owner.objectId === instance.id,
+      )
+    )
+      continue;
+    const nets = document.nets.filter((net) =>
+      net.terminals.some((terminal) => terminal.instanceId === instance.id),
+    );
+    if (nets.length !== 1) continue;
+    const net = nets[0]!;
+    if (options.netId && net.id !== options.netId) continue;
+    const logical = resolution.byBaseNetId.get(net.id)!;
+    if (logical.conflicts.length > 0) continue;
+    let name = logical.name;
+    let scope = logical.scope;
+    const ground = instance.symbolId === "ground";
+    if (
+      ground &&
+      !name &&
+      options.recoverImportedGround &&
+      logical.powerDomain === "none" &&
+      document.connectivityEvidence.some(
+        (evidence) =>
+          evidence.kind === "spice-source" &&
+          evidence.netId === net.id &&
+          groundSources.has(evidence.sourceNetId),
+      )
+    ) {
+      name = "0";
+      scope = "global";
+    }
+    if (!name || !scope) continue;
+    if (
+      ground
+        ? name !== "0" || scope !== "global" || logical.powerDomain === "vdd"
+        : logical.powerDomain !== "vdd"
+    )
+      continue;
+    const id = deriveStableId(
+      "connectivity-evidence",
+      "marker-ownership",
+      document.id,
+      instance.id,
+    );
+    // Preserve conflicting user-owned identifiers instead of overwriting them.
+    const occupied = [
+      document.instances,
+      document.nets,
+      document.routes,
+      document.junctions,
+      document.annotations,
+      document.connectivityEvidence,
+      document.noConnects,
+      document.layoutGroups,
+      document.constraints,
+      document.drafting?.objects ?? [],
+    ].some((items) => items.some((item) => item.id === id));
+    if (occupied) continue;
+    claims.push({
+      id,
+      kind: "name-claim",
+      netId: net.id,
+      name,
+      scope,
+      powerDomain: ground ? "ground" : "vdd",
+      owner: { kind: "power-marker", objectId: instance.id },
+    });
+  }
+  return claims;
+}
+
+export function withPowerMarkerOwnership(
+  document: SchematicDocument,
+): SchematicDocument {
+  const claims = missingPowerMarkerClaims(document);
+  return claims.length === 0
+    ? document
+    : {
+        ...document,
+        connectivityEvidence: [...document.connectivityEvidence, ...claims],
+      };
+}

--- a/packages/edit-engine/src/routing-copy-fragment.ts
+++ b/packages/edit-engine/src/routing-copy-fragment.ts
@@ -5,6 +5,7 @@ import {
   type RoutingSelectionSeed,
 } from "@icm/derived";
 import type { SchematicDocument } from "@icm/model";
+import { withPowerMarkerOwnership } from "./power-marker-ownership.js";
 
 export interface RoutingCopyCapture {
   readonly affected: RoutingAffectedClosure;
@@ -35,6 +36,7 @@ export function captureRoutingCopyFragment(
   seed: RoutingSelectionSeed,
   options: RoutingCopyCaptureOptions = {},
 ): RoutingCopyCapture {
+  document = withPowerMarkerOwnership(document);
   const affected = deriveRoutingAffectedClosure(document, seed, options);
   const selectedInstances = new Set(affected.instances);
   const selectedAnnotations = new Set([

--- a/packages/edit-engine/src/transaction-route-topology.ts
+++ b/packages/edit-engine/src/transaction-route-topology.ts
@@ -8,6 +8,7 @@ import {
 import type { SymbolResolver } from "@icm/symbols";
 
 import type { EditTransaction } from "./edit-schema.js";
+import { missingPowerMarkerClaims } from "./power-marker-ownership.js";
 import {
   type EditMutationOutcome,
   type RejectEdit,
@@ -435,6 +436,44 @@ export function applyRouteTopologyEdit(
         return rejectAt(
           "OBJECT_NOT_FOUND",
           `Route Net does not exist: ${route.netId}`,
+        );
+      }
+      // Capture inherited marker authority before any physical partition.
+      // Owner retargeting below then follows every surviving marker, not just
+      // the component that happens to retain the imported Base-Net ID.
+      for (const claim of missingPowerMarkerClaims(draft, { netId: net.id })) {
+        draft.connectivityEvidence.push(claim);
+        changedObjectIds.add(claim.id);
+      }
+      // Once visible Ground markers own node 0, an inherited source-wide
+      // declaration must not keep a newly detached, unmarked pin grounded.
+      const hasGroundOwner = draft.connectivityEvidence.some(
+        (claim) =>
+          claim.kind === "name-claim" &&
+          claim.netId === net.id &&
+          claim.name === "0" &&
+          claim.scope === "global" &&
+          claim.owner.kind === "power-marker" &&
+          draft.instances.some(
+            (instance) =>
+              claim.owner.kind === "power-marker" &&
+              instance.id === claim.owner.objectId &&
+              instance.symbolId === "ground",
+          ),
+      );
+      if (hasGroundOwner) {
+        draft.connectivityEvidence = draft.connectivityEvidence.filter(
+          (claim) => {
+            if (
+              claim.kind !== "name-claim" ||
+              claim.netId !== net.id ||
+              claim.owner.kind !== "global-declaration" ||
+              claim.name !== "0"
+            )
+              return true;
+            changedObjectIds.add(claim.id);
+            return false;
+          },
         );
       }
       const bulkDefaultBeforeCut =


### PR DESCRIPTION
## Changes
- Preserve existing unambiguous supply identity per visible marker before a Wire cut, copy, and flattened composition; keep physical Base Nets separate.
- Retire redundant source-global ground authority during cuts so a genuinely detached unmarked pin loses ground, while untouched marked branches remain global 0.
- File/Gallery import repairs unnamed split Ground markers only with explicit matching source-global-0 evidence. Preserve physical membership and authored geometry; keep raw parsing, Cloud opens, conflicting names and bare device fragments exact.

## Validation
- 94 focused unit contracts and typecheck passed.
- Local full gate: static, 3358 unit tests (31 existing skips), build, release/performance and production/MCP smoke passed. Browser run: 467 passed, with one obsolete import-status text assertion. The test-only follow-up corrects that exact expectation without dropping geometry assertions; all 12 project-file browser tests then passed, including the new Ground repair import/export journey.
- All seven required GitHub checks passed on 2d216339, run 34733653975, including all four full browser shards.
- Read-only local receipt against the user common-source Project: three INVALID_NET_MARKER errors become zero, design export IR succeeds, imported guides are empty, and save/reparse retains the repair. Original file unchanged. This is compile validation, not a new electrical simulation run.
- git diff --check passed; worktree clean.

Broader flightline UX and general operation-effect guard redesign remain outside this bounded target. No merge or deployment performed.

Test-Impact: tests-updated