### PR TITLE
Fix moving multiple selected text objects

### DIFF
--- a/apps/editor/e2e/context-menu.spec.ts
+++ b/apps/editor/e2e/context-menu.spec.ts
@@ -201,6 +201,165 @@ test("dragging drafting text carries its mixed component selection as one body",
   expect(textUndone?.y).toBeCloseTo(textBefore.y, 0);
 });
 
+test("Ctrl+A and a marquee both move drafting texts as one selection", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  const canvas = page.getByTestId("schematic-canvas");
+  const editor = page.getByRole("textbox", { name: "Canvas text editor" });
+  const apply = page.getByRole("button", { name: "Apply text changes" });
+
+  await clickDrawTool(page, "text");
+  await editor.fill("LEFT");
+  await apply.click();
+  const texts = page.locator('[data-canvas-hit-kind="drafting"]');
+  await texts.first().dragTo(canvas, { targetPosition: { x: 260, y: 180 } });
+  await clickDrawTool(page, "text");
+  await editor.fill("RIGHT");
+  await apply.click();
+  await expect(texts).toHaveCount(2);
+
+  await page.keyboard.press("ControlOrMeta+A");
+  await expect(texts.nth(0)).toHaveClass(/selected/);
+  await expect(texts.nth(1)).toHaveClass(/selected/);
+  const selectAllBefore = await Promise.all([
+    texts.nth(0).boundingBox(),
+    texts.nth(1).boundingBox(),
+  ]);
+  if (!selectAllBefore[0] || !selectAllBefore[1])
+    throw new Error("Texts are not measurable");
+  const dragStart = {
+    x: selectAllBefore[0].x + selectAllBefore[0].width / 2,
+    y: selectAllBefore[0].y + selectAllBefore[0].height / 2,
+  };
+  await page.mouse.move(dragStart.x, dragStart.y);
+  await page.mouse.down();
+  await page.mouse.move(dragStart.x + 80, dragStart.y + 60, { steps: 4 });
+  await page.mouse.up();
+  const selectAllAfter = await Promise.all([
+    texts.nth(0).boundingBox(),
+    texts.nth(1).boundingBox(),
+  ]);
+  if (!selectAllAfter[0] || !selectAllAfter[1])
+    throw new Error("Moved texts are not measurable");
+  expect(selectAllAfter[0].x - selectAllBefore[0].x).toBeCloseTo(
+    selectAllAfter[1].x - selectAllBefore[1].x,
+    0,
+  );
+  expect(selectAllAfter[0].y - selectAllBefore[0].y).toBeCloseTo(
+    selectAllAfter[1].y - selectAllBefore[1].y,
+    0,
+  );
+
+  await page.keyboard.press("ControlOrMeta+Z");
+  await page.keyboard.press("ControlOrMeta+D");
+  await expect(texts.nth(0)).not.toHaveClass(/selected/);
+  await expect(texts.nth(1)).not.toHaveClass(/selected/);
+
+  const boxes = await Promise.all([
+    texts.nth(0).boundingBox(),
+    texts.nth(1).boundingBox(),
+  ]);
+  if (!boxes[0] || !boxes[1]) throw new Error("Texts are not measurable");
+  const left = Math.min(boxes[0].x, boxes[1].x) - 15;
+  const top = Math.min(boxes[0].y, boxes[1].y) - 15;
+  const right =
+    Math.max(boxes[0].x + boxes[0].width, boxes[1].x + boxes[1].width) + 15;
+  const bottom =
+    Math.max(boxes[0].y + boxes[0].height, boxes[1].y + boxes[1].height) + 15;
+  await page.mouse.move(left, top);
+  await page.mouse.down();
+  await page.mouse.move(right, bottom, { steps: 8 });
+  await page.mouse.up();
+  await expect(texts.nth(0)).toHaveClass(/selected/);
+  await expect(texts.nth(1)).toHaveClass(/selected/);
+
+  const firstBefore = await texts.nth(0).boundingBox();
+  const secondBefore = await texts.nth(1).boundingBox();
+  if (!firstBefore || !secondBefore)
+    throw new Error("Texts are not measurable");
+  await texts.nth(0).dragTo(canvas, { targetPosition: { x: 560, y: 360 } });
+  const firstAfter = await texts.nth(0).boundingBox();
+  const secondAfter = await texts.nth(1).boundingBox();
+  if (!firstAfter || !secondAfter)
+    throw new Error("Moved texts are not measurable");
+  const firstDelta = {
+    x: firstAfter.x - firstBefore.x,
+    y: firstAfter.y - firstBefore.y,
+  };
+  const secondDelta = {
+    x: secondAfter.x - secondBefore.x,
+    y: secondAfter.y - secondBefore.y,
+  };
+  expect(Math.hypot(firstDelta.x, firstDelta.y)).toBeGreaterThan(0);
+  expect(secondDelta.x).toBeCloseTo(firstDelta.x, 0);
+  expect(secondDelta.y).toBeCloseTo(firstDelta.y, 0);
+});
+
+test("multiple selected component annotations move as one text selection", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await placeComponent(page, "resistor", { x: 300, y: 220 });
+  await placeComponent(page, "resistor", { x: 520, y: 220 });
+  const canvas = page.getByTestId("schematic-canvas");
+  const first = page.getByTestId("annotation-hit-instance-label-R1");
+  const second = page.getByTestId("annotation-hit-instance-label-R2");
+  const labelBoxes = await Promise.all([
+    first.boundingBox(),
+    second.boundingBox(),
+  ]);
+  if (!labelBoxes[0] || !labelBoxes[1])
+    throw new Error("Labels are not measurable");
+  const left = Math.min(labelBoxes[0].x, labelBoxes[1].x) - 5;
+  const top = Math.min(labelBoxes[0].y, labelBoxes[1].y) - 5;
+  const right =
+    Math.max(
+      labelBoxes[0].x + labelBoxes[0].width,
+      labelBoxes[1].x + labelBoxes[1].width,
+    ) + 5;
+  const bottom =
+    Math.max(
+      labelBoxes[0].y + labelBoxes[0].height,
+      labelBoxes[1].y + labelBoxes[1].height,
+    ) + 5;
+  await page.mouse.move(left, top);
+  await page.mouse.down();
+  await page.mouse.move(right, bottom, { steps: 8 });
+  await page.mouse.up();
+  await expect(first).toHaveClass(/selected/);
+  await expect(second).toHaveClass(/selected/);
+  await expect(
+    page.locator('[data-canvas-hit-kind="instance"].selected'),
+  ).toHaveCount(0);
+
+  const firstBefore = await first.boundingBox();
+  const secondBefore = await second.boundingBox();
+  if (!firstBefore || !secondBefore)
+    throw new Error("Labels are not measurable");
+  await first.dragTo(canvas, {
+    targetPosition: { x: 400, y: 340 },
+    force: true,
+  });
+  const firstAfter = await first.boundingBox();
+  const secondAfter = await second.boundingBox();
+  if (!firstAfter || !secondAfter)
+    throw new Error("Moved labels are not measurable");
+  const firstDelta = {
+    x: firstAfter.x - firstBefore.x,
+    y: firstAfter.y - firstBefore.y,
+  };
+  const secondDelta = {
+    x: secondAfter.x - secondBefore.x,
+    y: secondAfter.y - secondBefore.y,
+  };
+  expect(Math.hypot(firstDelta.x, firstDelta.y)).toBeGreaterThan(0);
+  expect(secondDelta.x).toBeCloseTo(firstDelta.x, 0);
+  expect(secondDelta.y).toBeCloseTo(firstDelta.y, 0);
+  await expect(first).toHaveClass(/selected/);
+  await expect(second).toHaveClass(/selected/);
+});
+
 test("drafting shapes join device selection from either order", async ({
   page,
 }) => {

--- a/apps/editor/src/features/selection/annotation-fine-move.test.ts
+++ b/apps/editor/src/features/selection/annotation-fine-move.test.ts
@@ -1,8 +1,4 @@
-/**
- * Wire-transform audit batch 4, #11: moving a free annotation with the
- * selection preserves its fine (sub-device-grid) placement — the grid
- * discipline rides on the delta, exactly like the drafting branch.
- */
+/** Selection movement keeps labels on their fine placement grid. */
 import { createEmptyDocument } from "@icm/model";
 import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
 import type { SchematicEdit, RoutingOperationIntent } from "@icm/edit-engine";
@@ -13,7 +9,7 @@ import { planSelectionMove } from "./selection-move-plan";
 
 const resolver = new InMemorySymbolResolver(builtInSymbols);
 
-describe("free annotation fine placement (#11)", () => {
+describe("annotation group movement", () => {
   it("a grid-aligned group move keeps the annotation's fine offset", () => {
     const document = createEmptyDocument("doc", "Fine");
     document.nets.push({ id: "net-a", terminals: [] });
@@ -62,5 +58,88 @@ describe("free annotation fine placement (#11)", () => {
       kind: "free",
       position: { x: 113, y: 57 },
     });
+  });
+
+  it("moves multiple object-anchored labels by one shared delta", () => {
+    const document = createEmptyDocument("doc", "Anchored labels");
+    document.instances.push(
+      {
+        id: "R1",
+        symbolId: "resistor",
+        placement: {
+          position: { x: 100, y: 100 },
+          rotation: 0,
+          mirror: "none",
+        },
+      },
+      {
+        id: "R2",
+        symbolId: "resistor",
+        placement: {
+          position: { x: 300, y: 100 },
+          rotation: 0,
+          mirror: "none",
+        },
+      },
+    );
+    document.annotations.push(
+      ...["R1", "R2"].map((instanceId) => ({
+        id: `label-${instanceId}`,
+        kind: "instance-label" as const,
+        binding: { kind: "instance-reference" as const, instanceId },
+        anchor: {
+          kind: "object" as const,
+          objectId: instanceId,
+          localOffset: { x: 10, y: -20 },
+          fallbackPosition: {
+            x: instanceId === "R1" ? 110 : 310,
+            y: 80,
+          },
+        },
+        alignment: "start" as const,
+        rotation: 0 as const,
+        locked: false,
+      })),
+    );
+    const captured: SchematicEdit[][] = [];
+    const controller = createSelectionMoveController({
+      document,
+      resolver,
+      visibleEndpoints: [],
+      routeGeometryRecords: [],
+      contactComponents: [],
+      transactConnectivity: (_intent, edits) => {
+        captured.push([...edits]);
+        return { ok: true };
+      },
+      setStatus: () => {},
+      nextRoutingSuffix: () => 1,
+    });
+    const movePlan = planSelectionMove(document, {
+      instanceIds: [],
+      routeIds: [],
+      junctionIds: [],
+      annotationIds: ["label-R1", "label-R2"],
+      draftingIds: [],
+    });
+
+    controller.completeVisualSelectionMove(movePlan, { x: 10, y: 20 });
+
+    const anchors = captured
+      .flat()
+      .filter((edit) => edit.kind === "upsert_schematic_annotation")
+      .map((edit) => edit.annotation.anchor);
+    expect(anchors).toEqual([
+      expect.objectContaining({
+        kind: "object",
+        localOffset: { x: 20, y: 0 },
+        fallbackPosition: { x: 120, y: 100 },
+      }),
+      expect.objectContaining({
+        kind: "object",
+        localOffset: { x: 20, y: 0 },
+        fallbackPosition: { x: 320, y: 100 },
+      }),
+    ]);
   });
 });

--- a/apps/editor/src/features/selection/selection-move-controller.ts
+++ b/apps/editor/src/features/selection/selection-move-controller.ts
@@ -49,6 +49,10 @@ import {
   translateDraftingObject,
 } from "../drafting/drafting-manipulation";
 import {
+  annotationDragPosition,
+  draggedAnnotationAtPosition,
+} from "../text-editing/annotation-drag-model";
+import {
   endpointNetId,
   type RouteGeometryRecord,
 } from "../wiring/route-interaction-geometry";
@@ -96,52 +100,69 @@ export function createSelectionMoveController({
     movePlan: SelectionMovePlan,
     delta: Point,
     sourceDocument: SchematicDocument = document,
-  ): SchematicEdit[] => [
-    ...movePlan.freeAnnotationIds.flatMap((annotationId) => {
-      const annotation = sourceDocument.annotations.find(
-        (candidate) => candidate.id === annotationId,
-      );
-      if (!annotation || annotation.anchor.kind !== "free") return [];
-      return [
-        {
-          kind: "upsert_schematic_annotation" as const,
-          annotation: {
-            ...annotation,
-            anchor: {
-              kind: "free" as const,
-              // Translation preserves the annotation's fine placement: the
-              // grid discipline rides on the delta, and the annotation pitch
-              // can be finer than the Document grid (drafting contract).
-              position: snapGridPoint(
-                {
-                  x: annotation.anchor.position.x + delta.x,
-                  y: annotation.anchor.position.y + delta.y,
-                },
+  ): SchematicEdit[] => {
+    const annotationRouteGeometryRecords =
+      sourceDocument === document
+        ? routeGeometryRecords
+        : (() => {
+            const resolved = resolveDocumentRoutingGeometry(
+              sourceDocument,
+              resolver,
+            );
+            return sourceDocument.routes.flatMap((route) => {
+              const geometry = resolved.routes.get(route.id);
+              return geometry ? [{ route, geometry }] : [];
+            });
+          })();
+    return [
+      ...movePlan.independentAnnotationIds.flatMap((annotationId) => {
+        const annotation = sourceDocument.annotations.find(
+          (candidate) => candidate.id === annotationId,
+        );
+        if (!annotation || annotation.locked) return [];
+        const geometryContext = {
+          document: sourceDocument,
+          // A group translation preserves every member's fine offset. The
+          // already grid-disciplined delta moves the group; re-snapping each
+          // label to the current annotation grid would deform it internally.
+          annotationGrid: 1,
+          resolver,
+          routeGeometryRecords: annotationRouteGeometryRecords,
+        };
+        const position = annotationDragPosition(geometryContext, annotation);
+        return [
+          {
+            kind: "upsert_schematic_annotation" as const,
+            annotation: draggedAnnotationAtPosition(
+              geometryContext,
+              annotation,
+              snapGridPoint(
+                { x: position.x + delta.x, y: position.y + delta.y },
                 1,
               ),
-            },
+            ),
           },
-        },
-      ];
-    }),
-    ...movePlan.draftingIds.flatMap((draftingId) => {
-      const object = sourceDocument.drafting?.objects.find(
-        (candidate) => candidate.id === draftingId,
-      );
-      return object
-        ? [
-            {
-              kind: "upsert_drafting_object" as const,
-              object: translateDraftingObject(
-                object,
-                delta,
-                sourceDocument.presentation.grid,
-              ),
-            },
-          ]
-        : [];
-    }),
-  ];
+        ];
+      }),
+      ...movePlan.draftingIds.flatMap((draftingId) => {
+        const object = sourceDocument.drafting?.objects.find(
+          (candidate) => candidate.id === draftingId,
+        );
+        return object
+          ? [
+              {
+                kind: "upsert_drafting_object" as const,
+                object: translateDraftingObject(
+                  object,
+                  delta,
+                  sourceDocument.presentation.grid,
+                ),
+              },
+            ]
+          : [];
+      }),
+    ];
+  };
 
   const completeVisualSelectionMove = (
     movePlan: SelectionMovePlan,
@@ -177,11 +198,9 @@ export function createSelectionMoveController({
   };
 
   const visualMoveOrigin = (movePlan: SelectionMovePlan): Point => {
-    const freeAnnotation = movePlan.freeAnnotationIds
-      .map((id) =>
-        document.annotations.find((annotation) => annotation.id === id),
-      )
-      .find((annotation) => annotation?.anchor.kind === "free");
+    const independentAnnotation = movePlan.independentAnnotationIds
+      .map((id) => document.annotations.find((item) => item.id === id))
+      .find((annotation) => annotation !== undefined);
     return (
       movePlan.draftingIds
         .flatMap((id) => {
@@ -192,8 +211,16 @@ export function createSelectionMoveController({
           return origin ? [origin] : [];
         })
         .find((point): point is Point => point !== null) ??
-      (freeAnnotation?.anchor.kind === "free"
-        ? freeAnnotation.anchor.position
+      (independentAnnotation
+        ? annotationDragPosition(
+            {
+              document,
+              annotationGrid: 1,
+              resolver,
+              routeGeometryRecords,
+            },
+            independentAnnotation,
+          )
         : undefined) ??
       movePlan.looseRouteIds
         .map(

--- a/apps/editor/src/features/selection/selection-move-plan.test.ts
+++ b/apps/editor/src/features/selection/selection-move-plan.test.ts
@@ -115,4 +115,53 @@ describe("selection move plan", () => {
     expect(plan.translatedJunctionIds).toEqual(["J1"]);
     expect(plan.fixedObjectIds).toEqual([]);
   });
+
+  it("moves an explicitly selected anchored label independently but not twice with its host", () => {
+    const document = createEmptyDocument("doc", "Doc");
+    document.instances.push({
+      id: "R1",
+      symbolId: "resistor",
+      placement: {
+        position: { x: 100, y: 100 },
+        rotation: 0,
+        mirror: "none",
+      },
+    });
+    document.annotations.push({
+      id: "label-r1",
+      kind: "instance-label",
+      binding: { kind: "instance-reference", instanceId: "R1" },
+      anchor: {
+        kind: "object",
+        objectId: "R1",
+        localOffset: { x: 10, y: -20 },
+        fallbackPosition: { x: 110, y: 80 },
+      },
+      alignment: "start",
+      rotation: 0,
+      locked: false,
+    });
+
+    const labelOnly = planSelectionMove(document, {
+      instanceIds: [],
+      routeIds: [],
+      junctionIds: [],
+      annotationIds: ["label-r1"],
+      draftingIds: [],
+    });
+    expect(labelOnly.independentAnnotationIds).toEqual(["label-r1"]);
+    expect(labelOnly.previewObjectIds).toContain("label-r1");
+
+    const withHost = planSelectionMove(document, {
+      instanceIds: ["R1"],
+      routeIds: [],
+      junctionIds: [],
+      annotationIds: ["label-r1"],
+      draftingIds: [],
+    });
+    expect(withHost.independentAnnotationIds).toEqual([]);
+    expect(withHost.previewObjectIds).toEqual(
+      expect.arrayContaining(["R1", "label-r1"]),
+    );
+  });
 });

--- a/apps/editor/src/features/selection/selection-move-plan.ts
+++ b/apps/editor/src/features/selection/selection-move-plan.ts
@@ -33,7 +33,8 @@ export interface SelectionMovePlan {
   translatedJunctionIds: string[];
   looseRouteIds: string[];
   previewObjectIds: string[];
-  freeAnnotationIds: string[];
+  /** Explicitly selected labels whose anchor target is not moving with them. */
+  independentAnnotationIds: string[];
   draftingIds: string[];
   fixedObjectIds: string[];
 }
@@ -120,11 +121,21 @@ export function planSelectionMove(
       ),
     )
     .map((annotation) => annotation.id);
-  const freeAnnotationIds = selection.annotationIds.filter((id) => {
+  const followingAnnotationIdSet = new Set(followingAnnotationIds);
+  const independentAnnotationIds = selection.annotationIds.filter((id) => {
     const annotation = document.annotations.find(
       (candidate) => candidate.id === id,
     );
-    return annotation?.anchor.kind === "free" && !annotation.locked;
+    if (!annotation) return false;
+    if (annotation.locked) {
+      fixedObjectIds.add(id);
+      return false;
+    }
+    // A selected label whose host is already in the routing transform is a
+    // follower. Updating its anchor as a second operation would apply the
+    // same gesture twice. Every other explicitly selected label owns one
+    // independent anchor update, regardless of free/object/route anchoring.
+    return !followingAnnotationIdSet.has(id);
   });
   const draftingIds = selection.draftingIds.filter((id) => {
     const object = document.drafting?.objects.find(
@@ -144,10 +155,10 @@ export function planSelectionMove(
       ...translatedRouteIds,
       ...translatedJunctionIds,
       ...followingAnnotationIds,
-      ...freeAnnotationIds,
+      ...independentAnnotationIds,
       ...draftingIds,
     ]),
-    freeAnnotationIds: stable(freeAnnotationIds),
+    independentAnnotationIds: stable(independentAnnotationIds),
     draftingIds: stable(draftingIds),
     fixedObjectIds: stable(fixedObjectIds),
   };

--- a/apps/editor/src/features/selection/use-selection-interaction.ts
+++ b/apps/editor/src/features/selection/use-selection-interaction.ts
@@ -311,7 +311,7 @@ export function useSelectionInteraction(
     }
     if (
       session.movePlan.looseRouteIds.length > 0 ||
-      session.movePlan.freeAnnotationIds.length > 0 ||
+      session.movePlan.independentAnnotationIds.length > 0 ||
       session.movePlan.draftingIds.length > 0
     ) {
       return "Rotate and mirror during Move require a component-and-wire closure";

--- a/apps/editor/src/features/text-editing/annotation-drag-controller.ts
+++ b/apps/editor/src/features/text-editing/annotation-drag-controller.ts
@@ -4,7 +4,6 @@ import type {
 } from "react";
 
 import type { SchematicEdit } from "@icm/edit-engine";
-import { resolveRouteAttachment } from "@icm/derived";
 import {
   snapGridPoint,
   type Annotation,
@@ -18,12 +17,11 @@ import {
   type CanvasDragSession,
 } from "../../canvas/canvas-drag-session";
 import { startCanvasDragVisual } from "../../canvas/canvas-drag-visual";
+import { type RouteGeometryRecord } from "../wiring/route-interaction-geometry";
 import {
-  effectiveRouteAttachment,
-  isRoutedMarker,
-  type RouteGeometryRecord,
-} from "../wiring/route-interaction-geometry";
-import { draggedAnnotationAtPosition } from "./annotation-drag-model";
+  annotationDragPosition,
+  draggedAnnotationAtPosition,
+} from "./annotation-drag-model";
 
 type TransactionResult = { ok: boolean };
 
@@ -84,23 +82,16 @@ export function createAnnotationDragController({
     dragSessionRef.current?.cancel();
     const svg = hitTarget.ownerSVGElement!;
     const pointerStart = pointFromClient(event.clientX, event.clientY, svg);
-    const currentAttachment = effectiveRouteAttachment(annotation);
-    const record = currentAttachment
-      ? routeGeometryRecords.find(
-          ({ route }) => route.id === currentAttachment.routeId,
-        )
-      : undefined;
-    const markerPlacement =
-      record && currentAttachment
-        ? resolveRouteAttachment(record.geometry, currentAttachment)
-        : null;
-    const originalPosition = {
-      ...(isRoutedMarker(annotation) && markerPlacement
-        ? markerPlacement.labelPoint
-        : annotation.anchor.kind === "free"
-          ? annotation.anchor.position
-          : annotation.anchor.fallbackPosition),
+    const geometryContext = {
+      document,
+      annotationGrid,
+      resolver,
+      routeGeometryRecords,
     };
+    const originalPosition = annotationDragPosition(
+      geometryContext,
+      annotation,
+    );
     let visual: ReturnType<typeof startCanvasDragVisual> | null = null;
     const dragVisual = () =>
       (visual ??= startCanvasDragVisual(svg, [annotation.id]));
@@ -135,7 +126,7 @@ export function createAnnotationDragController({
           {
             kind: "upsert_schematic_annotation",
             annotation: draggedAnnotationAtPosition(
-              { document, annotationGrid, resolver, routeGeometryRecords },
+              geometryContext,
               latest,
               snapGridPoint(positionAt(client.x, client.y), annotationGrid),
             ),

--- a/apps/editor/src/features/text-editing/annotation-drag-model.ts
+++ b/apps/editor/src/features/text-editing/annotation-drag-model.ts
@@ -1,5 +1,7 @@
 import {
   resolveAnchorTargetPosition,
+  resolveRouteAttachment,
+  resolveVisualAnchor,
   type ResolvedRouteGeometry,
 } from "@icm/derived";
 import type {
@@ -30,6 +32,31 @@ export interface AnnotationDragGeometryContext {
     route: RouteBranch;
     geometry: ResolvedRouteGeometry;
   }[];
+}
+
+/**
+ * Resolve the visual point from which a label drag starts. Single-label and
+ * composite movement must use the same origin or an object/route anchor will
+ * preview from one point and commit from another.
+ */
+export function annotationDragPosition(
+  { document, resolver, routeGeometryRecords }: AnnotationDragGeometryContext,
+  annotation: Annotation,
+): Point {
+  const currentAttachment = effectiveRouteAttachment(annotation);
+  const record = currentAttachment
+    ? routeGeometryRecords.find(
+        ({ route }) => route.id === currentAttachment.routeId,
+      )
+    : undefined;
+  const markerPlacement =
+    record && currentAttachment
+      ? resolveRouteAttachment(record.geometry, currentAttachment)
+      : null;
+  if (isRoutedMarker(annotation) && markerPlacement) {
+    return markerPlacement.labelPoint;
+  }
+  return resolveVisualAnchor(document, resolver, annotation.anchor).position;
 }
 
 function constrainAnnotationPosition(


### PR DESCRIPTION
## Summary\n- move explicitly selected annotations through the shared selection-move plan, including object- and route-anchored labels\n- keep labels carried by selected components/routes as followers so they are not translated twice\n- share canonical annotation drag geometry between single-label and multi-selection movement\n- cover Ctrl+A and marquee movement for Draft Text and component labels\n\n## Validation\n- pnpm gate:preflight -- --base origin/main\n- full workspace unit gate: 490 files / 3355 tests passed (one cold formula-render timeout passed 34/34 on focused rerun)\n- full manual editor browser suite: 154/156 passed; two unrelated bulk-control load timeouts passed 2/2 on isolated rerun\n- remaining affected browser suites: 45/45 passed\n- post-rebase focused unit: 14/14 passed\n- post-rebase focused isolated browser: 2/2 passed